### PR TITLE
Enable org-users to display all org users

### DIFF
--- a/src/cf/api/users.go
+++ b/src/cf/api/users.go
@@ -25,6 +25,7 @@ type UserEntity struct {
 }
 
 var orgRoleToPathMap = map[string]string{
+	cf.ORG_USER:        "users",
 	cf.ORG_MANAGER:     "managers",
 	cf.BILLING_MANAGER: "billing_managers",
 	cf.ORG_AUDITOR:     "auditors",

--- a/src/cf/api/users_test.go
+++ b/src/cf/api/users_test.go
@@ -69,6 +69,36 @@ func createUsersByRoleEndpoints(rolePath string) (ccReqs []testnet.TestRequest, 
 	return
 }
 
+func TestListAllUsersInOrg(t *testing.T) {
+	ccReqs, uaaReqs := createUsersByRoleEndpoints("/v2/organizations/my-org-guid/users")
+
+	cc, ccHandler, uaa, uaaHandler, repo := createUsersRepo(t, ccReqs, uaaReqs)
+	defer cc.Close()
+	defer uaa.Close()
+
+	stopChan := make(chan bool)
+	defer close(stopChan)
+	usersChan, statusChan := repo.ListUsersInOrgForRole("my-org-guid", cf.ORG_USER, stopChan)
+
+	users := []cf.UserFields{}
+	for chunk := range usersChan {
+		users = append(users, chunk...)
+	}
+	apiResponse := <-statusChan
+
+	assert.True(t, ccHandler.AllRequestsCalled())
+	assert.True(t, uaaHandler.AllRequestsCalled())
+	assert.True(t, apiResponse.IsSuccessful())
+
+	assert.Equal(t, len(users), 3)
+	assert.Equal(t, users[0].Guid, "user-1-guid")
+	assert.Equal(t, users[0].Username, "Super user 1")
+	assert.Equal(t, users[1].Guid, "user-2-guid")
+	assert.Equal(t, users[1].Username, "Super user 2")
+	assert.Equal(t, users[2].Guid, "user-3-guid")
+	assert.Equal(t, users[2].Username, "Super user 3")
+}
+
 func TestListUsersInOrgForRole(t *testing.T) {
 	ccReqs, uaaReqs := createUsersByRoleEndpoints("/v2/organizations/my-org-guid/managers")
 

--- a/src/cf/app/app.go
+++ b/src/cf/app/app.go
@@ -420,6 +420,9 @@ func NewApp(cmdRunner commands.Runner) (app *cli.App, err error) {
 			Name:        "org-users",
 			Description: "Show org users by role",
 			Usage:       fmt.Sprintf("%s org-users ORG", cf.Name()),
+			Flags: []cli.Flag{
+				cli.BoolFlag{Name: "a", Usage: "List all users in the org"},
+			},
 			Action: func(c *cli.Context) {
 				cmdRunner.RunCmdByName("org-users", c)
 			},

--- a/src/cf/commands/user/org_users.go
+++ b/src/cf/commands/user/org_users.go
@@ -13,6 +13,7 @@ import (
 var orgRoles = []string{cf.ORG_MANAGER, cf.BILLING_MANAGER, cf.ORG_AUDITOR}
 
 var orgRoleToDisplayName = map[string]string{
+	cf.ORG_USER:        "USERS",
 	cf.ORG_MANAGER:     "ORG MANAGER",
 	cf.BILLING_MANAGER: "BILLING MANAGER",
 	cf.ORG_AUDITOR:     "ORG AUDITOR",
@@ -49,13 +50,19 @@ func (cmd *OrgUsers) GetRequirements(reqFactory requirements.Factory, c *cli.Con
 
 func (cmd *OrgUsers) Run(c *cli.Context) {
 	org := cmd.orgReq.GetOrganization()
+	all := c.Bool("a")
 
 	cmd.ui.Say("Getting users in org %s as %s...",
 		terminal.EntityNameColor(org.Name),
 		terminal.EntityNameColor(cmd.config.Username()),
 	)
 
-	for _, role := range orgRoles {
+	roles := orgRoles
+	if all {
+		roles = []string{cf.ORG_USER}
+	}
+
+	for _, role := range roles {
 		stopChan := make(chan bool)
 		defer close(stopChan)
 

--- a/src/cf/user_roles.go
+++ b/src/cf/user_roles.go
@@ -1,6 +1,7 @@
 package cf
 
 const (
+	ORG_USER        = "OrgUser"
 	ORG_MANAGER     = "OrgManager"
 	BILLING_MANAGER = "BillingManager"
 	ORG_AUDITOR     = "OrgAuditor"


### PR DESCRIPTION
I was looking for a way to list all users that are in my organization but discovered that the go cli only reports users that have been associated with a non-default role.  That bummed me out so I decided to implement one.

This PR introduces a flag to list all users instead of only showing those in special roles.  If there's interest to this type of behavior using a different approach, I'm open to changing the implementation to be consistent with the desired user experience.

Thanks.
