### PR TITLE
update-service shows an error if the instance is missing and no plan is ...

### DIFF
--- a/cf/commands/service/update_service_test.go
+++ b/cf/commands/service/update_service_test.go
@@ -78,13 +78,27 @@ var _ = Describe("update-service command", func() {
 		})
 	})
 	Context("when no flags are passed", func() {
-		It("prints a user indicating it is a no-op", func() {
-			callUpdateService([]string{"my-service"})
+		Context("when there is an err finding the instance", func() {
+			It("returns an error", func() {
+				serviceRepo.FindInstanceByNameErr = true
 
-			Expect(ui.Outputs).To(ContainSubstrings(
-				[]string{"OK"},
-				[]string{"No changes were made"},
-			))
+				callUpdateService([]string{"some-stupid-not-real-instance"})
+
+				Expect(ui.Outputs).To(ContainSubstrings(
+					[]string{"Error finding instance"},
+					[]string{"FAILED"},
+				))
+			})
+		})
+		Context("when the instance exists", func() {
+			It("prints a user indicating it is a no-op", func() {
+				callUpdateService([]string{"my-service"})
+
+				Expect(ui.Outputs).To(ContainSubstrings(
+					[]string{"OK"},
+					[]string{"No changes were made"},
+				))
+			})
 		})
 	})
 	Context("when the plan flag is passed", func() {


### PR DESCRIPTION
...provided

In the case where the instance is missing AND the plan is not provided, the current behavior is to say "Ok, no changes were made", but we want to display the error that says that the service instance does not exist.
