### PR TITLE
User-Friendly message for invalid position

### DIFF
--- a/cf/commands/buildpack/create_buildpack.go
+++ b/cf/commands/buildpack/create_buildpack.go
@@ -89,7 +89,9 @@ func (cmd CreateBuildpack) Run(c *cli.Context) {
 func (cmd CreateBuildpack) createBuildpack(buildpackName string, c *cli.Context) (buildpack models.Buildpack, apiErr error) {
 	position, err := strconv.Atoi(c.Args()[2])
 	if err != nil {
-		apiErr = errors.NewWithFmt(T("Invalid position. {{.ErrorDescription}}", map[string]interface{}{"ErrorDescription": err.Error()}))
+		apiErr = errors.NewWithFmt(T("Error \"{{.Arguments}}\" is being passed in as the argument for 'Position' but 'Position' requires an integer. For more syntax help, see `cf create-buildpack -h`.", map[string]interface{}{
+			"Arguments": c.Args()[2],
+		}))
 		return
 	}
 

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -2405,8 +2405,8 @@
       "modified": false
    },
    {
-      "id": "Invalid position. {{.ErrorDescription}}",
-      "translation": "Invalid position. {{.ErrorDescription}}",
+      "id": "Error \"{{.Arguments}}\" is being passed in as the argument for 'Position' but 'Position' requires an integer. For more syntax help, see `cf create-buildpack -h`.",
+      "translation": "Error \"{{.Arguments}}\" is being passed in as the argument for 'Position' but 'Position' requires an integer. For more syntax help, see `cf create-buildpack -h`.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -2405,8 +2405,8 @@
       "modified": false
    },
    {
-      "id": "Invalid position. {{.ErrorDescription}}",
-      "translation": "Invalid position. {{.ErrorDescription}}",
+      "id": "Error \"{{.Arguments}}\" is being passed in as the argument for 'Position' but 'Position' requires an integer. For more syntax help, see `cf create-buildpack -h`.",
+      "translation": "Error \"{{.Arguments}}\" is being passed in as the argument for 'Position' but 'Position' requires an integer. For more syntax help, see `cf create-buildpack -h`.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -2405,8 +2405,8 @@
       "modified": false
    },
    {
-      "id": "Invalid position. {{.ErrorDescription}}",
-      "translation": "Posicion invalida. {{.ErrorDescription}}",
+      "id": "Error \"{{.Arguments}}\" is being passed in as the argument for 'Position' but 'Position' requires an integer. For more syntax help, see `cf create-buildpack -h`.",
+      "translation": "Error \"{{.Arguments}}\" is being passed in as the argument for 'Position' but 'Position' requires an integer. For more syntax help, see `cf create-buildpack -h`.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -2405,8 +2405,8 @@
       "modified": false
    },
    {
-      "id": "Invalid position. {{.ErrorDescription}}",
-      "translation": "Position non valide. {{.ErrorDescription}}",
+      "id": "Error \"{{.Arguments}}\" is being passed in as the argument for 'Position' but 'Position' requires an integer. For more syntax help, see `cf create-buildpack -h`.",
+      "translation": "Error \"{{.Arguments}}\" is being passed in as the argument for 'Position' but 'Position' requires an integer. For more syntax help, see `cf create-buildpack -h`.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -2405,8 +2405,8 @@
       "modified": false
    },
    {
-      "id": "Invalid position. {{.ErrorDescription}}",
-      "translation": "Invalid position. {{.ErrorDescription}}",
+      "id": "Error \"{{.Arguments}}\" is being passed in as the argument for 'Position' but 'Position' requires an integer. For more syntax help, see `cf create-buildpack -h`.",
+      "translation": "Error \"{{.Arguments}}\" is being passed in as the argument for 'Position' but 'Position' requires an integer. For more syntax help, see `cf create-buildpack -h`.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -2405,8 +2405,8 @@
       "modified": false
    },
    {
-      "id": "Invalid position. {{.ErrorDescription}}",
-      "translation": "Invalid position. {{.ErrorDescription}}",
+      "id": "Error \"{{.Arguments}}\" is being passed in as the argument for 'Position' but 'Position' requires an integer. For more syntax help, see `cf create-buildpack -h`.",
+      "translation": "Error \"{{.Arguments}}\" is being passed in as the argument for 'Position' but 'Position' requires an integer. For more syntax help, see `cf create-buildpack -h`.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -2405,8 +2405,8 @@
       "modified": false
    },
    {
-      "id": "Invalid position. {{.ErrorDescription}}",
-      "translation": "Posição inválida. {{.ErrorDescription}}",
+      "id": "Error \"{{.Arguments}}\" is being passed in as the argument for 'Position' but 'Position' requires an integer. For more syntax help, see `cf create-buildpack -h`.",
+      "translation": "Error \"{{.Arguments}}\" is being passed in as the argument for 'Position' but 'Position' requires an integer. For more syntax help, see `cf create-buildpack -h`.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -2405,8 +2405,8 @@
       "modified": false
    },
    {
-      "id": "Invalid position. {{.ErrorDescription}}",
-      "translation": "Invalid position. {{.ErrorDescription}}",
+      "id": "Error \"{{.Arguments}}\" is being passed in as the argument for 'Position' but 'Position' requires an integer. For more syntax help, see `cf create-buildpack -h`.",
+      "translation": "Error \"{{.Arguments}}\" is being passed in as the argument for 'Position' but 'Position' requires an integer. For more syntax help, see `cf create-buildpack -h`.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -2405,8 +2405,8 @@
       "modified": false
    },
    {
-      "id": "Invalid position. {{.ErrorDescription}}",
-      "translation": "Invalid position. {{.ErrorDescription}}",
+      "id": "Error \"{{.Arguments}}\" is being passed in as the argument for 'Position' but 'Position' requires an integer. For more syntax help, see `cf create-buildpack -h`.",
+      "translation": "Error \"{{.Arguments}}\" is being passed in as the argument for 'Position' but 'Position' requires an integer. For more syntax help, see `cf create-buildpack -h`.",
       "modified": false
    },
    {


### PR DESCRIPTION
Improved the error message of create-buildpack to a more clear and descriptive one
Before Change :  Invalid position. strconv.ParseInt: parsing input: invalid syntax
After Change : Error input is being passed in as the argument for 'Position' but 'Position' requires an integer.  For more syntax help, see 'cf create-buildpack -h'

https://www.pivotaltracker.com/n/projects/892938/stories/82598260
