### PR TITLE
Removed as admin.. clause from create-user since it is confusing.

### DIFF
--- a/cf/commands/user/create_user.go
+++ b/cf/commands/user/create_user.go
@@ -47,7 +47,7 @@ func (cmd CreateUser) Run(c *cli.Context) {
 	username := c.Args()[0]
 	password := c.Args()[1]
 
-	cmd.ui.Say(T("Creating user {{.TargetUser}} as {{.CurrentUser}}...",
+	cmd.ui.Say(T("Creating user {{.TargetUser}}...",
 		map[string]interface{}{
 			"TargetUser":  terminal.EntityNameColor(username),
 			"CurrentUser": terminal.EntityNameColor(cmd.config.Username()),

--- a/cf/commands/user/create_user_test.go
+++ b/cf/commands/user/create_user_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Create user command", func() {
 		runCommand("my-user", "my-password")
 
 		Expect(ui.Outputs).To(ContainSubstrings(
-			[]string{"Creating user", "my-user", "current-user"},
+			[]string{"Creating user", "my-user"},
 			[]string{"OK"},
 			[]string{"TIP"},
 		))

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -1465,8 +1465,8 @@
       "modified": false
    },
    {
-      "id": "Creating user {{.TargetUser}} as {{.CurrentUser}}...",
-      "translation": "Creating user {{.TargetUser}} as {{.CurrentUser}}...",
+      "id": "Creating user {{.TargetUser}}...",
+      "translation": "Creating user {{.TargetUser}}...",
       "modified": false
    },
    {

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -1465,8 +1465,8 @@
       "modified": false
    },
    {
-      "id": "Creating user {{.TargetUser}} as {{.CurrentUser}}...",
-      "translation": "Creating user {{.TargetUser}} as {{.CurrentUser}}...",
+      "id": "Creating user {{.TargetUser}}...",
+      "translation": "Creating user {{.TargetUser}}...",
       "modified": false
    },
    {

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -1465,8 +1465,8 @@
       "modified": false
    },
    {
-      "id": "Creating user {{.TargetUser}} as {{.CurrentUser}}...",
-      "translation": "Creando usuario {{.TargetUser}} como {{.CurrentUser}}...",
+      "id": "Creating user {{.TargetUser}}...",
+      "translation": "Creando usuario {{.TargetUser}}...",
       "modified": false
    },
    {

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -1465,8 +1465,8 @@
       "modified": false
    },
    {
-      "id": "Creating user {{.TargetUser}} as {{.CurrentUser}}...",
-      "translation": "Création de l'utilisateur {{.TargetUser}} en tant que {{.CurrentUser}}...",
+      "id": "Creating user {{.TargetUser}}...",
+      "translation": "Création de l'utilisateur {{.TargetUser}}...",
       "modified": false
    },
    {

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -1465,8 +1465,8 @@
       "modified": false
    },
    {
-      "id": "Creating user {{.TargetUser}} as {{.CurrentUser}}...",
-      "translation": "Creating user {{.TargetUser}} as {{.CurrentUser}}...",
+      "id": "Creating user {{.TargetUser}}...",
+      "translation": "Creating user {{.TargetUser}}...",
       "modified": false
    },
    {

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -1465,8 +1465,8 @@
       "modified": false
    },
    {
-      "id": "Creating user {{.TargetUser}} as {{.CurrentUser}}...",
-      "translation": "Creating user {{.TargetUser}} as {{.CurrentUser}}...",
+      "id": "Creating user {{.TargetUser}}...",
+      "translation": "Creating user {{.TargetUser}}...",
       "modified": false
    },
    {

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -1465,8 +1465,8 @@
       "modified": false
    },
    {
-      "id": "Creating user {{.TargetUser}} as {{.CurrentUser}}...",
-      "translation": "Criando usuário {{.TargetUser}} como {{.CurrentUser}}...",
+      "id": "Creating user {{.TargetUser}}...",
+      "translation": "Criando usuário {{.TargetUser}}...",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -1465,8 +1465,8 @@
       "modified": false
    },
    {
-      "id": "Creating user {{.TargetUser}} as {{.CurrentUser}}...",
-      "translation": "创建用户中:当前用户{{.CurrentUser}}正在创建新用户{{.TargetUser}}...",
+      "id": "Creating user {{.TargetUser}}...",
+      "translation": "Creating user {{.TargetUser}}...",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -1465,8 +1465,8 @@
       "modified": false
    },
    {
-      "id": "Creating user {{.TargetUser}} as {{.CurrentUser}}...",
-      "translation": "Creating user {{.TargetUser}} as {{.CurrentUser}}...",
+      "id": "Creating user {{.TargetUser}}...",
+      "translation": "Creating user {{.TargetUser}}...",
       "modified": false
    },
    {


### PR DESCRIPTION
Story in CLI [#74893356].

When we create users using the CLI while logged in as the admin user, the CLI feedback for this uses the wording: Creating user as admin.... This was confusing at first glance as we though it meant that the new user was going to be an administrator rather than this meaning that we were logged in as admin.

Before Fix :
$ cf create-user abc def
Creating user abc as admin...
OK

After Fix :
 create-user abc1 def1
Creating user abc1...
OK