### PR TITLE
Correct cups usage text.

### DIFF
--- a/src/cf/app/app.go
+++ b/src/cf/app/app.go
@@ -93,7 +93,7 @@ func NewApp(cmdFactory commands.Factory, reqFactory requirements.Factory) (app *
 			Name:        "create-user-provided-service",
 			ShortName:   "cups",
 			Description: "Make a user-provided service available to cf apps",
-			Usage: fmt.Sprintf("%s create-service SERVICE_INSTANCE \"comma, separated, parameter, names\"\n\n", cf.Name) +
+			Usage: fmt.Sprintf("%s create-user-provided-service SERVICE_INSTANCE \"comma, separated, parameter, names\"\n\n", cf.Name) +
 				"EXAMPLE:\n" +
 				fmt.Sprintf("   %s create-user-provided-service oracle-db-mine \"host, port, dbname, username, password\"", cf.Name),
 			Action: func(c *cli.Context) {

--- a/src/cf/app/app_test.go
+++ b/src/cf/app/app_test.go
@@ -6,6 +6,7 @@ import (
 	"cf/requirements"
 	"github.com/codegangsta/cli"
 	"github.com/stretchr/testify/assert"
+	"strings"
 	"testhelpers"
 	"testing"
 )
@@ -92,5 +93,14 @@ func TestCommands(t *testing.T) {
 
 		assert.Equal(t, cmdFactory.CmdName, cmdName)
 		assert.True(t, cmdFactory.CmdCompleted)
+	}
+}
+
+func TestUsageIncludesCommandName(t *testing.T) {
+	cmdFactory := &FakeCmdFactory{}
+	reqFactory := &testhelpers.FakeReqFactory{}
+	app, _ := app.NewApp(cmdFactory, reqFactory)
+	for _, cmd := range app.Commands {
+		assert.Contains(t, strings.Split(cmd.Usage, "\n")[0], cmd.Name)
 	}
 }


### PR DESCRIPTION
Cups should say 'create-user-provided-service' rather than `create-service` in usage:

```
$ cf create-user-provided-service | grep -A1 USAGE
USAGE:
   cf create-service SERVICE_INSTANCE "comma, separated, parameter, names"
```

Cheers,

Andrew.
