### PR TITLE
Honor keepalive

### DIFF
--- a/cf/net/gateway_test.go
+++ b/cf/net/gateway_test.go
@@ -57,13 +57,13 @@ var _ = Describe("Gateway", func() {
 	})
 
 	Describe("Connection errors", func() {
-		var oldNewHttpClient func(trustedCerts []tls.Certificate, disableSSL bool) HttpClientInterface
+		var oldNewHttpClient func(tr *http.Transport) HttpClientInterface
 
 		BeforeEach(func() {
 			client = &fakes.FakeHttpClientInterface{}
 
 			oldNewHttpClient = NewHttpClient
-			NewHttpClient = func(trustedCerts []tls.Certificate, disableSSL bool) HttpClientInterface {
+			NewHttpClient = func(tr *http.Transport) HttpClientInterface {
 				return client
 			}
 		})
@@ -475,6 +475,7 @@ var _ = Describe("Gateway", func() {
 			BeforeEach(func() {
 				apiServer.TLS.Certificates = []tls.Certificate{testnet.MakeExpiredTLSCert()}
 				config.SetSSLDisabled(true)
+				ccGateway = NewCloudControllerGateway(config, clock)
 			})
 
 			It("succeeds", func() {

--- a/cf/net/http_client.go
+++ b/cf/net/http_client.go
@@ -1,9 +1,7 @@
 package net
 
 import (
-	"crypto/tls"
 	"crypto/x509"
-	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -21,13 +19,7 @@ type HttpClientInterface interface {
 	Do(req *http.Request) (resp *http.Response, err error)
 }
 
-var NewHttpClient = func(trustedCerts []tls.Certificate, disableSSL bool) HttpClientInterface {
-	tr := &http.Transport{
-		Dial:            (&net.Dialer{Timeout: 5 * time.Second}).Dial,
-		TLSClientConfig: NewTLSConfig(trustedCerts, disableSSL),
-		Proxy:           http.ProxyFromEnvironment,
-	}
-
+var NewHttpClient = func(tr *http.Transport) HttpClientInterface {
 	return &http.Client{
 		Transport:     tr,
 		CheckRedirect: PrepareRedirect,


### PR DESCRIPTION
Previously the CLI would make a http.Transport per connection to the CC.
On long operations with a lot of polling, this leaves all the connections open, and eventually they time out.
