### PR TITLE
Travis builds should use ginkgo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: go
 go:
   - 1.2
-before_install:
-  - go get -u code.google.com/p/go.tools/cmd/vet
-  - go get -u github.com/tools/godep
-install: PATH=$PATH:$HOME/gopath/bin ./bin/build
-script:  PATH=$PATH:$HOME/gopath/bin ./bin/test
+install:
+  - go get -v code.google.com/p/go.tools/cmd/vet
+  - go get -v github.com/tools/godep
+  - go get -v github.com/onsi/ginkgo/ginkgo
+  - PATH=$PATH:$HOME/gopath/bin bin/generate-language-resources
+  - go get -v -t ./...
+script:  bin/travis
 branches:
   only:
   - master

--- a/bin/travis
+++ b/bin/travis
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+export PATH=$PATH:$HOME/gopath/bin
+export GOPATH=$(godep path):$(pwd):$GOPATH
+
+echo "go path is $GOPATH"
+ginkgo -r cf --randomizeAllSpecs --randomizeSuites --failOnPending --trace


### PR DESCRIPTION
We'd like to use ginkgo more for running our tests, and switching travis-ci builds over first is a great first step to see how painful this actually will be.
