### PR TITLE
Adding a way to see Security Group Rules

### DIFF
--- a/cf/commands/space/space.go
+++ b/cf/commands/space/space.go
@@ -38,6 +38,7 @@ func (cmd *ShowSpace) Metadata() command_metadata.CommandMetadata {
 		Usage:       T("CF_NAME space SPACE"),
 		Flags: []cli.Flag{
 			cli.BoolFlag{Name: "guid", Usage: T("Retrieve and display the given space's guid.  All other output for the space is suppressed.")},
+			cli.BoolFlag{Name: "security-group-rules", Usage: T("Retrive the rules for all the security groups associated with the space")},
 		},
 	}
 }
@@ -103,6 +104,21 @@ func (cmd *ShowSpace) Run(c *cli.Context) {
 		table.Add("", T("Space Quota:"), quotaString)
 
 		table.Print()
+	}
+	if c.Bool("security-group-rules") {
+		cmd.ui.Say("")
+		for _, group := range space.SecurityGroups {
+			cmd.ui.Say(T("Getting rules for the security group  : {{.SecurityGroupName}}...",
+				map[string]interface{}{"SecurityGroupName": terminal.EntityNameColor(group.Name)}))
+			table := terminal.NewTable(cmd.ui, []string{"", "", "", ""})
+			for _, rules := range group.Rules {
+				for ruleName, ruleValue := range rules {
+					table.Add("", ruleName, ":", ruleValue.(string))
+				}
+				table.Add("", "", "", "")
+			}
+			table.Print()
+		}
 	}
 }
 

--- a/cf/commands/space/space_test.go
+++ b/cf/commands/space/space_test.go
@@ -112,6 +112,16 @@ var _ = Describe("space command", func() {
 			})
 		})
 
+		Context("when the security-group-rules flag is passed", func() {
+			It("it shows space information and security group rules", func() {
+				runCommand("--security-group-rules", "whose-space-is-it-anyway")
+
+				Expect(ui.Outputs).To(ContainSubstrings(
+					[]string{"Getting rules for the security group"},
+				))
+			})
+		})
+
 		Context("when the space has a space quota", func() {
 			It("shows information about the given space", func() {
 				runCommand("whose-space-is-it-anyway")

--- a/cf/commands/space/space_test.go
+++ b/cf/commands/space/space_test.go
@@ -68,8 +68,12 @@ var _ = Describe("space command", func() {
 			serviceInstance.Guid = "service1-guid"
 			services := []models.ServiceInstanceFields{serviceInstance}
 
-			securityGroup1 := models.SecurityGroupFields{Name: "Nacho Security"}
-			securityGroup2 := models.SecurityGroupFields{Name: "Nacho Prime"}
+			securityGroup1 := models.SecurityGroupFields{Name: "Nacho Security", Rules: []map[string]interface{}{
+				{"protocol": "all", "destination": "0.0.0.0-9.255.255.255"},
+			}}
+			securityGroup2 := models.SecurityGroupFields{Name: "Nacho Prime", Rules: []map[string]interface{}{
+				{"protocol": "udp", "ports": "8080-9090", "destination": "198.41.191.47/1"},
+			}}
 			securityGroups := []models.SecurityGroupFields{securityGroup1, securityGroup2}
 
 			space := models.Space{}
@@ -117,7 +121,13 @@ var _ = Describe("space command", func() {
 				runCommand("--security-group-rules", "whose-space-is-it-anyway")
 
 				Expect(ui.Outputs).To(ContainSubstrings(
-					[]string{"Getting rules for the security group"},
+					[]string{"Getting rules for the security group", "Nacho Security"},
+					[]string{"protocol", "all"},
+					[]string{"destination", "0.0.0.0-9.255.255.255"},
+					[]string{"Getting rules for the security group", "Nacho Prime"},
+					[]string{"protocol", "udp"},
+					[]string{"ports", "8080-9090"},
+					[]string{"destination", "198.41.191.47/1"},
 				))
 			})
 		})

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -10,6 +10,16 @@
       "modified": false
    },
    {
+      "id": "Getting rules for the security group  : {{.SecurityGroupName}}...",
+      "translation": "Getting rules for the security group  : {{.SecurityGroupName}}...",
+      "modified": false
+   },
+   {
+      "id": "Retrive the rules for all the security groups associated with the space",
+      "translation": "Retrive the rules for all the security groups associated with the space",
+      "modified": false
+   },
+   {
       "id": "\n\nYour JSON string syntax is invalid.  Proper syntax is this:  cf set-staging-environment-variable-group '{\"name\":\"value\",\"name\":\"value\"}'",
       "translation": "\n\nYour JSON string syntax is invalid.  Proper syntax is this:  cf set-staging-environment-variable-group '{\"name\":\"value\",\"name\":\"value\"}'",
       "modified": false

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -5,6 +5,16 @@
       "modified": false
    },
    {
+      "id": "Getting rules for the security group  : {{.SecurityGroupName}}...",
+      "translation": "Getting rules for the security group  : {{.SecurityGroupName}}...",
+      "modified": false
+   },
+   {
+      "id": "Retrive the rules for all the security groups associated with the space",
+      "translation": "Retrive the rules for all the security groups associated with the space",
+      "modified": false
+   },
+   {
       "id": "\n\nYour JSON string syntax is invalid.  Proper syntax is this:  cf set-running-environment-variable-group '{\"name\":\"value\",\"name\":\"value\"}'",
       "translation": "\n\nYour JSON string syntax is invalid.  Proper syntax is this:  cf set-running-environment-variable-group '{\"name\":\"value\",\"name\":\"value\"}'",
       "modified": false

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -10,6 +10,16 @@
       "modified": false
    },
    {
+      "id": "Getting rules for the security group  : {{.SecurityGroupName}}...",
+      "translation": "Getting rules for the security group  : {{.SecurityGroupName}}...",
+      "modified": false
+   },
+   {
+      "id": "Retrive the rules for all the security groups associated with the space",
+      "translation": "Retrive the rules for all the security groups associated with the space",
+      "modified": false
+   },
+   {
       "id": "\n\nYour JSON string syntax is invalid.  Proper syntax is this:  cf set-staging-environment-variable-group '{\"name\":\"value\",\"name\":\"value\"}'",
       "translation": "\n\nYour JSON string syntax is invalid.  Proper syntax is this:  cf set-staging-environment-variable-group '{\"name\":\"value\",\"name\":\"value\"}'",
       "modified": false

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -5,6 +5,16 @@
       "modified": false
    },
    {
+      "id": "Getting rules for the security group  : {{.SecurityGroupName}}...",
+      "translation": "Getting rules for the security group  : {{.SecurityGroupName}}...",
+      "modified": false
+   },
+   {
+      "id": "Retrive the rules for all the security groups associated with the space",
+      "translation": "Retrive the rules for all the security groups associated with the space",
+      "modified": false
+   },
+   {
       "id": "\n\nYour JSON string syntax is invalid.  Proper syntax is this:  cf set-running-environment-variable-group '{\"name\":\"value\",\"name\":\"value\"}'",
       "translation": "\n\nLa syntaxe JSON est invalide.  Syntaxe correcte:  cf set-running-environment-variable-group '{\"name\":\"value\",\"name\":\"value\"}'",
       "modified": false

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -5,6 +5,16 @@
       "modified": false
    },
    {
+      "id": "Getting rules for the security group  : {{.SecurityGroupName}}...",
+      "translation": "Getting rules for the security group  : {{.SecurityGroupName}}...",
+      "modified": false
+   },
+   {
+      "id": "Retrive the rules for all the security groups associated with the space",
+      "translation": "Retrive the rules for all the security groups associated with the space",
+      "modified": false
+   },
+   {
       "id": "\n\nYour JSON string syntax is invalid.  Proper syntax is this:  cf set-running-environment-variable-group '{\"name\":\"value\",\"name\":\"value\"}'",
       "translation": "\n\nYour JSON string syntax is invalid.  Proper syntax is this:  cf set-running-environment-variable-group '{\"name\":\"value\",\"name\":\"value\"}'",
       "modified": false

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -10,6 +10,16 @@
       "modified": false
    },
    {
+      "id": "Getting rules for the security group  : {{.SecurityGroupName}}...",
+      "translation": "Getting rules for the security group  : {{.SecurityGroupName}}...",
+      "modified": false
+   },
+   {
+      "id": "Retrive the rules for all the security groups associated with the space",
+      "translation": "Retrive the rules for all the security groups associated with the space",
+      "modified": false
+   },
+   {
       "id": "\n\nYour JSON string syntax is invalid.  Proper syntax is this:  cf set-staging-environment-variable-group '{\"name\":\"value\",\"name\":\"value\"}'",
       "translation": "\n\nYour JSON string syntax is invalid.  Proper syntax is this:  cf set-staging-environment-variable-group '{\"name\":\"value\",\"name\":\"value\"}'",
       "modified": false

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -10,6 +10,16 @@
       "modified": false
    },
    {
+      "id": "Getting rules for the security group  : {{.SecurityGroupName}}...",
+      "translation": "Getting rules for the security group  : {{.SecurityGroupName}}...",
+      "modified": false
+   },
+   {
+      "id": "Retrive the rules for all the security groups associated with the space",
+      "translation": "Retrive the rules for all the security groups associated with the space",
+      "modified": false
+   },
+   {
       "id": "\n\nYour JSON string syntax is invalid.  Proper syntax is this:  cf set-staging-environment-variable-group '{\"name\":\"value\",\"name\":\"value\"}'",
       "translation": "\n\nYour JSON string syntax is invalid.  Proper syntax is this:  cf set-staging-environment-variable-group '{\"name\":\"value\",\"name\":\"value\"}'",
       "modified": false

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -10,6 +10,16 @@
       "modified": false
    },
    {
+      "id": "Getting rules for the security group  : {{.SecurityGroupName}}...",
+      "translation": "Getting rules for the security group  : {{.SecurityGroupName}}...",
+      "modified": false
+   },
+   {
+      "id": "Retrive the rules for all the security groups associated with the space",
+      "translation": "Retrive the rules for all the security groups associated with the space",
+      "modified": false
+   },
+   {
       "id": "\n\nYour JSON string syntax is invalid.  Proper syntax is this:  cf set-staging-environment-variable-group '{\"name\":\"value\",\"name\":\"value\"}'",
       "translation": "\n\nYour JSON string syntax is invalid.  Proper syntax is this:  cf set-staging-environment-variable-group '{\"name\":\"value\",\"name\":\"value\"}'",
       "modified": false

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -10,6 +10,16 @@
       "modified": false
    },
    {
+      "id": "Getting rules for the security group  : {{.SecurityGroupName}}...",
+      "translation": "Getting rules for the security group  : {{.SecurityGroupName}}...",
+      "modified": false
+   },
+   {
+      "id": "Retrive the rules for all the security groups associated with the space",
+      "translation": "Retrive the rules for all the security groups associated with the space",
+      "modified": false
+   },
+   {
       "id": "\n\nYour JSON string syntax is invalid.  Proper syntax is this:  cf set-staging-environment-variable-group '{\"name\":\"value\",\"name\":\"value\"}'",
       "translation": "\n\nYour JSON string syntax is invalid.  Proper syntax is this:  cf set-staging-environment-variable-group '{\"name\":\"value\",\"name\":\"value\"}'",
       "modified": false


### PR DESCRIPTION
Before Change :  Users were not able to see Security Group Rules applied to their spaces
After Change : Users(Admin and Non-admin) will be able to see the rules associated with the security groups applied to their spaces.

$ ./cf space mySpace --security-group-rules
Getting info for space mySpace in org huawei as asif...
OK

mySpace
       Org:               huawei
       Apps:
       Domains:           10.244.0.34.xip.io
       Services:
       Security Groups:   dns
       Space Quota:

Getting rules for the security group  : dns...

   destination   :   0.0.0.0/0
   ports         :   53
   protocol      :   tcp

   destination   :   0.0.0.0/0
   ports         :   53
   protocol      :   udp