### PR TITLE
Zipper

### DIFF
--- a/src/cf/zipper.go
+++ b/src/cf/zipper.go
@@ -44,9 +44,8 @@ func readZipFile(file string) (zipBuffer *bytes.Buffer, err error) {
 
 func createZipFile(dir string) (zipBuffer *bytes.Buffer, err error) {
 	zipBuffer = new(bytes.Buffer)
-
 	isEmpty, err := IsDirEmpty(dir)
-	if isEmpty {
+	if isEmpty || err != nil {
 		return
 	}
 

--- a/src/cf/zipper_test.go
+++ b/src/cf/zipper_test.go
@@ -76,3 +76,28 @@ func TestZipWithJarFile(t *testing.T) {
 
 	assert.Equal(t, string(zipFile.Bytes()), "This is an application jar file\n")
 }
+
+func TestZipWithInvalidFile(t *testing.T) {
+	dir, err := os.Getwd()
+	assert.NoError(t, err)
+
+	zipper := ApplicationZipper{}
+	zipFile, err := zipper.Zip(filepath.Join(dir, "../a/bogus/directory"))
+
+	assert.Error(t, err)
+	assert.Equal(t, zipFile.Len(), 0)
+}
+
+func TestZipWithEmptyDir(t *testing.T) {
+	tmpdir := os.TempDir()
+	emptyDir := filepath.Join(tmpdir, "emptyDir")
+	err := os.MkdirAll(emptyDir, 0755)
+	assert.NoError(t, err)
+	defer os.RemoveAll(emptyDir)
+
+	zipper := ApplicationZipper{}
+	zipFile, err := zipper.Zip(emptyDir)
+
+	assert.NoError(t, err)
+	assert.Equal(t, zipFile.Len(), 0)
+}


### PR DESCRIPTION
There are a few cases where return variables are being shadowed.  This catches one of those cases when a directory doesn't exist.
