### PR TITLE
Fix the random failure of manifest test cases

### DIFF
--- a/cf/manifest/manifest_test.go
+++ b/cf/manifest/manifest_test.go
@@ -248,8 +248,8 @@ var _ = Describe("Manifests", func() {
 
 		Expect(*apps[0].BuildpackUrl).To(Equal("my-buildpack"))
 		Expect(*apps[0].DiskQuota).To(Equal(int64(512)))
-		Expect(*apps[0].Domains).To(Equal([]string{"domain1.test", "domain2.test", "my-domain"}))
-		Expect(*apps[0].Hosts).To(Equal([]string{"host-1", "host-2", "my-hostname"}))
+		Expect(*apps[0].Domains).Should(ConsistOf([]string{"domain1.test", "domain2.test", "my-domain"}))
+		Expect(*apps[0].Hosts).Should(ConsistOf([]string{"host-1", "host-2", "my-hostname"}))
 		Expect(*apps[0].Name).To(Equal("my-app-name"))
 		Expect(*apps[0].StackName).To(Equal("my-stack"))
 		Expect(*apps[0].Memory).To(Equal(int64(256)))
@@ -278,9 +278,9 @@ var _ = Describe("Manifests", func() {
 		Expect(len(apps)).To(Equal(1))
 
 		Expect(len(*apps[0].Domains)).To(Equal(3))
-		Expect(*apps[0].Domains).To(Equal([]string{"my-domain", "domain1.test", "domain2.test"}))
+		Expect(*apps[0].Domains).Should(ConsistOf([]string{"my-domain", "domain1.test", "domain2.test"}))
 		Expect(len(*apps[0].Hosts)).To(Equal(3))
-		Expect(*apps[0].Hosts).To(Equal([]string{"my-hostname", "host-1", "host-2"}))
+		Expect(*apps[0].Hosts).Should(ConsistOf([]string{"my-hostname", "host-1", "host-2"}))
 	})
 
 	Describe("old-style property syntax", func() {


### PR DESCRIPTION
story #91289824
The test cases are failing randomly because of the map is used in the
removeDuplicatedValue  function which doesn't guaranteed the order.
so the changed the matcher from  To(Equal()) to Should(ConsistOf()) 
(which doesn't bother about order of items)


When iterating over a map with a range loop, the iteration order is not specified and is not guaranteed to be the same from one iteration to the next. Since Go 1 the runtime randomizes map iteration order, as programmers relied on the stable iteration order of the previous implementation. If you require a stable iteration order you must maintain a separate data structure that specifies that order(https://blog.golang.org/go-maps-in-action).

I had written a sample app & called the removeDuplicatedValue & executed multipletimes the output
order is different in multiple executions