### PR TITLE
Ginkgo matcher BeInDisplayOrder()

### DIFF
--- a/cf/commands/servicebroker/service_brokers_test.go
+++ b/cf/commands/servicebroker/service_brokers_test.go
@@ -99,7 +99,15 @@ var _ = Describe("service-brokers command", func() {
 		}}
 
 		testcmd.RunCommand(cmd, []string{}, requirementsFactory)
-		Expect(inAlphabeticalOrder(ui.Outputs, 3)).To(Equal(true))
+
+		Expect(ui.Outputs).To(BeInDisplayOrder(
+			[]string{"Getting service brokers as", "my-user"},
+			[]string{"name", "url"},
+			[]string{"123-service-broker-to-list", "http://service-d-url.com"},
+			[]string{"a-service-broker-to-list", "http://service-c-url.com"},
+			[]string{"fun-service-broker-to-list", "http://service-b-url.com"},
+			[]string{"z-service-broker-to-list", "http://service-a-url.com"},
+		))
 	})
 
 	It("says when no service brokers were found", func() {
@@ -121,21 +129,3 @@ var _ = Describe("service-brokers command", func() {
 		))
 	})
 })
-
-func inAlphabeticalOrder(actual []string, skipLine int) bool {
-	lastIndex := skipLine
-	index := skipLine + 1
-
-	if len(actual) <= skipLine+1 {
-		return true
-	}
-
-	for index < len(actual)-1 {
-		if actual[index] < actual[lastIndex] {
-			return false
-		}
-		index++
-		lastIndex++
-	}
-	return true
-}

--- a/testhelpers/matchers/be_in_display_order.go
+++ b/testhelpers/matchers/be_in_display_order.go
@@ -1,0 +1,89 @@
+package matchers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/onsi/gomega"
+)
+
+type OrderMatcher struct {
+	expected   [][]string
+	failedText string
+}
+
+func BeInDisplayOrder(substrings ...[]string) gomega.OmegaMatcher {
+	return &OrderMatcher{
+		expected: substrings,
+	}
+}
+
+func (matcher *OrderMatcher) Match(actualStr interface{}) (success bool, err error) {
+	actual, ok := actualStr.([]string)
+	if !ok {
+		return false, nil
+	}
+
+	//loop and match, stop at last actual[0] line
+	for len(actual) > 1 {
+		if matched, msg := matchSingleLine(actual[0], matcher.expected[0]); matched {
+			if len(matcher.expected) == 1 {
+				return true, nil //no more expected to match, all passed
+			}
+			matcher.expected = matcher.expected[1:]
+		} else if msg != "" {
+			matcher.failedText = msg
+			return false, nil
+		}
+		actual = actual[1:]
+	}
+
+	//match the last actual line with the rest of expected
+	matched, msg := matchSingleLine(actual[0], matcher.expected[0])
+	if matched && len(matcher.expected) == 1 {
+		return true, nil
+	} else if msg != "" {
+		matcher.failedText = msg
+		return false, nil
+	} else if matched {
+		matcher.failedText = matcher.expected[1][0]
+		return false, nil
+	}
+	matcher.failedText = matcher.expected[0][0]
+	return false, nil
+}
+
+func matchSingleLine(actual string, expected []string) (bool, string) {
+	matched := false
+	for i, target := range expected {
+		if index := strings.Index(actual, target); index != -1 {
+			if i == len(expected)-1 {
+				return true, ""
+			}
+			matched = true
+			actual = actual[index+len(target):]
+		} else if matched {
+			return false, target
+		} else {
+			return false, ""
+		}
+	}
+	return false, ""
+}
+
+func (matcher *OrderMatcher) FailureMessage(actual interface{}) string {
+	actualStrings, ok := actual.([]string)
+	if !ok {
+		return fmt.Sprintf("Expected actual to be a slice of strings, but it's actually a %T", actual)
+	}
+
+	return fmt.Sprintf("expected to find \"%s\" in display order in actual:\n'%s'\n", matcher.failedText, strings.Join(actualStrings, "\n"))
+}
+
+func (matcher *OrderMatcher) NegatedFailureMessage(actual interface{}) string {
+	actualStrings, ok := actual.([]string)
+	if !ok {
+		return fmt.Sprintf("Expected actual to be a slice of strings, but it's actually a %T", actual)
+	}
+	return fmt.Sprintf("expected to not find strings in display order in actual:\n'%s'\n", strings.Join(actualStrings, "\n"))
+}

--- a/testhelpers/matchers/be_in_display_order_test.go
+++ b/testhelpers/matchers/be_in_display_order_test.go
@@ -1,0 +1,116 @@
+package matchers_test
+
+import (
+	"strings"
+
+	. "github.com/cloudfoundry/cli/testhelpers/matchers"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("BeInDisplayOrder()", func() {
+	var (
+		matcher OmegaMatcher
+		actual  []string
+	)
+
+	actual = []string{
+		"1st line 1",
+		"2nd line 2",
+		"3rd line 3",
+		"4th line 4",
+	}
+
+	It("asserts actual is in same display order with expected", func() {
+		matcher = BeInDisplayOrder(
+			[]string{"1st"},
+			[]string{"2nd"},
+			[]string{"3rd"},
+			[]string{"4th"},
+		)
+
+		success, err := matcher.Match(actual)
+		Ω(success).To(Equal(true))
+		Ω(err).To(BeNil())
+
+		matcher = BeInDisplayOrder(
+			[]string{"1st"},
+			[]string{"3rd"},
+			[]string{"2nd"},
+			[]string{"4th"},
+		)
+
+		success, err = matcher.Match(actual)
+		Ω(success).To(Equal(false))
+		Ω(err).To(BeNil())
+		msg := matcher.FailureMessage([]string{})
+		Ω(strings.Contains(msg, "2nd")).To(Equal(true))
+	})
+
+	It("asserts actual contains the expected string", func() {
+		matcher = BeInDisplayOrder(
+			[]string{"Not in the actual"},
+		)
+
+		success, err := matcher.Match(actual)
+		Ω(success).To(Equal(false))
+		Ω(err).To(BeNil())
+
+		msg := matcher.FailureMessage([]string{})
+		Ω(strings.Contains(msg, "Not in the actual")).To(Equal(true))
+	})
+
+	It("asserts actual contains 2 substrings in the same display line ", func() {
+		matcher = BeInDisplayOrder(
+			[]string{"1st", "line"},
+			[]string{"4th", "line"},
+		)
+
+		success, err := matcher.Match(actual)
+		Ω(success).To(Equal(true))
+		Ω(err).To(BeNil())
+
+		matcher = BeInDisplayOrder(
+			[]string{"1st", "line 2"},
+		)
+
+		success, err = matcher.Match(actual)
+		Ω(success).To(Equal(false))
+
+		msg := matcher.FailureMessage([]string{})
+		Ω(strings.Contains(msg, "line 2")).To(Equal(true))
+
+		matcher = BeInDisplayOrder(
+			[]string{"1st"},
+			[]string{"line 1"},
+		)
+
+		success, err = matcher.Match(actual)
+		Ω(success).To(Equal(false))
+
+		msg = matcher.FailureMessage([]string{})
+		Ω(strings.Contains(msg, "line 1")).To(Equal(true))
+	})
+
+	It("asserts actual contains 2 substrings displaying in order on a single line ", func() {
+		matcher = BeInDisplayOrder(
+			[]string{"1st", "line 1"},
+		)
+
+		success, err := matcher.Match(actual)
+		Ω(success).To(Equal(true))
+		Ω(err).To(BeNil())
+
+		matcher = BeInDisplayOrder(
+			[]string{"line 1", "1st"},
+		)
+
+		success, err = matcher.Match(actual)
+		Ω(success).To(Equal(false))
+
+		msg := matcher.FailureMessage([]string{})
+		Ω(strings.Contains(msg, "1st")).To(Equal(true))
+	})
+
+})

--- a/testhelpers/matchers/matchers_suite_test.go
+++ b/testhelpers/matchers/matchers_suite_test.go
@@ -1,0 +1,13 @@
+package matchers_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestMatchers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Matchers Suite")
+}


### PR DESCRIPTION
Asserting string output order is always hard, but now it should be tons easier with this matcher.