### PR TITLE
Add (failing) test case for deep merge where two arrays of hashes are merged

### DIFF
--- a/generic/map_test.go
+++ b/generic/map_test.go
@@ -19,6 +19,12 @@ func init() {
 				"nest2": []interface{}{
 					"nest2Val1",
 				},
+				"nest3": []interface{}{
+					map[interface{}]interface{}{
+						"nestKey1": "nest3Val1",
+						"nestKey2": "nest3Val2",
+					},
+				},
 			})
 
 			map2 := NewMap(map[interface{}]interface{}{
@@ -28,6 +34,11 @@ func init() {
 				},
 				"nest2": []interface{}{
 					"something",
+				},
+				"nest3": []interface{}{
+					map[interface{}]interface{}{
+						"nestKey2": "nest3newval",
+					},
 				},
 			})
 
@@ -41,6 +52,12 @@ func init() {
 				"nest2": []interface{}{
 					"nest2Val1",
 					"something",
+				},
+				"nest3": []interface{}{
+					map[interface{}]interface{}{
+						"nestKey1": "nest3Val1",
+						"nestKey2": "nest3newval",
+					},
 				},
 			})
 


### PR DESCRIPTION
I am running into an issue with manifest inheritance where if I have the app specified in the main manifest and try to override it from the child one, two apps are created.

It is reproduced with the following test but I am not sure if this is an issue that we should solve at the merging level.

Some manifest examples:

```
---
# main.yml
memory: 512M
services:
- mydb
applications:
- name: myapp
  path: .
```

```
---
# dev.yml
inherit: main.yml
applications:
- name: myapp
  host: myapp-dev
```

And the merged result is something like:
```
memory: 512M
services:
- mydb
applications:
- name: myapp
  path: .
- name: myapp
  host: myapp-dev
```

When I was expecting:
```
memory: 512M
services:
- mydb
applications:
- name: myapp
  path: .
  host: myapp-dev
```
