### PR TITLE
Updated candiedyaml dependency to remove stack trace from error message

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -21,7 +21,7 @@
 		},
 		{
 			"ImportPath": "github.com/cloudfoundry-incubator/candiedyaml",
-			"Rev": "39fb5c673e898bc3343f306217f91f485c40a831"
+			"Rev": "6dddd32b16bbc48f1238b3c34642131e1d08c5bc"
 		},
 		{
 			"ImportPath": "github.com/cloudfoundry-incubator/cli-plugin-repo/models",

--- a/Godeps/_workspace/src/github.com/cloudfoundry-incubator/candiedyaml/.travis.yml
+++ b/Godeps/_workspace/src/github.com/cloudfoundry-incubator/candiedyaml/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.3
+  - 1.4.1
 
 install:
   - go get -t -v ./...

--- a/Godeps/_workspace/src/github.com/cloudfoundry-incubator/candiedyaml/README.md
+++ b/Godeps/_workspace/src/github.com/cloudfoundry-incubator/candiedyaml/README.md
@@ -5,6 +5,8 @@ candiedyaml
 
 YAML for Go
 
+A YAML 1.1 parser with support for YAML 1.2 features
+
 Usage
 -----
 

--- a/Godeps/_workspace/src/github.com/cloudfoundry-incubator/candiedyaml/decode.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry-incubator/candiedyaml/decode.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"reflect"
 	"runtime"
-	"runtime/debug"
 	"strconv"
 	"strings"
 )
@@ -47,11 +46,13 @@ func (n Number) Int64() (int64, error) {
 }
 
 type Decoder struct {
-	parser    yaml_parser_t
-	event     yaml_event_t
-	useNumber bool
+	parser        yaml_parser_t
+	event         yaml_event_t
+	replay_events []yaml_event_t
+	useNumber     bool
 
-	anchors map[string]interface{}
+	anchors          map[string][]yaml_event_t
+	tracking_anchors [][]yaml_event_t
 }
 
 type ParserError struct {
@@ -92,8 +93,7 @@ func recovery(err *error) {
 			tmpError = errors.New("Unknown panic: " + reflect.TypeOf(r).String())
 		}
 
-		stackTrace := debug.Stack()
-		*err = fmt.Errorf("%s\n%s", tmpError.Error(), string(stackTrace))
+		*err = fmt.Errorf("%s\n%s", tmpError.Error())
 	}
 }
 
@@ -104,7 +104,8 @@ func Unmarshal(data []byte, v interface{}) error {
 
 func NewDecoder(r io.Reader) *Decoder {
 	d := &Decoder{
-		anchors: make(map[string]interface{}),
+		anchors:          make(map[string][]yaml_event_t),
+		tracking_anchors: make([][]yaml_event_t, 1),
 	}
 	yaml_parser_initialize(&d.parser)
 	yaml_parser_set_input_reader(&d.parser, r)
@@ -149,16 +150,31 @@ func (d *Decoder) nextEvent() {
 		d.error(errors.New("The stream is closed"))
 	}
 
-	if !yaml_parser_parse(&d.parser, &d.event) {
-		yaml_event_delete(&d.event)
+	if d.replay_events != nil {
+		d.event = d.replay_events[0]
+		if len(d.replay_events) == 1 {
+			d.replay_events = nil
+		} else {
+			d.replay_events = d.replay_events[1:]
+		}
+	} else {
+		if !yaml_parser_parse(&d.parser, &d.event) {
+			yaml_event_delete(&d.event)
 
-		d.error(&ParserError{
-			ErrorType:   d.parser.error,
-			Context:     d.parser.context,
-			ContextMark: d.parser.context_mark,
-			Problem:     d.parser.problem,
-			ProblemMark: d.parser.problem_mark,
-		})
+			d.error(&ParserError{
+				ErrorType:   d.parser.error,
+				Context:     d.parser.context,
+				ContextMark: d.parser.context_mark,
+				Problem:     d.parser.problem,
+				ProblemMark: d.parser.problem_mark,
+			})
+		}
+	}
+
+	last := len(d.tracking_anchors)
+	// skip aliases when tracking an anchor
+	if last > 0 && d.event.event_type != yaml_ALIAS_EVENT {
+		d.tracking_anchors[last-1] = append(d.tracking_anchors[last-1], d.event)
 	}
 }
 
@@ -187,14 +203,17 @@ func (d *Decoder) parse(rv reflect.Value) {
 	anchor := string(d.event.anchor)
 	switch d.event.event_type {
 	case yaml_SEQUENCE_START_EVENT:
+		d.begin_anchor(anchor)
 		d.sequence(rv)
-		d.anchor(anchor, rv)
+		d.end_anchor(anchor)
 	case yaml_MAPPING_START_EVENT:
+		d.begin_anchor(anchor)
 		d.mapping(rv)
-		d.anchor(anchor, rv)
+		d.end_anchor(anchor)
 	case yaml_SCALAR_EVENT:
+		d.begin_anchor(anchor)
 		d.scalar(rv)
-		d.anchor(anchor, rv)
+		d.end_anchor(anchor)
 	case yaml_ALIAS_EVENT:
 		d.alias(rv)
 	case yaml_DOCUMENT_END_EVENT:
@@ -207,13 +226,30 @@ func (d *Decoder) parse(rv reflect.Value) {
 	}
 }
 
-func (d *Decoder) anchor(anchor string, rv reflect.Value) {
+func (d *Decoder) begin_anchor(anchor string) {
 	if anchor != "" {
-		d.anchors[anchor] = rv.Interface()
+		events := []yaml_event_t{d.event}
+		d.tracking_anchors = append(d.tracking_anchors, events)
 	}
 }
 
-func (d *Decoder) indirect(v reflect.Value) (Unmarshaler, reflect.Value) {
+func (d *Decoder) end_anchor(anchor string) {
+	if anchor != "" {
+		events := d.tracking_anchors[len(d.tracking_anchors)-1]
+		d.tracking_anchors = d.tracking_anchors[0 : len(d.tracking_anchors)-1]
+		// remove the anchor, replaying events shouldn't have anchors
+		events[0].anchor = nil
+		// we went one too many, remove the extra event
+		events = events[:len(events)-1]
+		// if nested, append to all the other anchors
+		for i, e := range d.tracking_anchors {
+			d.tracking_anchors[i] = append(e, events...)
+		}
+		d.anchors[anchor] = events
+	}
+}
+
+func (d *Decoder) indirect(v reflect.Value, decodingNull bool) (Unmarshaler, reflect.Value) {
 	// If v is a named type and is addressable,
 	// start with its address, so that if the type has pointer methods,
 	// we find them.
@@ -225,13 +261,17 @@ func (d *Decoder) indirect(v reflect.Value) (Unmarshaler, reflect.Value) {
 		// usefully addressable.
 		if v.Kind() == reflect.Interface && !v.IsNil() {
 			e := v.Elem()
-			if e.Kind() == reflect.Ptr && !e.IsNil() {
+			if e.Kind() == reflect.Ptr && !e.IsNil() && (!decodingNull || e.Elem().Kind() == reflect.Ptr) {
 				v = e
 				continue
 			}
 		}
 
 		if v.Kind() != reflect.Ptr {
+			break
+		}
+
+		if v.Elem().Kind() != reflect.Ptr && decodingNull && v.CanSet() {
 			break
 		}
 
@@ -257,14 +297,14 @@ func (d *Decoder) sequence(v reflect.Value) {
 		d.error(fmt.Errorf("Expected sequence start - found %d", d.event.event_type))
 	}
 
-	u, pv := d.indirect(v)
+	u, pv := d.indirect(v, false)
 	if u != nil {
 		defer func() {
-			if err := u.UnmarshalYAML("!!seq", pv.Interface()); err != nil {
+			if err := u.UnmarshalYAML(yaml_SEQ_TAG, pv.Interface()); err != nil {
 				d.error(err)
 			}
 		}()
-		_, pv = d.indirect(pv)
+		_, pv = d.indirect(pv, false)
 	}
 
 	v = pv
@@ -289,9 +329,11 @@ func (d *Decoder) sequence(v reflect.Value) {
 	d.nextEvent()
 
 	i := 0
+done:
 	for {
-		if d.event.event_type == yaml_SEQUENCE_END_EVENT {
-			break
+		switch d.event.event_type {
+		case yaml_SEQUENCE_END_EVENT, yaml_DOCUMENT_END_EVENT:
+			break done
 		}
 
 		// Get element of array, growing if necessary.
@@ -336,18 +378,20 @@ func (d *Decoder) sequence(v reflect.Value) {
 		v.Set(reflect.MakeSlice(v.Type(), 0, 0))
 	}
 
-	d.nextEvent()
+	if d.event.event_type != yaml_DOCUMENT_END_EVENT {
+		d.nextEvent()
+	}
 }
 
 func (d *Decoder) mapping(v reflect.Value) {
-	u, pv := d.indirect(v)
+	u, pv := d.indirect(v, false)
 	if u != nil {
 		defer func() {
-			if err := u.UnmarshalYAML("!!map", pv.Interface()); err != nil {
+			if err := u.UnmarshalYAML(yaml_MAP_TAG, pv.Interface()); err != nil {
 				d.error(err)
 			}
 		}()
-		_, pv = d.indirect(pv)
+		_, pv = d.indirect(pv, false)
 	}
 	v = pv
 
@@ -378,10 +422,15 @@ func (d *Decoder) mapping(v reflect.Value) {
 	mapElemt := mapt.Elem()
 
 	var mapElem reflect.Value
+done:
 	for {
-		if d.event.event_type == yaml_MAPPING_END_EVENT {
-			break
+		switch d.event.event_type {
+		case yaml_MAPPING_END_EVENT:
+			break done
+		case yaml_DOCUMENT_END_EVENT:
+			return
 		}
+
 		key := reflect.New(keyt)
 		d.parse(key.Elem())
 
@@ -406,10 +455,15 @@ func (d *Decoder) mappingStruct(v reflect.Value) {
 
 	d.nextEvent()
 
+done:
 	for {
-		if d.event.event_type == yaml_MAPPING_END_EVENT {
-			break
+		switch d.event.event_type {
+		case yaml_MAPPING_END_EVENT:
+			break done
+		case yaml_DOCUMENT_END_EVENT:
+			return
 		}
+
 		key := ""
 		d.parse(reflect.ValueOf(&key))
 
@@ -448,7 +502,10 @@ func (d *Decoder) mappingStruct(v reflect.Value) {
 }
 
 func (d *Decoder) scalar(v reflect.Value) {
-	u, pv := d.indirect(v)
+	val := string(d.event.value)
+	wantptr := null_values[val]
+
+	u, pv := d.indirect(v, wantptr)
 
 	var tag string
 	if u != nil {
@@ -458,7 +515,7 @@ func (d *Decoder) scalar(v reflect.Value) {
 			}
 		}()
 
-		_, pv = d.indirect(pv)
+		_, pv = d.indirect(pv, wantptr)
 	}
 	v = pv
 
@@ -472,11 +529,14 @@ func (d *Decoder) scalar(v reflect.Value) {
 }
 
 func (d *Decoder) alias(rv reflect.Value) {
-	if val, ok := d.anchors[string(d.event.anchor)]; ok {
-		rv.Set(reflect.ValueOf(val))
+	val, ok := d.anchors[string(d.event.anchor)]
+	if !ok {
+		d.error(fmt.Errorf("missing anchor: %s", d.event.anchor))
 	}
 
+	d.replay_events = val
 	d.nextEvent()
+	d.parse(rv)
 }
 
 func (d *Decoder) valueInterface() interface{} {
@@ -485,13 +545,18 @@ func (d *Decoder) valueInterface() interface{} {
 	anchor := string(d.event.anchor)
 	switch d.event.event_type {
 	case yaml_SEQUENCE_START_EVENT:
+		d.begin_anchor(anchor)
 		v = d.sequenceInterface()
 	case yaml_MAPPING_START_EVENT:
+		d.begin_anchor(anchor)
 		v = d.mappingInterface()
 	case yaml_SCALAR_EVENT:
+		d.begin_anchor(anchor)
 		v = d.scalarInterface()
 	case yaml_ALIAS_EVENT:
-		return d.aliasInterface()
+		rv := reflect.ValueOf(&v)
+		d.alias(rv)
+		return v
 	case yaml_DOCUMENT_END_EVENT:
 		d.error(&UnexpectedEventError{
 			Value:     string(d.event.value),
@@ -500,8 +565,8 @@ func (d *Decoder) valueInterface() interface{} {
 		})
 
 	}
+	d.end_anchor(anchor)
 
-	d.anchorInterface(anchor, v)
 	return v
 }
 
@@ -512,33 +577,26 @@ func (d *Decoder) scalarInterface() interface{} {
 	return v
 }
 
-func (d *Decoder) anchorInterface(anchor string, i interface{}) {
-	if anchor != "" {
-		d.anchors[anchor] = i
-	}
-}
-
-func (d *Decoder) aliasInterface() interface{} {
-	v := d.anchors[string(d.event.anchor)]
-
-	d.nextEvent()
-	return v
-}
-
 // arrayInterface is like array but returns []interface{}.
 func (d *Decoder) sequenceInterface() []interface{} {
 	var v = make([]interface{}, 0)
 
 	d.nextEvent()
+
+done:
 	for {
-		if d.event.event_type == yaml_SEQUENCE_END_EVENT {
-			break
+		switch d.event.event_type {
+		case yaml_SEQUENCE_END_EVENT, yaml_DOCUMENT_END_EVENT:
+			break done
 		}
 
 		v = append(v, d.valueInterface())
 	}
 
-	d.nextEvent()
+	if d.event.event_type != yaml_DOCUMENT_END_EVENT {
+		d.nextEvent()
+	}
+
 	return v
 }
 
@@ -548,9 +606,11 @@ func (d *Decoder) mappingInterface() map[interface{}]interface{} {
 
 	d.nextEvent()
 
+done:
 	for {
-		if d.event.event_type == yaml_MAPPING_END_EVENT {
-			break
+		switch d.event.event_type {
+		case yaml_MAPPING_END_EVENT, yaml_DOCUMENT_END_EVENT:
+			break done
 		}
 
 		key := d.valueInterface()
@@ -559,6 +619,9 @@ func (d *Decoder) mappingInterface() map[interface{}]interface{} {
 		m[key] = d.valueInterface()
 	}
 
-	d.nextEvent()
+	if d.event.event_type != yaml_DOCUMENT_END_EVENT {
+		d.nextEvent()
+	}
+
 	return m
 }

--- a/Godeps/_workspace/src/github.com/cloudfoundry-incubator/candiedyaml/decode_test.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry-incubator/candiedyaml/decode_test.go
@@ -138,6 +138,22 @@ var _ = Describe("Decode", func() {
 				}))
 			})
 
+			It("handles null values", func() {
+				type S struct {
+					Default interface{}
+				}
+
+				d := NewDecoder(strings.NewReader(`
+---
+default:
+`))
+				var s S
+				err := d.Decode(&s)
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(s).Should(Equal(S{Default: nil}))
+
+			})
+
 			It("ignores missing tags", func() {
 				f, _ := os.Open("fixtures/specification/example2_4.yaml")
 				d := NewDecoder(f)
@@ -292,7 +308,6 @@ var _ = Describe("Decode", func() {
 			Ω(v).Should(Equal(map[string]interface{}{
 				"canonical":   int64(12345),
 				"decimal":     int64(12345),
-				"sexagesimal": int64(12345),
 				"octal":       int64(12),
 				"hexadecimal": int64(12),
 			}))
@@ -308,7 +323,6 @@ var _ = Describe("Decode", func() {
 			Ω(v).Should(Equal(map[string]int64{
 				"canonical":   int64(12345),
 				"decimal":     int64(12345),
-				"sexagesimal": int64(12345),
 				"octal":       int64(12),
 				"hexadecimal": int64(12),
 			}))
@@ -375,7 +389,6 @@ var _ = Describe("Decode", func() {
 		Ω(v).Should(Equal(map[string]float64{
 			"canonical":         float64(1230.15),
 			"exponential":       float64(1230.15),
-			"sexagesimal":       float64(1230.15),
 			"fixed":             float64(1230.15),
 			"negative infinity": math.Inf(-1),
 		}))
@@ -396,6 +409,15 @@ var _ = Describe("Decode", func() {
 		}))
 	})
 
+	It("Decodes a null ptr", func() {
+		d := NewDecoder(strings.NewReader(`null
+`))
+		var v *bool
+		err := d.Decode(&v)
+		Ω(err).ShouldNot(HaveOccurred())
+		Ω(v).Should(BeNil())
+	})
+
 	It("Decodes dates/time", func() {
 		f, _ := os.Open("fixtures/specification/example2_22.yaml")
 		d := NewDecoder(f)
@@ -411,16 +433,41 @@ var _ = Describe("Decode", func() {
 		}))
 	})
 
-	It("Respects tags", func() {
-		f, _ := os.Open("fixtures/specification/example2_23_non_date.yaml")
-		d := NewDecoder(f)
-		v := make(map[string]string)
+	Context("Tags", func() {
+		It("Respects tags", func() {
+			f, _ := os.Open("fixtures/specification/example2_23_non_date.yaml")
+			d := NewDecoder(f)
+			v := make(map[string]string)
 
-		err := d.Decode(&v)
-		Ω(err).ShouldNot(HaveOccurred())
-		Ω(v).Should(Equal(map[string]string{
-			"not-date": "2002-04-28",
-		}))
+			err := d.Decode(&v)
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(v).Should(Equal(map[string]string{
+				"not-date": "2002-04-28",
+			}))
+		})
+
+		It("handles non-specific tags", func() {
+			d := NewDecoder(strings.NewReader(`
+---
+not_parsed: ! 123
+`))
+			v := make(map[string]int)
+			err := d.Decode(&v)
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(v).Should(Equal(map[string]int{"not_parsed": 123}))
+		})
+
+		It("handles non-specific tags", func() {
+			d := NewDecoder(strings.NewReader(`
+---
+? a complex key
+: ! "123"
+`))
+			v := make(map[string]string)
+			err := d.Decode(&v)
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(v).Should(Equal(map[string]string{"a complex key": "123"}))
+		})
 	})
 
 	Context("Decodes binary/base64", func() {
@@ -460,6 +507,14 @@ var _ = Describe("Decode", func() {
 			Ω(v).Should(Equal("abcdefg"))
 		})
 
+		It("to interface", func() {
+			d := NewDecoder(strings.NewReader("!binary YWJjZGVmZw=="))
+			var v interface{}
+
+			err := d.Decode(&v)
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(v).Should(Equal([]byte("abcdefg")))
+		})
 	})
 
 	Context("Aliases", func() {
@@ -511,6 +566,36 @@ rbi: *ss
 			})
 		})
 
+		It("aliases to different types", func() {
+			type S struct {
+				A map[string]int
+				C map[string]string
+			}
+			d := NewDecoder(strings.NewReader(`
+---
+a: &map
+  b : 1
+c: *map
+`))
+			var s S
+			err := d.Decode(&s)
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(s).Should(Equal(S{
+				A: map[string]int{"b": 1},
+				C: map[string]string{"b": "1"},
+			}))
+		})
+
+		It("fails if an anchor is undefined", func() {
+			d := NewDecoder(strings.NewReader(`
+---
+a: *missing
+`))
+			m := make(map[string]string)
+			err := d.Decode(&m)
+			Ω(err).Should(HaveOccurred())
+		})
+
 		Context("to Interface", func() {
 			It("aliases scalars", func() {
 				f, _ := os.Open("fixtures/specification/example2_10.yaml")
@@ -558,14 +643,108 @@ rbi: *ss
 				}))
 			})
 
-			It("supports binary", func() {
-				d := NewDecoder(strings.NewReader("!binary YWJjZGVmZw=="))
-				var v interface{}
-
+			It("supports duplicate aliases", func() {
+				d := NewDecoder(strings.NewReader(`
+---
+a: &a
+  b: 1
+x: *a
+y: *a
+`))
+				v := make(map[string]interface{})
 				err := d.Decode(&v)
 				Ω(err).ShouldNot(HaveOccurred())
-				Ω(v).Should(Equal([]byte("abcdefg")))
+				Ω(v).Should(Equal(map[string]interface{}{
+					"a": map[interface{}]interface{}{"b": int64(1)},
+					"x": map[interface{}]interface{}{"b": int64(1)},
+					"y": map[interface{}]interface{}{"b": int64(1)},
+				}))
 			})
+
+			It("supports overriden anchors", func() {
+				d := NewDecoder(strings.NewReader(`
+---
+First occurrence: &anchor Foo
+Second occurrence: *anchor
+Override anchor: &anchor Bar
+Reuse anchor: *anchor
+`))
+				v := make(map[string]interface{})
+				err := d.Decode(&v)
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(v).Should(Equal(map[string]interface{}{
+					"First occurrence":  "Foo",
+					"Second occurrence": "Foo",
+					"Override anchor":   "Bar",
+					"Reuse anchor":      "Bar",
+				}))
+			})
+
+			It("fails if an anchor is undefined", func() {
+				d := NewDecoder(strings.NewReader(`
+---
+a: *missing
+`))
+				var i interface{}
+				err := d.Decode(&i)
+				Ω(err).Should(HaveOccurred())
+			})
+
+		})
+
+		It("supports composing aliases", func() {
+			d := NewDecoder(strings.NewReader(`
+---
+a: &a b
+x: &b
+  d: *a
+z: *b
+`))
+			v := make(map[string]interface{})
+			err := d.Decode(&v)
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(v).Should(Equal(map[string]interface{}{
+				"a": "b",
+				"x": map[interface{}]interface{}{"d": "b"},
+				"z": map[interface{}]interface{}{"d": "b"},
+			}))
+		})
+
+		It("redefinition while composing aliases", func() {
+			d := NewDecoder(strings.NewReader(`
+---
+a: &a b
+x: &c
+  d : &a 1
+y: *a
+`))
+			v := make(map[string]interface{})
+			err := d.Decode(&v)
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(v).Should(Equal(map[string]interface{}{
+				"a": "b",
+				"x": map[interface{}]interface{}{"d": int64(1)},
+				"y": int64(1),
+			}))
+		})
+
+		It("can parse nested anchors", func() {
+			d := NewDecoder(strings.NewReader(`
+---
+a:
+  aa: &x
+    aaa: 1
+  ab:
+    aba: &y
+      abaa:
+        abaaa: *x
+b:
+- ba:
+    baa: *y
+`))
+			v := make(map[string]interface{})
+			err := d.Decode(&v)
+			Ω(err).ShouldNot(HaveOccurred())
 		})
 	})
 
@@ -607,7 +786,7 @@ rbi: *ss
 
 				err := d.Decode(&v)
 				Ω(err).ShouldNot(HaveOccurred())
-				Ω(v.Tag).Should(Equal("!!str"))
+				Ω(v.Tag).Should(Equal(yaml_STR_TAG))
 				Ω(v.Value).Should(Equal("abc"))
 			})
 
@@ -617,7 +796,7 @@ rbi: *ss
 
 				err := d.Decode(&v)
 				Ω(err).ShouldNot(HaveOccurred())
-				Ω(v.Tag).Should(Equal("!!seq"))
+				Ω(v.Tag).Should(Equal(yaml_SEQ_TAG))
 				Ω(v.Value).Should(Equal([]interface{}{"abc", "def"}))
 			})
 
@@ -627,7 +806,7 @@ rbi: *ss
 
 				err := d.Decode(&v)
 				Ω(err).ShouldNot(HaveOccurred())
-				Ω(v.Tag).Should(Equal("!!map"))
+				Ω(v.Tag).Should(Equal(yaml_MAP_TAG))
 				Ω(v.Value).Should(Equal(map[interface{}]interface{}{"a": "bc"}))
 			})
 		})
@@ -674,6 +853,23 @@ rbi: *ss
 
 			n := v.(Number)
 			Ω(n.String()).Should(Equal("123"))
+		})
+	})
+	Context("When there are special characters", func() {
+		It("returns an error", func() {
+			d := NewDecoder(strings.NewReader(`
+---
+applications:
+ - name: m
+   services:
+       - !@#
+`))
+			var v interface{}
+
+			err := d.Decode(&v)
+			Ω(err).Should(HaveOccurred())
+			Ω(err.Error()).ShouldNot(ContainSubstring("decode.go"))
+
 		})
 	})
 })

--- a/Godeps/_workspace/src/github.com/cloudfoundry-incubator/candiedyaml/encode.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry-incubator/candiedyaml/encode.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"math"
 	"reflect"
+	"regexp"
 	"sort"
 	"strconv"
 	"time"
@@ -29,6 +30,20 @@ var (
 	timeTimeType  = reflect.TypeOf(time.Time{})
 	marshalerType = reflect.TypeOf(new(Marshaler)).Elem()
 	numberType    = reflect.TypeOf(Number(""))
+	nonPrintable  = regexp.MustCompile("[^\t\n\r\u0020-\u007E\u0085\u00A0-\uD7FF\uE000-\uFFFD]")
+	multiline     = regexp.MustCompile("\n|\u0085|\u2028|\u2029")
+
+	shortTags = map[string]string{
+		yaml_NULL_TAG:      "!!null",
+		yaml_BOOL_TAG:      "!!bool",
+		yaml_STR_TAG:       "!!str",
+		yaml_INT_TAG:       "!!int",
+		yaml_FLOAT_TAG:     "!!float",
+		yaml_TIMESTAMP_TAG: "!!timestamp",
+		yaml_SEQ_TAG:       "!!seq",
+		yaml_MAP_TAG:       "!!map",
+		yaml_BINARY_TAG:    "!!binary",
+	}
 )
 
 type Marshaler interface {
@@ -245,14 +260,17 @@ func (e *Encoder) emitBase64(tag string, v reflect.Value) {
 	dst := make([]byte, base64.StdEncoding.EncodedLen(len(s)))
 
 	base64.StdEncoding.Encode(dst, s)
-	e.emitScalar(string(dst), "", "!!binary", yaml_DOUBLE_QUOTED_SCALAR_STYLE)
+	e.emitScalar(string(dst), "", yaml_BINARY_TAG, yaml_DOUBLE_QUOTED_SCALAR_STYLE)
 }
 
 func (e *Encoder) emitString(tag string, v reflect.Value) {
 	var style yaml_scalar_style_t
 	s := v.String()
 
-	style = yaml_DOUBLE_QUOTED_SCALAR_STYLE
+	if nonPrintable.MatchString(s) {
+		e.emitBase64(tag, v)
+		return
+	}
 
 	if v.Type() == numberType {
 		style = yaml_PLAIN_SCALAR_STYLE
@@ -261,7 +279,13 @@ func (e *Encoder) emitString(tag string, v reflect.Value) {
 			implicit: true,
 			value:    []byte(s),
 		}
-		if tag, _ := resolveInterface(event, false); tag == "!!str" {
+
+		rtag, _ := resolveInterface(event, false)
+		if tag == "" && rtag != yaml_STR_TAG {
+			style = yaml_DOUBLE_QUOTED_SCALAR_STYLE
+		} else if multiline.MatchString(s) {
+			style = yaml_LITERAL_SCALAR_STYLE
+		} else {
 			style = yaml_PLAIN_SCALAR_STYLE
 		}
 	}
@@ -311,7 +335,13 @@ func (e *Encoder) emitScalar(value, anchor, tag string, style yaml_scalar_style_
 	if !implicit {
 		style = yaml_PLAIN_SCALAR_STYLE
 	}
-	yaml_scalar_event_initialize(&e.event, []byte(anchor), []byte(tag), []byte(value), implicit, implicit, style)
+
+	stag := shortTags[tag]
+	if stag == "" {
+		stag = tag
+	}
+
+	yaml_scalar_event_initialize(&e.event, []byte(anchor), []byte(stag), []byte(value), implicit, implicit, style)
 	e.emit()
 }
 

--- a/Godeps/_workspace/src/github.com/cloudfoundry-incubator/candiedyaml/encode_test.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry-incubator/candiedyaml/encode_test.go
@@ -16,10 +16,11 @@ package candiedyaml
 
 import (
 	"bytes"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"math"
 	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Encode", func() {
@@ -36,6 +37,22 @@ var _ = Describe("Encode", func() {
 			err := enc.Encode("abc")
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(buf.String()).Should(Equal(`abc
+`))
+		})
+
+		It("encodes strings with multilines", func() {
+			err := enc.Encode("a\nc")
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(buf.String()).Should(Equal(`|-
+  a
+  c
+`))
+		})
+
+		It("handles strings that match known scalars", func() {
+			err := enc.Encode("true")
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(buf.String()).Should(Equal(`"true"
 `))
 		})
 

--- a/Godeps/_workspace/src/github.com/cloudfoundry-incubator/candiedyaml/fixtures/specification/example2_19.yaml
+++ b/Godeps/_workspace/src/github.com/cloudfoundry-incubator/candiedyaml/fixtures/specification/example2_19.yaml
@@ -1,5 +1,4 @@
 canonical: 12345
 decimal: +12_345
-sexagesimal: 3:25:45
 octal: 014
 hexadecimal: 0xC

--- a/Godeps/_workspace/src/github.com/cloudfoundry-incubator/candiedyaml/fixtures/specification/example2_20.yaml
+++ b/Godeps/_workspace/src/github.com/cloudfoundry-incubator/candiedyaml/fixtures/specification/example2_20.yaml
@@ -1,6 +1,5 @@
 canonical: 1.23015e+3
 exponential: 12.3015e+02
-sexagesimal: 20:30.15
 fixed: 1_230.15
 negative infinity: -.inf
 not a number: .NaN

--- a/Godeps/_workspace/src/github.com/cloudfoundry-incubator/candiedyaml/resolver.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry-incubator/candiedyaml/resolver.go
@@ -28,7 +28,7 @@ import (
 
 var byteSliceType = reflect.TypeOf([]byte(nil))
 
-var binary_tags = [][]byte{[]byte("!binary"), []byte("tag:yaml.org,2002:binary")}
+var binary_tags = [][]byte{[]byte("!binary"), []byte(yaml_BINARY_TAG)}
 var bool_values map[string]bool
 var null_values map[string]bool
 
@@ -65,7 +65,7 @@ func resolve(event yaml_event_t, v reflect.Value, useNumber bool) (string, error
 
 	if null_values[val] {
 		v.Set(reflect.Zero(v.Type()))
-		return "!!null", nil
+		return yaml_NULL_TAG, nil
 	}
 
 	switch v.Kind() {
@@ -90,7 +90,12 @@ func resolve(event yaml_event_t, v reflect.Value, useNumber bool) (string, error
 		return resolve_float(val, v, useNumber)
 	case reflect.Interface:
 		_, i := resolveInterface(event, useNumber)
-		v.Set(reflect.ValueOf(i))
+		if i != nil {
+			v.Set(reflect.ValueOf(i))
+		} else {
+			v.Set(reflect.Zero(v.Type()))
+		}
+
 	case reflect.Struct:
 		return resolve_time(val, v)
 	case reflect.Slice:
@@ -107,7 +112,7 @@ func resolve(event yaml_event_t, v reflect.Value, useNumber bool) (string, error
 		return "", errors.New("Resolve failed for " + v.Kind().String())
 	}
 
-	return "!!str", nil
+	return yaml_STR_TAG, nil
 }
 
 func hasBinaryTag(event yaml_event_t) bool {
@@ -136,7 +141,7 @@ func resolve_string(val string, v reflect.Value, event yaml_event_t) (string, er
 		}
 	}
 	v.SetString(val)
-	return "!!str", nil
+	return yaml_STR_TAG, nil
 }
 
 func resolve_bool(val string, v reflect.Value) (string, error) {
@@ -146,7 +151,7 @@ func resolve_bool(val string, v reflect.Value) (string, error) {
 	}
 
 	v.SetBool(b)
-	return "!!bool", nil
+	return yaml_BOOL_TAG, nil
 }
 
 func resolve_int(val string, v reflect.Value, useNumber bool) (string, error) {
@@ -172,25 +177,17 @@ func resolve_int(val string, v reflect.Value, useNumber bool) (string, error) {
 			v.Set(reflect.Zero(v.Type()))
 		}
 
-		return "!!int", nil
+		return yaml_INT_TAG, nil
 	}
 
-	var err error
-	if strings.Contains(val, ":") {
-		value, err = decode_int_base64(val)
-		if err != nil {
-			return "", errors.New("Integer: " + original)
-		}
-	} else {
-		if strings.HasPrefix(val, "0b") {
-			base = 2
-			val = val[2:]
-		}
+	if strings.HasPrefix(val, "0o") {
+		base = 8
+		val = val[2:]
+	}
 
-		value, err = strconv.ParseUint(val, base, 64)
-		if err != nil {
-			return "", errors.New("Integer: " + original)
-		}
+	value, err := strconv.ParseUint(val, base, 64)
+	if err != nil {
+		return "", errors.New("Integer: " + original)
 	}
 
 	var val64 int64
@@ -214,25 +211,7 @@ func resolve_int(val string, v reflect.Value, useNumber bool) (string, error) {
 		v.SetInt(val64)
 	}
 
-	return "!!int", nil
-}
-
-func decode_int_base64(val string) (uint64, error) {
-	digits := strings.Split(val, ":")
-
-	bes := uint64(1)
-	var value uint64
-	for j := len(digits) - 1; j >= 0; j-- {
-		n, err := strconv.ParseUint(digits[j], 10, 64)
-		if err != nil {
-			return 0, err
-		}
-
-		n *= bes
-		value += n
-		bes *= 60
-	}
-	return value, nil
+	return yaml_INT_TAG, nil
 }
 
 func resolve_uint(val string, v reflect.Value, useNumber bool) (string, error) {
@@ -250,7 +229,7 @@ func resolve_uint(val string, v reflect.Value, useNumber bool) (string, error) {
 		val = val[1:]
 	}
 
-	base := 10
+	base := 0
 	if val == "0" {
 		if isNumberValue {
 			v.SetString("0")
@@ -258,41 +237,12 @@ func resolve_uint(val string, v reflect.Value, useNumber bool) (string, error) {
 			v.Set(reflect.Zero(v.Type()))
 		}
 
-		return "!!int", nil
+		return yaml_INT_TAG, nil
 	}
 
-	if strings.HasPrefix(val, "0b") {
-		base = 2
-		val = val[2:]
-	} else if strings.HasPrefix(val, "0x") {
-		base = 16
-		val = val[2:]
-	} else if val[0] == '0' {
+	if strings.HasPrefix(val, "0o") {
 		base = 8
-		val = val[1:]
-	} else if strings.Contains(val, ":") {
-		digits := strings.Split(val, ":")
-		bes := uint64(1)
-		for j := len(digits) - 1; j >= 0; j-- {
-			n, err := strconv.ParseUint(digits[j], 10, 64)
-			n *= bes
-			if err != nil {
-				return "", errors.New("Unsigned Integer: " + original)
-			}
-			value += n
-			bes *= 60
-		}
-
-		if isNumberValue {
-			v.SetString(strconv.FormatUint(value, 10))
-		} else {
-			if v.OverflowUint(value) {
-				return "", errors.New("Unsigned Integer: " + original)
-			}
-
-			v.SetUint(value)
-		}
-		return "!!int", nil
+		val = val[2:]
 	}
 
 	value, err := strconv.ParseUint(val, base, 64)
@@ -310,7 +260,7 @@ func resolve_uint(val string, v reflect.Value, useNumber bool) (string, error) {
 		v.SetUint(value)
 	}
 
-	return "!!int", nil
+	return yaml_INT_TAG, nil
 }
 
 func resolve_float(val string, v reflect.Value, useNumber bool) (string, error) {
@@ -336,19 +286,6 @@ func resolve_float(val string, v reflect.Value, useNumber bool) (string, error) 
 		value = math.Inf(sign)
 	} else if valLower == ".nan" {
 		value = math.NaN()
-	} else if strings.Contains(val, ":") {
-		digits := strings.Split(val, ":")
-		bes := float64(1)
-		for j := len(digits) - 1; j >= 0; j-- {
-			n, err := strconv.ParseFloat(digits[j], typeBits)
-			n *= bes
-			if err != nil {
-				return "", errors.New("Float: " + val)
-			}
-			value += n
-			bes *= 60
-		}
-		value *= float64(sign)
 	} else {
 		var err error
 		value, err = strconv.ParseFloat(val, typeBits)
@@ -369,7 +306,7 @@ func resolve_float(val string, v reflect.Value, useNumber bool) (string, error) 
 		v.SetFloat(value)
 	}
 
-	return "!!float", nil
+	return yaml_FLOAT_TAG, nil
 }
 
 func resolve_time(val string, v reflect.Value) (string, error) {
@@ -429,7 +366,7 @@ func resolveInterface(event yaml_event_t, useNumber bool) (string, interface{}) 
 	}
 
 	if len(val) == 0 {
-		return "!!null", nil
+		return yaml_NULL_TAG, nil
 	}
 
 	var result interface{}
@@ -450,7 +387,7 @@ func resolveInterface(event yaml_event_t, useNumber bool) (string, interface{}) 
 
 		v := reflect.ValueOf(result).Elem()
 		if _, err := resolve_int(val, v, useNumber); err == nil {
-			return "!!int", v.Interface()
+			return yaml_INT_TAG, v.Interface()
 		}
 
 		f := float64(0)
@@ -462,7 +399,7 @@ func resolveInterface(event yaml_event_t, useNumber bool) (string, interface{}) 
 
 		v = reflect.ValueOf(result).Elem()
 		if _, err := resolve_float(val, v, useNumber); err == nil {
-			return "!!float", v.Interface()
+			return yaml_FLOAT_TAG, v.Interface()
 		}
 
 		if !sign {
@@ -473,11 +410,11 @@ func resolveInterface(event yaml_event_t, useNumber bool) (string, interface{}) 
 		}
 	case bytes.IndexByte(nulls, c) != -1:
 		if null_values[val] {
-			return "!!null", nil
+			return yaml_NULL_TAG, nil
 		}
 		b := false
 		if _, err := resolve_bool(val, reflect.ValueOf(&b).Elem()); err == nil {
-			return "!!bool", b
+			return yaml_BOOL_TAG, b
 		}
 	case c == '.':
 		f := float64(0)
@@ -489,21 +426,21 @@ func resolveInterface(event yaml_event_t, useNumber bool) (string, interface{}) 
 
 		v := reflect.ValueOf(result).Elem()
 		if _, err := resolve_float(val, v, useNumber); err == nil {
-			return "!!float", v.Interface()
+			return yaml_FLOAT_TAG, v.Interface()
 		}
 	case bytes.IndexByte(bools, c) != -1:
 		b := false
 		if _, err := resolve_bool(val, reflect.ValueOf(&b).Elem()); err == nil {
-			return "!!bool", b
+			return yaml_BOOL_TAG, b
 		}
 	}
 
 	if hasBinaryTag(event) {
 		bytes, err := decode_binary(event.value)
 		if err == nil {
-			return "!!binary", bytes
+			return yaml_BINARY_TAG, bytes
 		}
 	}
 
-	return "!!str", val
+	return yaml_STR_TAG, val
 }

--- a/Godeps/_workspace/src/github.com/cloudfoundry-incubator/candiedyaml/resolver_test.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry-incubator/candiedyaml/resolver_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Resolver", func() {
 
 					tag, err := resolve(event, v.Elem(), false)
 					Ω(err).ShouldNot(HaveOccurred())
-					Ω(tag).Should(Equal("!!str"))
+					Ω(tag).Should(Equal(yaml_STR_TAG))
 					Ω(aString).To(Equal("abc"))
 				})
 
@@ -65,7 +65,7 @@ var _ = Describe("Resolver", func() {
 
 					tag, err := resolve(event, v.Elem(), false)
 					Ω(err).ShouldNot(HaveOccurred())
-					Ω(tag).Should(Equal("!!str"))
+					Ω(tag).Should(Equal(yaml_STR_TAG))
 					Ω(aString).To(Equal(""))
 
 				})
@@ -77,7 +77,7 @@ var _ = Describe("Resolver", func() {
 
 						tag, err := resolve(event, v.Elem(), false)
 						Ω(err).ShouldNot(HaveOccurred())
-						Ω(tag).Should(Equal("!!null"))
+						Ω(tag).Should(Equal(yaml_NULL_TAG))
 						Ω(aString).To(Equal(""))
 					})
 				})
@@ -90,7 +90,7 @@ var _ = Describe("Resolver", func() {
 
 						tag, err := resolve(event, v.Elem(), false)
 						Ω(err).ShouldNot(HaveOccurred())
-						Ω(tag).Should(Equal("!!null"))
+						Ω(tag).Should(Equal(yaml_NULL_TAG))
 						Ω(pString).To(BeNil())
 					})
 				})
@@ -106,7 +106,7 @@ var _ = Describe("Resolver", func() {
 
 					tag, err := resolve(event, v.Elem(), false)
 					Ω(err).ShouldNot(HaveOccurred())
-					Ω(tag).Should(Equal("!!bool"))
+					Ω(tag).Should(Equal(yaml_BOOL_TAG))
 					Ω(b).To(Equal(expected))
 				}
 
@@ -156,7 +156,7 @@ var _ = Describe("Resolver", func() {
 
 						tag, err := resolve(event, v.Elem(), false)
 						Ω(err).ShouldNot(HaveOccurred())
-						Ω(tag).Should(Equal("!!null"))
+						Ω(tag).Should(Equal(yaml_NULL_TAG))
 						Ω(b).To(BeFalse())
 					})
 				})
@@ -169,7 +169,7 @@ var _ = Describe("Resolver", func() {
 
 						tag, err := resolve(event, v.Elem(), false)
 						Ω(err).ShouldNot(HaveOccurred())
-						Ω(tag).Should(Equal("!!null"))
+						Ω(tag).Should(Equal(yaml_NULL_TAG))
 						Ω(pb).To(BeNil())
 					})
 				})
@@ -183,7 +183,7 @@ var _ = Describe("Resolver", func() {
 
 					tag, err := resolve(event, v.Elem(), false)
 					Ω(err).ShouldNot(HaveOccurred())
-					Ω(tag).Should(Equal("!!int"))
+					Ω(tag).Should(Equal(yaml_INT_TAG))
 					Ω(i).To(Equal(1234))
 				})
 
@@ -194,7 +194,7 @@ var _ = Describe("Resolver", func() {
 
 					tag, err := resolve(event, v.Elem(), false)
 					Ω(err).ShouldNot(HaveOccurred())
-					Ω(tag).Should(Equal("!!int"))
+					Ω(tag).Should(Equal(yaml_INT_TAG))
 					Ω(i).To(Equal(int16(678)))
 				})
 
@@ -205,29 +205,18 @@ var _ = Describe("Resolver", func() {
 
 					tag, err := resolve(event, v.Elem(), false)
 					Ω(err).ShouldNot(HaveOccurred())
-					Ω(tag).Should(Equal("!!int"))
+					Ω(tag).Should(Equal(yaml_INT_TAG))
 					Ω(i).To(Equal(int32(-2345)))
-				})
-
-				It("base 2", func() {
-					i := 0
-					v := reflect.ValueOf(&i)
-					event.value = []byte("0b11")
-
-					tag, err := resolve(event, v.Elem(), false)
-					Ω(err).ShouldNot(HaveOccurred())
-					Ω(tag).Should(Equal("!!int"))
-					Ω(i).To(Equal(3))
 				})
 
 				It("base 8", func() {
 					i := 0
 					v := reflect.ValueOf(&i)
-					event.value = []byte("012")
+					event.value = []byte("0o12")
 
 					tag, err := resolve(event, v.Elem(), false)
 					Ω(err).ShouldNot(HaveOccurred())
-					Ω(tag).Should(Equal("!!int"))
+					Ω(tag).Should(Equal(yaml_INT_TAG))
 					Ω(i).To(Equal(10))
 				})
 
@@ -238,19 +227,8 @@ var _ = Describe("Resolver", func() {
 
 					tag, err := resolve(event, v.Elem(), false)
 					Ω(err).ShouldNot(HaveOccurred())
-					Ω(tag).Should(Equal("!!int"))
+					Ω(tag).Should(Equal(yaml_INT_TAG))
 					Ω(i).To(Equal(255))
-				})
-
-				It("base 60", func() {
-					i := 0
-					v := reflect.ValueOf(&i)
-					event.value = []byte("1:30:00")
-
-					tag, err := resolve(event, v.Elem(), false)
-					Ω(err).ShouldNot(HaveOccurred())
-					Ω(tag).Should(Equal("!!int"))
-					Ω(i).To(Equal(5400))
 				})
 
 				It("fails on overflow", func() {
@@ -278,7 +256,7 @@ var _ = Describe("Resolver", func() {
 
 						tag, err := resolve(event, v.Elem(), false)
 						Ω(err).ShouldNot(HaveOccurred())
-						Ω(tag).Should(Equal("!!null"))
+						Ω(tag).Should(Equal(yaml_NULL_TAG))
 						Ω(i).To(Equal(0))
 					})
 				})
@@ -291,7 +269,7 @@ var _ = Describe("Resolver", func() {
 
 						tag, err := resolve(event, v.Elem(), false)
 						Ω(err).ShouldNot(HaveOccurred())
-						Ω(tag).Should(Equal("!!null"))
+						Ω(tag).Should(Equal(yaml_NULL_TAG))
 						Ω(pi).To(BeNil())
 					})
 				})
@@ -302,14 +280,14 @@ var _ = Describe("Resolver", func() {
 
 					tag, err := resolve_int("12345", v.Elem(), true)
 					Ω(err).ShouldNot(HaveOccurred())
-					Ω(tag).Should(Equal("!!int"))
+					Ω(tag).Should(Equal(yaml_INT_TAG))
 					Ω(i).To(Equal(Number("12345")))
 					Ω(i.Int64()).Should(Equal(int64(12345)))
 
 					event.value = []byte("1234")
 					tag, err = resolve(event, v.Elem(), true)
 					Ω(err).ShouldNot(HaveOccurred())
-					Ω(tag).Should(Equal("!!int"))
+					Ω(tag).Should(Equal(yaml_INT_TAG))
 					Ω(i).To(Equal(Number("1234")))
 				})
 			})
@@ -322,7 +300,7 @@ var _ = Describe("Resolver", func() {
 
 					tag, err := resolve(event, v.Elem(), false)
 					Ω(err).ShouldNot(HaveOccurred())
-					Ω(tag).Should(Equal("!!int"))
+					Ω(tag).Should(Equal(yaml_INT_TAG))
 					Ω(i).To(Equal(uint(1234)))
 				})
 
@@ -333,29 +311,18 @@ var _ = Describe("Resolver", func() {
 
 					tag, err := resolve(event, v.Elem(), false)
 					Ω(err).ShouldNot(HaveOccurred())
-					Ω(tag).Should(Equal("!!int"))
+					Ω(tag).Should(Equal(yaml_INT_TAG))
 					Ω(i).To(Equal(uint16(678)))
-				})
-
-				It("base 2", func() {
-					i := uint(0)
-					v := reflect.ValueOf(&i)
-					event.value = []byte("0b11")
-
-					tag, err := resolve(event, v.Elem(), false)
-					Ω(err).ShouldNot(HaveOccurred())
-					Ω(tag).Should(Equal("!!int"))
-					Ω(i).To(Equal(uint(3)))
 				})
 
 				It("base 8", func() {
 					i := uint(0)
 					v := reflect.ValueOf(&i)
-					event.value = []byte("012")
+					event.value = []byte("0o12")
 
 					tag, err := resolve(event, v.Elem(), false)
 					Ω(err).ShouldNot(HaveOccurred())
-					Ω(tag).Should(Equal("!!int"))
+					Ω(tag).Should(Equal(yaml_INT_TAG))
 					Ω(i).To(Equal(uint(10)))
 				})
 
@@ -366,19 +333,8 @@ var _ = Describe("Resolver", func() {
 
 					tag, err := resolve(event, v.Elem(), false)
 					Ω(err).ShouldNot(HaveOccurred())
-					Ω(tag).Should(Equal("!!int"))
+					Ω(tag).Should(Equal(yaml_INT_TAG))
 					Ω(i).To(Equal(uint(255)))
-				})
-
-				It("base 60", func() {
-					i := uint(0)
-					v := reflect.ValueOf(&i)
-					event.value = []byte("1:30:01")
-
-					tag, err := resolve(event, v.Elem(), false)
-					Ω(err).ShouldNot(HaveOccurred())
-					Ω(tag).Should(Equal("!!int"))
-					Ω(i).To(Equal(uint(5401)))
 				})
 
 				It("fails with negative ints", func() {
@@ -406,7 +362,7 @@ var _ = Describe("Resolver", func() {
 
 						tag, err := resolve(event, v.Elem(), false)
 						Ω(err).ShouldNot(HaveOccurred())
-						Ω(tag).Should(Equal("!!null"))
+						Ω(tag).Should(Equal(yaml_NULL_TAG))
 						Ω(i).To(Equal(uint(0)))
 					})
 				})
@@ -419,7 +375,7 @@ var _ = Describe("Resolver", func() {
 
 						tag, err := resolve(event, v.Elem(), false)
 						Ω(err).ShouldNot(HaveOccurred())
-						Ω(tag).Should(Equal("!!null"))
+						Ω(tag).Should(Equal(yaml_NULL_TAG))
 						Ω(pi).To(BeNil())
 					})
 				})
@@ -430,13 +386,13 @@ var _ = Describe("Resolver", func() {
 
 					tag, err := resolve_uint("12345", v.Elem(), true)
 					Ω(err).ShouldNot(HaveOccurred())
-					Ω(tag).Should(Equal("!!int"))
+					Ω(tag).Should(Equal(yaml_INT_TAG))
 					Ω(i).To(Equal(Number("12345")))
 
 					event.value = []byte("1234")
 					tag, err = resolve(event, v.Elem(), true)
 					Ω(err).ShouldNot(HaveOccurred())
-					Ω(tag).Should(Equal("!!int"))
+					Ω(tag).Should(Equal(yaml_INT_TAG))
 					Ω(i).To(Equal(Number("1234")))
 				})
 			})
@@ -449,7 +405,7 @@ var _ = Describe("Resolver", func() {
 
 					tag, err := resolve(event, v.Elem(), false)
 					Ω(err).ShouldNot(HaveOccurred())
-					Ω(tag).Should(Equal("!!float"))
+					Ω(tag).Should(Equal(yaml_FLOAT_TAG))
 					Ω(f).To(Equal(float32(2345.01)))
 				})
 
@@ -460,7 +416,7 @@ var _ = Describe("Resolver", func() {
 
 					tag, err := resolve(event, v.Elem(), false)
 					Ω(err).ShouldNot(HaveOccurred())
-					Ω(tag).Should(Equal("!!float"))
+					Ω(tag).Should(Equal(yaml_FLOAT_TAG))
 					Ω(f).To(Equal(float64(-456456.01)))
 				})
 
@@ -471,7 +427,7 @@ var _ = Describe("Resolver", func() {
 
 					tag, err := resolve(event, v.Elem(), false)
 					Ω(err).ShouldNot(HaveOccurred())
-					Ω(tag).Should(Equal("!!float"))
+					Ω(tag).Should(Equal(yaml_FLOAT_TAG))
 					Ω(f).To(Equal(math.Inf(1)))
 				})
 
@@ -482,7 +438,7 @@ var _ = Describe("Resolver", func() {
 
 					tag, err := resolve(event, v.Elem(), false)
 					Ω(err).ShouldNot(HaveOccurred())
-					Ω(tag).Should(Equal("!!float"))
+					Ω(tag).Should(Equal(yaml_FLOAT_TAG))
 					Ω(f).To(Equal(float32(math.Inf(-1))))
 				})
 
@@ -493,19 +449,8 @@ var _ = Describe("Resolver", func() {
 
 					tag, err := resolve(event, v.Elem(), false)
 					Ω(err).ShouldNot(HaveOccurred())
-					Ω(tag).Should(Equal("!!float"))
+					Ω(tag).Should(Equal(yaml_FLOAT_TAG))
 					Ω(math.IsNaN(f)).To(BeTrue())
-				})
-
-				It("base 60", func() {
-					f := float64(0)
-					v := reflect.ValueOf(&f)
-					event.value = []byte("1:30:02")
-
-					tag, err := resolve(event, v.Elem(), false)
-					Ω(err).ShouldNot(HaveOccurred())
-					Ω(tag).Should(Equal("!!float"))
-					Ω(f).To(Equal(float64(5402)))
 				})
 
 				It("fails on overflow", func() {
@@ -533,7 +478,7 @@ var _ = Describe("Resolver", func() {
 
 						tag, err := resolve(event, v.Elem(), false)
 						Ω(err).ShouldNot(HaveOccurred())
-						Ω(tag).Should(Equal("!!null"))
+						Ω(tag).Should(Equal(yaml_NULL_TAG))
 						Ω(f).To(Equal(0.0))
 					})
 				})
@@ -546,7 +491,7 @@ var _ = Describe("Resolver", func() {
 
 						tag, err := resolve(event, v.Elem(), false)
 						Ω(err).ShouldNot(HaveOccurred())
-						Ω(tag).Should(Equal("!!null"))
+						Ω(tag).Should(Equal(yaml_NULL_TAG))
 						Ω(pf).To(BeNil())
 					})
 				})
@@ -557,14 +502,14 @@ var _ = Describe("Resolver", func() {
 
 					tag, err := resolve_float("12.345", v.Elem(), true)
 					Ω(err).ShouldNot(HaveOccurred())
-					Ω(tag).Should(Equal("!!float"))
+					Ω(tag).Should(Equal(yaml_FLOAT_TAG))
 					Ω(i).To(Equal(Number("12.345")))
 					Ω(i.Float64()).Should(Equal(12.345))
 
 					event.value = []byte("1.234")
 					tag, err = resolve(event, v.Elem(), true)
 					Ω(err).ShouldNot(HaveOccurred())
-					Ω(tag).Should(Equal("!!float"))
+					Ω(tag).Should(Equal(yaml_FLOAT_TAG))
 					Ω(i).To(Equal(Number("1.234")))
 				})
 			})
@@ -608,7 +553,7 @@ var _ = Describe("Resolver", func() {
 
 						tag, err := resolve(event, v.Elem(), false)
 						Ω(err).ShouldNot(HaveOccurred())
-						Ω(tag).Should(Equal("!!null"))
+						Ω(tag).Should(Equal(yaml_NULL_TAG))
 						Ω(d).To(Equal(time.Time{}))
 					})
 				})
@@ -621,7 +566,7 @@ var _ = Describe("Resolver", func() {
 
 						tag, err := resolve(event, v.Elem(), false)
 						Ω(err).ShouldNot(HaveOccurred())
-						Ω(tag).Should(Equal("!!null"))
+						Ω(tag).Should(Equal(yaml_NULL_TAG))
 						Ω(pd).To(BeNil())
 					})
 				})
@@ -637,7 +582,7 @@ var _ = Describe("Resolver", func() {
 
 						tag, err := resolve(event, v.Elem(), false)
 						Ω(err).ShouldNot(HaveOccurred())
-						Ω(tag).Should(Equal("!!str"))
+						Ω(tag).Should(Equal(yaml_STR_TAG))
 						Ω(aString).Should(Equal("abcdefg"))
 					})
 				})
@@ -651,7 +596,7 @@ var _ = Describe("Resolver", func() {
 
 						tag, err := resolve(event, v.Elem(), false)
 						Ω(err).ShouldNot(HaveOccurred())
-						Ω(tag).Should(Equal("!!str"))
+						Ω(tag).Should(Equal(yaml_STR_TAG))
 						Ω(bytes).Should(Equal([]byte("abcdefg")))
 					})
 				})
@@ -665,7 +610,7 @@ var _ = Describe("Resolver", func() {
 
 						tag, err := resolve(event, v.Elem(), false)
 						Ω(err).ShouldNot(HaveOccurred())
-						Ω(tag).Should(Equal("!!str"))
+						Ω(tag).Should(Equal(yaml_STR_TAG))
 						Ω(intf).Should(Equal([]byte("abcdefg")))
 					})
 				})

--- a/Godeps/_workspace/src/github.com/cloudfoundry-incubator/candiedyaml/yamlh.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry-incubator/candiedyaml/yamlh.go
@@ -359,6 +359,8 @@ const (
 	yaml_DEFAULT_SEQUENCE_TAG = yaml_SEQ_TAG
 	/** The default mapping tag is @c !!map. */
 	yaml_DEFAULT_MAPPING_TAG = yaml_MAP_TAG
+
+	yaml_BINARY_TAG = "tag:yaml.org,2002:binary"
 )
 
 /** Node types. */


### PR DESCRIPTION
When the manifest yaml is malformed (there is a parse error) `cf push` was throwing an error that included stack trace in its message. In order to avoid displaying stack traces to user, I modified candiedyaml repository to not include the stack trace. Since cli uses candiedyaml as Godeps dependency, I have updated candiedyaml Godeps.

This is done for the story in CF foundation tracker:
[#88539284]
