### PR TITLE
Do not send a quota guid if no quota is specified.

### DIFF
--- a/cf/api/organizations/organizations.go
+++ b/cf/api/organizations/organizations.go
@@ -70,7 +70,12 @@ func (repo CloudControllerOrganizationRepository) FindByName(name string) (org m
 
 func (repo CloudControllerOrganizationRepository) Create(org models.Organization) (apiErr error) {
 	url := repo.config.ApiEndpoint() + "/v2/organizations"
-	data := fmt.Sprintf(`{"name":"%s", "quota_definition_guid":"%s"}`, org.Name, org.QuotaDefinition.Guid)
+	quota_data := ""
+	if org.QuotaDefinition.Guid != "" {
+		quota_data = fmt.Sprintf(`,"quota_definition_guid":"%s"`, org.QuotaDefinition.Guid)
+	}
+
+	data := fmt.Sprintf(`{"name":"%s"%s}`, org.Name, quota_data)
 	return repo.gateway.CreateResource(url, strings.NewReader(data))
 }
 

--- a/cf/api/organizations/organizations_test.go
+++ b/cf/api/organizations/organizations_test.go
@@ -171,7 +171,7 @@ var _ = Describe("Organization Repository", func() {
 			req := testapi.NewCloudControllerTestRequest(testnet.TestRequest{
 				Method:   "POST",
 				Path:     "/v2/organizations",
-				Matcher:  testnet.RequestBodyMatcher(`{"name":"my-org", "quota_definition_guid":""}`),
+				Matcher:  testnet.RequestBodyMatcher(`{"name":"my-org"}`),
 				Response: testnet.TestResponse{Status: http.StatusCreated},
 			})
 


### PR DESCRIPTION
The runtime has added more checks to prevent bad quotas.  Sending a "" is caught as an invalid quota name.
Sending nothing is the right behavior now.
