### PR TITLE
Change 'cf app' instance index to start at 1

### DIFF
--- a/cf/commands/application/app.go
+++ b/cf/commands/application/app.go
@@ -121,7 +121,7 @@ func (cmd *ShowApp) ShowApp(app models.Application) {
 
 	for index, instance := range instances {
 		table.Add(
-			fmt.Sprintf("#%d", index),
+			fmt.Sprintf("#%d", index+1),
 			ui_helpers.ColoredInstanceState(instance),
 			instance.Since.Format("2006-01-02 03:04:05 PM"),
 			fmt.Sprintf("%.1f%%", instance.CpuUsage*100),

--- a/cf/commands/application/app_test.go
+++ b/cf/commands/application/app_test.go
@@ -100,8 +100,8 @@ var _ = Describe("app Command", func() {
 				[]string{"instances", "2/2"},
 				[]string{"usage", "256M x 2 instances"},
 				[]string{"urls", "my-app.example.com", "foo.example.com"},
-				[]string{"#0", "running", "2012-01-02 03:04:05 PM", "100.0%", "13 of 64M", "32M of 1G"},
-				[]string{"#1", "down", "2012-04-01 03:04:05 PM", "0%", "0 of 0", "0 of 0"},
+				[]string{"#1", "running", "2012-01-02 03:04:05 PM", "100.0%", "13 of 64M", "32M of 1G"},
+				[]string{"#2", "down", "2012-04-01 03:04:05 PM", "0%", "0 of 0", "0 of 0"},
 			))
 		})
 	})
@@ -191,8 +191,8 @@ var _ = Describe("app Command", func() {
 				[]string{"instances", "?/2"},
 				[]string{"usage", "256M x 2 instances"},
 				[]string{"urls", "my-app.example.com", "foo.example.com"},
-				[]string{"#0", "running", "2012-01-02 03:04:05 PM", "500.0%", "1G of 2G", "3G of 4G"},
-				[]string{"#1", "running", "2012-04-01 03:04:05 PM", "0%", "0 of 0", "0 of 0"},
+				[]string{"#1", "running", "2012-01-02 03:04:05 PM", "500.0%", "1G of 2G", "3G of 4G"},
+				[]string{"#2", "running", "2012-04-01 03:04:05 PM", "0%", "0 of 0", "0 of 0"},
 			))
 		})
 	})


### PR DESCRIPTION
Pretty obvious in retrospect. I'm sure I saw this a million times in the past year
and it never, ever occurred to me.

Also, I really wanted to test this out more before sending a PR, but there's some
weirdness going on with loggregator_consumer on master making the build script
fail. Running the tests on my rMBP causing terminal to consume two cores and
catch fire, so hopefully there's no unexpected test failures here that make me
look like a lazy bum.

Fixes #247. Shout out to @davebotelho for catching this. Lazer eyes, I tells ya.

Lazer eyes.

![lazer eyes](http://img4.wikia.nocookie.net/__cb20120809112924/uncyclopedia/images/4/49/LASER_EYE_MAN.png)
