### PR TITLE
Add enable support for build packs

### DIFF
--- a/src/cf/api/buildpacks.go
+++ b/src/cf/api/buildpacks.go
@@ -27,12 +27,13 @@ type BuildpackResource struct {
 type BuildpackEntity struct {
 	Name     string `json:"name"`
 	Position *int   `json:"position,omitempty"`
+	Enabled  *bool  `json:"enabled"`
 }
 
 type BuildpackRepository interface {
 	FindByName(name string) (buildpack cf.Buildpack, apiResponse net.ApiResponse)
 	ListBuildpacks(stop chan bool) (buildpacksChan chan []cf.Buildpack, statusChan chan net.ApiResponse)
-	Create(name string, position *int) (createdBuildpack cf.Buildpack, apiResponse net.ApiResponse)
+	Create(name string, position *int, enabled *bool) (createdBuildpack cf.Buildpack, apiResponse net.ApiResponse)
 	Delete(buildpackGuid string) (apiResponse net.ApiResponse)
 	Update(buildpack cf.Buildpack) (updatedBuildpack cf.Buildpack, apiResponse net.ApiResponse)
 }
@@ -119,9 +120,9 @@ func (repo CloudControllerBuildpackRepository) findNextWithPath(path string) (bu
 	return
 }
 
-func (repo CloudControllerBuildpackRepository) Create(name string, position *int) (createdBuildpack cf.Buildpack, apiResponse net.ApiResponse) {
+func (repo CloudControllerBuildpackRepository) Create(name string, position *int, enabled *bool) (createdBuildpack cf.Buildpack, apiResponse net.ApiResponse) {
 	path := repo.config.Target + buildpacks_path
-	entity := BuildpackEntity{Name: name, Position: position}
+	entity := BuildpackEntity{Name: name, Position: position, Enabled: enabled}
 	body, err := json.Marshal(entity)
 	if err != nil {
 		apiResponse = net.NewApiResponseWithError("Could not serialize information", err)
@@ -147,7 +148,7 @@ func (repo CloudControllerBuildpackRepository) Delete(buildpackGuid string) (api
 func (repo CloudControllerBuildpackRepository) Update(buildpack cf.Buildpack) (updatedBuildpack cf.Buildpack, apiResponse net.ApiResponse) {
 	path := fmt.Sprintf("%s%s/%s", repo.config.Target, buildpacks_path, buildpack.Guid)
 
-	entity := BuildpackEntity{buildpack.Name, buildpack.Position}
+	entity := BuildpackEntity{buildpack.Name, buildpack.Position, buildpack.Enabled}
 	body, err := json.Marshal(entity)
 	if err != nil {
 		apiResponse = net.NewApiResponseWithError("Could not serialize updates.", err)
@@ -168,5 +169,6 @@ func unmarshallBuildpack(resource BuildpackResource) (buildpack cf.Buildpack) {
 	buildpack.Guid = resource.Metadata.Guid
 	buildpack.Name = resource.Entity.Name
 	buildpack.Position = resource.Entity.Position
+	buildpack.Enabled = resource.Entity.Enabled
 	return
 }

--- a/src/cf/app/app.go
+++ b/src/cf/app/app.go
@@ -87,7 +87,10 @@ func NewApp(cmdRunner commands.Runner) (app *cli.App, err error) {
 		{
 			Name:        "create-buildpack",
 			Description: "Create a buildpack",
-			Usage:       fmt.Sprintf("%s create-buildpack BUILDPACK PATH POSITION", cf.Name()),
+			Usage:       fmt.Sprintf("%s create-buildpack BUILDPACK PATH POSITION [-enabled]", cf.Name()),
+			Flags: []cli.Flag{
+				cli.BoolFlag{Name: "enabled", Usage: "Enable the buildpack"},
+			},
 			Action: func(c *cli.Context) {
 				cmdRunner.RunCmdByName("create-buildpack", c)
 			},
@@ -744,8 +747,9 @@ func NewApp(cmdRunner commands.Runner) (app *cli.App, err error) {
 		{
 			Name:        "update-buildpack",
 			Description: "Update a buildpack",
-			Usage:       fmt.Sprintf("%s update-buildpack BUILDPACK [-p PATH] [-i POSITION]", cf.Name()),
+			Usage:       fmt.Sprintf("%s update-buildpack BUILDPACK [-p PATH] [-i POSITION] [-enabled]", cf.Name()),
 			Flags: []cli.Flag{
+				cli.BoolFlag{Name: "enabled", Usage: "Enable the buildpack"},
 				cli.IntFlag{Name: "i", Usage: "Buildpack position among other buildpacks"},
 				cli.StringFlag{Name: "p", Usage: "Path to directory or zip file"},
 			},

--- a/src/cf/commands/buildpack/create_buildpack.go
+++ b/src/cf/commands/buildpack/create_buildpack.go
@@ -72,7 +72,13 @@ func (cmd CreateBuildpack) createBuildpack(buildpackName string, c *cli.Context)
 		apiResponse = net.NewApiResponseWithMessage("Invalid position. %s", err.Error())
 	}
 
-	buildpack, apiResponse = cmd.buildpackRepo.Create(buildpackName, &position)
+	var enabled *bool
+	if c.String("enabled") != "" {
+		val := c.Bool("enabled")
+		enabled = &val
+	}
+
+	buildpack, apiResponse = cmd.buildpackRepo.Create(buildpackName, &position, enabled)
 
 	return
 }

--- a/src/cf/commands/buildpack/create_buildpack_test.go
+++ b/src/cf/commands/buildpack/create_buildpack_test.go
@@ -67,6 +67,23 @@ func TestCreateBuildpackWithPosition(t *testing.T) {
 	assert.Contains(t, fakeUI.Outputs[4], "OK")
 }
 
+func TestCreateBuildpackDisabled(t *testing.T) {
+	reqFactory := &testreq.FakeReqFactory{LoginSuccess: true}
+	repo, bitsRepo := getRepositories()
+	fakeUI := callCreateBuildpack([]string{"-enabled=false", "my-buildpack", "my.war", "5"}, reqFactory, repo, bitsRepo)
+
+	assert.NotNil(t, repo.CreateBuildpack.Enabled)
+	assert.Equal(t, *repo.CreateBuildpack.Enabled, false)
+
+	assert.Equal(t, len(fakeUI.Outputs), 5)
+	assert.Contains(t, fakeUI.Outputs[0], "Creating buildpack")
+	assert.Contains(t, fakeUI.Outputs[0], "my-buildpack")
+	assert.Contains(t, fakeUI.Outputs[1], "OK")
+	assert.Contains(t, fakeUI.Outputs[3], "Uploading buildpack")
+	assert.Contains(t, fakeUI.Outputs[3], "my-buildpack")
+	assert.Contains(t, fakeUI.Outputs[4], "OK")
+}
+
 func TestCreateBuildpackWithInvalidPath(t *testing.T) {
 	reqFactory := &testreq.FakeReqFactory{LoginSuccess: true}
 	repo, bitsRepo := getRepositories()

--- a/src/cf/commands/buildpack/list_buildpacks.go
+++ b/src/cf/commands/buildpack/list_buildpacks.go
@@ -34,7 +34,7 @@ func (cmd ListBuildpacks) Run(c *cli.Context) {
 
 	buildpackChan, statusChan := cmd.buildpackRepo.ListBuildpacks(stopChan)
 
-	table := cmd.ui.Table([]string{"buildpack", "position"})
+	table := cmd.ui.Table([]string{"buildpack", "position", "enabled"})
 	noBuildpacks := true
 
 	for buildpacks := range buildpackChan {
@@ -44,9 +44,14 @@ func (cmd ListBuildpacks) Run(c *cli.Context) {
 			if buildpack.Position != nil {
 				position = strconv.Itoa(*buildpack.Position)
 			}
+			enabled := ""
+			if buildpack.Enabled != nil {
+				enabled = strconv.FormatBool(*buildpack.Enabled)
+			}
 			rows = append(rows, []string{
 				buildpack.Name,
 				position,
+				enabled,
 			})
 		}
 		table.Print(rows)

--- a/src/cf/commands/buildpack/list_buildpacks_test.go
+++ b/src/cf/commands/buildpack/list_buildpacks_test.go
@@ -24,16 +24,17 @@ func TestListBuildpacksRequirements(t *testing.T) {
 }
 
 func TestListBuildpacks(t *testing.T) {
-	buildpackBuilder := func(name string, position int) (buildpack cf.Buildpack) {
+	buildpackBuilder := func(name string, position int, enabled bool) (buildpack cf.Buildpack) {
 		buildpack.Name = name
 		buildpack.Position = &position
+		buildpack.Enabled = &enabled
 		return
 	}
 
 	buildpacks := []cf.Buildpack{
-		buildpackBuilder("Buildpack-1", 5),
-		buildpackBuilder("Buildpack-2", 10),
-		buildpackBuilder("Buildpack-3", 15),
+		buildpackBuilder("Buildpack-1", 5, true),
+		buildpackBuilder("Buildpack-2", 10, false),
+		buildpackBuilder("Buildpack-3", 15, true),
 	}
 
 	buildpackRepo := &testapi.FakeBuildpackRepository{
@@ -51,12 +52,15 @@ func TestListBuildpacks(t *testing.T) {
 
 	assert.Contains(t, ui.Outputs[2], "Buildpack-1")
 	assert.Contains(t, ui.Outputs[2], "5")
+	assert.Contains(t, ui.Outputs[2], "true")
 
 	assert.Contains(t, ui.Outputs[3], "Buildpack-2")
 	assert.Contains(t, ui.Outputs[3], "10")
+	assert.Contains(t, ui.Outputs[3], "false")
 
 	assert.Contains(t, ui.Outputs[4], "Buildpack-3")
 	assert.Contains(t, ui.Outputs[4], "15")
+	assert.Contains(t, ui.Outputs[4], "true")
 }
 
 func TestListingBuildpacksWhenNoneExist(t *testing.T) {

--- a/src/cf/commands/buildpack/update_buildpack.go
+++ b/src/cf/commands/buildpack/update_buildpack.go
@@ -53,6 +53,19 @@ func (cmd *UpdateBuildpack) Run(c *cli.Context) {
 		buildpack.Position = &val
 		updateBuildpack = true
 	}
+	
+	if c.String("e") != "" {
+		val := c.Bool("e")
+		buildpack.Enabled = &val
+		updateBuildpack = true
+	}
+	
+
+	if c.String("enabled") != "" {
+		val := c.Bool("enabled")
+		buildpack.Enabled = &val
+		updateBuildpack = true
+	}
 
 	if updateBuildpack {
 		buildpack, apiResponse := cmd.buildpackRepo.Update(buildpack)

--- a/src/cf/commands/buildpack/update_buildpack_test.go
+++ b/src/cf/commands/buildpack/update_buildpack_test.go
@@ -54,6 +54,20 @@ func TestUpdateBuildpackPosition(t *testing.T) {
 	assert.Contains(t, fakeUI.Outputs[1], "OK")
 }
 
+func TestUpdateBuildpackEnabled(t *testing.T) {
+	reqFactory := &testreq.FakeReqFactory{LoginSuccess: true, BuildpackSuccess: true}
+	repo, bitsRepo := getRepositories()
+
+	fakeUI := callUpdateBuildpack([]string{"-enabled", "my-buildpack"}, reqFactory, repo, bitsRepo)
+
+	assert.NotNil(t, repo.UpdateBuildpack.Enabled)
+	assert.Equal(t, *repo.UpdateBuildpack.Enabled, true)
+
+	assert.Contains(t, fakeUI.Outputs[0], "Updating buildpack")
+	assert.Contains(t, fakeUI.Outputs[0], "my-buildpack")
+	assert.Contains(t, fakeUI.Outputs[1], "OK")
+}
+
 func TestUpdateBuildpackPath(t *testing.T) {
 	reqFactory := &testreq.FakeReqFactory{LoginSuccess: true, BuildpackSuccess: true}
 	repo, bitsRepo := getRepositories()

--- a/src/cf/domain.go
+++ b/src/cf/domain.go
@@ -256,4 +256,5 @@ type UserFields struct {
 type Buildpack struct {
 	BasicFields
 	Position *int
+	Enabled  *bool
 }

--- a/src/testhelpers/api/fake_buildpack_repo.go
+++ b/src/testhelpers/api/fake_buildpack_repo.go
@@ -17,8 +17,8 @@ type FakeBuildpackRepository struct {
 	CreateBuildpack       cf.Buildpack
 	CreateApiResponse     net.ApiResponse
 
-	DeleteBuildpackGuid   string
-	DeleteApiResponse net.ApiResponse
+	DeleteBuildpackGuid string
+	DeleteApiResponse   net.ApiResponse
 
 	UpdateBuildpack cf.Buildpack
 }
@@ -29,13 +29,13 @@ func (repo *FakeBuildpackRepository) ListBuildpacks(stop chan bool) (buildpacksC
 
 	go func() {
 		buildpackCount := len(repo.Buildpacks)
-		for i:= 0; i < buildpackCount; i += 2 {
+		for i := 0; i < buildpackCount; i += 2 {
 			select {
 			case <-stop:
 				break
 			default:
-				if buildpackCount - i > 1 {
-					buildpacksChan <- repo.Buildpacks[i:i+2]
+				if buildpackCount-i > 1 {
+					buildpacksChan <- repo.Buildpacks[i : i+2]
 				} else {
 					buildpacksChan <- repo.Buildpacks[i:]
 				}
@@ -62,11 +62,12 @@ func (repo *FakeBuildpackRepository) FindByName(name string) (buildpack cf.Build
 	return
 }
 
-func (repo *FakeBuildpackRepository) Create(name string, position *int) (createdBuildpack cf.Buildpack, apiResponse net.ApiResponse) {
+func (repo *FakeBuildpackRepository) Create(name string, position *int, enabled *bool) (createdBuildpack cf.Buildpack, apiResponse net.ApiResponse) {
 	if repo.CreateBuildpackExists {
 		return repo.CreateBuildpack, net.NewApiResponse("Buildpack already exists", cf.BUILDPACK_EXISTS, 400)
 	}
 
+	repo.CreateBuildpack = cf.Buildpack{BasicFields: cf.BasicFields{Name: name}, Position: position, Enabled: enabled}
 	return repo.CreateBuildpack, repo.CreateApiResponse
 }
 


### PR DESCRIPTION
This adds the "enable" support for buildpacks.  There is some inconsitency between codegansta/cli and flagset over multi-character options.  flagset supports both -enabled and --enabled.  codegansta will print --enabled.
Going with single character made less sense when looking at it on the cli, but I will take any advice.
