### PR TITLE
Convert all \ -> /, a must for Windows

### DIFF
--- a/src/cf/app_files.go
+++ b/src/cf/app_files.go
@@ -46,7 +46,7 @@ func AppFilesInDir(dir string) (appFiles []models.AppFileFields, err error) {
 		sha1 := fmt.Sprintf("%x", sha1Bytes)
 
 		appFiles = append(appFiles, models.AppFileFields{
-			Path: fileName,
+			Path: filepath.ToSlash(fileName),
 			Sha1: sha1,
 			Size: size,
 		})

--- a/src/cf/app_files_test.go
+++ b/src/cf/app_files_test.go
@@ -1,0 +1,24 @@
+package cf_test
+
+import (
+	"path/filepath"
+
+	. "cf"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("AppFiles", func() {
+
+	Context("AppFilesInDir", func() {
+		FIt("all files have '/' path separators", func() {
+			files, err := AppFilesInDir(filepath.Join("..", "fixtures", "applications"))
+			Ω(err).ShouldNot(HaveOccurred())
+
+			for _, afile := range files {
+				Ω(afile.Path).Should(Equal(filepath.ToSlash(afile.Path)))
+			}
+		})
+	})
+
+})


### PR DESCRIPTION
This seems to fix #98.
Just slashify the files to make it all consistent.
