### PR TITLE
fix spacing on last line of 'help' text

### DIFF
--- a/src/main/cf.go
+++ b/src/main/cf.go
@@ -104,8 +104,8 @@ USAGE:
    {{.Usage}}{{with .Flags}}
 
 OPTIONS:
-   {{range .}}{{.}}
-   {{end}}{{else}}
+{{range .}}   {{.}}
+{{end}}{{else}}
 {{end}}`
 
 }


### PR DESCRIPTION
I may have messed up, I can't seem to find the description of this issue in here so let me try again...

a minor thing, but right now when I do:  cf push --help      the last line is just a set of 3 spaces w/o a CR. This means that my cmd line prompt is indented:

   --no-hostname    Map the root domain to this app
   --no-manifest    Ignore manifest file
   --no-route       Do not map a route to this app
   --no-start       Do not start an app after pushing
   --random-route   Create a random route for this app
   dugmb:~/work>

kind of funky. A minor tweak is needed to the help text template to fix it.
