### PR TITLE
Added api endpoint option in target command

### DIFF
--- a/cf/command_factory/factory.go
+++ b/cf/command_factory/factory.go
@@ -154,7 +154,7 @@ func NewFactory(ui terminal.UI, config core_config.ReadWriter, manifestRepo mani
 	factory.cmdsByName["space-users"] = user.NewSpaceUsers(ui, config, repoLocator.GetSpaceRepository(), repoLocator.GetUserRepository())
 	factory.cmdsByName["spaces"] = space.NewListSpaces(ui, config, repoLocator.GetSpaceRepository())
 	factory.cmdsByName["stacks"] = commands.NewListStacks(ui, config, repoLocator.GetStackRepository())
-	factory.cmdsByName["target"] = commands.NewTarget(ui, config, repoLocator.GetOrganizationRepository(), repoLocator.GetSpaceRepository())
+	factory.cmdsByName["target"] = commands.NewTarget(ui, config, repoLocator.GetEndpointRepository(), repoLocator.GetOrganizationRepository(), repoLocator.GetSpaceRepository())
 	factory.cmdsByName["unbind-service"] = service.NewUnbindService(ui, config, repoLocator.GetServiceBindingRepository())
 	factory.cmdsByName["unset-env"] = application.NewUnsetEnv(ui, config, repoLocator.GetApplicationRepository())
 	factory.cmdsByName["unset-org-role"] = user.NewUnsetOrgRole(ui, config, repoLocator.GetUserRepository())

--- a/cf/commands/target_test.go
+++ b/cf/commands/target_test.go
@@ -7,6 +7,7 @@ import (
 	fake_org "github.com/cloudfoundry/cli/cf/api/organizations/fakes"
 	. "github.com/cloudfoundry/cli/cf/commands"
 	"github.com/cloudfoundry/cli/cf/configuration/core_config"
+	cferrors "github.com/cloudfoundry/cli/cf/errors"
 	"github.com/cloudfoundry/cli/cf/models"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -24,8 +25,10 @@ var _ = Describe("target command", func() {
 		orgRepo             *fake_org.FakeOrganizationRepository
 		spaceRepo           *testapi.FakeSpaceRepository
 		requirementsFactory *testreq.FakeReqFactory
+		endpointRepo        *testapi.FakeEndpointRepo
 		config              core_config.ReadWriter
 		ui                  *testterm.FakeUI
+		Flags               []string
 	)
 
 	BeforeEach(func() {
@@ -33,12 +36,13 @@ var _ = Describe("target command", func() {
 		orgRepo = new(fake_org.FakeOrganizationRepository)
 		spaceRepo = new(testapi.FakeSpaceRepository)
 		requirementsFactory = new(testreq.FakeReqFactory)
+		endpointRepo = &testapi.FakeEndpointRepo{}
 		config = testconfig.NewRepositoryWithDefaults()
 		requirementsFactory.ApiEndpointSuccess = true
 	})
 
 	var callTarget = func(args []string) bool {
-		cmd := NewTarget(ui, config, orgRepo, spaceRepo)
+		cmd := NewTarget(ui, config, endpointRepo, orgRepo, spaceRepo)
 		return testcmd.RunCommand(cmd, args, requirementsFactory)
 	}
 
@@ -54,6 +58,11 @@ var _ = Describe("target command", func() {
 
 		It("fails requirements", func() {
 			Expect(callTarget([]string{})).To(BeFalse())
+		})
+
+		It("able to set api endpoint", func() {
+			callTarget([]string{"-a", "https://api.example.com"})
+			Expect(endpointRepo.UpdateEndpointReceived).To(Equal("https://api.example.com"))
 		})
 	})
 
@@ -76,6 +85,17 @@ var _ = Describe("target command", func() {
 			Expect(callTarget([]string{"-o", "some-crazy-org-im-not-in"})).To(BeFalse())
 
 			Expect(callTarget([]string{"-s", "i-love-space"})).To(BeFalse())
+		})
+
+		It("able to set api endpoint", func() {
+			callTarget([]string{"-a", "https://api.example.com"})
+			Expect(endpointRepo.UpdateEndpointReceived).To(Equal("https://api.example.com"))
+		})
+
+		It("fails requirements when targeting a space or org with api endpoint set", func() {
+			Expect(callTarget([]string{"-a", "https://api.example.com", "-o", "some-crazy-org-im-not-in"})).To(BeFalse())
+
+			Expect(callTarget([]string{"-a", "https://api.example.com", "-s", "i-love-space"})).To(BeFalse())
 		})
 	})
 
@@ -162,6 +182,125 @@ var _ = Describe("target command", func() {
 					[]string{"Unable to access space", "my-space"},
 				))
 			})
+
+			It("it updates the organization in the config for new api endpoint", func() {
+				callTarget([]string{"-a", "https://api.example.com", "-o", "my-organization"})
+
+				Expect(orgRepo.FindByNameArgsForCall(0)).To(Equal("my-organization"))
+				Expect(ui.ShowConfigurationCalled).To(BeTrue())
+
+				Expect(config.OrganizationFields().Guid).To(Equal("my-organization-guid"))
+
+				Expect(endpointRepo.UpdateEndpointReceived).To(Equal("https://api.example.com"))
+			})
+
+			It("updates the space in the config for new api endpoint", func() {
+				space := models.Space{}
+				space.Name = "my-space"
+				space.Guid = "my-space-guid"
+
+				spaceRepo.Spaces = []models.Space{space}
+				spaceRepo.FindByNameSpace = space
+
+				callTarget([]string{"-a", "https://api.example.com", "-s", "my-space"})
+
+				Expect(spaceRepo.FindByNameName).To(Equal("my-space"))
+				Expect(config.SpaceFields().Guid).To(Equal("my-space-guid"))
+
+				Expect(ui.ShowConfigurationCalled).To(BeTrue())
+
+				Expect(endpointRepo.UpdateEndpointReceived).To(Equal("https://api.example.com"))
+			})
+
+			It("updates both the organization and the space in the config for new api endpoint", func() {
+				space := models.Space{}
+				space.Name = "my-space"
+				space.Guid = "my-space-guid"
+				spaceRepo.Spaces = []models.Space{space}
+
+				callTarget([]string{"-a", "https://api.example.com", "-o", "my-organization", "-s", "my-space"})
+
+				Expect(orgRepo.FindByNameArgsForCall(0)).To(Equal("my-organization"))
+				Expect(config.OrganizationFields().Guid).To(Equal("my-organization-guid"))
+
+				Expect(spaceRepo.FindByNameName).To(Equal("my-space"))
+				Expect(config.SpaceFields().Guid).To(Equal("my-space-guid"))
+
+				Expect(ui.ShowConfigurationCalled).To(BeTrue())
+
+				Expect(endpointRepo.UpdateEndpointReceived).To(Equal("https://api.example.com"))
+			})
+
+			It("only updates the api endpoint in the config when the org can't be found", func() {
+				config.SetOrganizationFields(models.OrganizationFields{})
+
+				orgRepo.FindByNameReturns(models.Organization{}, errors.New("my-organization not found"))
+
+				callTarget([]string{"-a", "https://api.example.com", "-o", "my-organization"})
+
+				Expect(config.OrganizationFields().Guid).To(Equal(""))
+
+				Expect(endpointRepo.UpdateEndpointReceived).To(Equal("https://api.example.com"))
+
+				Expect(ui.ShowConfigurationCalled).To(BeFalse())
+				Expect(ui.Outputs).To(ContainSubstrings(
+					[]string{"FAILED"},
+					[]string{"Could not target org."},
+					[]string{"my-organization not found"},
+				))
+			})
+
+			Context("when the user is setting an API", func() {
+				BeforeEach(func() {
+					Flags = []string{"-a", "https://api.example.com"}
+				})
+
+				Context("when the --skip-ssl-validation flag is provided", func() {
+					BeforeEach(func() {
+						Flags = append(Flags, "--skip-ssl-validation")
+					})
+
+					It("stores the API endpoint and the skip-ssl flag", func() {
+						callTarget(Flags)
+
+						Expect(endpointRepo.UpdateEndpointReceived).To(Equal("https://api.example.com"))
+						Expect(config.IsSSLDisabled()).To(BeTrue())
+					})
+				})
+
+				Context("when the --skip-ssl-validation flag is not provided", func() {
+					Describe("setting api endpoint is successful", func() {
+						BeforeEach(func() {
+							config.SetSSLDisabled(true)
+						})
+
+						It("updates the API endpoint and enables SSL validation", func() {
+							callTarget(Flags)
+
+							Expect(endpointRepo.UpdateEndpointReceived).To(Equal("https://api.example.com"))
+							Expect(config.IsSSLDisabled()).To(BeFalse())
+						})
+					})
+
+				})
+
+				Context("when there is an invalid SSL cert", func() {
+					BeforeEach(func() {
+						endpointRepo.UpdateEndpointError = cferrors.NewInvalidSSLCert("https://bobs-burgers.com", "SELF SIGNED SADNESS")
+						ui.Inputs = []string{"bobs-burgers.com"}
+					})
+
+					It("fails and suggests the user skip SSL validation", func() {
+						callTarget(Flags)
+
+						Expect(ui.Outputs).To(ContainSubstrings(
+							[]string{"FAILED"},
+							[]string{"SSL Cert", "https://bobs-burgers.com"},
+							[]string{"TIP", "target", "--skip-ssl-validation"},
+						))
+					})
+				})
+			})
 		})
 
 		Context("there are errors", func() {
@@ -228,6 +367,21 @@ var _ = Describe("target command", func() {
 					[]string{"FAILED"},
 					[]string{"my-space", "not found"},
 				))
+			})
+
+			Context("when setting api endpoint failed", func() {
+				BeforeEach(func() {
+					config.SetSSLDisabled(true)
+					endpointRepo.UpdateEndpointError = errors.New("API endpoint not found")
+				})
+
+				It("clears api endpoint from config", func() {
+					callTarget([]string{"-a", "https://api.example.com"})
+
+					Expect(config.ApiEndpoint()).To(BeEmpty())
+					Expect(config.IsSSLDisabled()).To(BeFalse())
+				})
+
 			})
 		})
 	})

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -1025,8 +1025,8 @@
       "modified": true
    },
    {
-      "id": "CF_NAME target [-o ORG] [-s SPACE]",
-      "translation": "CF_NAME target [-o ORG] [-s SPACE]",
+      "id": "CF_NAME target [-a API] [-o ORG] [-s SPACE]",
+      "translation": "CF_NAME target [-a API] [-o ORG] [-s SPACE]",
       "modified": false
    },
    {
@@ -3745,8 +3745,8 @@
       "modified": false
    },
    {
-      "id": "Set or view the targeted org or space",
-      "translation": "Set or view the targeted org or space",
+      "id": "Set or view the targeted org, space or api endpoint",
+      "translation": "Set or view the targeted org, space or api endpoint",
       "modified": false
    },
    {
@@ -5117,6 +5117,11 @@
    {
       "id": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
       "translation": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
+      "modified": false
+   },
+   {
+      "id": "user not logged in, cannot use [-o] or [-s] flag to target",
+      "translation": "user not logged in, cannot use [-o] or [-s] flag to target",
       "modified": false
    }
 ]

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -1025,8 +1025,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME target [-o ORG] [-s SPACE]",
-      "translation": "CF_NAME target [-o ORG] [-s SPACE]",
+      "id": "CF_NAME target [-a API] [-o ORG] [-s SPACE]",
+      "translation": "CF_NAME target [-a API] [-o ORG] [-s SPACE]",
       "modified": false
    },
    {
@@ -3745,8 +3745,8 @@
       "modified": false
    },
    {
-      "id": "Set or view the targeted org or space",
-      "translation": "Set or view the targeted org or space",
+      "id": "Set or view the targeted org, space or api endpoint",
+      "translation": "Set or view the targeted org, space or api endpoint",
       "modified": false
    },
    {
@@ -5117,6 +5117,11 @@
    {
       "id": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
       "translation": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
+      "modified": false
+   },
+   {
+      "id": "user not logged in, cannot use [-o] or [-s] flag to target",
+      "translation": "user not logged in, cannot use [-o] or [-s] flag to target",
       "modified": false
    }
 ]

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -1025,8 +1025,8 @@
       "modified": true
    },
    {
-      "id": "CF_NAME target [-o ORG] [-s SPACE]",
-      "translation": "CF_NAME target [-o ORG] [-s SPACE]",
+      "id": "CF_NAME target [-a API] [-o ORG] [-s SPACE]",
+      "translation": "CF_NAME target [-a API] [-o ORG] [-s SPACE]",
       "modified": false
    },
    {
@@ -3745,8 +3745,8 @@
       "modified": false
    },
    {
-      "id": "Set or view the targeted org or space",
-      "translation": "Configura o muestra la org y space seleccionada",
+      "id": "Set or view the targeted org, space or api endpoint",
+      "translation": "Set or view the targeted org, space or api endpoint",
       "modified": false
    },
    {
@@ -5117,6 +5117,11 @@
    {
       "id": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
       "translation": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
+      "modified": false
+   },
+   {
+      "id": "user not logged in, cannot use [-o] or [-s] flag to target",
+      "translation": "user not logged in, cannot use [-o] or [-s] flag to target",
       "modified": false
    }
 ]

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -1025,8 +1025,8 @@
       "modified": true
    },
    {
-      "id": "CF_NAME target [-o ORG] [-s SPACE]",
-      "translation": "CF_NAME target [-o ORG] [-s ESPACE]",
+      "id": "CF_NAME target [-a API] [-o ORG] [-s SPACE]",
+      "translation": "CF_NAME target [-a API] [-o ORG] [-s ESPACE]",
       "modified": false
    },
    {
@@ -3745,8 +3745,8 @@
       "modified": false
    },
    {
-      "id": "Set or view the targeted org or space",
-      "translation": "Définir ou afficher l'org ou de l'espace ciblé",
+      "id": "Set or view the targeted org, space or api endpoint",
+      "translation": "Set or view the targeted org, space or api endpoint",
       "modified": false
    },
    {
@@ -5117,6 +5117,11 @@
    {
       "id": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
       "translation": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
+      "modified": false
+   },
+   {
+      "id": "user not logged in, cannot use [-o] or [-s] flag to target",
+      "translation": "user not logged in, cannot use [-o] or [-s] flag to target",
       "modified": false
    }
 ]

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -1025,8 +1025,8 @@
       "modified": true
    },
    {
-      "id": "CF_NAME target [-o ORG] [-s SPACE]",
-      "translation": "CF_NAME target [-o ORG] [-s SPACE]",
+      "id": "CF_NAME target [-a API] [-o ORG] [-s SPACE]",
+      "translation": "CF_NAME target [-a API] [-o ORG] [-s SPACE]",
       "modified": false
    },
    {
@@ -3745,8 +3745,8 @@
       "modified": false
    },
    {
-      "id": "Set or view the targeted org or space",
-      "translation": "Set or view the targeted org or space",
+      "id": "Set or view the targeted org, space or api endpoint",
+      "translation": "Set or view the targeted org, space or api endpoint",
       "modified": false
    },
    {
@@ -5117,6 +5117,11 @@
    {
       "id": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
       "translation": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
+      "modified": false
+   },
+   {
+      "id": "user not logged in, cannot use [-o] or [-s] flag to target",
+      "translation": "user not logged in, cannot use [-o] or [-s] flag to target",
       "modified": false
    }
 ]

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -1025,8 +1025,8 @@
       "modified": true
    },
    {
-      "id": "CF_NAME target [-o ORG] [-s SPACE]",
-      "translation": "CF_NAME target [-o ORG] [-s SPACE]",
+      "id": "CF_NAME target [-a API] [-o ORG] [-s SPACE]",
+      "translation": "CF_NAME target [-a API] [-o ORG] [-s SPACE]",
       "modified": false
    },
    {
@@ -3745,8 +3745,8 @@
       "modified": false
    },
    {
-      "id": "Set or view the targeted org or space",
-      "translation": "Set or view the targeted org or space",
+      "id": "Set or view the targeted org, space or api endpoint",
+      "translation": "Set or view the targeted org, space or api endpoint",
       "modified": false
    },
    {
@@ -5117,6 +5117,11 @@
    {
       "id": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
       "translation": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
+      "modified": false
+   },
+   {
+      "id": "user not logged in, cannot use [-o] or [-s] flag to target",
+      "translation": "user not logged in, cannot use [-o] or [-s] flag to target",
       "modified": false
    }
 ]

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -1025,8 +1025,8 @@
       "modified": true
    },
    {
-      "id": "CF_NAME target [-o ORG] [-s SPACE]",
-      "translation": "CF_NAME target [-o ORG] [-s ESPAÇO]",
+      "id": "CF_NAME target [-a API] [-o ORG] [-s SPACE]",
+      "translation": "CF_NAME target [-a API] [-o ORG] [-s ESPAÇO]",
       "modified": false
    },
    {
@@ -3745,8 +3745,8 @@
       "modified": false
    },
    {
-      "id": "Set or view the targeted org or space",
-      "translation": "Definir ou exibir organização e/ou espaço alvo",
+      "id": "Set or view the targeted org, space or api endpoint",
+      "translation": "Set or view the targeted org, space or api endpoint",
       "modified": false
    },
    {
@@ -5117,6 +5117,11 @@
    {
       "id": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
       "translation": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
+      "modified": false
+   },
+   {
+      "id": "user not logged in, cannot use [-o] or [-s] flag to target",
+      "translation": "user not logged in, cannot use [-o] or [-s] flag to target",
       "modified": false
    }
 ]

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -1025,8 +1025,8 @@
       "modified": true
    },
    {
-      "id": "CF_NAME target [-o ORG] [-s SPACE]",
-      "translation": "CF_NAME target [-o 组织] [-s 空间]",
+      "id": "CF_NAME target [-a API] [-o ORG] [-s SPACE]",
+      "translation": "CF_NAME target [-a API] [-o 组织] [-s 空间]",
       "modified": false
    },
    {
@@ -3745,8 +3745,8 @@
       "modified": false
    },
    {
-      "id": "Set or view the targeted org or space",
-      "translation": "设置或查看指定的组织或空间",
+      "id": "Set or view the targeted org, space or api endpoint",
+      "translation": "Set or view the targeted org, space or api endpoint",
       "modified": false
    },
    {
@@ -5117,6 +5117,11 @@
    {
       "id": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
       "translation": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
+      "modified": false
+   },
+   {
+      "id": "user not logged in, cannot use [-o] or [-s] flag to target",
+      "translation": "user not logged in, cannot use [-o] or [-s] flag to target",
       "modified": false
    }
 ]

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -1025,8 +1025,8 @@
       "modified": true
    },
    {
-      "id": "CF_NAME target [-o ORG] [-s SPACE]",
-      "translation": "CF_NAME target [-o ORG] [-s SPACE]",
+      "id": "CF_NAME target [-a API] [-o ORG] [-s SPACE]",
+      "translation": "CF_NAME target [-a API] [-o ORG] [-s SPACE]",
       "modified": false
    },
    {
@@ -3745,8 +3745,8 @@
       "modified": false
    },
    {
-      "id": "Set or view the targeted org or space",
-      "translation": "Set or view the targeted org or space",
+      "id": "Set or view the targeted org, space or api endpoint",
+      "translation": "Set or view the targeted org, space or api endpoint",
       "modified": false
    },
    {
@@ -5117,6 +5117,11 @@
    {
       "id": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
       "translation": "Updating a plan requires API v{{.RequiredCCAPIVersion}} or newer. Your current target is v{{.CurrentCCAPIVersion}}.",
+      "modified": false
+   },
+   {
+      "id": "user not logged in, cannot use [-o] or [-s] flag to target",
+      "translation": "user not logged in, cannot use [-o] or [-s] flag to target",
       "modified": false
    }
 ]


### PR DESCRIPTION
Now user could easily switch between CF instances by targeting that instance,
and could also declare org and space, as the target command already supports these arguments.
User can also use target command to set api endpoint eventhough user is not logged in but it will fail
if user try to use space or org's flag along with api's flag without login.

Story ID : #87983128