### PR TITLE
Add symlink detection for Windows

### DIFF
--- a/src/cf/app_files/app_files.go
+++ b/src/cf/app_files/app_files.go
@@ -92,7 +92,7 @@ func WalkAppFiles(dir string, onEachFile walkAppFileFunc) (err error) {
 			return
 		}
 
-		if !f.Mode().IsRegular() {
+		if !fileutils.IsRegular(f) {
 			return
 		}
 

--- a/src/fileutils/file_utils_notwin.go
+++ b/src/fileutils/file_utils_notwin.go
@@ -1,0 +1,13 @@
+//
+
+// +build !windows
+
+package fileutils
+
+import (
+	"os"
+)
+
+func IsRegular(f os.FileInfo) bool {
+	return f.Mode().IsRegular()
+}

--- a/src/fileutils/file_utils_windows.go
+++ b/src/fileutils/file_utils_windows.go
@@ -1,0 +1,19 @@
+package fileutils
+
+import (
+	"os"
+	"syscall"
+)
+
+const (
+	FILE_ATTRIBUTE_REPARSE_POINT = 0x0400
+)
+
+func IsRegular(f os.FileInfo) bool {
+	if fileattrs, ok := f.Sys().(*syscall.Win32FileAttributeData); ok {
+		if fileattrs.FileAttributes&FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+			return false
+		}
+	}
+	return f.Mode().IsRegular()
+}


### PR DESCRIPTION
The right way is to provide symlink support in Golang, but this is the best we can do for now.
Windows will now behave like Unix when it comes to symlinks.
