### PR TITLE
Find the set of service offerings based on the space and label

### DIFF
--- a/src/cf/api/services.go
+++ b/src/cf/api/services.go
@@ -14,6 +14,7 @@ import (
 type ServiceRepository interface {
 	PurgeServiceOffering(offering models.ServiceOffering) errors.Error
 	FindServiceOfferingByLabelAndProvider(name, provider string) (offering models.ServiceOffering, apiErr errors.Error)
+	FindServiceOfferingsForSpaceByLabel(spaceGuid, name string) (offering models.ServiceOfferings, apiErr errors.Error)
 	GetAllServiceOfferings() (offerings models.ServiceOfferings, apiErr errors.Error)
 	GetServiceOfferingsForSpace(spaceGuid string) (offerings models.ServiceOfferings, apiErr errors.Error)
 	FindInstanceByName(name string) (instance models.ServiceInstance, apiErr errors.Error)
@@ -34,6 +35,11 @@ func NewCloudControllerServiceRepository(config configuration.Reader, gateway ne
 	repo.config = config
 	repo.gateway = gateway
 	return
+}
+
+func (repo CloudControllerServiceRepository) FindServiceOfferingsForSpaceByLabel(spaceGuid, name string) (offering models.ServiceOfferings, apiErr errors.Error) {
+	return repo.getServiceOfferings(
+		fmt.Sprintf("/v2/spaces/%s/services?q=%s&inline-relations-depth=1", spaceGuid, url.QueryEscape("label:"+name)))
 }
 
 func (repo CloudControllerServiceRepository) GetServiceOfferingsForSpace(spaceGuid string) (offerings models.ServiceOfferings, apiErr errors.Error) {

--- a/src/cf/commands/service/create_service.go
+++ b/src/cf/commands/service/create_service.go
@@ -46,15 +46,9 @@ func (cmd CreateService) Run(c *cli.Context) {
 		terminal.EntityNameColor(cmd.config.Username()),
 	)
 
-	offerings, apiErr := cmd.serviceRepo.GetServiceOfferingsForSpace(cmd.config.SpaceFields().Guid)
+	offerings, apiErr := cmd.serviceRepo.FindServiceOfferingsForSpaceByLabel(cmd.config.SpaceFields().Guid, offeringName)
 	if apiErr != nil {
 		cmd.ui.Failed(apiErr.Error())
-		return
-	}
-
-	offerings, err := findOfferings(offerings, offeringName)
-	if err != nil {
-		cmd.ui.Failed(err.Error())
 		return
 	}
 

--- a/src/cf/commands/service/create_service_test.go
+++ b/src/cf/commands/service/create_service_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Testing with ginkgo", func() {
 		offering2.Label = "postgres"
 
 		serviceRepo := &testapi.FakeServiceRepo{}
-		serviceRepo.GetServiceOfferingsForSpaceReturns.ServiceOfferings = []models.ServiceOffering{
+		serviceRepo.FindServiceOfferingsForSpaceByLabelReturns.ServiceOfferings = []models.ServiceOffering{
 			offering,
 			offering2,
 		}
@@ -67,7 +67,7 @@ var _ = Describe("Testing with ginkgo", func() {
 		offering2 := models.ServiceOffering{}
 		offering2.Label = "postgres"
 		serviceRepo := &testapi.FakeServiceRepo{CreateServiceAlreadyExists: true}
-		serviceRepo.GetServiceOfferingsForSpaceReturns.ServiceOfferings = []models.ServiceOffering{offering, offering2}
+		serviceRepo.FindServiceOfferingsForSpaceByLabelReturns.ServiceOfferings = []models.ServiceOffering{offering, offering2}
 		ui := callCreateService([]string{"cleardb", "spark", "my-cleardb-service"},
 			[]string{},
 			serviceRepo,
@@ -96,7 +96,7 @@ var _ = Describe("Testing with ginkgo", func() {
 			offering2.Plans = []models.ServicePlanFields{plan}
 
 			serviceRepo := &testapi.FakeServiceRepo{CreateServiceAlreadyExists: true}
-			serviceRepo.GetServiceOfferingsForSpaceReturns.ServiceOfferings = []models.ServiceOffering{offering, offering2}
+			serviceRepo.FindServiceOfferingsForSpaceByLabelReturns.ServiceOfferings = []models.ServiceOffering{offering, offering2}
 			ui := callCreateService([]string{"cleardb", "spark", "my-cleardb-service"},
 				[]string{},
 				serviceRepo,

--- a/src/testhelpers/api/fake_service_repo.go
+++ b/src/testhelpers/api/fake_service_repo.go
@@ -21,6 +21,16 @@ type FakeServiceRepo struct {
 		SpaceGuid string
 	}
 
+	FindServiceOfferingsForSpaceByLabelArgs struct {
+		SpaceGuid string
+		Name      string
+	}
+
+	FindServiceOfferingsForSpaceByLabelReturns struct {
+		ServiceOfferings []models.ServiceOffering
+		Error            errors.Error
+	}
+
 	CreateServiceInstanceName     string
 	CreateServiceInstancePlanGuid string
 	CreateServiceAlreadyExists    bool
@@ -71,6 +81,12 @@ func (repo *FakeServiceRepo) GetAllServiceOfferings() (models.ServiceOfferings, 
 func (repo *FakeServiceRepo) GetServiceOfferingsForSpace(spaceGuid string) (models.ServiceOfferings, errors.Error) {
 	repo.GetServiceOfferingsForSpaceArgs.SpaceGuid = spaceGuid
 	return repo.GetServiceOfferingsForSpaceReturns.ServiceOfferings, repo.GetServiceOfferingsForSpaceReturns.Error
+}
+
+func (repo *FakeServiceRepo) FindServiceOfferingsForSpaceByLabel(spaceGuid, name string) (models.ServiceOfferings, errors.Error) {
+	repo.FindServiceOfferingsForSpaceByLabelArgs.Name = name
+	repo.FindServiceOfferingsForSpaceByLabelArgs.SpaceGuid = spaceGuid
+	return repo.FindServiceOfferingsForSpaceByLabelReturns.ServiceOfferings, repo.FindServiceOfferingsForSpaceByLabelReturns.Error
 }
 
 func (repo *FakeServiceRepo) PurgeServiceOffering(offering models.ServiceOffering) (apiErr errors.Error) {


### PR DESCRIPTION
I did this in two phases.
1. Just commit with pagination support.
2. Rather than walk all service offerings, we can have the endpoint filter by label.

The current test framework doesn't support pagination which I think is sorely missing.  I have a hunch that there are other APIs in need of similar work.
