### PR TITLE
Change the word UserFields to User in the messages seen in the console

### DIFF
--- a/src/cf/api/users.go
+++ b/src/cf/api/users.go
@@ -75,7 +75,7 @@ func (repo CloudControllerUserRepository) FindByUsername(username string) (user 
 
 	users, apiResponse := repo.updateOrFindUsersWithUAAPath([]cf.UserFields{}, path)
 	if len(users) == 0 {
-		apiResponse = net.NewNotFoundApiResponse("UserFields %s not found", username)
+		apiResponse = net.NewNotFoundApiResponse("User %s not found", username)
 		return
 	}
 

--- a/src/cf/api/users_test.go
+++ b/src/cf/api/users_test.go
@@ -268,6 +268,7 @@ func init() {
 			assert.True(mr.T(), handler.AllRequestsCalled())
 			assert.False(mr.T(), apiResponse.IsError())
 			assert.True(mr.T(), apiResponse.IsNotFound())
+			assert.Contains(mr.T(), apiResponse.Message, "User my-user not found")
 		})
 
 		It("TestCreateUser", func() {

--- a/src/cf/commands/user/delete_user.go
+++ b/src/cf/commands/user/delete_user.go
@@ -57,7 +57,7 @@ func (cmd DeleteUserFields) Run(c *cli.Context) {
 	}
 	if apiResponse.IsNotFound() {
 		cmd.ui.Ok()
-		cmd.ui.Warn("UserFields %s does not exist.", username)
+		cmd.ui.Warn("User %s does not exist.", username)
 		return
 	}
 

--- a/src/cf/requirements/user_test.go
+++ b/src/cf/requirements/user_test.go
@@ -39,7 +39,7 @@ func init() {
 
 			testassert.SliceContains(mr.T(), ui.Outputs, testassert.Lines{
 				{"FAILED"},
-				{"UserFields not found"},
+				{"User not found"},
 			})
 		})
 	})

--- a/src/rewriter.go
+++ b/src/rewriter.go
@@ -40,7 +40,7 @@ func main() {
 		"Quota":                  "quota",
 		"ServiceAuthTokenFields": "authToken",
 		"ServiceBroker":          "broker",
-		"UserFields":             "user",
+		"User":             "user",
 		"Buildpack":              "buildpack",
 		"Organization":           "org",
 		"Space":                  "space",

--- a/src/testhelpers/api/fake_user_repo.go
+++ b/src/testhelpers/api/fake_user_repo.go
@@ -43,7 +43,7 @@ func (repo *FakeUserRepository) FindByUsername(username string) (user cf.UserFie
 	user = repo.FindByUsernameUserFields
 
 	if repo.FindByUsernameNotFound {
-		apiResponse = net.NewNotFoundApiResponse("UserFields not found")
+		apiResponse = net.NewNotFoundApiResponse("User not found")
 	}
 
 	return
@@ -92,7 +92,7 @@ func (repo *FakeUserRepository) Create(username, password string) (apiResponse n
 	repo.CreateUserPassword = password
 
 	if repo.CreateUserExists {
-		apiResponse = net.NewApiResponse("UserFields already exists", cf.USER_EXISTS, 400)
+		apiResponse = net.NewApiResponse("User already exists", cf.USER_EXISTS, 400)
 	}
 
 	return


### PR DESCRIPTION
This just makes the messages seen when using the CLI refer to 'User' rather than 'UserFields'. eg. 'User my_user not found' instead of 'UserFields my_user not found' when trying to set-space-role for a user that doesnt exist.
