### PR TITLE
Fix the requirmements issue in some of the application commands

### DIFF
--- a/cf/commands/application/delete.go
+++ b/cf/commands/application/delete.go
@@ -47,7 +47,8 @@ func (cmd *DeleteApp) GetRequirements(requirementsFactory requirements.Factory, 
 		cmd.ui.FailWithUsage(c)
 	}
 
-	reqs = []requirements.Requirement{requirementsFactory.NewLoginRequirement()}
+	reqs = []requirements.Requirement{requirementsFactory.NewLoginRequirement(),
+		requirementsFactory.NewTargetedSpaceRequirement()}
 	return
 }
 

--- a/cf/commands/application/delete_test.go
+++ b/cf/commands/application/delete_test.go
@@ -50,10 +50,16 @@ var _ = Describe("delete app command", func() {
 		requirementsFactory.LoginSuccess = false
 		Expect(runCommand("-f", "delete-this-app-plz")).To(BeFalse())
 	})
+	It("fails if a space is not targeted", func() {
+		requirementsFactory.LoginSuccess = true
+		requirementsFactory.TargetedSpaceSuccess = false
+		Expect(runCommand("-f", "delete-this-app-plz")).To(BeFalse())
+	})
 
 	Context("when logged in", func() {
 		BeforeEach(func() {
 			requirementsFactory.LoginSuccess = true
+			requirementsFactory.TargetedSpaceSuccess = true
 		})
 
 		It("fails with usage when not provided exactly one arg", func() {

--- a/cf/commands/application/env.go
+++ b/cf/commands/application/env.go
@@ -38,12 +38,15 @@ func (cmd *Env) Metadata() command_metadata.CommandMetadata {
 	}
 }
 
-func (cmd *Env) GetRequirements(requirementsFactory requirements.Factory, c *cli.Context) ([]requirements.Requirement, error) {
+func (cmd *Env) GetRequirements(requirementsFactory requirements.Factory, c *cli.Context) (reqs []requirements.Requirement, err error) {
 	if len(c.Args()) != 1 {
 		cmd.ui.FailWithUsage(c)
 	}
-
-	return []requirements.Requirement{requirementsFactory.NewLoginRequirement()}, nil
+	reqs = []requirements.Requirement{
+		requirementsFactory.NewLoginRequirement(),
+		requirementsFactory.NewTargetedSpaceRequirement(),
+	}
+	return
 }
 
 func (cmd *Env) Run(c *cli.Context) {

--- a/cf/commands/application/env_test.go
+++ b/cf/commands/application/env_test.go
@@ -34,7 +34,7 @@ var _ = Describe("env command", func() {
 		appRepo.ReadReturns.App = app
 
 		configRepo = testconfig.NewRepositoryWithDefaults()
-		requirementsFactory = &testreq.FakeReqFactory{LoginSuccess: true}
+		requirementsFactory = &testreq.FakeReqFactory{LoginSuccess: true, TargetedSpaceSuccess: true}
 	})
 
 	runCommand := func(args ...string) bool {
@@ -45,6 +45,10 @@ var _ = Describe("env command", func() {
 	Describe("Requirements", func() {
 		It("fails when the user is not logged in", func() {
 			requirementsFactory.LoginSuccess = false
+			Expect(runCommand("my-app")).To(BeFalse())
+		})
+		It("fails if a space is not targeted", func() {
+			requirementsFactory.TargetedSpaceSuccess = false
 			Expect(runCommand("my-app")).To(BeFalse())
 		})
 	})

--- a/cf/commands/application/logs.go
+++ b/cf/commands/application/logs.go
@@ -52,6 +52,7 @@ func (cmd *Logs) GetRequirements(requirementsFactory requirements.Factory, c *cl
 
 	reqs = []requirements.Requirement{
 		requirementsFactory.NewLoginRequirement(),
+		requirementsFactory.NewTargetedSpaceRequirement(),
 		cmd.appReq,
 	}
 

--- a/cf/commands/application/logs_test.go
+++ b/cf/commands/application/logs_test.go
@@ -52,6 +52,12 @@ var _ = Describe("logs command", func() {
 		It("fails requirements when not logged in", func() {
 			Expect(runCommand("my-app")).To(BeFalse())
 		})
+		It("fails if a space is not targeted", func() {
+			requirementsFactory.LoginSuccess = true
+			requirementsFactory.TargetedSpaceSuccess = false
+			Expect(runCommand("--recent", "my-app")).To(BeFalse())
+		})
+
 	})
 
 	Context("when logged in", func() {
@@ -61,6 +67,7 @@ var _ = Describe("logs command", func() {
 
 		BeforeEach(func() {
 			requirementsFactory.LoginSuccess = true
+			requirementsFactory.TargetedSpaceSuccess = true
 
 			app = models.Application{}
 			app.Name = "my-app"

--- a/cf/commands/application/rename.go
+++ b/cf/commands/application/rename.go
@@ -42,6 +42,7 @@ func (cmd *RenameApp) GetRequirements(requirementsFactory requirements.Factory, 
 	cmd.appReq = requirementsFactory.NewApplicationRequirement(c.Args()[0])
 	reqs = []requirements.Requirement{
 		requirementsFactory.NewLoginRequirement(),
+		requirementsFactory.NewTargetedSpaceRequirement(),
 		cmd.appReq,
 	}
 	return

--- a/cf/commands/application/rename_test.go
+++ b/cf/commands/application/rename_test.go
@@ -44,6 +44,11 @@ var _ = Describe("Rename command", func() {
 		It("fails when not logged in", func() {
 			Expect(runCommand("my-app", "my-new-app")).To(BeFalse())
 		})
+		It("fails if a space is not targeted", func() {
+			requirementsFactory.LoginSuccess = true
+			requirementsFactory.TargetedSpaceSuccess = false
+			Expect(runCommand("my-app", "my-new-app")).To(BeFalse())
+		})
 	})
 
 	It("renames an application", func() {
@@ -51,6 +56,7 @@ var _ = Describe("Rename command", func() {
 		app.Name = "my-app"
 		app.Guid = "my-app-guid"
 		requirementsFactory.LoginSuccess = true
+		requirementsFactory.TargetedSpaceSuccess = true
 		requirementsFactory.Application = app
 		runCommand("my-app", "my-new-app")
 

--- a/cf/commands/application/restage.go
+++ b/cf/commands/application/restage.go
@@ -42,7 +42,11 @@ func (cmd *Restage) GetRequirements(requirementsFactory requirements.Factory, c 
 		cmd.ui.FailWithUsage(c)
 	}
 
-	return []requirements.Requirement{requirementsFactory.NewLoginRequirement()}, nil
+	reqs = []requirements.Requirement{
+		requirementsFactory.NewLoginRequirement(),
+		requirementsFactory.NewTargetedSpaceRequirement(),
+	}
+	return
 }
 
 func (cmd *Restage) Run(c *cli.Context) {

--- a/cf/commands/application/restage_test.go
+++ b/cf/commands/application/restage_test.go
@@ -34,7 +34,7 @@ var _ = Describe("restage command", func() {
 		appRepo.ReadReturns.App = app
 
 		configRepo = testconfig.NewRepositoryWithDefaults()
-		requirementsFactory = &testreq.FakeReqFactory{LoginSuccess: true}
+		requirementsFactory = &testreq.FakeReqFactory{LoginSuccess: true, TargetedSpaceSuccess: true}
 
 		stagingWatcher = &fakeStagingWatcher{}
 	})
@@ -54,6 +54,11 @@ var _ = Describe("restage command", func() {
 			passed := runCommand()
 			Expect(ui.FailedWithUsage).To(BeTrue())
 			Expect(passed).To(BeFalse())
+		})
+		It("fails if a space is not targeted", func() {
+			requirementsFactory.LoginSuccess = true
+			requirementsFactory.TargetedSpaceSuccess = false
+			Expect(runCommand("my-app")).To(BeFalse())
 		})
 	})
 

--- a/cf/commands/application/start.go
+++ b/cf/commands/application/start.go
@@ -108,7 +108,8 @@ func (cmd *Start) GetRequirements(requirementsFactory requirements.Factory, c *c
 
 	cmd.appReq = requirementsFactory.NewApplicationRequirement(c.Args()[0])
 
-	reqs = []requirements.Requirement{requirementsFactory.NewLoginRequirement(), cmd.appReq}
+	reqs = []requirements.Requirement{requirementsFactory.NewLoginRequirement(),
+		requirementsFactory.NewTargetedSpaceRequirement(), cmd.appReq}
 	return
 }
 

--- a/cf/commands/application/start_test.go
+++ b/cf/commands/application/start_test.go
@@ -141,6 +141,12 @@ var _ = Describe("start command", func() {
 
 		Expect(testcmd.RunCommand(cmd, []string{"some-app-name"}, requirementsFactory)).To(BeFalse())
 	})
+	It("fails requirements when a space is not targeted", func() {
+		requirementsFactory.LoginSuccess = true
+		requirementsFactory.TargetedSpaceSuccess = false
+		cmd := NewStart(new(testterm.FakeUI), testconfig.NewRepository(), &testcmd.FakeAppDisplayer{}, &testApplication.FakeApplicationRepository{}, &testAppInstanaces.FakeAppInstancesRepository{}, &testapi.FakeLogsRepository{})
+		Expect(testcmd.RunCommand(cmd, []string{"some-app-name"}, requirementsFactory)).To(BeFalse())
+	})
 
 	Describe("timeouts", func() {
 		It("has sane default timeout values", func() {
@@ -182,6 +188,7 @@ var _ = Describe("start command", func() {
 				appInstancesRepo.GetInstancesReturns(instances, errors.New("Error staging app"))
 
 				requirementsFactory.LoginSuccess = true
+				requirementsFactory.TargetedSpaceSuccess = true
 				requirementsFactory.Application = app
 				config := testconfig.NewRepository()
 				displayApp := &testcmd.FakeAppDisplayer{}
@@ -207,6 +214,7 @@ var _ = Describe("start command", func() {
 	Context("when logged in", func() {
 		BeforeEach(func() {
 			requirementsFactory.LoginSuccess = true
+			requirementsFactory.TargetedSpaceSuccess = true
 		})
 
 		It("fails with usage when not provided exactly one arg", func() {

--- a/cf/commands/application/stop.go
+++ b/cf/commands/application/stop.go
@@ -50,7 +50,8 @@ func (cmd *Stop) GetRequirements(requirementsFactory requirements.Factory, c *cl
 
 	cmd.appReq = requirementsFactory.NewApplicationRequirement(c.Args()[0])
 
-	reqs = []requirements.Requirement{requirementsFactory.NewLoginRequirement(), cmd.appReq}
+	reqs = []requirements.Requirement{requirementsFactory.NewLoginRequirement(),
+		requirementsFactory.NewTargetedSpaceRequirement(), cmd.appReq}
 	return
 }
 

--- a/cf/commands/application/stop_test.go
+++ b/cf/commands/application/stop_test.go
@@ -38,10 +38,16 @@ var _ = Describe("stop command", func() {
 	It("fails requirements when not logged in", func() {
 		Expect(runCommand("some-app-name")).To(BeFalse())
 	})
+	It("fails requirements when a space is not targeted", func() {
+		requirementsFactory.LoginSuccess = true
+		requirementsFactory.TargetedSpaceSuccess = false
+		Expect(runCommand("some-app-name")).To(BeFalse())
+	})
 
 	Context("when logged in and an app exists", func() {
 		BeforeEach(func() {
 			requirementsFactory.LoginSuccess = true
+			requirementsFactory.TargetedSpaceSuccess = true
 
 			app = models.Application{}
 			app.Name = "my-app"


### PR DESCRIPTION
In some of the application related commands code the requirements are not handled properly
comparing other app commands for example cf apps return failure immediately if user has not
targetted the space as shown below but not in the following application commands
' cf delete' , 'cf rename' , 'cf logs', 'cf env','cf start', cf stop', ' cf restage'.

CLI is sending empty space guid & receiving error from cloud controller, So in ivalid conditions
CLI can validate & return error to user immediately.

htipl@cf5:~$ cf apps
 FAILED
 No space targeted, use 'cf target -s' to target a space

Before Fix: If cf user does 'cf delete testapp -f' without targetting the space

htipl@cf5:~$ cf delete testapp -f
 Deleting app testapp in org SriniOrg / space as admin...
 FAILED
 Server error, status code: 404, error code: 40004, message: The app space could not be found: apps

So CLI is sending empty space guid & receiving error from cloud controller which we can validate at CLI it self.

After Fix:If cf user does same steps
htipl@cf5:~/go/src/github.com/cloudfoundry/cli$ ./out/cf delete testapp

VERSION:
 BUILT_FROM_SOURCE

FAILED
 No space targeted, use 'cf target -s' to target a space