### PR TITLE
Prevent updating service plans when the CC is less than v191.

### DIFF
--- a/cf/api/applications/fakes/fake_application_repository.go
+++ b/cf/api/applications/fakes/fake_application_repository.go
@@ -2,6 +2,7 @@ package fakes
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/cloudfoundry/cli/cf/api/applications"

--- a/cf/api/applications/fakes/fake_application_repository.go
+++ b/cf/api/applications/fakes/fake_application_repository.go
@@ -2,7 +2,6 @@ package fakes
 
 import (
 	"errors"
-	"fmt"
 	"sync"
 
 	"github.com/cloudfoundry/cli/cf/api/applications"

--- a/cf/commands/service/update_service.go
+++ b/cf/commands/service/update_service.go
@@ -75,15 +75,23 @@ func (cmd *UpdateService) Run(c *cli.Context) {
 				"UserName":    terminal.EntityNameColor(cmd.config.Username()),
 			}))
 
-		err := cmd.updateServiceWithPlan(serviceInstance, planName)
-		switch err.(type) {
-		case nil:
-			err = printSuccessMessageForServiceInstance(serviceInstanceName, cmd.serviceRepo, cmd.ui)
-			if err != nil {
+		if cmd.config.IsMinApiVersion("2.16.0") {
+			err := cmd.updateServiceWithPlan(serviceInstance, planName)
+			switch err.(type) {
+			case nil:
+				err = printSuccessMessageForServiceInstance(serviceInstanceName, cmd.serviceRepo, cmd.ui)
+				if err != nil {
+					cmd.ui.Failed(err.Error())
+				}
+			default:
 				cmd.ui.Failed(err.Error())
 			}
-		default:
-			cmd.ui.Failed(err.Error())
+		} else {
+			cmd.ui.Failed(T("Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
+				map[string]interface{}{
+					"RequiredCCAPIVersion": "2.16.0",
+					"CurrentCCAPIVersion":  cmd.config.ApiVersion(),
+				}))
 		}
 	} else {
 		cmd.ui.Ok()

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -5113,5 +5113,10 @@
       "id": "state",
       "translation": "state",
       "modified": false
+   },
+   {
+      "id": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
+      "translation": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -5113,5 +5113,10 @@
       "id": "state",
       "translation": "state",
       "modified": false
+   },
+   {
+      "id": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
+      "translation": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -5113,5 +5113,10 @@
       "id": "state",
       "translation": "estado",
       "modified": false
+   },
+   {
+      "id": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
+      "translation": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -5113,5 +5113,10 @@
       "id": "state",
       "translation": "state",
       "modified": false
+   },
+   {
+      "id": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
+      "translation": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -5113,5 +5113,10 @@
       "id": "state",
       "translation": "state",
       "modified": false
+   },
+   {
+      "id": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
+      "translation": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -5113,5 +5113,10 @@
       "id": "state",
       "translation": "state",
       "modified": false
+   },
+   {
+      "id": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
+      "translation": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -5113,5 +5113,10 @@
       "id": "state",
       "translation": "estado",
       "modified": false
+   },
+   {
+      "id": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
+      "translation": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -5113,5 +5113,10 @@
       "id": "state",
       "translation": "状态",
       "modified": false
+   },
+   {
+      "id": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
+      "translation": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -5113,5 +5113,10 @@
       "id": "state",
       "translation": "state",
       "modified": false
+   },
+   {
+      "id": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
+      "translation": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
+      "modified": false
    }
 ]


### PR DESCRIPTION
v191 corresponds to CC API 2.16.0.

This is to prevent a bug with older CC and newer CLIs where plans can be
updated without talking to the service broker.

[#88798806, #88689444]