### PR TITLE
Make ErrorResponse/ErrorHandler public

### DIFF
--- a/src/cf/net/cloud_controller_gateway.go
+++ b/src/cf/net/cloud_controller_gateway.go
@@ -15,7 +15,7 @@ func NewCloudControllerGateway() Gateway {
 		Description string
 	}
 
-	errorHandler := func(response *http.Response) errorResponse {
+	errorHandler := func(response *http.Response) ErrorResponse {
 		jsonBytes, _ := ioutil.ReadAll(response.Body)
 		response.Body.Close()
 
@@ -27,7 +27,7 @@ func NewCloudControllerGateway() Gateway {
 			code = INVALID_TOKEN_CODE
 		}
 
-		return errorResponse{Code: code, Description: ccResp.Description}
+		return ErrorResponse{Code: code, Description: ccResp.Description}
 	}
 
 	gateway := newGateway(errorHandler)

--- a/src/cf/net/gateway.go
+++ b/src/cf/net/gateway.go
@@ -36,12 +36,12 @@ type AsyncResponse struct {
 	Metadata AsyncMetadata
 }
 
-type errorResponse struct {
+type ErrorResponse struct {
 	Code        string
 	Description string
 }
 
-type errorHandler func(*http.Response) errorResponse
+type ErrorHandler func(*http.Response) ErrorResponse
 
 type tokenRefresher interface {
 	RefreshAuthToken() (string, ApiResponse)
@@ -54,12 +54,12 @@ type Request struct {
 
 type Gateway struct {
 	authenticator   tokenRefresher
-	errHandler      errorHandler
+	errHandler      ErrorHandler
 	PollingEnabled  bool
 	PollingThrottle time.Duration
 }
 
-func newGateway(errHandler errorHandler) (gateway Gateway) {
+func newGateway(errHandler ErrorHandler) (gateway Gateway) {
 	gateway.errHandler = errHandler
 	gateway.PollingThrottle = DEFAULT_POLLING_THROTTLE
 	return

--- a/src/cf/net/uaa_gateway.go
+++ b/src/cf/net/uaa_gateway.go
@@ -11,7 +11,7 @@ type uaaErrorResponse struct {
 	Description string `json:"error_description"`
 }
 
-var uaaErrorHandler = func(response *http.Response) errorResponse {
+var uaaErrorHandler = func(response *http.Response) ErrorResponse {
 	invalidTokenCode := "invalid_token"
 
 	jsonBytes, _ := ioutil.ReadAll(response.Body)
@@ -25,7 +25,7 @@ var uaaErrorHandler = func(response *http.Response) errorResponse {
 		code = INVALID_TOKEN_CODE
 	}
 
-	return errorResponse{Code: code, Description: uaaResp.Description}
+	return ErrorResponse{Code: code, Description: uaaResp.Description}
 }
 
 func NewUAAGateway() Gateway {


### PR DESCRIPTION
To allow other projects to re-use these types/functions, the Gateway needs to expose the errorHandler/errorResponse variables.
