### PR TITLE
make accepts_incomplete configurable (i.e. for build jobs)

### DIFF
--- a/cf/commands/service/create_service.go
+++ b/cf/commands/service/create_service.go
@@ -40,6 +40,9 @@ EXAMPLE:
 
 TIP:
    Use 'CF_NAME create-user-provided-service' to make user-provided services available to cf apps`),
+		Flags: []cli.Flag{
+			cli.BoolFlag{Name: "w", Usage: T("Wait for creation confirmation")},
+		},
 	}
 }
 
@@ -69,7 +72,8 @@ func (cmd CreateService) Run(c *cli.Context) {
 			"CurrentUser": terminal.EntityNameColor(cmd.config.Username()),
 		}))
 
-	plan, err := cmd.CreateService(serviceName, planName, serviceInstanceName)
+	var wait bool = c.Bool("w") || false
+	plan, err := cmd.CreateService(serviceName, planName, serviceInstanceName, wait)
 
 	switch err.(type) {
 	case nil:
@@ -96,7 +100,7 @@ func (cmd CreateService) Run(c *cli.Context) {
 	}
 }
 
-func (cmd CreateService) CreateService(serviceName string, planName string, serviceInstanceName string) (models.ServicePlanFields, error) {
+func (cmd CreateService) CreateService(serviceName string, planName string, serviceInstanceName string, wait bool) (models.ServicePlanFields, error) {
 	offerings, apiErr := cmd.serviceBuilder.GetServicesByNameForSpaceWithPlans(cmd.config.SpaceFields().Guid, serviceName)
 	if apiErr != nil {
 		return models.ServicePlanFields{}, apiErr
@@ -107,7 +111,7 @@ func (cmd CreateService) CreateService(serviceName string, planName string, serv
 		return plan, apiErr
 	}
 
-	apiErr = cmd.serviceRepo.CreateServiceInstance(serviceInstanceName, plan.Guid)
+	apiErr = cmd.serviceRepo.CreateServiceInstance(serviceInstanceName, plan.Guid, wait)
 	return plan, apiErr
 }
 

--- a/cf/commands/service/delete_service.go
+++ b/cf/commands/service/delete_service.go
@@ -34,6 +34,7 @@ func (cmd *DeleteService) Metadata() command_metadata.CommandMetadata {
 		Usage:       T("CF_NAME delete-service SERVICE_INSTANCE [-f]"),
 		Flags: []cli.Flag{
 			cli.BoolFlag{Name: "f", Usage: T("Force deletion without confirmation")},
+			cli.BoolFlag{Name: "w", Usage: T("Wait for deletion confirmation")},
 		},
 	}
 }
@@ -76,7 +77,9 @@ func (cmd *DeleteService) Run(c *cli.Context) {
 		return
 	}
 
-	apiErr = cmd.serviceRepo.DeleteService(instance)
+	var wait bool = c.Bool("w") || false
+
+	apiErr = cmd.serviceRepo.DeleteService(instance, wait)
 	if apiErr != nil {
 		cmd.ui.Failed(apiErr.Error())
 		return

--- a/cf/commands/service/rename_service.go
+++ b/cf/commands/service/rename_service.go
@@ -32,6 +32,9 @@ func (cmd *RenameService) Metadata() command_metadata.CommandMetadata {
 		Name:        "rename-service",
 		Description: T("Rename a service instance"),
 		Usage:       T("CF_NAME rename-service SERVICE_INSTANCE NEW_SERVICE_INSTANCE"),
+		Flags: []cli.Flag{
+			cli.BoolFlag{Name: "w", Usage: T("Wait for rename confirmation")},
+		},
 	}
 }
 
@@ -64,7 +67,8 @@ func (cmd *RenameService) Run(c *cli.Context) {
 			"SpaceName":      terminal.EntityNameColor(cmd.config.SpaceFields().Name),
 			"CurrentUser":    terminal.EntityNameColor(cmd.config.Username()),
 		}))
-	err := cmd.serviceRepo.RenameService(serviceInstance, newName)
+	var wait bool = c.Bool("w") || false
+	err := cmd.serviceRepo.RenameService(serviceInstance, newName, wait)
 
 	if err != nil {
 		if httpError, ok := err.(errors.HttpError); ok && httpError.ErrorCode() == errors.SERVICE_INSTANCE_NAME_TAKEN {

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -4505,6 +4505,26 @@
       "modified": false
    },
    {
+      "id": "Wait for update confirmation",
+      "translation": "Wait for update confirmation",
+      "modified": false
+   },
+   {
+      "id": "Wait for rename confirmation",
+      "translation": "Wait for rename confirmation",
+      "modified": false
+   },
+   {
+      "id": "Wait for creation confirmation",
+      "translation": "Wait for creation confirmation",
+      "modified": false
+   },
+   {
+      "id": "Wait for deletion confirmation",
+      "translation": "Wait for deletion confirmation",
+      "modified": false
+   },
+   {
       "id": "WARNING:\n   Providing your password as a command line option is highly discouraged\n   Your password may be visible to others and may be recorded in your shell history\n\n",
       "translation": "WARNING:\n   Providing your password as a command line option is highly discouraged\n   Your password may be visible to others and may be recorded in your shell history\n\n",
       "modified": false


### PR DESCRIPTION
I've never written go code but it would be really nice to choose to "accepts_incomplete" calls.
For example in build jobs this would be really nice.