### PR TITLE
Adding the no-hostname attribute in create-app-manifest

### DIFF
--- a/cf/manifest/generate_manifest.go
+++ b/cf/manifest/generate_manifest.go
@@ -131,8 +131,14 @@ func (m *appManifest) Save() error {
 		}
 
 		if len(app.Routes) > 0 {
-			if _, err := fmt.Fprintf(f, "  host: %s\n", app.Routes[0].Host); err != nil {
-				return err
+			if app.Routes[0].Host == "" {
+				if _, err := fmt.Fprintf(f, "  no-hostname: true\n"); err != nil {
+					return err
+				}
+			} else {
+				if _, err := fmt.Fprintf(f, "  host: %s\n", app.Routes[0].Host); err != nil {
+					return err
+				}
 			}
 			if _, err := fmt.Fprintf(f, "  domain: %s\n", app.Routes[0].Domain.Name); err != nil {
 				return err

--- a/cf/manifest/generate_manifest_test.go
+++ b/cf/manifest/generate_manifest_test.go
@@ -111,6 +111,19 @@ var _ = Describe("generate_manifest", func() {
 		))
 	})
 
+	It("generates a manifest containing the attributes noHostName", func() {
+		m.Memory("app1", 128)
+		m.Domain("app1", "", "blahblahblah.com")
+		err := m.Save()
+		Ω(err).NotTo(HaveOccurred())
+
+		Ω(getYamlContent("./output.yml")).To(ContainSubstrings(
+			[]string{"- name: app1"},
+			[]string{"  memory: 128M"},
+			[]string{"  no-hostname: true"},
+			[]string{"  domain: blahblahblah.com"},
+		))
+	})
 })
 
 func getYamlContent(path string) []string {


### PR DESCRIPTION
Solution: story [90554794]
Before : There was no support for --no-hostname attribute in  cf create-app-manifest 
After : If the app is mapped to the root domain then  cf create-app-manifest  will contain  no-hostname : true 
