### PR TITLE
CreateServiceInstance always returns cf.ServiceInstance

### DIFF
--- a/src/cf/commands/service/create_service.go
+++ b/src/cf/commands/service/create_service.go
@@ -65,7 +65,7 @@ func (cmd CreateService) Run(c *cli.Context) {
 	}
 
 	var identicalAlreadyExists bool
-	identicalAlreadyExists, apiResponse = cmd.serviceRepo.CreateServiceInstance(name, plan.Guid)
+	_, identicalAlreadyExists, apiResponse = cmd.serviceRepo.CreateServiceInstance(name, plan.Guid)
 	if apiResponse.IsNotSuccessful() {
 		cmd.ui.Failed(apiResponse.Message)
 		return

--- a/src/testhelpers/api/fake_service_repo.go
+++ b/src/testhelpers/api/fake_service_repo.go
@@ -9,6 +9,8 @@ import (
 type FakeServiceRepo struct {
 	ServiceOfferings []cf.ServiceOffering
 
+	ServiceInstance cf.ServiceInstance
+
 	CreateServiceInstanceName string
 	CreateServiceInstancePlanGuid string
 	CreateServiceAlreadyExists bool
@@ -31,7 +33,8 @@ func (repo *FakeServiceRepo) GetServiceOfferings() (offerings cf.ServiceOffering
 	return
 }
 
-func (repo *FakeServiceRepo) CreateServiceInstance(name, planGuid string) (identicalAlreadyExists bool, apiResponse net.ApiResponse) {
+func (repo *FakeServiceRepo) CreateServiceInstance(name, planGuid string) (serviceInstance cf.ServiceInstance, identicalAlreadyExists bool, apiResponse net.ApiResponse) {
+	serviceInstance = repo.ServiceInstance
 	repo.CreateServiceInstanceName = name
 	repo.CreateServiceInstancePlanGuid = planGuid
 	identicalAlreadyExists = repo.CreateServiceAlreadyExists


### PR DESCRIPTION
To allow super-CLIs & golang-based web apps to reuse these types/functions it is sometimes necessary for the caller of CreateServiceInstance to use the created cf.ServiceInstance immediately (and its DashboardURL)
