### PR TITLE
Fix the usage info in cf feature-flag command

### DIFF
--- a/cf/commands/featureflag/feature_flag.go
+++ b/cf/commands/featureflag/feature_flag.go
@@ -31,7 +31,7 @@ func (cmd ShowFeatureFlag) Metadata() command_metadata.CommandMetadata {
 	return command_metadata.CommandMetadata{
 		Name:        "feature-flag",
 		Description: T("Retrieve an individual feature flag with status"),
-		Usage:       T("CF_NAME feature-flag"),
+		Usage:       T("CF_NAME feature-flag FEATURE_NAME"),
 	}
 }
 

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -695,8 +695,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME feature-flag",
-      "translation": "CF_NAME feature-flag",
+      "id": "CF_NAME feature-flag FEATURE_NAME",
+      "translation": "CF_NAME feature-flag FEATURE_NAME",
       "modified": false
    },
    {

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -695,8 +695,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME feature-flag",
-      "translation": "CF_NAME feature-flag",
+      "id": "CF_NAME feature-flag FEATURE_NAME",
+      "translation": "CF_NAME feature-flag FEATURE_NAME",
       "modified": false
    },
    {

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -695,8 +695,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME feature-flag",
-      "translation": "CF_NAME feature-flag",
+      "id": "CF_NAME feature-flag FEATURE_NAME",
+      "translation": "CF_NAME feature-flag FEATURE_NAME",
       "modified": false
    },
    {

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -695,8 +695,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME feature-flag",
-      "translation": "CF_NAME feature-flag",
+      "id": "CF_NAME feature-flag FEATURE_NAME",
+      "translation": "CF_NAME feature-flag FEATURE_NAME",
       "modified": false
    },
    {

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -695,8 +695,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME feature-flag",
-      "translation": "CF_NAME feature-flag",
+      "id": "CF_NAME feature-flag FEATURE_NAME",
+      "translation": "CF_NAME feature-flag FEATURE_NAME",
       "modified": false
    },
    {

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -695,8 +695,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME feature-flag",
-      "translation": "CF_NAME feature-flag",
+      "id": "CF_NAME feature-flag FEATURE_NAME",
+      "translation": "CF_NAME feature-flag FEATURE_NAME",
       "modified": false
    },
    {

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -695,8 +695,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME feature-flag",
-      "translation": "CF_NAME feature-flag",
+      "id": "CF_NAME feature-flag FEATURE_NAME",
+      "translation": "CF_NAME feature-flag FEATURE_NAME",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_CN.all.json
+++ b/cf/i18n/resources/zh_CN.all.json
@@ -695,8 +695,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME feature-flag",
-      "translation": "CF_NAME feature-flag",
+      "id": "CF_NAME feature-flag FEATURE_NAME",
+      "translation": "CF_NAME feature-flag FEATURE_NAME",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_HK.all.json
+++ b/cf/i18n/resources/zh_HK.all.json
@@ -695,8 +695,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME feature-flag",
-      "translation": "CF_NAME feature-flag",
+      "id": "CF_NAME feature-flag FEATURE_NAME",
+      "translation": "CF_NAME feature-flag FEATURE_NAME",
       "modified": false
    },
    {


### PR DESCRIPTION
when we use 'cf feature-flag' without any feature name, the message is:

```
the usage is
USAGE:
   cf feature-flag
```

It's not correct exactly, better to add the required argument as FEATURE_NAME.
