### PR TITLE
Fixed delete-domain to fail early if domain is shared

### DIFF
--- a/cf/commands/domain/delete_domain.go
+++ b/cf/commands/domain/delete_domain.go
@@ -59,6 +59,12 @@ func (cmd *DeleteDomain) Run(c *cli.Context) {
 
 	switch apiErr.(type) {
 	case nil: //do nothing
+		if domain.Shared {
+			cmd.ui.Say(T("domain {{.DomainName}} is not a owned domain",
+				map[string]interface{}{
+					"DomainName": domainName}))
+			return
+		}
 	case *errors.ModelNotFoundError:
 		cmd.ui.Ok()
 		cmd.ui.Warn(apiErr.Error())

--- a/cf/commands/domain/delete_domain_test.go
+++ b/cf/commands/domain/delete_domain_test.go
@@ -57,6 +57,29 @@ var _ = Describe("delete-domain command", func() {
 		})
 	})
 
+	Context("Checks whether the domain is owned or shared", func() {
+		BeforeEach(func() {
+			domainRepo.FindByNameInOrgDomain = models.DomainFields{
+				Name:   "foo1.com",
+				Guid:   "foo1-guid",
+				Shared: true,
+			}
+		})
+		It("If domain is shared", func() {
+
+			runCommand("foo1.com")
+
+			Expect(domainRepo.DeleteDomainGuid).To(Equal(""))
+
+			Expect(ui.Outputs).To(ContainSubstrings(
+				[]string{"domain"},
+				[]string{"foo1.com"},
+				[]string{"is not a owned domain"},
+			))
+
+		})
+	})
+
 	Context("when the domain exists", func() {
 		BeforeEach(func() {
 			domainRepo.FindByNameInOrgDomain = models.DomainFields{

--- a/cf/commands/domain/delete_shared_domain.go
+++ b/cf/commands/domain/delete_shared_domain.go
@@ -65,6 +65,11 @@ func (cmd *DeleteSharedDomain) Run(c *cli.Context) {
 	domain, apiErr := cmd.domainRepo.FindByNameInOrg(domainName, cmd.orgReq.GetOrganizationFields().Guid)
 	switch apiErr.(type) {
 	case nil:
+		if !domain.Shared {
+			cmd.ui.Say(T("domain {{.DomainName}} is not a shared domain",
+				map[string]interface{}{"DomainName": domainName}))
+			return
+		}
 	case *errors.ModelNotFoundError:
 		cmd.ui.Ok()
 		cmd.ui.Warn(apiErr.Error())

--- a/cf/commands/domain/delete_shared_domain_test.go
+++ b/cf/commands/domain/delete_shared_domain_test.go
@@ -49,6 +49,21 @@ var _ = Describe("delete-shared-domain command", func() {
 		})
 	})
 
+	Context("Checks whether the domain is owned or shared", func() {
+		BeforeEach(func() {
+			domainRepo.FindByNameInOrgDomain = models.DomainFields{
+				Name: "foo1.com",
+				Guid: "foo1-guid",
+			}
+		})
+		It("If domain is owned", func() {
+
+			runCommand("foo1.com")
+
+			Expect(domainRepo.DeleteSharedDomainGuid).To(Equal(""))
+		})
+	})
+
 	Context("when logged in and targeted an organiztion", func() {
 		BeforeEach(func() {
 			requirementsFactory.LoginSuccess = true

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -1535,6 +1535,16 @@
       "modified": false
    },
    {
+      "id": "domain {{.DomainName}} is not a owned domain",
+      "translation": "domain {{.DomainName}} is not a owned domain",
+      "modified": false
+   },
+   {
+      "id": "domain {{.DomainName}} is not a shared domain",
+      "translation": "domain {{.DomainName}} is not a shared domain",
+      "modified": false
+   },
+   {
       "id": "Deleting org {{.OrgName}} as {{.Username}}...",
       "translation": "Deleting org {{.OrgName}} as {{.Username}}...",
       "modified": false

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -1535,6 +1535,16 @@
       "modified": false
    },
    {
+      "id": "domain {{.DomainName}} is not a owned domain",
+      "translation": "domain {{.DomainName}} is not a owned domain",
+      "modified": false
+   },
+   {
+      "id": "domain {{.DomainName}} is not a shared domain",
+      "translation": "domain {{.DomainName}} is not a shared domain",
+      "modified": false
+   },
+   {
       "id": "Deleting org {{.OrgName}} as {{.Username}}...",
       "translation": "Deleting org {{.OrgName}} as {{.Username}}...",
       "modified": false

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -1535,6 +1535,16 @@
       "modified": false
    },
    {
+      "id": "domain {{.DomainName}} is not a owned domain",
+      "translation": "domain {{.DomainName}} is not a owned domain",
+      "modified": false
+   },
+   {
+      "id": "domain {{.DomainName}} is not a shared domain",
+      "translation": "domain {{.DomainName}} is not a shared domain",
+      "modified": false
+   },
+   {
       "id": "Deleting org {{.OrgName}} as {{.Username}}...",
       "translation": "Borrando org {{.OrgName}} como {{.Username}}...",
       "modified": false

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -1535,6 +1535,16 @@
       "modified": false
    },
    {
+      "id": "domain {{.DomainName}} is not a owned domain",
+      "translation": "domain {{.DomainName}} is not a owned domain",
+      "modified": false
+   },
+   {
+      "id": "domain {{.DomainName}} is not a shared domain",
+      "translation": "domain {{.DomainName}} is not a shared domain",
+      "modified": false
+   },
+   {
       "id": "Deleting org {{.OrgName}} as {{.Username}}...",
       "translation": "Suppression de l'org {{.OrgName}} en tant que {{.Username}}...",
       "modified": false

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -1535,6 +1535,16 @@
       "modified": false
    },
    {
+      "id": "domain {{.DomainName}} is not a owned domain",
+      "translation": "domain {{.DomainName}} is not a owned domain",
+      "modified": false
+   },
+   {
+      "id": "domain {{.DomainName}} is not a shared domain",
+      "translation": "domain {{.DomainName}} is not a shared domain",
+      "modified": false
+   },
+   {
       "id": "Deleting org {{.OrgName}} as {{.Username}}...",
       "translation": "Deleting org {{.OrgName}} as {{.Username}}...",
       "modified": false

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -1535,6 +1535,16 @@
       "modified": false
    },
    {
+      "id": "domain {{.DomainName}} is not a owned domain",
+      "translation": "domain {{.DomainName}} is not a owned domain",
+      "modified": false
+   },
+   {
+      "id": "domain {{.DomainName}} is not a shared domain",
+      "translation": "domain {{.DomainName}} is not a shared domain",
+      "modified": false
+   },
+   {
       "id": "Deleting org {{.OrgName}} as {{.Username}}...",
       "translation": "Deleting org {{.OrgName}} as {{.Username}}...",
       "modified": false

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -1535,6 +1535,16 @@
       "modified": false
    },
    {
+      "id": "domain {{.DomainName}} is not a owned domain",
+      "translation": "domain {{.DomainName}} is not a owned domain",
+      "modified": false
+   },
+   {
+      "id": "domain {{.DomainName}} is not a shared domain",
+      "translation": "domain {{.DomainName}} is not a shared domain",
+      "modified": false
+   },
+   {
       "id": "Deleting org {{.OrgName}} as {{.Username}}...",
       "translation": "Removendo org {{.OrgName}} como {{.Username}}...",
       "modified": false

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -1535,6 +1535,16 @@
       "modified": false
    },
    {
+      "id": "domain {{.DomainName}} is not a owned domain",
+      "translation": "domain {{.DomainName}} is not a owned domain",
+      "modified": false
+   },
+   {
+      "id": "domain {{.DomainName}} is not a shared domain",
+      "translation": "domain {{.DomainName}} is not a shared domain",
+      "modified": false
+   },
+   {
       "id": "Deleting org {{.OrgName}} as {{.Username}}...",
       "translation": "用户{{.Username}}删除组织{{.OrgName}}...",
       "modified": false

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -1535,6 +1535,16 @@
       "modified": false
    },
    {
+      "id": "domain {{.DomainName}} is not a owned domain",
+      "translation": "domain {{.DomainName}} is not a owned domain",
+      "modified": false
+   },
+   {
+      "id": "domain {{.DomainName}} is not a shared domain",
+      "translation": "domain {{.DomainName}} is not a shared domain",
+      "modified": false
+   },
+   {
       "id": "Deleting org {{.OrgName}} as {{.Username}}...",
       "translation": "Deleting org {{.OrgName}} as {{.Username}}...",
       "modified": false


### PR DESCRIPTION
delete-domain command is not failing early if given name is a shared
domain and delete-shared-domain is not failing early if given name is
owned domain.
Modified the delete-domain and delete-shared-domain commands to check
the domain type and fail early based on domain type.

$ cf domains
Getting domains in org me as admin...
name                 status
10.244.0.34.xip.io   shared
savita.org           shared
savi.org             owned

Before Fix :
$ cf delete-domain savita.org
Really delete the domain savita.org?> y
Deleting domain savita.org as admin...
FAILED
Error deleting domain savita.org
Server error, status code: 404, error code: 130002, message: The domain could not be found: 0045491d-bf47-44b7-995c-7f779e05ebea

$ cf delete-shared-domain savi.org
Deleting domain savi.org as admin...

This domain is shared across all orgs.
Deleting it will remove all associated routes, and will make any app with this domain unreachable.
Are you sure you want to delete the domain savi.org? > y
FAILED
Error deleting domain savi.org
Server error, status code: 404, error code: 130002, message: The domain could not be found: 2627fd75-7bc2-4097-8e31-891bd0a71414

After Fix :
$ ./out/cf delete-domain savita.org
domain savita.org is not a owned domain

$ ./out/cf delete-shared-domain savi.org
Deleting domain savi.org as admin...
domain savi.org is not a shared domain

[#68736518]