### PR TITLE
Remove unneeded godep from build

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -1,17 +1,8 @@
 #!/bin/bash
 
-set -e
-set -u
-
 echo -e "\nGenerating Binary..."
 
-ROOT_DIR=$(cd $(dirname $(dirname $0)) && pwd)
+ROOT=$(cd $(dirname $0)/.. ; pwd -P)
+GOPATH=$ROOT/Godeps/_workspace:$GOPATH
 
-CLI_GOPATH=$ROOT_DIR/tmp/cli_gopath
-rm -rf $CLI_GOPATH
-mkdir -p $CLI_GOPATH/src/github.com/cloudfoundry/
-ln -s $ROOT_DIR $CLI_GOPATH/src/github.com/cloudfoundry/cli
-
-GODEP_GOPATH=$ROOT_DIR/Godeps/_workspace
-
-GOPATH=$CLI_GOPATH:$GODEP_GOPATH:$GOPATH go build -o $ROOT_DIR/out/cf ./main
+go build -o $ROOT/out/cf ./main

--- a/bin/run
+++ b/bin/run
@@ -1,12 +1,6 @@
 #!/bin/bash
 
-set -e
+ROOT=$(cd $(dirname $0)/.. ; pwd -P)
+GOPATH=$ROOT/Godeps/_workspace:$GOPATH
 
-GODEP=$(which godep)
-
-if [[ -z $GODEP ]] ; then
-  echo -e "godep is not installed. Run 'go get github.com/tools/godep'"
-  exit 1
-fi
-
-GOPATH=$($GODEP path):$GOPATH go run -race $(dirname $0)/../main/main.go "$@"
+go run -race $ROOT/main/main.go "$@"


### PR DESCRIPTION
As described in this [GitHub comment](https://github.com/XenoPhex/homebrew/commit/a885c669908886d4cf9214ed1e812bd29dc7e217#commitcomment-6494522) the use of `godep` in the build script is unneeded.  Having it there requires all builders of the
project to have it installed even though it never needs to be called.  As an example, this causes the Homebrew formula for the project to be massively more complex than it needs to be.  This change removes that use of `godep` in the buildscript, instead calculating the absolute path to the checked-in godep workspace and using that.
