### PR TITLE
wait for instance on start is properly throttled

### DIFF
--- a/cf/commands/application/start_test.go
+++ b/cf/commands/application/start_test.go
@@ -410,7 +410,7 @@ func callStart(args []string, config configuration.Reader, requirementsFactory *
 
 	cmd := NewStart(ui, config, displayApp, appRepo, appInstancesRepo, logRepo)
 	cmd.StagingTimeout = 50 * time.Millisecond
-	cmd.StartupTimeout = 50 * time.Millisecond
+	cmd.StartupTimeout = 500 * time.Millisecond
 	cmd.PingerThrottle = 50 * time.Millisecond
 
 	testcmd.RunCommand(cmd, args, requirementsFactory)


### PR DESCRIPTION
throttling instance requests only occurred on error.  we should always throttle, to avoid spamming cloud controller.

broke waitForOneRunningInstance into two methods, to avoid long-method syndrome.
