### PR TITLE
Match traditional Chinese dialects to zh_Hant

### DIFF
--- a/cf/i18n/init.go
+++ b/cf/i18n/init.go
@@ -80,6 +80,10 @@ func initWithUserLocale() (string, error) {
 	}
 
 	userLocale = strings.Replace(userLocale, "-", "_", 1)
+	if strings.HasPrefix(userLocale, "zh_TW") || strings.HasPrefix(userLocale, "zh_HK") {
+		userLocale = "zh_Hant"
+		language = "zh"
+	}
 
 	err = loadFromAsset(userLocale, language)
 	if err != nil {

--- a/cf/i18n/init_unix_test.go
+++ b/cf/i18n/init_unix_test.go
@@ -151,6 +151,39 @@ var _ = Describe("i18n.Init() function", func() {
 					Ω("Pas buildpacks trouvés").Should(Equal(translation))
 				})
 			})
+
+			Context("matches zh_CN to simplified Chinese", func() {
+				BeforeEach(func() {
+					os.Setenv("LC_ALL", "zh_CN.UTF-8")
+				})
+
+				It("matches to zh_Hans", func() {
+					translation := T("No buildpacks found")
+					Ω("buildpack未找到").Should(Equal(translation))
+				})
+			})
+
+			Context("matches zh_TW locale to traditional Chinese", func() {
+				BeforeEach(func() {
+					os.Setenv("LC_ALL", "zh_TW.UTF-8")
+				})
+
+				It("matches to zh_Hant", func() {
+					translation := T("No buildpacks found")
+					Ω("(Hant)No buildpacks found").Should(Equal(translation))
+				})
+			})
+
+			Context("matches zh_HK locale to traditional Chinese", func() {
+				BeforeEach(func() {
+					os.Setenv("LC_ALL", "zh_HK.UTF-8")
+				})
+
+				It("matches to zh_Hant", func() {
+					translation := T("No buildpacks found")
+					Ω("(Hant)No buildpacks found").Should(Equal(translation))
+				})
+			})
 		})
 
 		Context("creates a valid T function", func() {

--- a/cf/i18n/init_windows_test.go
+++ b/cf/i18n/init_windows_test.go
@@ -76,5 +76,32 @@ var _ = Describe("i18n.Init() function", func() {
 				Ω("Deleting domain foo as Anand...").Should(Equal(translation))
 			})
 		})
+
+		It("matches zh_CN to zh_Hans", func() {
+			os.Setenv("LC_ALL", "zh_CN.UTF-8")
+			T := i18n.Init(configRepo)
+			Ω(T).ShouldNot(BeNil())
+
+			translation := T("No buildpacks found")
+			Ω("buildpack未找到").Should(Equal(translation))
+		})
+
+		It("matches zh_TW to zh_Hant", func() {
+			os.Setenv("LC_ALL", "zh_TW.UTF-8")
+			T := i18n.Init(configRepo)
+			Ω(T).ShouldNot(BeNil())
+
+			translation := T("No buildpacks found")
+			Ω("(Hant)No buildpacks found").Should(Equal(translation))
+		})
+
+		It("matches zh_HK to zh_Hant", func() {
+			os.Setenv("LC_ALL", "zh_HK.UTF-8")
+			T := i18n.Init(configRepo)
+			Ω(T).ShouldNot(BeNil())
+
+			translation := T("No buildpacks found")
+			Ω("(Hant)No buildpacks found").Should(Equal(translation))
+		})
 	})
 })

--- a/cf/i18n/test_fixtures/zh_Hans.all.json
+++ b/cf/i18n/test_fixtures/zh_Hans.all.json
@@ -1,0 +1,22 @@
+[
+   {
+      "id": "Deletes a security group",
+      "translation": "Deletes a security group",
+      "modified": false
+   },
+   {
+      "id": "No buildpacks found",
+      "translation": "buildpack未找到",
+      "modified": false
+   },
+   {
+      "id": "Change user password",
+      "translation": "更改用户密码",
+      "modified": false
+   },
+   {
+      "id": "Deleting domain {{.DomainName}} as {{.Username}}...",
+      "translation": "Deleting domain {{.DomainName}} as {{.Username}}...",
+      "modified": false
+   }
+]

--- a/cf/i18n/test_fixtures/zh_Hant.all.json
+++ b/cf/i18n/test_fixtures/zh_Hant.all.json
@@ -1,0 +1,22 @@
+[
+   {
+      "id": "Deletes a security group",
+      "translation": "(Hant)Deletes a security group",
+      "modified": false
+   },
+   {
+      "id": "No buildpacks found",
+      "translation": "(Hant)No buildpacks found",
+      "modified": false
+   },
+   {
+      "id": "Change user password",
+      "translation": "(Hant)Change user password",
+      "modified": false
+   },
+   {
+      "id": "Deleting domain {{.DomainName}} as {{.Username}}...",
+      "translation": "(Hant)Deleting domain {{.DomainName}} as {{.Username}}...",
+      "modified": false
+   }
+]


### PR DESCRIPTION
Added functionality to match zh_TW and zh_HK locales to the traditional Chinese translation: zh_Hant. This will display as English until that translation is finished and those files are added.
