### PR TITLE
Finishes async work for CLI

### DIFF
--- a/cf/api/services.go
+++ b/cf/api/services.go
@@ -175,7 +175,7 @@ func (repo CloudControllerServiceRepository) DeleteService(instance models.Servi
 	if len(instance.ServiceBindings) > 0 {
 		return errors.New("Cannot delete service instance, apps are still bound to it")
 	}
-	path := fmt.Sprintf("/v2/service_instances/%s", instance.Guid)
+	path := fmt.Sprintf("/v2/service_instances/%s?%s", instance.Guid, "accepts_incomplete=true")
 	return repo.gateway.DeleteResource(repo.config.ApiEndpoint(), path)
 }
 

--- a/cf/api/services_test.go
+++ b/cf/api/services_test.go
@@ -381,7 +381,7 @@ var _ = Describe("Services Repo", func() {
 		It("it deletes the service when no apps are bound", func() {
 			setupTestServer(testapi.NewCloudControllerTestRequest(testnet.TestRequest{
 				Method:   "DELETE",
-				Path:     "/v2/service_instances/my-service-instance-guid",
+				Path:     "/v2/service_instances/my-service-instance-guid?accepts_incomplete=true&async=true",
 				Response: testnet.TestResponse{Status: http.StatusOK},
 			}))
 

--- a/cf/commands/service/create_service.go
+++ b/cf/commands/service/create_service.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"fmt"
 	"github.com/cloudfoundry/cli/cf/actors/service_builder"
 	"github.com/cloudfoundry/cli/cf/api"
 	"github.com/cloudfoundry/cli/cf/command_metadata"
@@ -74,7 +73,7 @@ func (cmd CreateService) Run(c *cli.Context) {
 
 	switch err.(type) {
 	case nil:
-		err := cmd.printSuccessMessage(serviceInstanceName)
+		err := printSuccessMessageForServiceInstance(serviceInstanceName, cmd.serviceRepo, cmd.ui)
 		if err != nil {
 			cmd.ui.Failed(err.Error())
 		}
@@ -110,27 +109,6 @@ func (cmd CreateService) CreateService(serviceName string, planName string, serv
 
 	apiErr = cmd.serviceRepo.CreateServiceInstance(serviceInstanceName, plan.Guid)
 	return plan, apiErr
-}
-
-func (cmd CreateService) printSuccessMessage(serviceInstanceName string) error {
-	instance, apiErr := cmd.serviceRepo.FindInstanceByName(serviceInstanceName)
-	if apiErr != nil {
-		return apiErr
-	}
-
-	if instance.ServiceInstanceFields.LastOperation.State == "in progress" {
-		cmd.ui.Ok()
-		cmd.ui.Say("")
-		cmd.ui.Say(T("Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
-			map[string]interface{}{
-				"ServicesCommand": terminal.EntityNameColor("cf services"),
-				"ServiceCommand":  terminal.EntityNameColor(fmt.Sprintf("cf service %s", serviceInstanceName)),
-			}))
-	} else {
-		cmd.ui.Ok()
-	}
-
-	return nil
 }
 
 func findPlanFromOfferings(offerings models.ServiceOfferings, name string) (plan models.ServicePlanFields, err error) {

--- a/cf/commands/service/create_service.go
+++ b/cf/commands/service/create_service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"github.com/cloudfoundry/cli/cf/actors/service_builder"
 	"github.com/cloudfoundry/cli/cf/api"
 	"github.com/cloudfoundry/cli/cf/command_metadata"
@@ -61,7 +62,7 @@ func (cmd CreateService) Run(c *cli.Context) {
 	planName := c.Args()[1]
 	serviceInstanceName := c.Args()[2]
 
-	cmd.ui.Say(T("Creating service {{.ServiceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
+	cmd.ui.Say(T("Creating service instance {{.ServiceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
 		map[string]interface{}{
 			"ServiceName": terminal.EntityNameColor(serviceInstanceName),
 			"OrgName":     terminal.EntityNameColor(cmd.config.OrganizationFields().Name),
@@ -120,8 +121,11 @@ func (cmd CreateService) printSuccessMessage(serviceInstanceName string) error {
 	if instance.ServiceInstanceFields.LastOperation.State == "in progress" {
 		cmd.ui.Ok()
 		cmd.ui.Say("")
-		cmd.ui.Say(T("Create in progress. Use 'cf services' or 'cf service {{.ServiceInstanceName}}' to check operation status.",
-			map[string]interface{}{"ServiceInstanceName": serviceInstanceName}))
+		cmd.ui.Say(T("Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
+			map[string]interface{}{
+				"ServicesCommand": terminal.EntityNameColor("cf services"),
+				"ServiceCommand":  terminal.EntityNameColor(fmt.Sprintf("cf service %s", serviceInstanceName)),
+			}))
 	} else {
 		cmd.ui.Ok()
 	}

--- a/cf/commands/service/create_service_test.go
+++ b/cf/commands/service/create_service_test.go
@@ -89,7 +89,7 @@ var _ = Describe("create-service command", func() {
 		Expect(spaceGuid).To(Equal(config.SpaceFields().Guid))
 		Expect(serviceName).To(Equal("cleardb"))
 		Expect(ui.Outputs).To(ContainSubstrings(
-			[]string{"Creating service", "my-cleardb-service", "my-org", "my-space", "my-user"},
+			[]string{"Creating service instance", "my-cleardb-service", "my-org", "my-space", "my-user"},
 			[]string{"OK"},
 		))
 		Expect(serviceRepo.CreateServiceInstanceArgs.Name).To(Equal("my-cleardb-service"))
@@ -121,10 +121,10 @@ var _ = Describe("create-service command", func() {
 			Expect(spaceGuid).To(Equal(config.SpaceFields().Guid))
 			Expect(serviceName).To(Equal("cleardb"))
 
-			creatingServiceMessage := fmt.Sprintf("Create in progress. Use 'cf services' or 'cf service %s' to check operation status.", serviceInstance.ServiceInstanceFields.Name)
+			creatingServiceMessage := fmt.Sprintf("Create in progress. Use cf services or cf service %s to check operation status.", serviceInstance.ServiceInstanceFields.Name)
 
 			Expect(ui.Outputs).To(ContainSubstrings(
-				[]string{"Creating service", "my-cleardb-service", "my-org", "my-space", "my-user"},
+				[]string{"Creating service instance", "my-cleardb-service", "my-org", "my-space", "my-user"},
 				[]string{"OK"},
 				[]string{creatingServiceMessage},
 			))
@@ -137,7 +137,7 @@ var _ = Describe("create-service command", func() {
 			callCreateService([]string{"cleardb", "spark", "fake-service-instance-name"})
 
 			Expect(ui.Outputs).To(ContainSubstrings(
-				[]string{"Creating service fake-service-instance-name in org my-org / space my-space as my-user..."},
+				[]string{"Creating service instance fake-service-instance-name in org my-org / space my-space as my-user..."},
 				[]string{"FAILED"},
 				[]string{"Error finding instance"}))
 		})
@@ -147,7 +147,7 @@ var _ = Describe("create-service command", func() {
 		It("does not warn the user when the service is free", func() {
 			callCreateService([]string{"cleardb", "spark", "my-free-cleardb-service"})
 			Expect(ui.Outputs).To(ContainSubstrings(
-				[]string{"Creating service", "my-free-cleardb-service", "my-org", "my-space", "my-user"},
+				[]string{"Creating service instance", "my-free-cleardb-service", "my-org", "my-space", "my-user"},
 				[]string{"OK"},
 			))
 			Expect(ui.Outputs).NotTo(ContainSubstrings([]string{"will incurr a cost"}))
@@ -156,7 +156,7 @@ var _ = Describe("create-service command", func() {
 		It("warns the user when the service is not free", func() {
 			callCreateService([]string{"cleardb", "expensive", "my-expensive-cleardb-service"})
 			Expect(ui.Outputs).To(ContainSubstrings(
-				[]string{"Creating service", "my-expensive-cleardb-service", "my-org", "my-space", "my-user"},
+				[]string{"Creating service instance", "my-expensive-cleardb-service", "my-org", "my-space", "my-user"},
 				[]string{"OK"},
 				[]string{"Attention: The plan `expensive` of service `cleardb` is not free.  The instance `my-expensive-cleardb-service` will incur a cost.  Contact your administrator if you think this is in error."},
 			))
@@ -169,7 +169,7 @@ var _ = Describe("create-service command", func() {
 		callCreateService([]string{"cleardb", "spark", "my-cleardb-service"})
 
 		Expect(ui.Outputs).To(ContainSubstrings(
-			[]string{"Creating service", "my-cleardb-service"},
+			[]string{"Creating service instance", "my-cleardb-service"},
 			[]string{"OK"},
 			[]string{"my-cleardb-service", "already exists"},
 		))
@@ -185,7 +185,7 @@ var _ = Describe("create-service command", func() {
 			callCreateService([]string{"cleardb", "spark", "my-cleardb-service"})
 
 			Expect(ui.Outputs).To(ContainSubstrings(
-				[]string{"Creating service", "my-cleardb-service", "my-org", "my-space", "my-user"},
+				[]string{"Creating service instance", "my-cleardb-service", "my-org", "my-space", "my-user"},
 				[]string{"OK"},
 			))
 			Expect(serviceRepo.CreateServiceInstanceArgs.Name).To(Equal("my-cleardb-service"))

--- a/cf/commands/service/delete_service.go
+++ b/cf/commands/service/delete_service.go
@@ -82,5 +82,8 @@ func (cmd *DeleteService) Run(c *cli.Context) {
 		return
 	}
 
-	cmd.ui.Ok()
+	apiErr = printSuccessMessageForServiceInstance(serviceName, cmd.serviceRepo, cmd.ui)
+	if apiErr != nil {
+		cmd.ui.Ok()
+	}
 }

--- a/cf/commands/service/delete_service_test.go
+++ b/cf/commands/service/delete_service_test.go
@@ -60,36 +60,77 @@ var _ = Describe("delete-service command", func() {
 		})
 
 		Context("when the service exists", func() {
-			BeforeEach(func() {
-				serviceInstance = models.ServiceInstance{}
-				serviceInstance.Name = "my-service"
-				serviceInstance.Guid = "my-service-guid"
-				serviceRepo.FindInstanceByNameServiceInstance = serviceInstance
-			})
+			Context("and the service deletion is asynchronous", func() {
+				BeforeEach(func() {
+					serviceInstance = models.ServiceInstance{}
+					serviceInstance.Name = "my-service"
+					serviceInstance.Guid = "my-service-guid"
+					serviceInstance.LastOperation.Type = "delete"
+					serviceInstance.LastOperation.State = "in progress"
+					serviceInstance.LastOperation.Description = "delete"
+					serviceRepo.FindInstanceByNameServiceInstance = serviceInstance
+				})
 
-			Context("when the command is confirmed", func() {
-				It("deletes the service", func() {
-					runCommand("my-service")
+				Context("when the command is confirmed", func() {
+					It("deletes the service", func() {
+						runCommand("my-service")
 
-					Expect(ui.Prompts).To(ContainSubstrings([]string{"Really delete the service my-service"}))
+						Expect(ui.Prompts).To(ContainSubstrings([]string{"Really delete the service my-service"}))
 
+						Expect(ui.Outputs).To(ContainSubstrings(
+							[]string{"Deleting service", "my-service", "my-org", "my-space", "my-user"},
+							[]string{"OK"},
+							[]string{"Delete in progress. Use cf services or cf service my-service to check operation status."},
+						))
+
+						Expect(serviceRepo.DeleteServiceServiceInstance).To(Equal(serviceInstance))
+					})
+				})
+
+				It("skips confirmation when the -f flag is given", func() {
+					runCommand("-f", "foo.com")
+
+					Expect(ui.Prompts).To(BeEmpty())
 					Expect(ui.Outputs).To(ContainSubstrings(
-						[]string{"Deleting service", "my-service", "my-org", "my-space", "my-user"},
+						[]string{"Deleting service", "foo.com"},
 						[]string{"OK"},
+						[]string{"Delete in progress. Use cf services or cf service foo.com to check operation status."},
 					))
-
-					Expect(serviceRepo.DeleteServiceServiceInstance).To(Equal(serviceInstance))
 				})
 			})
 
-			It("skips confirmation when the -f flag is given", func() {
-				runCommand("-f", "foo.com")
+			Context("and the service deletion is synchronous", func() {
+				BeforeEach(func() {
+					serviceInstance = models.ServiceInstance{}
+					serviceInstance.Name = "my-service"
+					serviceInstance.Guid = "my-service-guid"
+					serviceRepo.FindInstanceByNameServiceInstance = serviceInstance
+				})
 
-				Expect(ui.Prompts).To(BeEmpty())
-				Expect(ui.Outputs).To(ContainSubstrings(
-					[]string{"Deleting service", "foo.com"},
-					[]string{"OK"},
-				))
+				Context("when the command is confirmed", func() {
+					It("deletes the service", func() {
+						runCommand("my-service")
+
+						Expect(ui.Prompts).To(ContainSubstrings([]string{"Really delete the service my-service"}))
+
+						Expect(ui.Outputs).To(ContainSubstrings(
+							[]string{"Deleting service", "my-service", "my-org", "my-space", "my-user"},
+							[]string{"OK"},
+						))
+
+						Expect(serviceRepo.DeleteServiceServiceInstance).To(Equal(serviceInstance))
+					})
+				})
+
+				It("skips confirmation when the -f flag is given", func() {
+					runCommand("-f", "foo.com")
+
+					Expect(ui.Prompts).To(BeEmpty())
+					Expect(ui.Outputs).To(ContainSubstrings(
+						[]string{"Deleting service", "foo.com"},
+						[]string{"OK"},
+					))
+				})
 			})
 		})
 

--- a/cf/commands/service/update_service_test.go
+++ b/cf/commands/service/update_service_test.go
@@ -72,6 +72,7 @@ var _ = Describe("update-service command", func() {
 			Expect(callUpdateService([]string{"cleardb", "spark", "my-cleardb-service"})).To(BeFalse())
 		})
 	})
+
 	Context("when no flags are passed", func() {
 		Context("when there is an err finding the instance", func() {
 			It("returns an error", func() {
@@ -96,90 +97,185 @@ var _ = Describe("update-service command", func() {
 			})
 		})
 	})
-	Context("when the plan flag is passed", func() {
-		BeforeEach(func() {
-			serviceInstance := models.ServiceInstance{
-				ServiceInstanceFields: models.ServiceInstanceFields{
-					Name: "my-service-instance",
-					Guid: "my-service-instance-guid",
+
+	Context("when service creation is asynchronous", func() {
+		Context("when the plan flag is passed", func() {
+			BeforeEach(func() {
+				serviceInstance := models.ServiceInstance{
+					ServiceInstanceFields: models.ServiceInstanceFields{
+						Name: "my-service-instance",
+						Guid: "my-service-instance-guid",
+						LastOperation: models.LastOperationFields{
+							Type:        "update",
+							State:       "in progress",
+							Description: "fake service instance description",
+						},
+					},
+					ServiceOffering: models.ServiceOfferingFields{
+						Label: "murkydb",
+						Guid:  "murkydb-guid",
+					},
+				}
+
+				servicePlans := []models.ServicePlanFields{{
+					Name: "spark",
+					Guid: "murkydb-spark-guid",
+				}, {
+					Name: "flare",
+					Guid: "murkydb-flare-guid",
 				},
-				ServiceOffering: models.ServiceOfferingFields{
-					Label: "murkydb",
-					Guid:  "murkydb-guid",
-				},
-			}
+				}
+				serviceRepo.FindInstanceByNameServiceInstance = serviceInstance
+				planBuilder.GetPlansForServiceForOrgReturns(servicePlans, nil)
 
-			servicePlans := []models.ServicePlanFields{{
-				Name: "spark",
-				Guid: "murkydb-spark-guid",
-			}, {
-				Name: "flare",
-				Guid: "murkydb-flare-guid",
-			},
-			}
-			serviceRepo.FindInstanceByNameServiceInstance = serviceInstance
-			planBuilder.GetPlansForServiceForOrgReturns(servicePlans, nil)
-
-		})
-		It("successfully updates a service", func() {
-			callUpdateService([]string{"-p", "flare", "my-service-instance"})
-
-			Expect(ui.Outputs).To(ContainSubstrings(
-				[]string{"Updating service", "my-service", "as", "my-user", "..."},
-				[]string{"OK"},
-			))
-			Expect(serviceRepo.FindInstanceByNameName).To(Equal("my-service-instance"))
-			serviceGuid, orgName := planBuilder.GetPlansForServiceForOrgArgsForCall(0)
-			Expect(serviceGuid).To(Equal("murkydb-guid"))
-			Expect(orgName).To(Equal("my-org"))
-			Expect(serviceRepo.UpdateServiceInstanceArgs.InstanceGuid).To(Equal("my-service-instance-guid"))
-			Expect(serviceRepo.UpdateServiceInstanceArgs.PlanGuid).To(Equal("murkydb-flare-guid"))
-		})
-
-		Context("when there is an err finding the instance", func() {
-			It("returns an error", func() {
-				serviceRepo.FindInstanceByNameErr = true
-
-				callUpdateService([]string{"-p", "flare", "some-stupid-not-real-instance"})
-
-				Expect(ui.Outputs).To(ContainSubstrings(
-					[]string{"Error finding instance"},
-					[]string{"FAILED"},
-				))
 			})
-		})
-		Context("when there is an err finding service plans", func() {
-			It("returns an error", func() {
-				planBuilder.GetPlansForServiceForOrgReturns(nil, errors.New("Error fetching plans"))
-
-				callUpdateService([]string{"-p", "flare", "some-stupid-not-real-instance"})
-
-				Expect(ui.Outputs).To(ContainSubstrings(
-					[]string{"Error fetching plans"},
-					[]string{"FAILED"},
-				))
-			})
-		})
-		Context("when the plan specified does not exist in the service offering", func() {
-			It("returns an error", func() {
-				callUpdateService([]string{"-p", "not-a-real-plan", "instance-without-service-offering"})
-
-				Expect(ui.Outputs).To(ContainSubstrings(
-					[]string{"Plan does not exist for the murkydb service"},
-					[]string{"FAILED"},
-				))
-			})
-		})
-		Context("when there is an error updating the service instance", func() {
-			It("returns an error", func() {
-				serviceRepo.UpdateServiceInstanceReturnsErr = true
+			It("successfully updates a service", func() {
 				callUpdateService([]string{"-p", "flare", "my-service-instance"})
 
 				Expect(ui.Outputs).To(ContainSubstrings(
-					[]string{"Error updating service instance"},
-					[]string{"FAILED"},
+					[]string{"Updating service", "my-service", "as", "my-user", "..."},
+					[]string{"Update in progress. Use cf services or cf service my-service-instance to check operation status."},
 				))
+				Expect(serviceRepo.FindInstanceByNameName).To(Equal("my-service-instance"))
+				Expect(serviceRepo.UpdateServiceInstanceArgs.InstanceGuid).To(Equal("my-service-instance-guid"))
+				Expect(serviceRepo.UpdateServiceInstanceArgs.PlanGuid).To(Equal("murkydb-flare-guid"))
+			})
+
+			Context("when there is an err finding the instance", func() {
+				It("returns an error", func() {
+					serviceRepo.FindInstanceByNameErr = true
+
+					callUpdateService([]string{"-p", "flare", "some-stupid-not-real-instance"})
+
+					Expect(ui.Outputs).To(ContainSubstrings(
+						[]string{"Error finding instance"},
+						[]string{"FAILED"},
+					))
+				})
+			})
+			Context("when there is an err finding service plans", func() {
+				It("returns an error", func() {
+					planBuilder.GetPlansForServiceForOrgReturns(nil, errors.New("Error fetching plans"))
+
+					callUpdateService([]string{"-p", "flare", "some-stupid-not-real-instance"})
+
+					Expect(ui.Outputs).To(ContainSubstrings(
+						[]string{"Error fetching plans"},
+						[]string{"FAILED"},
+					))
+				})
+			})
+			Context("when the plan specified does not exist in the service offering", func() {
+				It("returns an error", func() {
+					callUpdateService([]string{"-p", "not-a-real-plan", "instance-without-service-offering"})
+
+					Expect(ui.Outputs).To(ContainSubstrings(
+						[]string{"Plan does not exist for the murkydb service"},
+						[]string{"FAILED"},
+					))
+				})
+			})
+			Context("when there is an error updating the service instance", func() {
+				It("returns an error", func() {
+					serviceRepo.UpdateServiceInstanceReturnsErr = true
+					callUpdateService([]string{"-p", "flare", "my-service-instance"})
+
+					Expect(ui.Outputs).To(ContainSubstrings(
+						[]string{"Error updating service instance"},
+						[]string{"FAILED"},
+					))
+				})
 			})
 		})
+	})
+
+	Context("when service creation is synchronous", func() {
+		Context("when the plan flag is passed", func() {
+			BeforeEach(func() {
+				serviceInstance := models.ServiceInstance{
+					ServiceInstanceFields: models.ServiceInstanceFields{
+						Name: "my-service-instance",
+						Guid: "my-service-instance-guid",
+					},
+					ServiceOffering: models.ServiceOfferingFields{
+						Label: "murkydb",
+						Guid:  "murkydb-guid",
+					},
+				}
+
+				servicePlans := []models.ServicePlanFields{{
+					Name: "spark",
+					Guid: "murkydb-spark-guid",
+				}, {
+					Name: "flare",
+					Guid: "murkydb-flare-guid",
+				},
+				}
+				serviceRepo.FindInstanceByNameServiceInstance = serviceInstance
+				planBuilder.GetPlansForServiceForOrgReturns(servicePlans, nil)
+
+			})
+			It("successfully updates a service", func() {
+				callUpdateService([]string{"-p", "flare", "my-service-instance"})
+
+				Expect(ui.Outputs).To(ContainSubstrings(
+					[]string{"Updating service", "my-service", "as", "my-user", "..."},
+					[]string{"OK"},
+				))
+				Expect(serviceRepo.FindInstanceByNameName).To(Equal("my-service-instance"))
+				serviceGuid, orgName := planBuilder.GetPlansForServiceForOrgArgsForCall(0)
+				Expect(serviceGuid).To(Equal("murkydb-guid"))
+				Expect(orgName).To(Equal("my-org"))
+				Expect(serviceRepo.UpdateServiceInstanceArgs.InstanceGuid).To(Equal("my-service-instance-guid"))
+				Expect(serviceRepo.UpdateServiceInstanceArgs.PlanGuid).To(Equal("murkydb-flare-guid"))
+			})
+
+			Context("when there is an err finding the instance", func() {
+				It("returns an error", func() {
+					serviceRepo.FindInstanceByNameErr = true
+
+					callUpdateService([]string{"-p", "flare", "some-stupid-not-real-instance"})
+
+					Expect(ui.Outputs).To(ContainSubstrings(
+						[]string{"Error finding instance"},
+						[]string{"FAILED"},
+					))
+				})
+			})
+			Context("when there is an err finding service plans", func() {
+				It("returns an error", func() {
+					planBuilder.GetPlansForServiceForOrgReturns(nil, errors.New("Error fetching plans"))
+
+					callUpdateService([]string{"-p", "flare", "some-stupid-not-real-instance"})
+
+					Expect(ui.Outputs).To(ContainSubstrings(
+						[]string{"Error fetching plans"},
+						[]string{"FAILED"},
+					))
+				})
+			})
+			Context("when the plan specified does not exist in the service offering", func() {
+				It("returns an error", func() {
+					callUpdateService([]string{"-p", "not-a-real-plan", "instance-without-service-offering"})
+
+					Expect(ui.Outputs).To(ContainSubstrings(
+						[]string{"Plan does not exist for the murkydb service"},
+						[]string{"FAILED"},
+					))
+				})
+			})
+			Context("when there is an error updating the service instance", func() {
+				It("returns an error", func() {
+					serviceRepo.UpdateServiceInstanceReturnsErr = true
+					callUpdateService([]string{"-p", "flare", "my-service-instance"})
+
+					Expect(ui.Outputs).To(ContainSubstrings(
+						[]string{"Error updating service instance"},
+						[]string{"FAILED"},
+					))
+				})
+			})
+		})
+
 	})
 })

--- a/cf/commands/service/update_service_test.go
+++ b/cf/commands/service/update_service_test.go
@@ -134,6 +134,7 @@ var _ = Describe("update-service command", func() {
 
 				Expect(ui.Outputs).To(ContainSubstrings(
 					[]string{"Updating service", "my-service", "as", "my-user", "..."},
+					[]string{"OK"},
 					[]string{"Update in progress. Use cf services or cf service my-service-instance to check operation status."},
 				))
 				Expect(serviceRepo.FindInstanceByNameName).To(Equal("my-service-instance"))

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -2525,8 +2525,8 @@
       "modified": false
    },
    {
-      "id": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
-      "translation": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
+      "id": "{{.State}} in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
+      "translation": "{{.State}} in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -1440,8 +1440,8 @@
       "modified": false
    },
    {
-      "id": "Creating service {{.ServiceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
-      "translation": "Creating service {{.ServiceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
+      "id": "Creating service instance {{.ServiceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
+      "translation": "Creating service instance {{.ServiceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
       "modified": false
    },
    {
@@ -2525,8 +2525,8 @@
       "modified": false
    },
    {
-      "id": "Create in progress. Use 'cf services' or 'cf service {{.ServiceInstanceName}}' to check operation status.",
-      "translation": "Create in progress. Use 'cf services' or 'cf service {{.ServiceInstanceName}}' to check operation status.",
+      "id": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
+      "translation": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -2525,8 +2525,8 @@
       "modified": false
    },
    {
-      "id": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
-      "translation": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
+      "id": "{{.State}} in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
+      "translation": "{{.State}} in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -1440,8 +1440,8 @@
       "modified": false
    },
    {
-      "id": "Creating service {{.ServiceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
-      "translation": "Creating service {{.ServiceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
+      "id": "Creating service instance {{.ServiceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
+      "translation": "Creating service instance {{.ServiceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
       "modified": false
    },
    {
@@ -2525,8 +2525,8 @@
       "modified": false
    },
    {
-      "id": "Create in progress. Use 'cf services' or 'cf service {{.ServiceInstanceName}}' to check operation status.",
-      "translation": "Create in progress. Use 'cf services' or 'cf service {{.ServiceInstanceName}}' to check operation status.",
+      "id": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
+      "translation": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -1440,7 +1440,7 @@
       "modified": false
    },
    {
-      "id": "Creating service {{.ServiceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
+      "id": "Creating service instance {{.ServiceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
       "translation": "Creando servicio {{.ServiceName}} en org {{.OrgName}} / space {{.SpaceName}} como {{.CurrentUser}}...",
       "modified": false
    },
@@ -2525,8 +2525,8 @@
       "modified": false
    },
    {
-      "id": "Create in progress. Use 'cf services' or 'cf service {{.ServiceInstanceName}}' to check operation status.",
-      "translation": "Create in progress. Use 'cf services' or 'cf service {{.ServiceInstanceName}}' to check operation status.",
+      "id": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
+      "translation": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -2525,8 +2525,8 @@
       "modified": false
    },
    {
-      "id": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
-      "translation": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
+      "id": "{{.State}} in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
+      "translation": "{{.State}} in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -1440,7 +1440,7 @@
       "modified": false
    },
    {
-      "id": "Creating service {{.ServiceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
+      "id": "Creating service instance {{.ServiceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
       "translation": "Création d'un service {{.ServiceName}} dans l'org {{.OrgName}} / espace {{.SpaceName}} en tant que {{.CurrentUser}}...",
       "modified": false
    },
@@ -2525,8 +2525,8 @@
       "modified": false
    },
    {
-      "id": "Create in progress. Use 'cf services' or 'cf service {{.ServiceInstanceName}}' to check operation status.",
-      "translation": "Création en progres. Utilizer 'cf services' ou 'cf service {{.ServiceInstanceName}}' pour vérifier le status courant.",
+      "id": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
+      "translation": "Création en progres. Utilizer {{.ServicesCommand}} ou {{.ServiceCommand}} pour vérifier le status courant.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -2525,8 +2525,8 @@
       "modified": false
    },
    {
-      "id": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
-      "translation": "Création en progres. Utilizer {{.ServicesCommand}} ou {{.ServiceCommand}} pour vérifier le status courant.",
+      "id": "{{.State}} in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
+      "translation": "{{.State}} en progres. Utilizer {{.ServicesCommand}} ou {{.ServiceCommand}} pour vérifier le status courant.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -2525,8 +2525,8 @@
       "modified": false
    },
    {
-      "id": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
-      "translation": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
+      "id": "{{.State}} in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
+      "translation": "{{.State}} in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -1440,8 +1440,8 @@
       "modified": false
    },
    {
-      "id": "Creating service {{.ServiceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
-      "translation": "Creating service {{.ServiceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
+      "id": "Creating service instance {{.ServiceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
+      "translation": "Creating service instance {{.ServiceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
       "modified": false
    },
    {
@@ -2525,8 +2525,8 @@
       "modified": false
    },
    {
-      "id": "Create in progress. Use 'cf services' or 'cf service {{.ServiceInstanceName}}' to check operation status.",
-      "translation": "Create in progress. Use 'cf services' or 'cf service {{.ServiceInstanceName}}' to check operation status.",
+      "id": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
+      "translation": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -2525,8 +2525,8 @@
       "modified": false
    },
    {
-      "id": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
-      "translation": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
+      "id": "{{.State}} in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
+      "translation": "{{.State}} in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -1440,8 +1440,8 @@
       "modified": false
    },
    {
-      "id": "Creating service {{.ServiceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
-      "translation": "Creating service {{.ServiceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
+      "id": "Creating service instance {{.ServiceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
+      "translation": "Creating service instance {{.ServiceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
       "modified": false
    },
    {
@@ -2525,8 +2525,8 @@
       "modified": false
    },
    {
-      "id": "Create in progress. Use 'cf services' or 'cf service {{.ServiceInstanceName}}' to check operation status.",
-      "translation": "Create in progress. Use 'cf services' or 'cf service {{.ServiceInstanceName}}' to check operation status.",
+      "id": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
+      "translation": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -2525,8 +2525,8 @@
       "modified": false
    },
    {
-      "id": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
-      "translation": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
+      "id": "{{.State}} in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
+      "translation": "{{.State}} in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -1440,7 +1440,7 @@
       "modified": false
    },
    {
-      "id": "Creating service {{.ServiceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
+      "id": "Creating service instance {{.ServiceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
       "translation": "Criando serviço {{.ServiceName}} na org {{.OrgName}} / espaço {{.SpaceName}} como {{.CurrentUser}}...",
       "modified": false
    },
@@ -2525,8 +2525,8 @@
       "modified": false
    },
    {
-      "id": "Create in progress. Use 'cf services' or 'cf service {{.ServiceInstanceName}}' to check operation status.",
-      "translation": "Create in progress. Use 'cf services' or 'cf service {{.ServiceInstanceName}}' to check operation status.",
+      "id": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
+      "translation": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -2525,8 +2525,8 @@
       "modified": false
    },
    {
-      "id": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
-      "translation": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
+      "id": "{{.State}} in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
+      "translation": "{{.State}} in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -1440,7 +1440,7 @@
       "modified": false
    },
    {
-      "id": "Creating service {{.ServiceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
+      "id": "Creating service instance {{.ServiceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
       "translation": "用户{{.CurrentUser}}在组织{{.OrgName}}/空间{{.SpaceName}}中创建服务{{.ServiceName}}...",
       "modified": false
    },
@@ -2525,8 +2525,8 @@
       "modified": false
    },
    {
-      "id": "Create in progress. Use 'cf services' or 'cf service {{.ServiceInstanceName}}' to check operation status.",
-      "translation": "Create in progress. Use 'cf services' or 'cf service {{.ServiceInstanceName}}' to check operation status.",
+      "id": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
+      "translation": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -2525,8 +2525,8 @@
       "modified": false
    },
    {
-      "id": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
-      "translation": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
+      "id": "{{.State}} in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
+      "translation": "{{.State}} in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -1440,8 +1440,8 @@
       "modified": false
    },
    {
-      "id": "Creating service {{.ServiceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
-      "translation": "Creating service {{.ServiceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
+      "id": "Creating service instance {{.ServiceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
+      "translation": "Creating service instance {{.ServiceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
       "modified": false
    },
    {
@@ -2525,8 +2525,8 @@
       "modified": false
    },
    {
-      "id": "Create in progress. Use 'cf services' or 'cf service {{.ServiceInstanceName}}' to check operation status.",
-      "translation": "Create in progress. Use 'cf services' or 'cf service {{.ServiceInstanceName}}' to check operation status.",
+      "id": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
+      "translation": "Create in progress. Use {{.ServicesCommand}} or {{.ServiceCommand}} to check operation status.",
       "modified": false
    },
    {


### PR DESCRIPTION
- Changed "Creating service foo" to "Creating service instance foo"
- Changed "Updating service foo" to "Updating service instance foo"
- Suggested commands to run after creating a service are highlighted instead of quoted.
- `cf delete-service` passes along `accepts_incomplete=true` to perform async deprovision.

[#86668046, #88279874, #87584124]

@gtona & Jeff