### PR TITLE
Add a flag to force a restage after bind/unbind service instance

### DIFF
--- a/cf/command_factory/factory.go
+++ b/cf/command_factory/factory.go
@@ -156,7 +156,6 @@ func NewFactory(ui terminal.UI, config core_config.ReadWriter, manifestRepo mani
 	factory.cmdsByName["stacks"] = commands.NewListStacks(ui, config, repoLocator.GetStackRepository())
 	factory.cmdsByName["stack"] = commands.NewListStack(ui, config, repoLocator.GetStackRepository())
 	factory.cmdsByName["target"] = commands.NewTarget(ui, config, repoLocator.GetOrganizationRepository(), repoLocator.GetSpaceRepository())
-	factory.cmdsByName["unbind-service"] = service.NewUnbindService(ui, config, repoLocator.GetServiceBindingRepository())
 	factory.cmdsByName["unset-env"] = application.NewUnsetEnv(ui, config, repoLocator.GetApplicationRepository())
 	factory.cmdsByName["unset-org-role"] = user.NewUnsetOrgRole(ui, config, repoLocator.GetUserRepository())
 	factory.cmdsByName["unset-space-role"] = user.NewUnsetSpaceRole(ui, config, repoLocator.GetSpaceRepository(), repoLocator.GetUserRepository())
@@ -215,10 +214,12 @@ func NewFactory(ui terminal.UI, config core_config.ReadWriter, manifestRepo mani
 	stop := application.NewStop(ui, config, repoLocator.GetApplicationRepository())
 	restart := application.NewRestart(ui, config, start, stop)
 	restage := application.NewRestage(ui, config, repoLocator.GetApplicationRepository(), start)
-	bind := service.NewBindService(ui, config, repoLocator.GetServiceBindingRepository())
+	bind := service.NewBindService(ui, config, repoLocator.GetServiceBindingRepository(), repoLocator.GetApplicationRepository(), start)
+	unbind := service.NewUnbindService(ui, config, repoLocator.GetServiceBindingRepository(), repoLocator.GetApplicationRepository(), start)
 
 	factory.cmdsByName["app"] = displayApp
 	factory.cmdsByName["bind-service"] = bind
+	factory.cmdsByName["unbind-service"] = unbind
 	factory.cmdsByName["start"] = start
 	factory.cmdsByName["stop"] = stop
 	factory.cmdsByName["restart"] = restart

--- a/cf/commands/service/bind_service_test.go
+++ b/cf/commands/service/bind_service_test.go
@@ -2,8 +2,11 @@ package service_test
 
 import (
 	"github.com/cloudfoundry/cli/cf/api"
+	"github.com/cloudfoundry/cli/cf/api/applications"
+	testApplication "github.com/cloudfoundry/cli/cf/api/applications/fakes"
 	testapi "github.com/cloudfoundry/cli/cf/api/fakes"
 	. "github.com/cloudfoundry/cli/cf/commands/service"
+	"github.com/cloudfoundry/cli/cf/configuration/core_config"
 	"github.com/cloudfoundry/cli/cf/models"
 	testcmd "github.com/cloudfoundry/cli/testhelpers/commands"
 	testconfig "github.com/cloudfoundry/cli/testhelpers/configuration"
@@ -18,14 +21,29 @@ import (
 var _ = Describe("bind-service command", func() {
 	var (
 		requirementsFactory *testreq.FakeReqFactory
+		stagingWatcher      *fakeStagingWatcher
+		appRepo             *testApplication.FakeApplicationRepository
+		configRepo          core_config.ReadWriter
+		serviceRepo         *testapi.FakeServiceRepo
 	)
 
 	BeforeEach(func() {
 		requirementsFactory = &testreq.FakeReqFactory{}
+		appRepo = &testApplication.FakeApplicationRepository{}
+		stagingWatcher = &fakeStagingWatcher{}
+		serviceRepo = &testapi.FakeServiceRepo{}
 	})
 
 	It("fails requirements when not logged in", func() {
-		cmd := NewBindService(&testterm.FakeUI{}, testconfig.NewRepository(), &testapi.FakeServiceBindingRepo{})
+		cmd := NewBindService(&testterm.FakeUI{}, testconfig.NewRepository(), &testapi.FakeServiceBindingRepo{}, appRepo, stagingWatcher)
+
+		Expect(testcmd.RunCommand(cmd, []string{"service", "app"}, requirementsFactory)).To(BeFalse())
+	})
+
+	It("fails requirements when service not found", func() {
+		serviceRepo.FindInstanceByNameNotFound = true
+
+		cmd := NewBindService(&testterm.FakeUI{}, testconfig.NewRepository(), &testapi.FakeServiceBindingRepo{}, appRepo, stagingWatcher)
 
 		Expect(testcmd.RunCommand(cmd, []string{"service", "app"}, requirementsFactory)).To(BeFalse())
 	})
@@ -33,6 +51,7 @@ var _ = Describe("bind-service command", func() {
 	Context("when logged in", func() {
 		BeforeEach(func() {
 			requirementsFactory.LoginSuccess = true
+			configRepo = testconfig.NewRepositoryWithDefaults()
 		})
 
 		It("binds a service instance to an app", func() {
@@ -45,7 +64,7 @@ var _ = Describe("bind-service command", func() {
 			requirementsFactory.Application = app
 			requirementsFactory.ServiceInstance = serviceInstance
 			serviceBindingRepo := &testapi.FakeServiceBindingRepo{}
-			ui := callBindService([]string{"my-app", "my-service"}, requirementsFactory, serviceBindingRepo)
+			ui := callBindService([]string{"my-app", "my-service"}, requirementsFactory, serviceBindingRepo, appRepo, stagingWatcher)
 
 			Expect(requirementsFactory.ApplicationName).To(Equal("my-app"))
 			Expect(requirementsFactory.ServiceInstanceName).To(Equal("my-service"))
@@ -69,7 +88,7 @@ var _ = Describe("bind-service command", func() {
 			requirementsFactory.Application = app
 			requirementsFactory.ServiceInstance = serviceInstance
 			serviceBindingRepo := &testapi.FakeServiceBindingRepo{CreateErrorCode: "90003"}
-			ui := callBindService([]string{"my-app", "my-service"}, requirementsFactory, serviceBindingRepo)
+			ui := callBindService([]string{"my-app", "my-service"}, requirementsFactory, serviceBindingRepo, appRepo, stagingWatcher)
 
 			Expect(ui.Outputs).To(ContainSubstrings(
 				[]string{"Binding service"},
@@ -88,7 +107,7 @@ var _ = Describe("bind-service command", func() {
 			requirementsFactory.Application = app
 			requirementsFactory.ServiceInstance = serviceInstance
 			serviceBindingRepo := &testapi.FakeServiceBindingRepo{CreateNonHttpErrCode: "1001"}
-			ui := callBindService([]string{"my-app1", "my-service1"}, requirementsFactory, serviceBindingRepo)
+			ui := callBindService([]string{"my-app1", "my-service1"}, requirementsFactory, serviceBindingRepo, appRepo, stagingWatcher)
 			Expect(ui.Outputs).To(ContainSubstrings(
 				[]string{"Binding service", "my-service", "my-app", "my-org", "my-space", "my-user"},
 				[]string{"FAILED"},
@@ -99,24 +118,90 @@ var _ = Describe("bind-service command", func() {
 		It("fails with usage when called without a service instance and app", func() {
 			serviceBindingRepo := &testapi.FakeServiceBindingRepo{}
 
-			ui := callBindService([]string{"my-service"}, requirementsFactory, serviceBindingRepo)
+			ui := callBindService([]string{"my-service"}, requirementsFactory, serviceBindingRepo, appRepo, stagingWatcher)
 			Expect(ui.FailedWithUsage).To(BeTrue())
 
-			ui = callBindService([]string{"my-app"}, requirementsFactory, serviceBindingRepo)
+			ui = callBindService([]string{"my-app"}, requirementsFactory, serviceBindingRepo, appRepo, stagingWatcher)
 			Expect(ui.FailedWithUsage).To(BeTrue())
 
-			ui = callBindService([]string{"my-app", "my-service"}, requirementsFactory, serviceBindingRepo)
+			ui = callBindService([]string{"my-app", "my-service"}, requirementsFactory, serviceBindingRepo, appRepo, stagingWatcher)
 			Expect(ui.FailedWithUsage).To(BeFalse())
+		})
+
+		It("restage app after bind when force restage", func() {
+			app := models.Application{}
+			app.Name = "my-app"
+			app.Guid = "my-app-guid"
+			serviceInstance := models.ServiceInstance{}
+			serviceInstance.Name = "my-service"
+			serviceInstance.Guid = "my-service-guid"
+			requirementsFactory.Application = app
+			requirementsFactory.ServiceInstance = serviceInstance
+			serviceBindingRepo := &testapi.FakeServiceBindingRepo{}
+			ui := callBindService([]string{"my-app", "my-service", "--force-restage"}, requirementsFactory, serviceBindingRepo, appRepo, stagingWatcher)
+
+			Expect(requirementsFactory.ApplicationName).To(Equal("my-app"))
+			Expect(requirementsFactory.ServiceInstanceName).To(Equal("my-service"))
+
+			Expect(ui.Outputs).To(ContainSubstrings(
+				[]string{"Binding service", "my-service", "my-app", "my-org", "my-space", "my-user"},
+				[]string{"OK"},
+				[]string{"Restaging app", "my-app", "my-org", "my-space", "my-user"},
+			))
+			Expect(serviceBindingRepo.CreateServiceInstanceGuid).To(Equal("my-service-guid"))
+			Expect(serviceBindingRepo.CreateApplicationGuid).To(Equal("my-app-guid"))
+			Expect(stagingWatcher.watched).To(Equal(app))
+			Expect(stagingWatcher.orgName).To(Equal(configRepo.OrganizationFields().Name))
+			Expect(stagingWatcher.spaceName).To(Equal(configRepo.SpaceFields().Name))
+		})
+
+		It("do not restage app after bind when not force restage", func() {
+			app := models.Application{}
+			app.Name = "my-app"
+			app.Guid = "my-app-guid"
+			serviceInstance := models.ServiceInstance{}
+			serviceInstance.Name = "my-service"
+			serviceInstance.Guid = "my-service-guid"
+			requirementsFactory.Application = app
+			requirementsFactory.ServiceInstance = serviceInstance
+			serviceBindingRepo := &testapi.FakeServiceBindingRepo{}
+			ui := callBindService([]string{"my-app", "my-service"}, requirementsFactory, serviceBindingRepo, appRepo, stagingWatcher)
+
+			Expect(requirementsFactory.ApplicationName).To(Equal("my-app"))
+			Expect(requirementsFactory.ServiceInstanceName).To(Equal("my-service"))
+
+			Expect(ui.Outputs).To(ContainSubstrings(
+				[]string{"Binding service", "my-service", "my-app", "my-org", "my-space", "my-user"},
+				[]string{"OK"},
+			))
+			Expect(serviceBindingRepo.CreateServiceInstanceGuid).To(Equal("my-service-guid"))
+			Expect(serviceBindingRepo.CreateApplicationGuid).To(Equal("my-app-guid"))
+			Expect(stagingWatcher.watched).To(Equal(models.Application{}))
+			Expect(stagingWatcher.orgName).To(Equal(""))
+			Expect(stagingWatcher.spaceName).To(Equal(""))
 		})
 	})
 })
 
-func callBindService(args []string, requirementsFactory *testreq.FakeReqFactory, serviceBindingRepo api.ServiceBindingRepository) (fakeUI *testterm.FakeUI) {
+func callBindService(args []string, requirementsFactory *testreq.FakeReqFactory, serviceBindingRepo api.ServiceBindingRepository, appRepo applications.ApplicationRepository, stagingWatcher ApplicationStagingWatcher) (fakeUI *testterm.FakeUI) {
 	fakeUI = new(testterm.FakeUI)
 
 	config := testconfig.NewRepositoryWithDefaults()
 
-	cmd := NewBindService(fakeUI, config, serviceBindingRepo)
+	cmd := NewBindService(fakeUI, config, serviceBindingRepo, appRepo, stagingWatcher)
 	testcmd.RunCommand(cmd, args, requirementsFactory)
 	return
+}
+
+type fakeStagingWatcher struct {
+	watched   models.Application
+	orgName   string
+	spaceName string
+}
+
+func (f *fakeStagingWatcher) ApplicationWatchStaging(app models.Application, orgName, spaceName string, start func(models.Application) (models.Application, error)) (updatedApp models.Application, err error) {
+	f.watched = app
+	f.orgName = orgName
+	f.spaceName = spaceName
+	return start(app)
 }

--- a/cf/commands/service/unbind_service.go
+++ b/cf/commands/service/unbind_service.go
@@ -1,10 +1,15 @@
 package service
 
 import (
+	"strings"
+
+	"github.com/cloudfoundry/cli/cf"
 	"github.com/cloudfoundry/cli/cf/api"
+	"github.com/cloudfoundry/cli/cf/api/applications"
 	"github.com/cloudfoundry/cli/cf/command_metadata"
 	"github.com/cloudfoundry/cli/cf/configuration/core_config"
 	. "github.com/cloudfoundry/cli/cf/i18n"
+	"github.com/cloudfoundry/cli/cf/models"
 	"github.com/cloudfoundry/cli/cf/requirements"
 	"github.com/cloudfoundry/cli/cf/terminal"
 	"github.com/codegangsta/cli"
@@ -16,22 +21,31 @@ type UnbindService struct {
 	serviceBindingRepo api.ServiceBindingRepository
 	appReq             requirements.ApplicationRequirement
 	serviceInstanceReq requirements.ServiceInstanceRequirement
+	appStagingWatcher  ApplicationStagingWatcher
+	appRepo            applications.ApplicationRepository
 }
 
-func NewUnbindService(ui terminal.UI, config core_config.Reader, serviceBindingRepo api.ServiceBindingRepository) (cmd *UnbindService) {
+func NewUnbindService(ui terminal.UI, config core_config.Reader, serviceBindingRepo api.ServiceBindingRepository, appRepo applications.ApplicationRepository, stagingWatcher ApplicationStagingWatcher) (cmd *UnbindService) {
 	cmd = new(UnbindService)
 	cmd.ui = ui
 	cmd.config = config
 	cmd.serviceBindingRepo = serviceBindingRepo
+	cmd.appRepo = appRepo
+	cmd.appStagingWatcher = stagingWatcher
 	return
 }
 
 func (cmd *UnbindService) Metadata() command_metadata.CommandMetadata {
+	flagUsage := T("Restage app")
+	tipUsage := T("TIP: Changes will not apply to existing running applications until they are restaged. Use `unbind-service --force-restage` to force restage app.")
 	return command_metadata.CommandMetadata{
 		Name:        "unbind-service",
 		ShortName:   "us",
 		Description: T("Unbind a service instance from an app"),
 		Usage:       T("CF_NAME unbind-service APP_NAME SERVICE_INSTANCE"),
+		Flags: []cli.Flag{
+			cli.BoolFlag{Name: "force-restage", Usage: strings.Join([]string{flagUsage, tipUsage}, "\n\n")},
+		},
 	}
 }
 
@@ -61,6 +75,7 @@ func (cmd *UnbindService) GetRequirements(requirementsFactory requirements.Facto
 func (cmd *UnbindService) Run(c *cli.Context) {
 	app := cmd.appReq.GetApplication()
 	instance := cmd.serviceInstanceReq.GetServiceInstance()
+	restageFlag := c.Bool("force-restage")
 
 	cmd.ui.Say(T("Unbinding app {{.AppName}} from service {{.ServiceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
 		map[string]interface{}{
@@ -82,6 +97,22 @@ func (cmd *UnbindService) Run(c *cli.Context) {
 	if !found {
 		cmd.ui.Warn(T("Binding between {{.InstanceName}} and {{.AppName}} did not exist",
 			map[string]interface{}{"InstanceName": instance.Name, "AppName": app.Name}))
+	} else if true == restageFlag {
+		cmd.ui.Say("")
+		cmd.ui.Say(T("Restaging app {{.AppName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
+			map[string]interface{}{
+				"AppName":     terminal.EntityNameColor(app.Name),
+				"OrgName":     terminal.EntityNameColor(cmd.config.OrganizationFields().Name),
+				"SpaceName":   terminal.EntityNameColor(cmd.config.SpaceFields().Name),
+				"CurrentUser": terminal.EntityNameColor(cmd.config.Username()),
+			}))
+
+		cmd.appStagingWatcher.ApplicationWatchStaging(app, cmd.config.OrganizationFields().Name, cmd.config.SpaceFields().Name, func(app models.Application) (models.Application, error) {
+			return app, cmd.appRepo.CreateRestageRequest(app.Guid)
+		})
+	} else {
+		cmd.ui.Say(T("TIP: Use '{{.CFCommand}}' to ensure your env variable changes take effect",
+			map[string]interface{}{"CFCommand": terminal.CommandColor(cf.Name() + " restage")}))
 	}
 
 }

--- a/cf/commands/service/unbind_service_test.go
+++ b/cf/commands/service/unbind_service_test.go
@@ -2,8 +2,11 @@ package service_test
 
 import (
 	"github.com/cloudfoundry/cli/cf/api"
+	"github.com/cloudfoundry/cli/cf/api/applications"
+	testApplication "github.com/cloudfoundry/cli/cf/api/applications/fakes"
 	testapi "github.com/cloudfoundry/cli/cf/api/fakes"
 	. "github.com/cloudfoundry/cli/cf/commands/service"
+	"github.com/cloudfoundry/cli/cf/configuration/core_config"
 	"github.com/cloudfoundry/cli/cf/models"
 	testcmd "github.com/cloudfoundry/cli/testhelpers/commands"
 	testconfig "github.com/cloudfoundry/cli/testhelpers/configuration"
@@ -21,6 +24,9 @@ var _ = Describe("unbind-service command", func() {
 		serviceInstance     models.ServiceInstance
 		requirementsFactory *testreq.FakeReqFactory
 		serviceBindingRepo  *testapi.FakeServiceBindingRepo
+		stagingWatcher      *fakeStagingWatcher
+		appRepo             *testApplication.FakeApplicationRepository
+		configRepo          core_config.ReadWriter
 	)
 
 	BeforeEach(func() {
@@ -34,12 +40,15 @@ var _ = Describe("unbind-service command", func() {
 		requirementsFactory.Application = app
 		requirementsFactory.ServiceInstance = serviceInstance
 
+		appRepo = &testApplication.FakeApplicationRepository{}
+		stagingWatcher = &fakeStagingWatcher{}
+
 		serviceBindingRepo = &testapi.FakeServiceBindingRepo{}
 	})
 
 	Context("when not logged in", func() {
 		It("fails requirements when not logged in", func() {
-			cmd := NewUnbindService(&testterm.FakeUI{}, testconfig.NewRepository(), serviceBindingRepo)
+			cmd := NewUnbindService(&testterm.FakeUI{}, testconfig.NewRepository(), serviceBindingRepo, appRepo, stagingWatcher)
 			Expect(testcmd.RunCommand(cmd, []string{"my-service", "my-app"}, requirementsFactory)).To(BeFalse())
 		})
 	})
@@ -47,11 +56,12 @@ var _ = Describe("unbind-service command", func() {
 	Context("when logged in", func() {
 		BeforeEach(func() {
 			requirementsFactory.LoginSuccess = true
+			configRepo = testconfig.NewRepositoryWithDefaults()
 		})
 
 		Context("when the service instance exists", func() {
 			It("unbinds a service from an app", func() {
-				ui := callUnbindService([]string{"my-app", "my-service"}, requirementsFactory, serviceBindingRepo)
+				ui := callUnbindService([]string{"my-app", "my-service"}, requirementsFactory, serviceBindingRepo, appRepo, stagingWatcher)
 
 				Expect(requirementsFactory.ApplicationName).To(Equal("my-app"))
 				Expect(requirementsFactory.ServiceInstanceName).To(Equal("my-service"))
@@ -63,6 +73,41 @@ var _ = Describe("unbind-service command", func() {
 				Expect(serviceBindingRepo.DeleteServiceInstance).To(Equal(serviceInstance))
 				Expect(serviceBindingRepo.DeleteApplicationGuid).To(Equal("my-app-guid"))
 			})
+
+			It("restage app after unbinds a service when force restage", func() {
+				ui := callUnbindService([]string{"my-app", "my-service", "--force-restage"}, requirementsFactory, serviceBindingRepo, appRepo, stagingWatcher)
+
+				Expect(requirementsFactory.ApplicationName).To(Equal("my-app"))
+				Expect(requirementsFactory.ServiceInstanceName).To(Equal("my-service"))
+
+				Expect(ui.Outputs).To(ContainSubstrings(
+					[]string{"Unbinding app", "my-service", "my-app", "my-org", "my-space", "my-user"},
+					[]string{"OK"},
+					[]string{"Restaging app", "my-app", "my-org", "my-space", "my-user"},
+				))
+				Expect(serviceBindingRepo.DeleteServiceInstance).To(Equal(serviceInstance))
+				Expect(serviceBindingRepo.DeleteApplicationGuid).To(Equal("my-app-guid"))
+				Expect(stagingWatcher.watched).To(Equal(app))
+				Expect(stagingWatcher.orgName).To(Equal(configRepo.OrganizationFields().Name))
+				Expect(stagingWatcher.spaceName).To(Equal(configRepo.SpaceFields().Name))
+			})
+
+			It("do not restage app after unbinds a service when not force restage", func() {
+				ui := callUnbindService([]string{"my-app", "my-service"}, requirementsFactory, serviceBindingRepo, appRepo, stagingWatcher)
+
+				Expect(requirementsFactory.ApplicationName).To(Equal("my-app"))
+				Expect(requirementsFactory.ServiceInstanceName).To(Equal("my-service"))
+
+				Expect(ui.Outputs).To(ContainSubstrings(
+					[]string{"Unbinding app", "my-service", "my-app", "my-org", "my-space", "my-user"},
+					[]string{"OK"},
+				))
+				Expect(serviceBindingRepo.DeleteServiceInstance).To(Equal(serviceInstance))
+				Expect(serviceBindingRepo.DeleteApplicationGuid).To(Equal("my-app-guid"))
+				Expect(stagingWatcher.watched).To(Equal(models.Application{}))
+				Expect(stagingWatcher.orgName).To(Equal(""))
+				Expect(stagingWatcher.spaceName).To(Equal(""))
+			})
 		})
 
 		Context("when the service instance does not exist", func() {
@@ -71,7 +116,7 @@ var _ = Describe("unbind-service command", func() {
 			})
 
 			It("warns the user the the service instance does not exist", func() {
-				ui := callUnbindService([]string{"my-app", "my-service"}, requirementsFactory, serviceBindingRepo)
+				ui := callUnbindService([]string{"my-app", "my-service"}, requirementsFactory, serviceBindingRepo, appRepo, stagingWatcher)
 
 				Expect(requirementsFactory.ApplicationName).To(Equal("my-app"))
 				Expect(requirementsFactory.ServiceInstanceName).To(Equal("my-service"))
@@ -87,24 +132,24 @@ var _ = Describe("unbind-service command", func() {
 		})
 
 		It("when no parameters are given the command fails with usage", func() {
-			ui := callUnbindService([]string{"my-service"}, requirementsFactory, serviceBindingRepo)
+			ui := callUnbindService([]string{"my-service"}, requirementsFactory, serviceBindingRepo, appRepo, stagingWatcher)
 			Expect(ui.FailedWithUsage).To(BeTrue())
 
-			ui = callUnbindService([]string{"my-app"}, requirementsFactory, serviceBindingRepo)
+			ui = callUnbindService([]string{"my-app"}, requirementsFactory, serviceBindingRepo, appRepo, stagingWatcher)
 			Expect(ui.FailedWithUsage).To(BeTrue())
 
-			ui = callUnbindService([]string{"my-app", "my-service"}, requirementsFactory, serviceBindingRepo)
+			ui = callUnbindService([]string{"my-app", "my-service"}, requirementsFactory, serviceBindingRepo, appRepo, stagingWatcher)
 			Expect(ui.FailedWithUsage).To(BeFalse())
 		})
 	})
 })
 
-func callUnbindService(args []string, requirementsFactory *testreq.FakeReqFactory, serviceBindingRepo api.ServiceBindingRepository) (fakeUI *testterm.FakeUI) {
+func callUnbindService(args []string, requirementsFactory *testreq.FakeReqFactory, serviceBindingRepo api.ServiceBindingRepository, appRepo applications.ApplicationRepository, stagingWatcher ApplicationStagingWatcher) (fakeUI *testterm.FakeUI) {
 	fakeUI = &testterm.FakeUI{}
 
 	config := testconfig.NewRepositoryWithDefaults()
 
-	cmd := NewUnbindService(fakeUI, config, serviceBindingRepo)
+	cmd := NewUnbindService(fakeUI, config, serviceBindingRepo, appRepo, stagingWatcher)
 	testcmd.RunCommand(cmd, args, requirementsFactory)
 	return
 }

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -5163,5 +5163,20 @@
       "id": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "translation": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "modified": false
+   },
+   {
+      "id": "Restage app",
+      "translation": "Restage app",
+      "modified": false
+   },
+   {
+      "id": "TIP: Changes will not apply to existing running applications until they are restaged. Use `bind-service --force-restage` to force restage app.",
+      "translation": "TIP: Changes will not apply to existing running applications until they are restaged. Use `bind-service --force-restage` to force restage app.",
+      "modified": false
+   },
+   {
+      "id": "TIP: Changes will not apply to existing running applications until they are restaged. Use `unbind-service --force-restage` to force restage app.",
+      "translation": "TIP: Changes will not apply to existing running applications until they are restaged. Use `unbind-service --force-restage` to force restage app.",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -5163,5 +5163,20 @@
       "id": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "translation": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "modified": false
+   },
+   {
+      "id": "Restage app",
+      "translation": "Restage app",
+      "modified": false
+   },
+   {
+      "id": "TIP: Changes will not apply to existing running applications until they are restaged. Use `bind-service --force-restage` to force restage app.",
+      "translation": "TIP: Changes will not apply to existing running applications until they are restaged. Use `bind-service --force-restage` to force restage app.",
+      "modified": false
+   },
+   {
+      "id": "TIP: Changes will not apply to existing running applications until they are restaged. Use `unbind-service --force-restage` to force restage app.",
+      "translation": "TIP: Changes will not apply to existing running applications until they are restaged. Use `unbind-service --force-restage` to force restage app.",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -5163,5 +5163,20 @@
       "id": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "translation": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instancias",
       "modified": false
+   },
+   {
+      "id": "Restage app",
+      "translation": "Restage app",
+      "modified": false
+   },
+   {
+      "id": "TIP: Changes will not apply to existing running applications until they are restaged. Use `bind-service --force-restage` to force restage app.",
+      "translation": "TIP: Changes will not apply to existing running applications until they are restaged. Use `bind-service --force-restage` to force restage app.",
+      "modified": false
+   },
+   {
+      "id": "TIP: Changes will not apply to existing running applications until they are restaged. Use `unbind-service --force-restage` to force restage app.",
+      "translation": "TIP: Changes will not apply to existing running applications until they are restaged. Use `unbind-service --force-restage` to force restage app.",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -5163,5 +5163,20 @@
       "id": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "translation": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "modified": false
+   },
+   {
+      "id": "Restage app",
+      "translation": "Restage app",
+      "modified": false
+   },
+   {
+      "id": "TIP: Changes will not apply to existing running applications until they are restaged. Use `bind-service --force-restage` to force restage app.",
+      "translation": "TIP: Changes will not apply to existing running applications until they are restaged. Use `bind-service --force-restage` to force restage app.",
+      "modified": false
+   },
+   {
+      "id": "TIP: Changes will not apply to existing running applications until they are restaged. Use `unbind-service --force-restage` to force restage app.",
+      "translation": "TIP: Changes will not apply to existing running applications until they are restaged. Use `unbind-service --force-restage` to force restage app.",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -5163,5 +5163,20 @@
       "id": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "translation": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "modified": false
+   },
+   {
+      "id": "Restage app",
+      "translation": "Restage app",
+      "modified": false
+   },
+   {
+      "id": "TIP: Changes will not apply to existing running applications until they are restaged. Use `bind-service --force-restage` to force restage app.",
+      "translation": "TIP: Changes will not apply to existing running applications until they are restaged. Use `bind-service --force-restage` to force restage app.",
+      "modified": false
+   },
+   {
+      "id": "TIP: Changes will not apply to existing running applications until they are restaged. Use `unbind-service --force-restage` to force restage app.",
+      "translation": "TIP: Changes will not apply to existing running applications until they are restaged. Use `unbind-service --force-restage` to force restage app.",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -5163,5 +5163,20 @@
       "id": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "translation": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "modified": false
+   },
+   {
+      "id": "Restage app",
+      "translation": "Restage app",
+      "modified": false
+   },
+   {
+      "id": "TIP: Changes will not apply to existing running applications until they are restaged. Use `bind-service --force-restage` to force restage app.",
+      "translation": "TIP: Changes will not apply to existing running applications until they are restaged. Use `bind-service --force-restage` to force restage app.",
+      "modified": false
+   },
+   {
+      "id": "TIP: Changes will not apply to existing running applications until they are restaged. Use `unbind-service --force-restage` to force restage app.",
+      "translation": "TIP: Changes will not apply to existing running applications until they are restaged. Use `unbind-service --force-restage` to force restage app.",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -5163,5 +5163,20 @@
       "id": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "translation": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instâncias",
       "modified": false
+   },
+   {
+      "id": "Restage app",
+      "translation": "Restage app",
+      "modified": false
+   },
+   {
+      "id": "TIP: Changes will not apply to existing running applications until they are restaged. Use `bind-service --force-restage` to force restage app.",
+      "translation": "TIP: Changes will not apply to existing running applications until they are restaged. Use `bind-service --force-restage` to force restage app.",
+      "modified": false
+   },
+   {
+      "id": "TIP: Changes will not apply to existing running applications until they are restaged. Use `unbind-service --force-restage` to force restage app.",
+      "translation": "TIP: Changes will not apply to existing running applications until they are restaged. Use `unbind-service --force-restage` to force restage app.",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -5163,5 +5163,20 @@
       "id": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "translation": "{{.Usage}} {{.FormattedMemory}} 乘以 {{.InstanceCount}}实例数",
       "modified": false
+   },
+   {
+      "id": "Restage app",
+      "translation": "Restage app",
+      "modified": false
+   },
+   {
+      "id": "TIP: Changes will not apply to existing running applications until they are restaged. Use `bind-service --force-restage` to force restage app.",
+      "translation": "TIP: Changes will not apply to existing running applications until they are restaged. Use `bind-service --force-restage` to force restage app.",
+      "modified": false
+   },
+   {
+      "id": "TIP: Changes will not apply to existing running applications until they are restaged. Use `unbind-service --force-restage` to force restage app.",
+      "translation": "TIP: Changes will not apply to existing running applications until they are restaged. Use `unbind-service --force-restage` to force restage app.",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -5163,5 +5163,20 @@
       "id": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "translation": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "modified": false
+   },
+   {
+      "id": "Restage app",
+      "translation": "Restage app",
+      "modified": false
+   },
+   {
+      "id": "TIP: Changes will not apply to existing running applications until they are restaged. Use `bind-service --force-restage` to force restage app.",
+      "translation": "TIP: Changes will not apply to existing running applications until they are restaged. Use `bind-service --force-restage` to force restage app.",
+      "modified": false
+   },
+   {
+      "id": "TIP: Changes will not apply to existing running applications until they are restaged. Use `unbind-service --force-restage` to force restage app.",
+      "translation": "TIP: Changes will not apply to existing running applications until they are restaged. Use `unbind-service --force-restage` to force restage app.",
+      "modified": false
    }
 ]


### PR DESCRIPTION
Solution to Story [82140190]
As of now user has to restage an app with 'cf restage SOME_APP' command after
binding or unbinding to ensure bind/unbind env variable changes take effect.
With --force-restage flag , User has option to restage an app with bind/unbind itself.

Note: Currently we have not handled this flag for if its already bind. If you want to handle that situation we are ready to change.

