### PR TITLE
Ignore Mercurial metadata from App upload by default

### DIFF
--- a/src/cf/app_files/app_files.go
+++ b/src/cf/app_files/app_files.go
@@ -15,6 +15,7 @@ var DefaultIgnoreFiles = []string{
 	".cfignore",
 	".gitignore",
 	".git",
+	".hg",
 	".svn",
 	"_darcs",
 	".DS_Store",


### PR DESCRIPTION
Ignore Mercurial metadata from App upload by default.
