### PR TITLE
[cfignore] explicitly include globs [fixes #105]

### DIFF
--- a/src/fixtures/applications/example-app/.cfignore
+++ b/src/fixtures/applications/example-app/.cfignore
@@ -1,0 +1,2 @@
+*.yml
+!manifest.yml


### PR DESCRIPTION
Explicitly include globs of files, that were otherwise ignored/excluded by the .cfignore file using the prefix !

```
# .cfignore
node_modules
!node_modules/common
```

This matches the .gitignore syntax for explicit inclusion.
