### PR TITLE
Remove routes if they exist when --no-routes specified

### DIFF
--- a/src/cf/commands/application/push.go
+++ b/src/cf/commands/application/push.go
@@ -163,7 +163,15 @@ func (cmd *Push) fetchStackGuid(appParams *models.AppParams) {
 
 func (cmd *Push) bindAppToRoute(app models.Application, params models.AppParams, c *cli.Context) {
 	if params.NoRoute {
-		cmd.ui.Say("App %s is a worker, skipping route creation", terminal.EntityNameColor(app.Name))
+		if len(app.Routes) == 0 {
+			cmd.ui.Say("App %s is a worker, skipping route creation", terminal.EntityNameColor(app.Name))
+		} else {
+			for _, route := range app.Routes {
+				cmd.ui.Say("Removing route %s...", terminal.EntityNameColor(route.URL()))
+				cmd.routeRepo.Unbind(route.Guid, app.Guid)
+			}
+		}
+
 		return
 	}
 

--- a/src/cf/commands/application/push_test.go
+++ b/src/cf/commands/application/push_test.go
@@ -685,6 +685,7 @@ var _ = Describe("Push Command", func() {
 				}
 
 				existingApp.Routes = []models.RouteSummary{models.RouteSummary{
+					Guid:   "existing-route-guid",
 					Host:   "existing-app",
 					Domain: domain,
 				}}
@@ -750,7 +751,7 @@ var _ = Describe("Push Command", func() {
 				Expect(routeRepo.CreatedDomainGuid).To(Equal("domain-guid"))
 			})
 
-			It("does not create a route when the --no-route flag is given", func() {
+			It("removes the route when the --no-route flag is given", func() {
 				callPush("--no-route", "existing-app")
 
 				Expect(appBitsRepo.UploadedAppGuid).To(Equal("existing-app-guid"))
@@ -759,6 +760,8 @@ var _ = Describe("Push Command", func() {
 				Expect(routeRepo.FindByHostAndDomainHost).To(Equal(""))
 				Expect(routeRepo.CreatedHost).To(Equal(""))
 				Expect(routeRepo.CreatedDomainGuid).To(Equal(""))
+				Expect(routeRepo.UnboundRouteGuid).To(Equal("existing-route-guid"))
+				Expect(routeRepo.UnboundAppGuid).To(Equal("existing-app-guid"))
 			})
 
 			It("binds the root domain route to an app with a pre-existing route when the --no-hostname flag is given", func() {


### PR DESCRIPTION
If you push an app that already exists with --no-routes, you end up with the previous routes.
This will remove routes if they exist.
