### PR TITLE
Fix 'cf routes'output should be scoped to org and grouped by space

### DIFF
--- a/cf/api/fakes/fake_route_repo.go
+++ b/cf/api/fakes/fake_route_repo.go
@@ -56,6 +56,19 @@ func (repo *FakeRouteRepository) ListRoutes(cb func(models.Route) bool) (apiErr 
 	return
 }
 
+func (repo *FakeRouteRepository) ListAllRoutes(cb func(models.Route) bool) (apiErr error) {
+	if repo.ListErr {
+		return errors.New("WHOOPSIE")
+	}
+
+	for _, route := range repo.Routes {
+		if !cb(route) {
+			break
+		}
+	}
+	return
+}
+
 func (repo *FakeRouteRepository) FindByHostAndDomain(host string, domain models.DomainFields) (route models.Route, apiErr error) {
 	repo.FindByHostAndDomainCalledWith.Host = host
 	repo.FindByHostAndDomainCalledWith.Domain = domain

--- a/cf/api/routes_test.go
+++ b/cf/api/routes_test.go
@@ -72,6 +72,35 @@ var _ = Describe("route repository", func() {
 			Expect(apiErr).NotTo(HaveOccurred())
 		})
 
+		It("lists routes from all the spaces of current org", func() {
+			ts, handler = testnet.NewServer([]testnet.TestRequest{
+				testapi.NewCloudControllerTestRequest(testnet.TestRequest{
+					Method:   "GET",
+					Path:     "/v2/routes?q=organization_guid:my-org-guid&inline-relations-depth=1",
+					Response: firstPageRoutesOrgLvlResponse,
+				}),
+				testapi.NewCloudControllerTestRequest(testnet.TestRequest{
+					Method:   "GET",
+					Path:     "/v2/routes?q=organization_guid:my-org-guid&inline-relations-depth=1&page=2",
+					Response: secondPageRoutesResponse,
+				}),
+			})
+			configRepo.SetApiEndpoint(ts.URL)
+
+			routes := []models.Route{}
+			apiErr := repo.ListAllRoutes(func(route models.Route) bool {
+				routes = append(routes, route)
+				return true
+			})
+
+			Expect(len(routes)).To(Equal(2))
+			Expect(routes[0].Guid).To(Equal("route-1-guid"))
+			Expect(routes[0].Space.Guid).To(Equal("space-1-guid"))
+			Expect(routes[1].Guid).To(Equal("route-2-guid"))
+			Expect(routes[1].Space.Guid).To(Equal("space-2-guid"))
+			Expect(handler).To(HaveAllRequestsCalled())
+			Expect(apiErr).NotTo(HaveOccurred())
+		})
 		It("finds a route by host and domain", func() {
 			ts, handler = testnet.NewServer([]testnet.TestRequest{
 				testapi.NewCloudControllerTestRequest(testnet.TestRequest{
@@ -385,3 +414,44 @@ var findRouteByHostResponse = testnet.TestResponse{Status: http.StatusCreated, B
     	}
     }
 ]}`}
+
+var firstPageRoutesOrgLvlResponse = testnet.TestResponse{Status: http.StatusOK, Body: `
+{
+  "next_url": "/v2/routes?q=organization_guid:my-org-guid&inline-relations-depth=1&page=2",
+  "resources": [
+    {
+      "metadata": {
+        "guid": "route-1-guid"
+      },
+      "entity": {
+        "host": "route-1-host",
+        "domain": {
+          "metadata": {
+            "guid": "domain-1-guid"
+          },
+          "entity": {
+            "name": "cfapps.io"
+          }
+        },
+        "space": {
+          "metadata": {
+            "guid": "space-1-guid"
+          },
+          "entity": {
+            "name": "space-1"
+          }
+        },
+        "apps": [
+          {
+            "metadata": {
+              "guid": "app-1-guid"
+            },
+            "entity": {
+              "name": "app-1"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}`}

--- a/cf/commands/route/routes_test.go
+++ b/cf/commands/route/routes_test.go
@@ -89,6 +89,43 @@ var _ = Describe("routes command", func() {
 		})
 	})
 
+	Context("when there are routes in different spaces", func() {
+		BeforeEach(func() {
+			space1 := models.SpaceFields{Name: "space-1"}
+			space2 := models.SpaceFields{Name: "space-2"}
+
+			domain := models.DomainFields{Name: "example.com"}
+			domain2 := models.DomainFields{Name: "cookieclicker.co"}
+
+			app1 := models.ApplicationFields{Name: "dora"}
+			app2 := models.ApplicationFields{Name: "bora"}
+
+			route := models.Route{}
+			route.Host = "hostname-1"
+			route.Domain = domain
+			route.Apps = []models.ApplicationFields{app1}
+			route.Space = space1
+
+			route2 := models.Route{}
+			route2.Host = "hostname-2"
+			route2.Domain = domain2
+			route2.Apps = []models.ApplicationFields{app1, app2}
+			route2.Space = space2
+			routeRepo.Routes = []models.Route{route, route2}
+		})
+
+		It("lists routes at orglevel", func() {
+			runCommand("--orglevel")
+
+			Expect(ui.Outputs).To(ContainSubstrings(
+				[]string{"Getting routes", "my-user"},
+				[]string{"space", "host", "domain", "apps"},
+				[]string{"space-1", "hostname-1", "example.com", "dora"},
+				[]string{"space-2", "hostname-2", "cookieclicker.co", "dora", "bora"},
+			))
+		})
+
+	})
 	Context("when there are not routes", func() {
 		It("tells the user when no routes were found", func() {
 			runCommand()

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -2645,8 +2645,13 @@
       "modified": false
    },
    {
-      "id": "List all routes in the current space",
-      "translation": "List all routes in the current space",
+      "id": "List all routes in the current space or the current organization",
+      "translation": "List all routes in the current space or the current organization",
+      "modified": false
+   },
+   {
+      "id": "List all the routes for all spaces of current organization",
+      "translation": "List all the routes for all spaces of current organization",
       "modified": false
    },
    {

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -2645,8 +2645,13 @@
       "modified": false
    },
    {
-      "id": "List all routes in the current space",
-      "translation": "List all routes in the current space",
+      "id": "List all routes in the current space or the current organization",
+      "translation": "List all routes in the current space or the current organization",
+      "modified": false
+   },
+   {
+      "id": "List all the routes for all spaces of current organization",
+      "translation": "List all the routes for all spaces of current organization",
       "modified": false
    },
    {

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -2645,8 +2645,13 @@
       "modified": false
    },
    {
-      "id": "List all routes in the current space",
-      "translation": "Lista todas las rutas del space actual",
+      "id": "List all routes in the current space or the current organization",
+      "translation": "List all routes in the current space or the current organization",
+      "modified": false
+   },
+   {
+      "id": "List all the routes for all spaces of current organization",
+      "translation": "List all the routes for all spaces of current organization",
       "modified": false
    },
    {

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -2645,8 +2645,13 @@
       "modified": false
    },
    {
-      "id": "List all routes in the current space",
-      "translation": "Lister toutes les routes dans l'espace actuel",
+      "id": "List all routes in the current space or the current organization",
+      "translation": "List all routes in the current space or the current organization",
+      "modified": false
+   },
+   {
+      "id": "List all the routes for all spaces of current organization",
+      "translation": "List all the routes for all spaces of current organization",
       "modified": false
    },
    {

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -2645,8 +2645,13 @@
       "modified": false
    },
    {
-      "id": "List all routes in the current space",
-      "translation": "List all routes in the current space",
+      "id": "List all routes in the current space or the current organization",
+      "translation": "List all routes in the current space or the current organization",
+      "modified": false
+   },
+   {
+      "id": "List all the routes for all spaces of current organization",
+      "translation": "List all the routes for all spaces of current organization",
       "modified": false
    },
    {

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -2645,8 +2645,13 @@
       "modified": false
    },
    {
-      "id": "List all routes in the current space",
-      "translation": "List all routes in the current space",
+      "id": "List all routes in the current space or the current organization",
+      "translation": "List all routes in the current space or the current organization",
+      "modified": false
+   },
+   {
+      "id": "List all the routes for all spaces of current organization",
+      "translation": "List all the routes for all spaces of current organization",
       "modified": false
    },
    {

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -2645,8 +2645,13 @@
       "modified": false
    },
    {
-      "id": "List all routes in the current space",
-      "translation": "Exibir todas as rotas disponíveis no espaço alvo",
+      "id": "List all routes in the current space or the current organization",
+      "translation": "List all routes in the current space or the current organization",
+      "modified": false
+   },
+   {
+      "id": "List all the routes for all spaces of current organization",
+      "translation": "List all the routes for all spaces of current organization",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -2645,8 +2645,13 @@
       "modified": false
    },
    {
-      "id": "List all routes in the current space",
-      "translation": "List all routes in the current space",
+      "id": "List all routes in the current space or the current organization",
+      "translation": "List all routes in the current space or the current organization",
+      "modified": false
+   },
+   {
+      "id": "List all the routes for all spaces of current organization",
+      "translation": "List all the routes for all spaces of current organization",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -2645,8 +2645,13 @@
       "modified": false
    },
    {
-      "id": "List all routes in the current space",
-      "translation": "List all routes in the current space",
+      "id": "List all routes in the current space or the current organization",
+      "translation": "List all routes in the current space or the current organization",
+      "modified": false
+   },
+   {
+      "id": "List all the routes for all spaces of current organization",
+      "translation": "List all the routes for all spaces of current organization",
       "modified": false
    },
    {


### PR DESCRIPTION
Solution to the bug:- [#70300846]
 Added the --orglevel flag to the cf routes command to get all the routes of
 all the spaces of an org.

The output is as folows

cf5:~/go/src/github.com/cloudfoundry/cli$ ./out/cf routes --orglevel
Getting routes as admin ...

space         host          domain               apps
smoke-tests   my-app        10.244.0.34.xip.io
smoke-tests   myapp2        10.244.0.34.xip.io   myapp2
smoke-tests   myapp         10.244.0.34.xip.io   myapp
testspace     mytestapp     10.244.0.34.xip.io   mytestapp
testspace     mytestapp-2   10.244.0.34.xip.io   mytestapp-2