### PR TITLE
Fix the hostname panic issue story [91881010]

### DIFF
--- a/cf/manifest/manifest.go
+++ b/cf/manifest/manifest.go
@@ -136,17 +136,21 @@ func mapToAppParams(basePath string, yamlMap generic.Map) (appParams models.AppP
 	appParams.BuildpackUrl = stringValOrDefault(yamlMap, "buildpack", &errs)
 	appParams.DiskQuota = bytesVal(yamlMap, "disk_quota", &errs)
 
-	domainAry := *sliceOrEmptyVal(yamlMap, "domains", &errs)
-	if domain := stringVal(yamlMap, "domain", &errs); domain != nil {
-		domainAry = append(domainAry, *domain)
+	domainAry := sliceOrEmptyVal(yamlMap, "domains", &errs)
+	if domain := stringVal(yamlMap, "domain", &errs); domain != nil && domainAry != nil {
+		*domainAry = append(*domainAry, *domain)
 	}
-	appParams.Domains = removeDuplicatedValue(domainAry)
+	if domainAry != nil {
+		appParams.Domains = removeDuplicatedValue(*domainAry)
+	}
+	hostsArr := sliceOrEmptyVal(yamlMap, "hosts", &errs)
 
-	hostsArr := *sliceOrEmptyVal(yamlMap, "hosts", &errs)
-	if host := stringVal(yamlMap, "host", &errs); host != nil {
-		hostsArr = append(hostsArr, *host)
+	if host := stringVal(yamlMap, "host", &errs); host != nil && hostsArr != nil {
+		*hostsArr = append(*hostsArr, *host)
 	}
-	appParams.Hosts = removeDuplicatedValue(hostsArr)
+	if hostsArr != nil {
+		appParams.Hosts = removeDuplicatedValue(*hostsArr)
+	}
 
 	appParams.Name = stringVal(yamlMap, "name", &errs)
 	appParams.Path = stringVal(yamlMap, "path", &errs)

--- a/cf/manifest/manifest_test.go
+++ b/cf/manifest/manifest_test.go
@@ -220,6 +220,29 @@ var _ = Describe("Manifests", func() {
 		}
 	})
 
+	It("returns errors when there is invalid value in 'hosts' and 'domains'", func() {
+		m := NewManifest("/some/path", generic.NewMap(map[interface{}]interface{}{
+			"applications": []interface{}{
+				map[interface{}]interface{}{
+					"buildpack":  "my-buildpack",
+					"disk_quota": "512M",
+					"hosts":      "n",
+					"domains":    "m",
+				},
+			},
+		}))
+
+		_, err := m.Applications()
+		Expect(err).To(HaveOccurred())
+		errorSlice := strings.Split(err.Error(), "\n")
+		manifestKeys := []string{"hosts", "domains"}
+
+		for _, key := range manifestKeys {
+			Expect(errorSlice).To(ContainSubstrings([]string{key, "to be a list of strings"}))
+		}
+
+	})
+
 	It("parses known manifest keys", func() {
 		m := NewManifest("/some/path", generic.NewMap(map[interface{}]interface{}{
 			"applications": []interface{}{


### PR DESCRIPTION
The sliceOrEmptyVal function can return nil, but in mapToAppParams function
we are invoking the function sliceOrEmptyVal as shown below.
So on returning nil its panicking because accessing value from nil pointer by (* nil) which is wrong.
hostsArr := *sliceOrEmptyVal(yamlMap, hosts, &errs)

After fixing the output as

@cf5:~/go/src/github.com/cloudfoundry/cli$ ./out/cf push -f ~/cf-downloads/simple-go-web-app/manifest.yml
FAILED
Error reading manifest file:
Expected hosts to be a list of strings