### PR TITLE
Autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Cloud Foundry CLI written in Go [![Build Status](https://travis-ci.org/cloudfoundry/cli.png?branch=master)](https://travis-ci.org/cloudfoundry/cli)
 
+## Usage tips
+
+To enable tab-completion in Bash, you can either:
+
+* Enable tab-completion only for your current shell with `eval "$(cf bash-autocomplete)"`
+* Enable it for all users by putting the script in a central sourced location, e.g. `cf bash-autocomplete > /etc/bash_completion.d/cf`
+
 ## Background
 
 Project to rewrite the Cloud Foundry CLI tool using Go. This project should currently be considered alpha quality

--- a/src/cf/app/app.go
+++ b/src/cf/app/app.go
@@ -88,6 +88,15 @@ OPTIONS:
 			},
 		},
 		{
+			Name:        "bash-autocomplete",
+			Description: "Print out code to enable bash autocompletion for cf (see README for directions)",
+			Usage:       "cf bash-autocomplete",
+			Action: func(c *cli.Context) {
+				cmd := cmdFactory.NewBashAutocompletion(app.Commands)
+				cmdRunner.Run(cmd, c)
+			},
+		},
+		{
 			Name:        "bind-service",
 			ShortName:   "bs",
 			Description: "Bind a service instance to an application",

--- a/src/cf/commands/bash_autocomplete.go
+++ b/src/cf/commands/bash_autocomplete.go
@@ -1,0 +1,72 @@
+package commands
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"text/template"
+
+	"cf/requirements"
+	"cf/terminal"
+
+	"github.com/codegangsta/cli"
+)
+
+type BashAutocomplete struct {
+	ui       terminal.UI
+	commands []cli.Command
+}
+
+func NewBashAutocomplete(ui terminal.UI, commands []cli.Command) *BashAutocomplete {
+	return &BashAutocomplete{
+		ui:       ui,
+		commands: commands,
+	}
+}
+
+func (cmd *BashAutocomplete) GetRequirements(reqFactory requirements.Factory, c *cli.Context) (reqs []requirements.Requirement, err error) {
+	if len(c.Args()) > 0 {
+		err = errors.New("Incorrect Usage")
+		cmd.ui.FailWithUsage(c, "bash-autocomplete")
+		return
+	}
+
+	return
+}
+
+func (cmd *BashAutocomplete) Run(c *cli.Context) {
+	// Very helpful article on autocompletion:
+	// http://www.debian-administration.org/article/317/An_introduction_to_bash_completion_part_2
+	completion := `_cf()
+{
+    local cur prev cmds
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    cmds="{{range .}}{{.Name}} {{end}} bash-autocomplete"
+
+    case "${prev}" in
+      {{programName}})
+        COMPREPLY=( $(compgen -W "${cmds}" -- ${cur}) )
+        return 0
+        ;;
+      help)
+        COMPREPLY=( $(compgen -W "${cmds}" -- ${cur}) )
+        return 0
+        ;;
+    esac
+}
+complete -F _cf {{programName}}`
+
+	helpers := template.FuncMap{
+		"programName": func() string {
+			return os.Args[0]
+		},
+	}
+
+	t := template.Must(template.New("bashCompletion").Funcs(helpers).Parse(completion))
+
+	var output bytes.Buffer
+	t.Execute(&output, cmd.commands)
+	cmd.ui.Say(output.String())
+}

--- a/src/cf/commands/bash_autocomplete_test.go
+++ b/src/cf/commands/bash_autocomplete_test.go
@@ -1,0 +1,41 @@
+package commands_test
+
+import (
+	. "cf/commands"
+	"github.com/stretchr/testify/assert"
+	"testhelpers"
+	"testing"
+
+	"github.com/codegangsta/cli"
+)
+
+func TestBashAutocompleteFailsWithUsage(t *testing.T) {
+	reqFactory := &testhelpers.FakeReqFactory{}
+
+	fakeUI := callBashAutocomplete([]string{"foo"}, reqFactory)
+	assert.True(t, fakeUI.FailedWithUsage)
+}
+
+func TestBashAutocompleteRequirements(t *testing.T) {
+	reqFactory := &testhelpers.FakeReqFactory{}
+
+	callBashAutocomplete([]string{}, reqFactory)
+	assert.True(t, testhelpers.CommandDidPassRequirements)
+}
+
+func TestBashAutocompleteOutput(t *testing.T) {
+	reqFactory := &testhelpers.FakeReqFactory{}
+
+	fakeUI := callBashAutocomplete([]string{}, reqFactory)
+	assert.Contains(t, fakeUI.Outputs[0], "_cf()")
+	assert.Contains(t, fakeUI.Outputs[len(fakeUI.Outputs)-1], "complete -F _cf ")
+}
+
+func callBashAutocomplete(args []string, reqFactory *testhelpers.FakeReqFactory) (ui *testhelpers.FakeUI) {
+	ui = new(testhelpers.FakeUI)
+	ctxt := testhelpers.NewContext("bash-autocomplete", args)
+
+	cmd := NewBashAutocomplete(ui, []cli.Command{})
+	testhelpers.RunCommand(cmd, ctxt, reqFactory)
+	return
+}

--- a/src/cf/commands/factory.go
+++ b/src/cf/commands/factory.go
@@ -4,6 +4,8 @@ import (
 	"cf"
 	"cf/api"
 	"cf/terminal"
+
+	"github.com/codegangsta/cli"
 )
 
 type Factory struct {
@@ -29,6 +31,10 @@ func (f Factory) NewApps() Apps {
 		f.ui,
 		f.repoLocator.GetSpaceRepository(),
 	)
+}
+
+func (f Factory) NewBashAutocompletion(commands []cli.Command) *BashAutocomplete {
+	return NewBashAutocomplete(f.ui, commands)
 }
 
 func (f Factory) NewBindService() *BindService {


### PR DESCRIPTION
Add a way to enable bash autocompletion.

Right now it only autocompletes the first command, but there's nothing explicitly stopping us from enabling tab-completions on arguments or options to sub-commands too.
