### PR TITLE
Adding a new command equivalent to linux shell 'whoami'

### DIFF
--- a/cf/api/fakes/fake_space_repo.go
+++ b/cf/api/fakes/fake_space_repo.go
@@ -32,10 +32,23 @@ type FakeSpaceRepository struct {
 	RenameNewName   string
 
 	DeletedSpaceGuid string
+
+	ListOfRolesOfSpace map[string]string
 }
 
 func (repo FakeSpaceRepository) GetCurrentSpace() (space models.Space) {
 	return repo.CurrentSpace
+}
+
+func (repo FakeSpaceRepository) GetSpaceRole(callback func(models.Space) bool, apiName string) error {
+	if repo.ListOfRolesOfSpace[apiName] != "" {
+		space := models.Space{}
+		space.Name = repo.ListOfRolesOfSpace[apiName]
+		if !callback(space) {
+			return nil
+		}
+	}
+	return nil
 }
 
 func (repo FakeSpaceRepository) ListSpaces(callback func(models.Space) bool) error {

--- a/cf/app/help.go
+++ b/cf/app/help.go
@@ -105,6 +105,7 @@ func newAppPresenter(app *cli.App) (presenter appPresenter) {
 					presentCommand("logout"),
 					presentCommand("passwd"),
 					presentCommand("target"),
+					presentCommand("user-info"),
 				}, {
 					presentCommand("api"),
 					presentCommand("auth"),

--- a/cf/command_factory/factory.go
+++ b/cf/command_factory/factory.go
@@ -316,7 +316,7 @@ func NewFactory(ui terminal.UI, config core_config.ReadWriter, manifestRepo mani
 
 	factory.cmdsByName["share-private-domain"] = organization.NewSharePrivateDomain(ui, config, repoLocator.GetOrganizationRepository(), repoLocator.GetDomainRepository())
 	factory.cmdsByName["unshare-private-domain"] = organization.NewUnsharePrivateDomain(ui, config, repoLocator.GetOrganizationRepository(), repoLocator.GetDomainRepository())
-
+	factory.cmdsByName["user-info"] = user.ShowUserInfo(ui, config, repoLocator.GetOrganizationRepository(), repoLocator.GetSpaceRepository())
 	return
 }
 

--- a/cf/commands/user/user-info.go
+++ b/cf/commands/user/user-info.go
@@ -1,0 +1,117 @@
+package user
+
+import (
+	"github.com/cloudfoundry/cli/cf/api/organizations"
+	"github.com/cloudfoundry/cli/cf/api/spaces"
+	"github.com/cloudfoundry/cli/cf/command_metadata"
+	"github.com/cloudfoundry/cli/cf/configuration/core_config"
+	. "github.com/cloudfoundry/cli/cf/i18n"
+	"github.com/cloudfoundry/cli/cf/models"
+	"github.com/cloudfoundry/cli/cf/requirements"
+	"github.com/cloudfoundry/cli/cf/terminal"
+	"github.com/codegangsta/cli"
+	"strings"
+)
+
+type CFUsers struct {
+	ui        terminal.UI
+	config    core_config.Reader
+	orgRepo   organizations.OrganizationRepository
+	spaceRepo spaces.SpaceRepository
+}
+
+func ShowUserInfo(ui terminal.UI, config core_config.Reader, orgRepo organizations.OrganizationRepository, spaceRepo spaces.SpaceRepository) (cmd *CFUsers) {
+	cmd = new(CFUsers)
+	cmd.ui = ui
+	cmd.config = config
+	cmd.orgRepo = orgRepo
+	cmd.spaceRepo = spaceRepo
+	return
+}
+
+func (cmd *CFUsers) Metadata() command_metadata.CommandMetadata {
+	return command_metadata.CommandMetadata{
+		Name:        "user-info",
+		Description: T("Show user-info with roles"),
+		Usage:       T("CF_NAME user-info"),
+		Flags:       []cli.Flag{},
+	}
+}
+
+func (cmd *CFUsers) GetRequirements(requirementsFactory requirements.Factory, c *cli.Context) (reqs []requirements.Requirement, err error) {
+
+	if len(c.Args()) != 0 {
+		cmd.ui.FailWithUsage(c)
+	}
+
+	reqs = []requirements.Requirement{
+		requirementsFactory.NewLoginRequirement(),
+		requirementsFactory.NewTargetedOrgRequirement(),
+	}
+	return
+}
+
+func (cmd *CFUsers) Run(c *cli.Context) {
+	cmd.ui.Say(T("Getting user information..."))
+
+	table := terminal.NewTable(cmd.ui, []string{T("User"), T("Org"), T("Space"), T("Role")})
+	retrivedRoles := []string{} //Variable to store all the roles
+
+	//Fetching the Roles at Organization level
+
+	var orgName = cmd.config.OrganizationFields().Name
+
+	var orgRoleToDisplayName = map[string]string{
+		models.ORG_MANAGER:     T("ORG MANAGER"),
+		models.BILLING_MANAGER: T("BILLING MANAGER"),
+		models.ORG_AUDITOR:     T("ORG AUDITOR"),
+	}
+
+	for apiName, displayName := range models.QueryParmToOrgRole {
+		org, apiErr := cmd.orgRepo.GetOrgRoleForUser(apiName, orgName)
+
+		if apiErr != nil {
+			cmd.ui.Failed(T("Failed fetching org-users for role {{.OrgRoleToDisplayName}}.\n{{.Error}}",
+				map[string]interface{}{
+					"Error":                apiErr.Error(),
+					"OrgRoleToDisplayName": orgRoleToDisplayName[displayName],
+				}))
+			return
+		}
+
+		if org.Name != "" {
+			retrivedRoles = append(retrivedRoles, orgRoleToDisplayName[displayName])
+		}
+
+	}
+
+	// Fetching space roles
+	// If the space is not targeted then space roles will not be fetched
+	if cmd.config.SpaceFields().Name != "" {
+		var spaceRoleToDisplayName = map[string]string{
+			models.SPACE_MANAGER:   T("SPACE MANAGER"),
+			models.SPACE_DEVELOPER: T("SPACE DEVELOPER"),
+			models.SPACE_AUDITOR:   T("SPACE AUDITOR"),
+		}
+
+		for apiName, displayName := range models.QueryParmToSpaceRole {
+
+			apiErr := cmd.spaceRepo.GetSpaceRole(func(space models.Space) bool {
+				if space.Name != "" {
+					retrivedRoles = append(retrivedRoles, spaceRoleToDisplayName[displayName])
+				}
+				return true
+			}, apiName)
+			if apiErr != nil {
+				cmd.ui.Failed(T("Failed fetching space-users for role {{.SpaceRoleToDisplayName}}.\n{{.Error}}",
+					map[string]interface{}{
+						"Error":                  apiErr.Error(),
+						"SpaceRoleToDisplayName": spaceRoleToDisplayName[displayName],
+					}))
+				return
+			}
+		}
+	}
+	table.Add(cmd.config.Username(), cmd.config.OrganizationFields().Name, cmd.config.SpaceFields().Name, strings.Join(retrivedRoles, ", "))
+	table.Print()
+}

--- a/cf/commands/user/user-info_test.go
+++ b/cf/commands/user/user-info_test.go
@@ -1,0 +1,153 @@
+package user_test
+
+import (
+	testapi "github.com/cloudfoundry/cli/cf/api/fakes"
+	testOrgApi "github.com/cloudfoundry/cli/cf/api/organizations/fakes"
+	. "github.com/cloudfoundry/cli/cf/commands/user"
+	"github.com/cloudfoundry/cli/cf/configuration/core_config"
+	"github.com/cloudfoundry/cli/cf/models"
+	testcmd "github.com/cloudfoundry/cli/testhelpers/commands"
+	testconfig "github.com/cloudfoundry/cli/testhelpers/configuration"
+	. "github.com/cloudfoundry/cli/testhelpers/matchers"
+	testreq "github.com/cloudfoundry/cli/testhelpers/requirements"
+	testterm "github.com/cloudfoundry/cli/testhelpers/terminal"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("user-info command", func() {
+	var (
+		ui                  *testterm.FakeUI
+		requirementsFactory *testreq.FakeReqFactory
+		configRepo          core_config.ReadWriter
+		orgRepo             *testOrgApi.FakeOrganizationRepository
+		spaceRepo           *testapi.FakeSpaceRepository
+	)
+
+	BeforeEach(func() {
+		ui = &testterm.FakeUI{}
+		spaceRepo = &testapi.FakeSpaceRepository{}
+		orgRepo = &testOrgApi.FakeOrganizationRepository{}
+		configRepo = testconfig.NewRepositoryWithDefaults()
+		requirementsFactory = &testreq.FakeReqFactory{}
+	})
+
+	runCommand := func(args ...string) bool {
+		return testcmd.RunCommand(ShowUserInfo(ui, configRepo, orgRepo, spaceRepo), args, requirementsFactory)
+	}
+
+	Describe("requirements", func() {
+		It("fails when not logged in", func() {
+			Expect(runCommand()).To(BeFalse())
+		})
+
+		It("should fail with usage when provided any arguments", func() {
+			requirementsFactory.LoginSuccess = true
+			requirementsFactory.TargetedOrgSuccess = true
+			Expect(runCommand("blahblah")).To(BeFalse())
+			Expect(ui.FailedWithUsage).To(BeTrue())
+		})
+
+		It("fails when no org or space is targeted", func() {
+			requirementsFactory.LoginSuccess = true
+			requirementsFactory.TargetedOrgSuccess = false
+
+			Expect(runCommand()).To(BeFalse())
+		})
+
+	})
+
+	Context("when logged in and targeted with proper orgs", func() {
+		BeforeEach(func() {
+			org := models.Organization{}
+			org.Name = "Org1"
+			org.Guid = "org1-guid"
+
+			user := models.UserFields{}
+			user.Username = "user1"
+
+			requirementsFactory.LoginSuccess = true
+			requirementsFactory.TargetedOrgSuccess = true
+			requirementsFactory.UserFields = user
+			requirementsFactory.Organization = org
+
+			configRepo = testconfig.NewRepositoryWithAccessToken(core_config.TokenInfo{Username: "user1"})
+
+			configRepo.SetOrganizationFields(models.OrganizationFields{
+				Name: "Org1",
+				Guid: "org1-guid",
+			})
+		})
+
+		It("shows the roles for orgs when only Org is targeted", func() {
+
+			orgRepo.ListOfRolesOfAnOrg = map[string]string{
+				"manager_guid":         "Org1",
+				"billing_manager_guid": "Org1",
+				"auditor_guid":         "Org1",
+			}
+			configRepo.SetSpaceFields(models.SpaceFields{})
+			runCommand()
+
+			Expect(ui.Outputs).To(ContainSubstrings(
+				[]string{"Getting user information..."},
+				[]string{"User", "Org", "Space", "Role"},
+				[]string{"user", "Org1", "ORG MANAGER", "BILLING MANAGER", "ORG AUDITOR"},
+			))
+		})
+
+		It("shows the roles when proper org and space is targeted", func() {
+
+			orgRepo.ListOfRolesOfAnOrg = map[string]string{
+				"manager_guid":         "Org1",
+				"billing_manager_guid": "Org1",
+				"auditor_guid":         "Org1",
+			}
+
+			spaceRepo.ListOfRolesOfSpace = map[string]string{
+				"managed_spaces": "Space1",
+				"developer_guid": "Space1",
+				"audited_spaces": "Space1",
+			}
+
+			space := models.Space{}
+			space.Name = "Space1"
+			space.Guid = "space1-guid"
+
+			spaceRepo.FindByNameInOrgSpace = space
+			requirementsFactory.Space = space
+
+			configRepo.SetSpaceFields(models.SpaceFields{
+				Name: "Space1",
+				Guid: "space1-guid",
+			})
+
+			runCommand()
+
+			Expect(ui.Outputs).To(ContainSubstrings(
+				[]string{"Getting user information..."},
+				[]string{"User", "Org", "Space", "Role"},
+				[]string{"user", "Org1", "Space1", "SPACE MANAGER", "SPACE DEVELOPER", "SPACE AUDITOR", "ORG MANAGER", "BILLING MANAGER", "ORG AUDITOR"},
+			))
+		})
+
+		It("should fail when QueryParam is wrong", func() {
+
+			orgRepo.ListOfRolesOfAnOrg = map[string]string{
+				"apiErrorCheck1":  "Org1",
+				"apiErrorCheck12": "Org1",
+				"apiErrorCheck13": "Org1",
+			}
+			configRepo.SetSpaceFields(models.SpaceFields{})
+			runCommand()
+
+			Expect(ui.Outputs).To(ContainSubstrings(
+				[]string{"Failed"},
+				[]string{"query param not found"},
+			))
+
+		})
+
+	})
+
+})

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -5153,5 +5153,30 @@
       "id": "CF_NAME unshare-private-domain ORG DOMAIN",
       "translation": "CF_NAME unshare-private-domain ORG DOMAIN",
       "modified": false
+   },
+   {
+      "id": "Show user-info with roles",
+      "translation": "Show user-info with roles",
+      "modified": false
+   },
+   {
+      "id": "CF_NAME user-info",
+      "translation": "CF_NAME user-info",
+      "modified": false
+   },
+   {
+      "id": "Getting user information...",
+      "translation": "Getting user information...",
+      "modified": false
+   },
+   {
+      "id": "User",
+      "translation": "User",
+      "modified": false
+   },
+   {
+      "id": "Role",
+      "translation": "Role",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -5153,5 +5153,30 @@
       "id": "CF_NAME unshare-private-domain ORG DOMAIN",
       "translation": "CF_NAME unshare-private-domain ORG DOMAIN",
       "modified": false
+   },
+   {
+      "id": "Show user-info with roles",
+      "translation": "Show user-info with roles",
+      "modified": false
+   },
+   {
+      "id": "CF_NAME user-info",
+      "translation": "CF_NAME user-info",
+      "modified": false
+   },
+   {
+      "id": "Getting user information...",
+      "translation": "Getting user information...",
+      "modified": false
+   },
+   {
+      "id": "User",
+      "translation": "User",
+      "modified": false
+   },
+   {
+      "id": "Role",
+      "translation": "Role",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -5153,5 +5153,30 @@
       "id": "CF_NAME unshare-private-domain ORG DOMAIN",
       "translation": "CF_NAME unshare-private-domain ORG DOMAIN",
       "modified": false
+   },
+   {
+      "id": "Show user-info with roles",
+      "translation": "Show user-info with roles",
+      "modified": false
+   },
+   {
+      "id": "CF_NAME user-info",
+      "translation": "CF_NAME user-info",
+      "modified": false
+   },
+   {
+      "id": "Getting user information...",
+      "translation": "Getting user information...",
+      "modified": false
+   },
+   {
+      "id": "User",
+      "translation": "User",
+      "modified": false
+   },
+   {
+      "id": "Role",
+      "translation": "Role",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -5153,5 +5153,30 @@
       "id": "CF_NAME unshare-private-domain ORG DOMAIN",
       "translation": "CF_NAME unshare-private-domain ORG DOMAIN",
       "modified": false
+   },
+   {
+      "id": "Show user-info with roles",
+      "translation": "Show user-info with roles",
+      "modified": false
+   },
+   {
+      "id": "CF_NAME user-info",
+      "translation": "CF_NAME user-info",
+      "modified": false
+   },
+   {
+      "id": "Getting user information...",
+      "translation": "Getting user information...",
+      "modified": false
+   },
+   {
+      "id": "User",
+      "translation": "User",
+      "modified": false
+   },
+   {
+      "id": "Role",
+      "translation": "Role",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -5153,5 +5153,30 @@
       "id": "CF_NAME unshare-private-domain ORG DOMAIN",
       "translation": "CF_NAME unshare-private-domain ORG DOMAIN",
       "modified": false
+   },
+   {
+      "id": "Show user-info with roles",
+      "translation": "Show user-info with roles",
+      "modified": false
+   },
+   {
+      "id": "CF_NAME user-info",
+      "translation": "CF_NAME user-info",
+      "modified": false
+   },
+   {
+      "id": "Getting user information...",
+      "translation": "Getting user information...",
+      "modified": false
+   },
+   {
+      "id": "User",
+      "translation": "User",
+      "modified": false
+   },
+   {
+      "id": "Role",
+      "translation": "Role",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -5153,5 +5153,30 @@
       "id": "CF_NAME unshare-private-domain ORG DOMAIN",
       "translation": "CF_NAME unshare-private-domain ORG DOMAIN",
       "modified": false
+   },
+   {
+      "id": "Show user-info with roles",
+      "translation": "Show user-info with roles",
+      "modified": false
+   },
+   {
+      "id": "CF_NAME user-info",
+      "translation": "CF_NAME user-info",
+      "modified": false
+   },
+   {
+      "id": "Getting user information...",
+      "translation": "Getting user information...",
+      "modified": false
+   },
+   {
+      "id": "User",
+      "translation": "User",
+      "modified": false
+   },
+   {
+      "id": "Role",
+      "translation": "Role",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -5153,5 +5153,30 @@
       "id": "CF_NAME unshare-private-domain ORG DOMAIN",
       "translation": "CF_NAME unshare-private-domain ORG DOMAIN",
       "modified": false
+   },
+   {
+      "id": "Show user-info with roles",
+      "translation": "Show user-info with roles",
+      "modified": false
+   },
+   {
+      "id": "CF_NAME user-info",
+      "translation": "CF_NAME user-info",
+      "modified": false
+   },
+   {
+      "id": "Getting user information...",
+      "translation": "Getting user information...",
+      "modified": false
+   },
+   {
+      "id": "User",
+      "translation": "User",
+      "modified": false
+   },
+   {
+      "id": "Role",
+      "translation": "Role",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -5153,5 +5153,30 @@
       "id": "CF_NAME unshare-private-domain ORG DOMAIN",
       "translation": "CF_NAME unshare-private-domain ORG DOMAIN",
       "modified": false
+   },
+   {
+      "id": "Show user-info with roles",
+      "translation": "Show user-info with roles",
+      "modified": false
+   },
+   {
+      "id": "CF_NAME user-info",
+      "translation": "CF_NAME user-info",
+      "modified": false
+   },
+   {
+      "id": "Getting user information...",
+      "translation": "Getting user information...",
+      "modified": false
+   },
+   {
+      "id": "User",
+      "translation": "User",
+      "modified": false
+   },
+   {
+      "id": "Role",
+      "translation": "Role",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -5153,5 +5153,30 @@
       "id": "CF_NAME unshare-private-domain ORG DOMAIN",
       "translation": "CF_NAME unshare-private-domain ORG DOMAIN",
       "modified": false
+   },
+   {
+      "id": "Show user-info with roles",
+      "translation": "Show user-info with roles",
+      "modified": false
+   },
+   {
+      "id": "CF_NAME user-info",
+      "translation": "CF_NAME user-info",
+      "modified": false
+   },
+   {
+      "id": "Getting user information...",
+      "translation": "Getting user information...",
+      "modified": false
+   },
+   {
+      "id": "User",
+      "translation": "User",
+      "modified": false
+   },
+   {
+      "id": "Role",
+      "translation": "Role",
+      "modified": false
    }
 ]

--- a/cf/models/user_roles.go
+++ b/cf/models/user_roles.go
@@ -27,3 +27,15 @@ var SpaceRoleToUserInput = map[string]string{
 	SPACE_DEVELOPER: "SpaceDeveloper",
 	SPACE_AUDITOR:   "SpaceAuditor",
 }
+
+var QueryParmToOrgRole = map[string]string{
+	"manager_guid":         ORG_MANAGER,
+	"billing_manager_guid": BILLING_MANAGER,
+	"auditor_guid":         ORG_AUDITOR,
+}
+
+var QueryParmToSpaceRole = map[string]string{
+	"managed_spaces": SPACE_MANAGER,
+	"developer_guid": SPACE_DEVELOPER,
+	"audited_spaces": SPACE_AUDITOR,
+}


### PR DESCRIPTION
This command will help user to get the information related to the Org and Space they have targeted and the role associated with them.

***Output :***  
```
$ cf user-info
Getting user information......
User    Org       Space       Role
asif    asifOrg   asifSpace   ORG MANAGER, BILLING MANAGER, SPACE MANAGER, SPACE DEVELOPER
```
Documentation for this command  : https://github.com/asifhuawei/Docs/blob/master/user-info.md