### PR TITLE
Fixes go vet errors:

### DIFF
--- a/cf/actors/broker_builder/broker_builder_test.go
+++ b/cf/actors/broker_builder/broker_builder_test.go
@@ -89,10 +89,11 @@ var _ = Describe("Broker Builder", func() {
 			},
 		}
 
-		services = models.ServiceOfferings{
-			service1,
-			service2,
-		}
+		services = models.ServiceOfferings(
+			[]models.ServiceOffering{
+				service1,
+				service2,
+			})
 
 		brokerRepo.FindByGuidServiceBroker = serviceBroker1
 	})
@@ -121,11 +122,12 @@ var _ = Describe("Broker Builder", func() {
 					privateServicePlan,
 				},
 			}
-			services = models.ServiceOfferings{
-				service1,
-				service2,
-				brokerlessService,
-			}
+			services = models.ServiceOfferings(
+				[]models.ServiceOffering{
+					service1,
+					service2,
+					brokerlessService,
+				})
 
 			brokers, err := brokerBuilder.AttachBrokersToServices(services)
 			Expect(err).NotTo(HaveOccurred())

--- a/cf/actors/service_builder/service_builder_test.go
+++ b/cf/actors/service_builder/service_builder_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Service Builder", func() {
 		}
 
 		serviceRepo.FindServiceOfferingsByLabelName = "my-service1"
-		serviceRepo.FindServiceOfferingsByLabelServiceOfferings = models.ServiceOfferings{service1, v1Service}
+		serviceRepo.FindServiceOfferingsByLabelServiceOfferings = models.ServiceOfferings([]models.ServiceOffering{service1, v1Service})
 
 		serviceRepo.GetServiceOfferingByGuidReturns = struct {
 			ServiceOffering models.ServiceOffering
@@ -216,7 +216,8 @@ var _ = Describe("Service Builder", func() {
 					ServiceOfferings models.ServiceOfferings
 					Error            error
 				}{
-					models.ServiceOfferings{service1, service2},
+					models.ServiceOfferings([]models.ServiceOffering{
+						service1, service2}),
 					nil,
 				}
 			})
@@ -243,7 +244,8 @@ var _ = Describe("Service Builder", func() {
 					ServiceOfferings models.ServiceOfferings
 					Error            error
 				}{
-					models.ServiceOfferings{service},
+					models.ServiceOfferings([]models.ServiceOffering{
+						service}),
 					nil,
 				}
 			})
@@ -271,7 +273,8 @@ var _ = Describe("Service Builder", func() {
 					ServiceOfferings models.ServiceOfferings
 					Error            error
 				}{
-					models.ServiceOfferings{service},
+					models.ServiceOfferings([]models.ServiceOffering{
+						service}),
 					nil,
 				}
 			})
@@ -296,7 +299,7 @@ var _ = Describe("Service Builder", func() {
 				ServiceOfferings models.ServiceOfferings
 				Error            error
 			}{
-				models.ServiceOfferings{service},
+				models.ServiceOfferings([]models.ServiceOffering{service}),
 				nil,
 			}
 
@@ -319,7 +322,7 @@ var _ = Describe("Service Builder", func() {
 				ServiceOfferings models.ServiceOfferings
 				Error            error
 			}{
-				models.ServiceOfferings{service1, v1Service},
+				models.ServiceOfferings([]models.ServiceOffering{service1, v1Service}),
 				nil,
 			}
 

--- a/cf/commands/service/create_service_test.go
+++ b/cf/commands/service/create_service_test.go
@@ -53,7 +53,7 @@ var _ = Describe("create-service command", func() {
 		offering2 = models.ServiceOffering{}
 		offering2.Label = "postgres"
 
-		serviceBuilder.GetServicesByNameForSpaceWithPlansReturns(models.ServiceOfferings{offering1, offering2}, nil)
+		serviceBuilder.GetServicesByNameForSpaceWithPlansReturns(models.ServiceOfferings([]models.ServiceOffering{offering1, offering2}), nil)
 	})
 
 	var callCreateService = func(args []string) bool {


### PR DESCRIPTION
Since I've built off a go vet installed today, I get the following errors:

cf/actors/broker_builder/broker_builder_test.go:92:
models.ServiceOfferings composite literal uses unkeyed fields
cf/actors/broker_builder/broker_builder_test.go:124:
models.ServiceOfferings composite literal uses unkeyed fields
cf/actors/service_builder/service_builder_test.go:49:
models.ServiceOfferings composite literal uses unkeyed fields
cf/actors/service_builder/service_builder_test.go:219:
models.ServiceOfferings composite literal uses unkeyed fields
cf/actors/service_builder/service_builder_test.go:246:
models.ServiceOfferings composite literal uses unkeyed fields
cf/actors/service_builder/service_builder_test.go:274:
models.ServiceOfferings composite literal uses unkeyed fields
cf/actors/service_builder/service_builder_test.go:299:
models.ServiceOfferings composite literal uses unkeyed fields
cf/actors/service_builder/service_builder_test.go:322:
models.ServiceOfferings composite literal uses unkeyed fields
cf/commands/service/create_service_test.go:56: models.ServiceOfferings
composite literal uses unkeyed fields

This uses a longer syntax to instantiate models.ServiceOfferings types, but gives go vet enough detail to not complain.