### PR TITLE
Fix ui.Ask to return strings with spaces from stdin

### DIFF
--- a/cf/terminal/ui.go
+++ b/cf/terminal/ui.go
@@ -1,6 +1,7 @@
 package terminal
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"os"
@@ -124,8 +125,13 @@ func (c *terminalUI) Confirm(message string, args ...interface{}) bool {
 func (c *terminalUI) Ask(prompt string, args ...interface{}) (answer string) {
 	c.printer.Println("")
 	c.printer.Printf(prompt+PromptColor(">")+" ", args...)
-	fmt.Fscanln(c.stdin, &answer)
-	return
+
+	rd := bufio.NewReader(c.stdin)
+	line, err := rd.ReadString('\n')
+	if err == nil {
+		return strings.TrimSpace(line)
+	}
+	return ""
 }
 
 func (c *terminalUI) Ok() {

--- a/cf/terminal/ui_test.go
+++ b/cf/terminal/ui_test.go
@@ -68,6 +68,22 @@ var _ = Describe("UI", func() {
 		})
 	})
 
+	Describe("Asking user for input", func() {
+		It("allows string with whitespaces", func() {
+			io_helpers.SimulateStdin("foo bar\n", func(reader io.Reader) {
+				ui := NewUI(reader, NewTeePrinter())
+				Expect(ui.Ask("?")).To(Equal("foo bar"))
+			})
+		})
+
+		It("returns empty string if an error occured while reading string", func() {
+			io_helpers.SimulateStdin("string without expected delimiter", func(reader io.Reader) {
+				ui := NewUI(reader, NewTeePrinter())
+				Expect(ui.Ask("?")).To(Equal(""))
+			})
+		})
+	})
+
 	Describe("Confirming user input", func() {
 		It("treats 'y' as an affirmative confirmation", func() {
 			io_helpers.SimulateStdin("y\n", func(reader io.Reader) {


### PR DESCRIPTION
Hi.

I'm happy to help with it. The issue was in ui.Ask method, which used for windows terminal ui implementation (and there's a custom implementation for unix terminal ui). I think it's a good idea to fix this method, not just windows password prompt because in theory other prompts could contain spaces (such as login for instance).
