### PR TITLE
Fixed logs crash when source name is too long.

### DIFF
--- a/src/cf/commands/application/helpers.go
+++ b/src/cf/commands/application/helpers.go
@@ -50,6 +50,13 @@ func logMessageOutput(msg *logmessage.Message) string {
 	return fmt.Sprintf("%s%s", coloredLogHeader, logContent)
 }
 
+func max(a,b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
 func extractLogHeader(msg *logmessage.Message) (logHeader, coloredLogHeader string) {
 	logMsg := msg.GetLogMessage()
 	sourceName := logMsg.GetSourceName()
@@ -69,7 +76,7 @@ func extractLogHeader(msg *logmessage.Message) (logHeader, coloredLogHeader stri
 	// Calculate padding
 	longestHeader := fmt.Sprintf("%s  [App/0]  ", timeFormat)
 	expectedHeaderLength := len(longestHeader)
-	padding := strings.Repeat(" ", expectedHeaderLength-len(logHeader))
+	padding := strings.Repeat(" ", max(0, expectedHeaderLength-len(logHeader)))
 
 	logHeader = logHeader + padding
 	coloredLogHeader = coloredLogHeader + padding


### PR DESCRIPTION
If the log message source_name is longer than 8 characters you get the following error:

```
/home/mheath/paas/src/cli/src/main/cf.go:126 (0x41c9cf)
    displayCrashDialog: stackTrace := "\t" + strings.Replace(string(debug.Stack()), "\n", "\n\t", -1)
/home/mheath/paas/src/cli/src/main/cf.go:26 (0x41ccbc)
    func.001: displayCrashDialog()
/usr/local/go/src/pkg/runtime/panic.c:248 (0x42f966)
    panic: runtime·newstackcall(d->fn, (byte*)d->args, d->siz);
/usr/local/go/src/pkg/runtime/panic.c:482 (0x43020d)
    panicstring: runtime·panic(err);
/usr/local/go/src/pkg/runtime/slice.c:33 (0x438155)
    makeslice: runtime·panicstring("makeslice: len out of range");
/usr/local/go/src/pkg/strings/strings.go:425 (0x4ebd34)
    Repeat: b := make([]byte, len(s)*count)
/home/mheath/paas/src/cli/src/cf/commands/application/helpers.go:72 (0x5b3e91)
    extractLogHeader: padding := strings.Repeat(" ", expectedHeaderLength-len(logHeader))
/home/mheath/paas/src/cli/src/cf/commands/application/helpers.go:46 (0x5b37a2)
    logMessageOutput: logHeader, coloredLogHeader := extractLogHeader(msg)
/home/mheath/paas/src/cli/src/cf/commands/application/logs.go:103 (0x5b5f8a)
    (*Logs).displayLogMessages: cmd.ui.Say("%s", logMessageOutput(msg))
/home/mheath/paas/src/cli/src/cf/commands/application/logs.go:60 (0x5b5c60)
    (*Logs).Run: cmd.displayLogMessages(logChan)
/home/mheath/paas/src/cli/src/cf/commands/runner.go:52 (0x4a72cd)
    ConcreteRunner.RunCmdByName: cmd.Run(c)
/home/mheath/paas/src/cli/src/cf/commands/api.go:1 (0x4ac5d6)
    (*ConcreteRunner).RunCmdByName: package commands
/home/mheath/paas/src/cli/src/cf/app/app.go:399 (0x493ffc)
    func.035: cmdRunner.RunCmdByName("logs", c)
/home/mheath/paas/src/cli/src/github.com/codegangsta/cli/command.go:73 (0x4dae74)
    com/codegangsta/cli.Command.Run: c.Action(context)
/home/mheath/paas/src/cli/src/github.com/codegangsta/cli/app.go:101 (0x4da0c4)
    com/codegangsta/cli.(*App).Run: return c.Run(context)
/home/mheath/paas/src/cli/src/main/cf.go:54 (0x41c559)
    main: app.Run(os.Args)
/usr/local/go/src/pkg/runtime/proc.c:220 (0x43173f)
    main: main·main();
/usr/local/go/src/pkg/runtime/proc.c:1394 (0x433c60)
    goexit: runtime·goexit(void)
```

The long source name causes the padding length to be negative. This PR solves that problem. The output is entirely pretty though since the source name part of the output over runs the message part.
