### PR TITLE
Restart command: load application(s) from manifest if no app name provided

### DIFF
--- a/cf/command_factory/factory.go
+++ b/cf/command_factory/factory.go
@@ -217,7 +217,7 @@ func NewFactory(ui terminal.UI, config core_config.ReadWriter, manifestRepo mani
 	displayApp := application.NewShowApp(ui, config, repoLocator.GetAppSummaryRepository(), repoLocator.GetAppInstancesRepository(), repoLocator.GetLogsNoaaRepository())
 	start := application.NewStart(ui, config, displayApp, repoLocator.GetApplicationRepository(), repoLocator.GetAppInstancesRepository(), repoLocator.GetLogsNoaaRepository())
 	stop := application.NewStop(ui, config, repoLocator.GetApplicationRepository())
-	restart := application.NewRestart(ui, config, start, stop)
+	restart := application.NewRestart(ui, config, start, stop, manifestRepo, repoLocator.GetApplicationRepository())
 	restage := application.NewRestage(ui, config, repoLocator.GetApplicationRepository(), start)
 	bind := service.NewBindService(ui, config, repoLocator.GetServiceBindingRepository())
 

--- a/cf/commands/application/restart.go
+++ b/cf/commands/application/restart.go
@@ -1,9 +1,13 @@
 package application
 
 import (
+	"os"
+
+	"github.com/cloudfoundry/cli/cf/api/applications"
 	"github.com/cloudfoundry/cli/cf/command_metadata"
 	"github.com/cloudfoundry/cli/cf/configuration/core_config"
 	. "github.com/cloudfoundry/cli/cf/i18n"
+	"github.com/cloudfoundry/cli/cf/manifest"
 	"github.com/cloudfoundry/cli/cf/models"
 	"github.com/cloudfoundry/cli/cf/requirements"
 	"github.com/cloudfoundry/cli/cf/terminal"
@@ -11,23 +15,26 @@ import (
 )
 
 type Restart struct {
-	ui      terminal.UI
-	config  core_config.Reader
-	starter ApplicationStarter
-	stopper ApplicationStopper
-	appReq  requirements.ApplicationRequirement
+	ui           terminal.UI
+	config       core_config.Reader
+	starter      ApplicationStarter
+	stopper      ApplicationStopper
+	appRepo      applications.ApplicationRepository
+	manifestRepo manifest.ManifestRepository
 }
 
 type ApplicationRestarter interface {
 	ApplicationRestart(app models.Application, orgName string, spaceName string)
 }
 
-func NewRestart(ui terminal.UI, config core_config.Reader, starter ApplicationStarter, stopper ApplicationStopper) (cmd *Restart) {
+func NewRestart(ui terminal.UI, config core_config.Reader, starter ApplicationStarter, stopper ApplicationStopper, manifestRepo manifest.ManifestRepository, appRepo applications.ApplicationRepository) (cmd *Restart) {
 	cmd = new(Restart)
 	cmd.ui = ui
 	cmd.config = config
 	cmd.starter = starter
 	cmd.stopper = stopper
+	cmd.manifestRepo = manifestRepo
+	cmd.appRepo = appRepo
 	return
 }
 
@@ -36,32 +43,33 @@ func (cmd *Restart) Metadata() command_metadata.CommandMetadata {
 		Name:        "restart",
 		ShortName:   "rs",
 		Description: T("Restart an app"),
-		Usage:       T("CF_NAME restart APP_NAME"),
+		Usage: T("Restart a single app:\n") + T("   CF_NAME restart APP_NAME\n") +
+			"\n" + T("   Restart an app(s) with a manifest from a current directory:\n") + T("   CF_NAME restart\n"),
 	}
 }
 
 func (cmd *Restart) GetRequirements(requirementsFactory requirements.Factory, c *cli.Context) (reqs []requirements.Requirement, err error) {
-	if len(c.Args()) != 1 {
+	if len(c.Args()) > 1 {
 		cmd.ui.FailWithUsage(c)
-	}
-
-	if cmd.appReq == nil {
-		cmd.appReq = requirementsFactory.NewApplicationRequirement(c.Args()[0])
-	} else {
-		cmd.appReq.SetApplicationName(c.Args()[0])
 	}
 
 	reqs = []requirements.Requirement{
 		requirementsFactory.NewLoginRequirement(),
 		requirementsFactory.NewTargetedSpaceRequirement(),
-		cmd.appReq,
 	}
 	return
 }
 
 func (cmd *Restart) Run(c *cli.Context) {
-	app := cmd.appReq.GetApplication()
-	cmd.ApplicationRestart(app, cmd.config.OrganizationFields().Name, cmd.config.SpaceFields().Name)
+	appNames := cmd.findAppNamesToRestart(c)
+	for _, appName := range appNames {
+		app, apiErr := cmd.appRepo.Read(appName)
+		if apiErr != nil {
+			cmd.ui.Failed(apiErr.Error())
+			return
+		}
+		cmd.ApplicationRestart(app, cmd.config.OrganizationFields().Name, cmd.config.SpaceFields().Name)
+	}
 }
 
 func (cmd *Restart) ApplicationRestart(app models.Application, orgName, spaceName string) {
@@ -78,4 +86,43 @@ func (cmd *Restart) ApplicationRestart(app models.Application, orgName, spaceNam
 		cmd.ui.Failed(err.Error())
 		return
 	}
+}
+
+func (cmd *Restart) findAppNamesToRestart(c *cli.Context) []string {
+	if len(c.Args()) > 0 {
+		return []string{c.Args()[0]}
+	} else {
+		return cmd.findAppsFromManifest(c)
+	}
+}
+
+func (cmd *Restart) findAppsFromManifest(c *cli.Context) []string {
+	var err error
+	var path string
+
+	path, err = os.Getwd()
+	if err != nil {
+		cmd.ui.Failed(T("Could not determine the current working directory!"), err)
+	}
+
+	m, err := cmd.manifestRepo.ReadManifest(path)
+	if err != nil {
+		cmd.ui.Warn(T("Error reading manifest file:\n{{.Err}}", map[string]interface{}{"Err": err.Error()}))
+		cmd.ui.Say("")
+		cmd.ui.FailWithUsage(c)
+	}
+
+	apps, err := m.Applications()
+	if err != nil {
+		cmd.ui.Failed("Error reading manifest file:\n%s", err)
+	}
+	cmd.ui.Say(T("Using manifest file {{.Path}}\n",
+		map[string]interface{}{"Path": terminal.EntityNameColor(m.Path)}))
+
+	appNames := make([]string, len(apps))
+	for index, app := range apps {
+		appNames[index] = *app.Name
+	}
+
+	return appNames
 }

--- a/cf/commands/application/restart_test.go
+++ b/cf/commands/application/restart_test.go
@@ -1,9 +1,13 @@
 package application_test
 
 import (
+	testApplication "github.com/cloudfoundry/cli/cf/api/applications/fakes"
+	"github.com/cloudfoundry/cli/cf/manifest"
 	"github.com/cloudfoundry/cli/cf/models"
+	"github.com/cloudfoundry/cli/generic"
 	testcmd "github.com/cloudfoundry/cli/testhelpers/commands"
 	testconfig "github.com/cloudfoundry/cli/testhelpers/configuration"
+	testmanifest "github.com/cloudfoundry/cli/testhelpers/manifest"
 	testreq "github.com/cloudfoundry/cli/testhelpers/requirements"
 	testterm "github.com/cloudfoundry/cli/testhelpers/terminal"
 
@@ -19,6 +23,8 @@ var _ = Describe("restart command", func() {
 		requirementsFactory *testreq.FakeReqFactory
 		starter             *testcmd.FakeApplicationStarter
 		stopper             *testcmd.FakeApplicationStopper
+		manifestRepo        *testmanifest.FakeManifestRepository
+		appRepo             *testApplication.FakeApplicationRepository
 		config              core_config.ReadWriter
 		app                 models.Application
 	)
@@ -29,6 +35,8 @@ var _ = Describe("restart command", func() {
 		starter = &testcmd.FakeApplicationStarter{}
 		stopper = &testcmd.FakeApplicationStopper{}
 		config = testconfig.NewRepositoryWithDefaults()
+		manifestRepo = &testmanifest.FakeManifestRepository{}
+		appRepo = &testApplication.FakeApplicationRepository{}
 
 		app = models.Application{}
 		app.Name = "my-app"
@@ -36,25 +44,17 @@ var _ = Describe("restart command", func() {
 	})
 
 	runCommand := func(args ...string) bool {
-		return testcmd.RunCommand(NewRestart(ui, config, starter, stopper), args, requirementsFactory)
+		return testcmd.RunCommand(NewRestart(ui, config, starter, stopper, manifestRepo, appRepo), args, requirementsFactory)
 	}
 
 	Describe("requirements", func() {
-		It("fails with usage when not provided exactly one arg", func() {
-			requirementsFactory.LoginSuccess = true
-			runCommand()
-			Expect(ui.FailedWithUsage).To(BeTrue())
-		})
-
 		It("fails when not logged in", func() {
-			requirementsFactory.Application = app
 			requirementsFactory.TargetedSpaceSuccess = true
 
 			Expect(runCommand()).To(BeFalse())
 		})
 
 		It("fails when a space is not targeted", func() {
-			requirementsFactory.Application = app
 			requirementsFactory.LoginSuccess = true
 
 			Expect(runCommand()).To(BeFalse())
@@ -63,27 +63,62 @@ var _ = Describe("restart command", func() {
 
 	Context("when logged in, targeting a space, and an app name is provided", func() {
 		BeforeEach(func() {
-			requirementsFactory.Application = app
 			requirementsFactory.LoginSuccess = true
 			requirementsFactory.TargetedSpaceSuccess = true
+			appRepo.ReadReturns.App = app
 
 			stopper.ApplicationStopReturns(app, nil)
 		})
 
-		It("restarts the given app", func() {
-			runCommand("my-app")
+		Context("app name is provided", func() {
+			It("restarts the given app", func() {
+				runCommand("my-app")
 
-			application, orgName, spaceName := stopper.ApplicationStopArgsForCall(0)
-			Expect(application).To(Equal(app))
-			Expect(orgName).To(Equal(config.OrganizationFields().Name))
-			Expect(spaceName).To(Equal(config.SpaceFields().Name))
+				application, orgName, spaceName := stopper.ApplicationStopArgsForCall(0)
+				Expect(application).To(Equal(app))
+				Expect(orgName).To(Equal(config.OrganizationFields().Name))
+				Expect(spaceName).To(Equal(config.SpaceFields().Name))
 
-			application, orgName, spaceName = starter.ApplicationStartArgsForCall(0)
-			Expect(application).To(Equal(app))
-			Expect(orgName).To(Equal(config.OrganizationFields().Name))
-			Expect(spaceName).To(Equal(config.SpaceFields().Name))
+				application, orgName, spaceName = starter.ApplicationStartArgsForCall(0)
+				Expect(application).To(Equal(app))
+				Expect(orgName).To(Equal(config.OrganizationFields().Name))
+				Expect(spaceName).To(Equal(config.SpaceFields().Name))
 
-			Expect(requirementsFactory.ApplicationName).To(Equal("my-app"))
+				Expect(appRepo.ReadArgs.Name).To(Equal("my-app"))
+			})
+		})
+
+		Context("app name is not provided", func() {
+			BeforeEach(func() {
+				manifestRepo.ReadManifestReturns.Manifest = &manifest.Manifest{
+					Path: "manifest.yml",
+					Data: generic.NewMap(map[interface{}]interface{}{
+						"applications": []interface{}{
+							generic.NewMap(map[interface{}]interface{}{
+								"name":      "my-app",
+								"memory":    "128MB",
+								"instances": 1,
+							}),
+						},
+					}),
+				}
+			})
+
+			It("restarts app from manifest", func() {
+				runCommand()
+
+				application, orgName, spaceName := stopper.ApplicationStopArgsForCall(0)
+				Expect(application).To(Equal(app))
+				Expect(orgName).To(Equal(config.OrganizationFields().Name))
+				Expect(spaceName).To(Equal(config.SpaceFields().Name))
+
+				application, orgName, spaceName = starter.ApplicationStartArgsForCall(0)
+				Expect(application).To(Equal(app))
+				Expect(orgName).To(Equal(config.OrganizationFields().Name))
+				Expect(spaceName).To(Equal(config.SpaceFields().Name))
+
+				Expect(appRepo.ReadArgs.Name).To(Equal("my-app"))
+			})
 		})
 	})
 })

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -910,13 +910,28 @@
       "modified": false
    },
    {
+      "id": "Restart a single app:\n",
+      "translation": "Restart a single app:\n",
+      "modified": false
+   },
+   {
       "id": "CF_NAME restage APP_NAME",
       "translation": "CF_NAME restage APP_NAME",
       "modified": false
    },
    {
-      "id": "CF_NAME restart APP_NAME",
-      "translation": "CF_NAME restart APP_NAME",
+      "id": "   CF_NAME restart APP_NAME\n",
+      "translation": "   CF_NAME restart APP_NAME\n",
+      "modified": false
+   },
+   {
+      "id": "   Restart an app(s) with a manifest from a current directory:\n",
+      "translation": "   Restart an app(s) with a manifest from a current directory:\n",
+      "modified": false
+   },
+   {
+      "id": "   CF_NAME restart\n",
+      "translation": "   CF_NAME restart\n",
       "modified": false
    },
    {


### PR DESCRIPTION
Hi

I found it annoying to type app name every time when I run CF commands from an app dir with manifest.yml. I don't have to specify app name when I run "cf push", but I have to type it when I run cf restart/start/stop/restage/etc. This patch is not a merge-ready, at least because of missing translations in language files (which leads to failing ./bin/test). First of all I want to demonstrate an idea on restart command and get any feedback.