### PR TITLE
 Fix for stack and stacks command

### DIFF
--- a/cf/commands/stack.go
+++ b/cf/commands/stack.go
@@ -26,8 +26,8 @@ func NewListStack(ui terminal.UI, config core_config.Reader, stacksRepo stacks.S
 func (cmd ListStack) Metadata() command_metadata.CommandMetadata {
 	return command_metadata.CommandMetadata{
 		Name:        "stack",
-		Description: "Show information for a stack (a stack is a pre-built file system, including an operating system, that can run apps)",
-		Usage:       "CF_NAME stack",
+		Description: T("Show information for a stack (a stack is a pre-built file system, including an operating system, that can run apps)"),
+		Usage:       T("CF_NAME stack STACK_NAME"),
 		Flags: []cli.Flag{
 			cli.BoolFlag{Name: "guid", Usage: T("Retrieve and display the given stack's guid. All other output for the stack is suppressed.")},
 		},

--- a/cf/commands/stack_test.go
+++ b/cf/commands/stack_test.go
@@ -39,6 +39,16 @@ var _ = Describe("stack command", func() {
 
 			Expect(testcmd.RunCommand(cmd, []string{}, requirementsFactory)).To(BeFalse())
 		})
+
+		It("fails with usage when not provided exactly one arg", func() {
+			requirementsFactory.LoginSuccess = true
+			Expect(testcmd.RunCommand(cmd, []string{}, requirementsFactory)).To(BeFalse())
+			Expect(ui.FailedWithUsage).To(BeTrue())
+			Expect(ui.Outputs).To(ContainSubstrings(
+				[]string{"FAILED"},
+				[]string{"Incorrect Usage."},
+			))
+		})
 	})
 
 	It("returns the stack guid when '--guid' flag is provided", func() {

--- a/cf/commands/stacks.go
+++ b/cf/commands/stacks.go
@@ -32,6 +32,10 @@ func (cmd ListStacks) Metadata() command_metadata.CommandMetadata {
 }
 
 func (cmd ListStacks) GetRequirements(requirementsFactory requirements.Factory, c *cli.Context) (reqs []requirements.Requirement, err error) {
+	if len(c.Args()) != 0 {
+		cmd.ui.FailWithUsage(c)
+	}
+
 	reqs = append(reqs, requirementsFactory.NewLoginRequirement())
 	return
 }

--- a/cf/commands/stacks_test.go
+++ b/cf/commands/stacks_test.go
@@ -36,6 +36,16 @@ var _ = Describe("stacks command", func() {
 
 			Expect(testcmd.RunCommand(cmd, []string{}, requirementsFactory)).To(BeFalse())
 		})
+
+		It("should fail with usage when provided any arguments", func() {
+			requirementsFactory.LoginSuccess = true
+			Expect(testcmd.RunCommand(cmd, []string{"etcetc"}, requirementsFactory)).To(BeFalse())
+			Expect(ui.FailedWithUsage).To(BeTrue())
+			Expect(ui.Outputs).To(ContainSubstrings(
+				[]string{"FAILED"},
+				[]string{"Incorrect Usage."},
+			))
+		})
 	})
 
 	It("lists the stacks", func() {

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -1020,6 +1020,11 @@
       "modified": false
    },
    {
+      "id": "CF_NAME stack STACK_NAME",
+      "translation": "CF_NAME stack STACK_NAME",
+      "modified": false
+   },
+   {
       "id": "CF_NAME staging-environment-variable-group",
       "translation": "CF_NAME staging-environment-variable-group",
       "modified": false
@@ -2727,6 +2732,11 @@
    {
       "id": "List all stacks (a stack is a pre-built file system, including an operating system, that can run apps)",
       "translation": "List all stacks (a stack is a pre-built file system, including an operating system, that can run apps)",
+      "modified": false
+   },
+   {
+      "id": "Show information for a stack (a stack is a pre-built file system, including an operating system, that can run apps)",
+      "translation": "Show information for a stack (a stack is a pre-built file system, including an operating system, that can run apps)",
       "modified": false
    },
    {

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -1020,6 +1020,11 @@
       "modified": false
    },
    {
+      "id": "CF_NAME stack STACK_NAME",
+      "translation": "CF_NAME stack STACK_NAME",
+      "modified": false
+   },
+   {
       "id": "CF_NAME staging-environment-variable-group",
       "translation": "CF_NAME staging-environment-variable-group",
       "modified": false
@@ -2727,6 +2732,11 @@
    {
       "id": "List all stacks (a stack is a pre-built file system, including an operating system, that can run apps)",
       "translation": "List all stacks (a stack is a pre-built file system, including an operating system, that can run apps)",
+      "modified": false
+   },
+   {
+      "id": "Show information for a stack (a stack is a pre-built file system, including an operating system, that can run apps)",
+      "translation": "Show information for a stack (a stack is a pre-built file system, including an operating system, that can run apps)",
       "modified": false
    },
    {

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -1020,6 +1020,11 @@
       "modified": false
    },
    {
+      "id": "CF_NAME stack STACK_NAME",
+      "translation": "CF_NAME stack STACK_NAME",
+      "modified": false
+   },
+   {
       "id": "CF_NAME staging-environment-variable-group",
       "translation": "CF_NAME staging-environment-variable-group",
       "modified": false
@@ -2727,6 +2732,11 @@
    {
       "id": "List all stacks (a stack is a pre-built file system, including an operating system, that can run apps)",
       "translation": "Lista todos los stacks(un stack es un sistema de archivos pre construid, Incluyendo un sistema operativo, que puede correr apps)",
+      "modified": false
+   },
+   {
+      "id": "Show information for a stack (a stack is a pre-built file system, including an operating system, that can run apps)",
+      "translation": "Show information for a stack (a stack is a pre-built file system, including an operating system, that can run apps)",
       "modified": false
    },
    {

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -1020,6 +1020,11 @@
       "modified": false
    },
    {
+      "id": "CF_NAME stack STACK_NAME",
+      "translation": "CF_NAME stack STACK_NAME",
+      "modified": false
+   },
+   {
       "id": "CF_NAME staging-environment-variable-group",
       "translation": "CF_NAME staging-environment-variable-group",
       "modified": false
@@ -2730,8 +2735,13 @@
       "modified": false
    },
    {
+      "id": "Show information for a stack (a stack is a pre-built file system, including an operating system, that can run apps)",
+      "translation": "Montrez information pour un stack (un stack est un system de fichier pré-construit qui inclus un system d'exploitation qui peut executer des logiciels)",
+      "modified": false
+   },
+   {
       "id": "List all the routes for all spaces of current organization",
-      "translation": "List all the routes for all spaces of current organization",
+      "translation": "Lister toutes les routes pour tous les espaces de l'organization courrant",
       "modified": false
    },
    {

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -1020,6 +1020,11 @@
       "modified": false
    },
    {
+      "id": "CF_NAME stack STACK_NAME",
+      "translation": "CF_NAME stack STACK_NAME",
+      "modified": false
+   },
+   {
       "id": "CF_NAME staging-environment-variable-group",
       "translation": "CF_NAME staging-environment-variable-group",
       "modified": false
@@ -2727,6 +2732,11 @@
    {
       "id": "List all stacks (a stack is a pre-built file system, including an operating system, that can run apps)",
       "translation": "List all stacks (a stack is a pre-built file system, including an operating system, that can run apps)",
+      "modified": false
+   },
+   {
+      "id": "Show information for a stack (a stack is a pre-built file system, including an operating system, that can run apps)",
+      "translation": "Show information for a stack (a stack is a pre-built file system, including an operating system, that can run apps)",
       "modified": false
    },
    {

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -1020,6 +1020,11 @@
       "modified": false
    },
    {
+      "id": "CF_NAME stack STACK_NAME",
+      "translation": "CF_NAME stack STACK_NAME",
+      "modified": false
+   },
+   {
       "id": "CF_NAME staging-environment-variable-group",
       "translation": "CF_NAME staging-environment-variable-group",
       "modified": false
@@ -2727,6 +2732,11 @@
    {
       "id": "List all stacks (a stack is a pre-built file system, including an operating system, that can run apps)",
       "translation": "List all stacks (a stack is a pre-built file system, including an operating system, that can run apps)",
+      "modified": false
+   },
+   {
+      "id": "Show information for a stack (a stack is a pre-built file system, including an operating system, that can run apps)",
+      "translation": "Show information for a stack (a stack is a pre-built file system, including an operating system, that can run apps)",
       "modified": false
    },
    {

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -1020,6 +1020,11 @@
       "modified": false
    },
    {
+      "id": "CF_NAME stack STACK_NAME",
+      "translation": "CF_NAME stack STACK_NAME",
+      "modified": false
+   },
+   {
       "id": "CF_NAME staging-environment-variable-group",
       "translation": "CF_NAME staging-environment-variable-group",
       "modified": false
@@ -2727,6 +2732,11 @@
    {
       "id": "List all stacks (a stack is a pre-built file system, including an operating system, that can run apps)",
       "translation": "Exibir todas as stacks (uma stack é um container pré-contruído, incluindo um sistema de arquivos e operacional, capaz de executar apps)",
+      "modified": false
+   },
+   {
+      "id": "Show information for a stack (a stack is a pre-built file system, including an operating system, that can run apps)",
+      "translation": "Show information for a stack (a stack is a pre-built file system, including an operating system, that can run apps)",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -1020,6 +1020,11 @@
       "modified": false
    },
    {
+      "id": "CF_NAME stack STACK_NAME",
+      "translation": "CF_NAME stack STACK_NAME",
+      "modified": false
+   },
+   {
       "id": "CF_NAME staging-environment-variable-group",
       "translation": "CF_NAME staging-environment-variable-group",
       "modified": false
@@ -2727,6 +2732,11 @@
    {
       "id": "List all stacks (a stack is a pre-built file system, including an operating system, that can run apps)",
       "translation": "列出所有stacks (stack是预先建立好的文件系统， 包含可以运行应用程序的操作系统)",
+      "modified": false
+   },
+   {
+      "id": "Show information for a stack (a stack is a pre-built file system, including an operating system, that can run apps)",
+      "translation": "示信息为叠层（堆叠是一个预先建立的文件系统，包括一个操作系统，可以运行应用程序）",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -1020,6 +1020,11 @@
       "modified": false
    },
    {
+      "id": "CF_NAME stack STACK_NAME",
+      "translation": "CF_NAME stack STACK_NAME",
+      "modified": false
+   },
+   {
       "id": "CF_NAME staging-environment-variable-group",
       "translation": "CF_NAME staging-environment-variable-group",
       "modified": false
@@ -2727,6 +2732,11 @@
    {
       "id": "List all stacks (a stack is a pre-built file system, including an operating system, that can run apps)",
       "translation": "List all stacks (a stack is a pre-built file system, including an operating system, that can run apps)",
+      "modified": false
+   },
+   {
+      "id": "Show information for a stack (a stack is a pre-built file system, including an operating system, that can run apps)",
+      "translation": "Show information for a stack (a stack is a pre-built file system, including an operating system, that can run apps)",
       "modified": false
    },
    {


### PR DESCRIPTION
cf version 6.11.0-bba7fcf-2015-04-14T00:39:44+00:00
For  stack  command when we type
# cf stack -h
NAME:
   stack - Show information for a stack (a stack is a pre-built file system, including an operating system, that can run apps)

USAGE:
   cf stack

OPTIONS:
   --guid       Retrieve and display the given stack's guid. All other output for the stack is suppressed.
It is not showing how to use the  stack  command and if we follow the current usage instruction of  stack  command we are getting
# cf stack
FAILED
Incorrect Usage.

NAME:
   stack - Show information for a stack (a stack is a pre-built file system, including an operating system, that can run apps)

USAGE:
   cf stack

OPTIONS:
   --guid       Retrieve and display the given stack's guid. All other output for the stack is suppressed.


for  stacks  command when we type 
# cf stacks hhh
Getting stacks in org shweOrg / space secspace as admin...
OK

name         description
lucid64      Ubuntu 10.04 on x86-64
cflinuxfs2   Cloud Foundry Linux-based filesystem

It should through error as per the USAGE of  stacks  command.

After fix :
# ./out/cf stack -h
NAME:
   stack - Show information for a stack (a stack is a pre-built file system, including an operating system, that can run apps)

USAGE:
   cf stack STACK_NAME

OPTIONS:
   --guid       Retrieve and display the given stack's guid. All other output for the stack is suppressed.


When we type
# ./out/cf stacks hhhh
FAILED
Incorrect Usage.

NAME:
   stacks - List all stacks (a stack is a pre-built file system, including an operating system, that can run apps)

USAGE:
   cf stacks
