### PR TITLE
Extract guid & dashboard_url from Service Instance/Summaries

### DIFF
--- a/src/cf/api/service_summary.go
+++ b/src/cf/api/service_summary.go
@@ -29,6 +29,8 @@ func (resource ServiceInstancesSummaries) ToModels() (instances []cf.ServiceInst
 
 		instance := cf.ServiceInstance{}
 		instance.Name = instanceSummary.Name
+		instance.Guid = instanceSummary.Guid
+		instance.DashboardURL = instanceSummary.DashboardURL
 		instance.ApplicationNames = applicationNames
 		instance.ServicePlan = servicePlan
 		instance.ServiceOffering = serviceOffering
@@ -57,8 +59,10 @@ type ServiceInstanceSummaryApp struct {
 }
 
 type ServiceInstanceSummary struct {
-	Name        string
-	ServicePlan ServicePlanSummary `json:"service_plan"`
+	Name         string
+	Guid         string
+	DashboardURL string             `json:"dashboard_url"`
+	ServicePlan  ServicePlanSummary `json:"service_plan"`
 }
 
 type ServicePlanSummary struct {

--- a/src/cf/api/service_summary_test.go
+++ b/src/cf/api/service_summary_test.go
@@ -30,6 +30,7 @@ var serviceInstanceSummariesResponse = testnet.TestResponse{Status: http.StatusO
   "services": [
     {
       "guid": "my-service-instance-guid",
+      "dashboard_url": "http://myservice.com/instance/my-service-instance-guid?token=foobar",
       "name": "my-service-instance",
       "bound_app_count": 2,
       "service_plan": {
@@ -64,6 +65,8 @@ func TestServiceSummaryGetSummariesInCurrentSpace(t *testing.T) {
 
 	instance1 := serviceInstances[0]
 	assert.Equal(t, instance1.Name, "my-service-instance")
+	assert.Equal(t, instance1.Guid, "my-service-instance-guid")
+	assert.Equal(t, instance1.DashboardURL, "http://myservice.com/instance/my-service-instance-guid?token=foobar")
 	assert.Equal(t, instance1.ServicePlan.Name, "spark")
 	assert.Equal(t, instance1.ServiceOffering.Label, "cleardb")
 	assert.Equal(t, instance1.ServiceOffering.Label, "cleardb")

--- a/src/cf/api/services.go
+++ b/src/cf/api/services.go
@@ -75,6 +75,7 @@ type ServiceInstanceResource struct {
 func (resource ServiceInstanceResource) ToFields() (fields cf.ServiceInstanceFields) {
 	fields.Guid = resource.Metadata.Guid
 	fields.Name = resource.Entity.Name
+	fields.DashboardURL = resource.Entity.DashboardURL
 	return
 }
 
@@ -92,6 +93,7 @@ func (resource ServiceInstanceResource) ToModel() (instance cf.ServiceInstance) 
 
 type ServiceInstanceEntity struct {
 	Name            string
+	DashboardURL    string                   `json:"dashboard_url"`
 	ServiceBindings []ServiceBindingResource `json:"service_bindings"`
 	ServicePlan     ServicePlanResource      `json:"service_plan"`
 }

--- a/src/cf/domain.go
+++ b/src/cf/domain.go
@@ -262,6 +262,7 @@ func (s ServiceOfferings) Less(i, j int) bool {
 
 type ServiceInstanceFields struct {
 	BasicFields
+	DashboardURL     string
 	SysLogDrainUrl   string
 	ApplicationNames []string
 	Params           map[string]string


### PR DESCRIPTION
This commit extends the base structs & functions towards allowing this codebase to be used for super-CLIs (forks/extensions) or Golang web applications that can interact with the dashboard_url for a service instance.
