### PR TITLE
Copy original request's headers when handling redirect

### DIFF
--- a/cf/net/http_client.go
+++ b/cf/net/http_client.go
@@ -33,10 +33,19 @@ func PrepareRedirect(req *http.Request, via []*http.Request) error {
 	}
 
 	prevReq := via[len(via)-1]
-	req.Header.Set("Authorization", prevReq.Header.Get("Authorization"))
+	copyHeaders(prevReq, req)
 	dumpRequest(req)
 
 	return nil
+}
+
+func copyHeaders(from *http.Request, to *http.Request) {
+	for key, values := range from.Header {
+		// do not copy POST-specific headers
+		if key != "Content-Type" && key != "Content-Length" {
+			to.Header.Set(key, strings.Join(values, ","))
+		}
+	}
 }
 
 func dumpRequest(req *http.Request) {


### PR DESCRIPTION
Hi

This PR is about #318 issue. I think it's good idea to copy all headers (except POST-specific) from original request, at least curl does it when flag L (Follow redirects) given. What do you think about it?

```
curl -v -L -H 'X-Test-Header: value' http://google.com

> GET / HTTP/1.1
> User-Agent: curl/7.37.1
> Host: google.com
> Accept: */*
> X-Test-Header: value
> 
< HTTP/1.1 302 Found
< Location: http://www.google.by/
[...omited...]

> GET / HTTP/1.1
> User-Agent: curl/7.37.1
> Host: www.google.by
> Accept: */*
> X-Test-Header: value
> 
< HTTP/1.1 200 OK
< Date: Tue, 06 Jan 2015 09:07:22 GMT
[...omited...]
```