### PR TITLE
Fix create-app-manifest only includes one host [92530254]

### DIFF
--- a/cf/commands/create_app_manifest.go
+++ b/cf/commands/create_app_manifest.go
@@ -129,7 +129,9 @@ func (cmd *CreateAppManifest) createManifest(app models.Application, savePath st
 	}
 
 	if len(app.Routes) > 0 {
-		cmd.manifest.Domain(app.Name, app.Routes[0].Host, app.Routes[0].Domain.Name)
+		for i := 0; i < len(app.Routes); i++ {
+			cmd.manifest.Domain(app.Name, app.Routes[i].Host, app.Routes[i].Domain.Name)
+		}
 	}
 
 	err := cmd.manifest.Save()

--- a/cf/commands/create_app_manifest_test.go
+++ b/cf/commands/create_app_manifest_test.go
@@ -106,7 +106,7 @@ var _ = Describe("create-app-manifest Command", func() {
 				Ω(fakeManifest.EnvironmentVarsCallCount()).To(Equal(1))
 				Ω(fakeManifest.HealthCheckTimeoutCallCount()).To(Equal(1))
 				Ω(fakeManifest.InstancesCallCount()).To(Equal(1))
-				Ω(fakeManifest.DomainCallCount()).To(Equal(1))
+				Ω(fakeManifest.DomainCallCount()).To(Equal(2))
 				Ω(fakeManifest.ServiceCallCount()).To(Equal(1))
 				Ω(fakeManifest.StartupCommandCallCount()).To(Equal(1))
 			})

--- a/cf/manifest/generate_manifest_test.go
+++ b/cf/manifest/generate_manifest_test.go
@@ -111,6 +111,106 @@ var _ = Describe("generate_manifest", func() {
 		))
 	})
 
+	Context("When there are multiple hosts and domains", func() {
+
+		It("generates a manifest containing two hosts two domains", func() {
+			m.Memory("app1", 128)
+			m.StartupCommand("app1", "run main.go")
+			m.Service("app1", "service1")
+			m.EnvironmentVars("app1", "foo", "boo")
+			m.HealthCheckTimeout("app1", 100)
+			m.Instances("app1", 3)
+			m.Domain("app1", "foo1", "test1.com")
+			m.Domain("app1", "foo1", "test2.com")
+			m.Domain("app1", "foo2", "test1.com")
+			m.Domain("app1", "foo2", "test2.com")
+			err := m.Save()
+			Ω(err).NotTo(HaveOccurred())
+
+			Ω(getYamlContent("./output.yml")).To(ContainSubstrings(
+				[]string{"- name: app1"},
+				[]string{"  memory: 128M"},
+				[]string{"  command: run main.go"},
+				[]string{"  services:"},
+				[]string{"  - service1"},
+				[]string{"  env:"},
+				[]string{"    foo: boo"},
+				[]string{"  timeout: 100"},
+				[]string{"  instances: 3"},
+				[]string{"  hosts:"},
+				[]string{"  - foo1"},
+				[]string{"  - foo2"},
+				[]string{"  domains:"},
+				[]string{"  - test1.com"},
+				[]string{"  - test2.com"},
+			))
+		})
+	})
+
+	Context("When there are multiple hosts and single domain", func() {
+
+		It("generates a manifest containing two hosts one domain", func() {
+			m.Memory("app1", 128)
+			m.StartupCommand("app1", "run main.go")
+			m.Service("app1", "service1")
+			m.EnvironmentVars("app1", "foo", "boo")
+			m.HealthCheckTimeout("app1", 100)
+			m.Instances("app1", 3)
+			m.Domain("app1", "foo1", "test.com")
+			m.Domain("app1", "foo2", "test.com")
+			err := m.Save()
+			Ω(err).NotTo(HaveOccurred())
+
+			Ω(getYamlContent("./output.yml")).To(ContainSubstrings(
+				[]string{"- name: app1"},
+				[]string{"  memory: 128M"},
+				[]string{"  command: run main.go"},
+				[]string{"  services:"},
+				[]string{"  - service1"},
+				[]string{"  env:"},
+				[]string{"    foo: boo"},
+				[]string{"  timeout: 100"},
+				[]string{"  instances: 3"},
+				[]string{"  hosts:"},
+				[]string{"  - foo1"},
+				[]string{"  - foo2"},
+				[]string{"  domain: test.com"},
+			))
+		})
+	})
+
+	Context("When there is single host and multiple domains", func() {
+
+		It("generates a manifest containing one host two domains", func() {
+			m.Memory("app1", 128)
+			m.StartupCommand("app1", "run main.go")
+			m.Service("app1", "service1")
+			m.EnvironmentVars("app1", "foo", "boo")
+			m.HealthCheckTimeout("app1", 100)
+			m.Instances("app1", 3)
+			m.Domain("app1", "foo", "test1.com")
+			m.Domain("app1", "foo", "test2.com")
+			err := m.Save()
+			Ω(err).NotTo(HaveOccurred())
+
+			Ω(getYamlContent("./output.yml")).To(ContainSubstrings(
+				[]string{"- name: app1"},
+				[]string{"  memory: 128M"},
+				[]string{"  command: run main.go"},
+				[]string{"  services:"},
+				[]string{"  - service1"},
+				[]string{"  env:"},
+				[]string{"    foo: boo"},
+				[]string{"  timeout: 100"},
+				[]string{"  instances: 3"},
+				[]string{"  host: foo"},
+				[]string{"  domains:"},
+				[]string{"  - test1.com"},
+				[]string{"  - test2.com"},
+			))
+		})
+	})
+
 })
 
 func getYamlContent(path string) []string {


### PR DESCRIPTION
After fixing the issue cli create-app-manifest will cosiders
hosts,domains based on multiple routes to an app,so when ever
has more then one host or domain uses the hosts & domains
key word  respectively.
the changed code doesn't have perf impact if an app has single route...
story: #92530254
Any comments/suggestions are welcome. From my side i have some other options as follows

Option1: I can remove the below code which hits on single route case because which has taken care in writeRoutesToFile   but will have little less performance.

if len(app.Routes) == 1 {
				if _, err := fmt.Fprintf(f, "  host: %s\n", app.Routes[0].Host); err != nil {
					return err
				}
				if _, err := fmt.Fprintf(f, "  domain: %s\n", app.Routes[0].Domain.Name); err != nil {
					return err
				}
			} 


Option 2: Option 1 & always use only the hosts & domains keys in manifest.yml  file so i can remove below code from writeRoutesToFile & change  the required test cases


if len(hosts) == 1 {
		if _, err := fmt.Fprintf(f, "  host: %s\n", hosts[0]); err != nil {
			return err
		}
	}
if len(domains) == 1 {
		if _, err := fmt.Fprintf(f, "  domain: %s\n", domains[0]); err != nil {
			return err
		}
	}