### PR TITLE
Use '?' instead of '-1' when running instances is unknown

### DIFF
--- a/cf/commands/application/apps_test.go
+++ b/cf/commands/application/apps_test.go
@@ -106,6 +106,34 @@ var _ = Describe("list-apps command", func() {
 			))
 		})
 
+		Context("when an app's running instances is unknown", func() {
+			It("dipslays a '?' for running instances", func() {
+				appRoutes := []models.RouteSummary{
+					models.RouteSummary{
+						Host:   "app1",
+						Domain: models.DomainFields{Name: "cfapps.io"},
+					}}
+				app := models.Application{}
+				app.Name = "Application-1"
+				app.State = "started"
+				app.RunningInstances = -1
+				app.InstanceCount = 2
+				app.Memory = 512
+				app.DiskQuota = 1024
+				app.Routes = appRoutes
+
+				appSummaryRepo.GetSummariesInCurrentSpaceApps = []models.Application{app}
+
+				runCommand()
+
+				Expect(ui.Outputs).To(ContainSubstrings(
+					[]string{"Getting apps in", "my-org", "my-space", "my-user"},
+					[]string{"OK"},
+					[]string{"Application-1", "started", "?/2", "512M", "1G", "app1.cfapps.io"},
+				))
+			})
+		})
+
 		Context("when there are no apps", func() {
 			It("tells the user that there are no apps", func() {
 				runCommand()

--- a/cf/ui_helpers/ui.go
+++ b/cf/ui_helpers/ui.go
@@ -2,8 +2,9 @@ package ui_helpers
 
 import (
 	"fmt"
-	. "github.com/cloudfoundry/cli/cf/i18n"
 	"strings"
+
+	. "github.com/cloudfoundry/cli/cf/i18n"
 
 	"github.com/cloudfoundry/cli/cf/models"
 	"github.com/cloudfoundry/cli/cf/terminal"
@@ -29,6 +30,10 @@ func ColoredAppState(app models.ApplicationFields) string {
 
 func ColoredAppInstances(app models.ApplicationFields) string {
 	healthString := fmt.Sprintf("%d/%d", app.RunningInstances, app.InstanceCount)
+
+	if app.RunningInstances < 0 {
+		healthString = fmt.Sprintf("?/%d", app.InstanceCount)
+	}
 
 	if app.RunningInstances == 0 {
 		if strings.ToLower(app.State) == "stopped" {


### PR DESCRIPTION
When the health manager is unable to determine the desired or actual running instances of an application, the cloud controller will present a -1 value for running instances to the caller.  This is a relatively recent behavior change.

To more accurately represent the unknown state, use a '?' in the cli output for running instances when the value from the cloud controller is negative.
