### PR TITLE
Add instructions necessary for bin/test to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Optionally, you can use `bin/run` to compile and run the executable in one step.
 Developing
 ==========
 
+1. Install [Mercurial](http://mercurial.selenic.com/)
+1. Run `go get code.google.com/p/go.tools/cmd/vet`
 1. Write a Ginkgo test.
 1. Run `bin/test` and watch the test fail.
 1. Make the test pass.


### PR DESCRIPTION
Without these additional steps, `./bin/test` yields the following:

```
 Formatting packages...

 Installing package dependencies...

 Testing packages:
ok      cf  0.904s
ok      cf/api  7.987s
ok      cf/app  0.824s
ok      cf/commands 1.196s
ok      cf/commands/application 1.299s
ok      cf/commands/buildpack   0.828s
ok      cf/commands/domain  0.757s
ok      cf/commands/organization    0.598s
ok      cf/commands/route   0.510s
ok      cf/commands/service 0.634s
ok      cf/commands/serviceauthtoken    0.447s
ok      cf/commands/servicebroker   0.297s
ok      cf/commands/space   0.911s
ok      cf/commands/user    0.744s
ok      cf/configuration    0.509s
ok      cf/formatters   0.053s
ok      cf/manifest 0.088s
ok      cf/models   0.019s
ok      cf/net  0.713s
ok      cf/requirements 0.081s
ok      cf/terminal 0.061s
ok      cf/trace    0.046s
ok      generic 0.044s

 Vetting packages for potential issues...
go tool: no such tool "vet"; to install:
    go get code.google.com/p/go.tools/cmd/vet

SUITE FAILURE
```

Mercurial must be installed, or else `go get code.google.com/p/go.tools/cmd/vet` yields:

```
go: missing Mercurial command. See http://golang.org/s/gogetcmd
package code.google.com/p/go.tools/cmd/vet: exec: "hg": executable file not found in $PATH
```
