### PR TITLE
[readme] Document $GOPATH usage for cloning.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Development
 NOTE: Currently only development on OSX 10.8 is supported
 
 1. Install Go ```brew install go --cross-compile-common```
-1. Fork and clone.
+1. Setup `$GOLANG` env variable and add `$GOLANG/bin` to `$PATH`
+1. Fork and clone: `git clone https://github.com/cloudfoundry/cli.git $GOPATH/src/github.com/cloudfoundry/cli`
 1. Run ```git submodule update --init --recursive```
 1. Write a test.
 1. Run ``` bin/test ``` and watch test fail.


### PR DESCRIPTION
Note: this updates to suggest using $GOPATH/bin in $PATH though
this PR does not fix that `build` is currently sending the `go-cf`
executable into `./out` instead of `$GOPATH/bin` which I think is more common.
