### PR TITLE
Arbitrary params for create-service

### DIFF
--- a/cf/api/fakes/fake_service_repo.go
+++ b/cf/api/fakes/fake_service_repo.go
@@ -39,6 +39,7 @@ type FakeServiceRepo struct {
 	CreateServiceInstanceArgs struct {
 		Name     string
 		PlanGuid string
+		Params   map[string]interface{}
 	}
 	CreateServiceInstanceReturns struct {
 		Error error
@@ -140,9 +141,10 @@ func (repo *FakeServiceRepo) FindServiceOfferingsByLabel(name string) (offerings
 	return
 }
 
-func (repo *FakeServiceRepo) CreateServiceInstance(name, planGuid string) (apiErr error) {
+func (repo *FakeServiceRepo) CreateServiceInstance(name, planGuid string, params map[string]interface{}) (apiErr error) {
 	repo.CreateServiceInstanceArgs.Name = name
 	repo.CreateServiceInstanceArgs.PlanGuid = planGuid
+	repo.CreateServiceInstanceArgs.Params = params
 
 	return repo.CreateServiceInstanceReturns.Error
 }

--- a/cf/api/services.go
+++ b/cf/api/services.go
@@ -135,7 +135,7 @@ func (repo CloudControllerServiceRepository) FindInstanceByName(name string) (in
 func (repo CloudControllerServiceRepository) CreateServiceInstance(name, planGuid string) (err error) {
 	path := "/v2/service_instances?accepts_incomplete=true"
 	data := fmt.Sprintf(
-		`{"name":"%s","service_plan_guid":"%s","space_guid":"%s", "async": true}`,
+		`{"name":"%s","service_plan_guid":"%s","space_guid":"%s"}`,
 		name, planGuid, repo.config.SpaceFields().Guid,
 	)
 

--- a/cf/api/services_test.go
+++ b/cf/api/services_test.go
@@ -46,7 +46,9 @@ var _ = Describe("Services Repo", func() {
 	})
 
 	AfterEach(func() {
-		testServer.Close()
+		if testServer != nil {
+			testServer.Close()
+		}
 	})
 
 	Describe("GetAllServiceOfferings", func() {
@@ -201,9 +203,37 @@ var _ = Describe("Services Repo", func() {
 				Response: testnet.TestResponse{Status: http.StatusCreated},
 			}))
 
-			err := repo.CreateServiceInstance("instance-name", "plan-guid")
+			err := repo.CreateServiceInstance("instance-name", "plan-guid", nil)
 			Expect(testHandler).To(HaveAllRequestsCalled())
 			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("when there are parameters", func() {
+			It("sends the parameters as part of the request body", func() {
+				setupTestServer(testapi.NewCloudControllerTestRequest(testnet.TestRequest{
+					Method:   "POST",
+					Path:     "/v2/service_instances?accepts_incomplete=true",
+					Matcher:  testnet.RequestBodyMatcher(`{"name":"instance-name","service_plan_guid":"plan-guid","space_guid":"my-space-guid","parameters": {"data": "hello"}}`),
+					Response: testnet.TestResponse{Status: http.StatusCreated},
+				}))
+
+				paramsMap := make(map[string]interface{})
+				paramsMap["data"] = "hello"
+
+				err := repo.CreateServiceInstance("instance-name", "plan-guid", paramsMap)
+				Expect(testHandler).To(HaveAllRequestsCalled())
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		Context("and there is a failure during serialization", func() {
+			It("returns the serialization error", func() {
+				paramsMap := make(map[string]interface{})
+				paramsMap["data"] = make(chan bool)
+
+				err := repo.CreateServiceInstance("instance-name", "plan-guid", paramsMap)
+				Expect(err).To(MatchError("json: unsupported type: chan bool"))
+			})
 		})
 
 		Context("when the name is taken but an identical service exists", func() {
@@ -222,7 +252,7 @@ var _ = Describe("Services Repo", func() {
 			})
 
 			It("returns a ModelAlreadyExistsError if the plan is the same", func() {
-				err := repo.CreateServiceInstance("my-service", "plan-guid")
+				err := repo.CreateServiceInstance("my-service", "plan-guid", nil)
 				Expect(testHandler).To(HaveAllRequestsCalled())
 				Expect(err).To(BeAssignableToTypeOf(&errors.ModelAlreadyExistsError{}))
 			})
@@ -244,7 +274,7 @@ var _ = Describe("Services Repo", func() {
 			})
 
 			It("fails if the plan is different", func() {
-				err := repo.CreateServiceInstance("my-service", "different-plan-guid")
+				err := repo.CreateServiceInstance("my-service", "different-plan-guid", nil)
 
 				Expect(testHandler).To(HaveAllRequestsCalled())
 				Expect(err).To(HaveOccurred())

--- a/cf/api/services_test.go
+++ b/cf/api/services_test.go
@@ -193,11 +193,11 @@ var _ = Describe("Services Repo", func() {
 	})
 
 	Describe("creating a service instance", func() {
-		It("makes the right request with the async flag", func() {
+		It("makes the right request", func() {
 			setupTestServer(testapi.NewCloudControllerTestRequest(testnet.TestRequest{
 				Method:   "POST",
 				Path:     "/v2/service_instances?accepts_incomplete=true",
-				Matcher:  testnet.RequestBodyMatcher(`{"name":"instance-name","service_plan_guid":"plan-guid","space_guid":"my-space-guid","async":true}`),
+				Matcher:  testnet.RequestBodyMatcher(`{"name":"instance-name","service_plan_guid":"plan-guid","space_guid":"my-space-guid"}`),
 				Response: testnet.TestResponse{Status: http.StatusCreated},
 			}))
 
@@ -212,7 +212,7 @@ var _ = Describe("Services Repo", func() {
 					testapi.NewCloudControllerTestRequest(testnet.TestRequest{
 						Method:  "POST",
 						Path:    "/v2/service_instances?accepts_incomplete=true",
-						Matcher: testnet.RequestBodyMatcher(`{"name":"my-service","service_plan_guid":"plan-guid","space_guid":"my-space-guid","async":true}`),
+						Matcher: testnet.RequestBodyMatcher(`{"name":"my-service","service_plan_guid":"plan-guid","space_guid":"my-space-guid"}`),
 						Response: testnet.TestResponse{
 							Status: http.StatusBadRequest,
 							Body:   `{"code":60002,"description":"The service instance name is taken: my-service"}`,
@@ -234,7 +234,7 @@ var _ = Describe("Services Repo", func() {
 					testapi.NewCloudControllerTestRequest(testnet.TestRequest{
 						Method:  "POST",
 						Path:    "/v2/service_instances?accepts_incomplete=true",
-						Matcher: testnet.RequestBodyMatcher(`{"name":"my-service","service_plan_guid":"different-plan-guid","space_guid":"my-space-guid","async":true}`),
+						Matcher: testnet.RequestBodyMatcher(`{"name":"my-service","service_plan_guid":"different-plan-guid","space_guid":"my-space-guid"}`),
 						Response: testnet.TestResponse{
 							Status: http.StatusBadRequest,
 							Body:   `{"code":60002,"description":"The service instance name is taken: my-service"}`,

--- a/cf/commands/service/create_service.go
+++ b/cf/commands/service/create_service.go
@@ -71,7 +71,7 @@ func (cmd CreateService) Run(c *cli.Context) {
 	paramsMap := make(map[string]interface{})
 	err := json.Unmarshal([]byte(params), &paramsMap)
 	if err != nil && params != "" {
-		cmd.ui.Failed(T("Invalid JSON provided in parameters argument"))
+		cmd.ui.Failed(T("Invalid JSON provided in -c argument"))
 	}
 
 	cmd.ui.Say(T("Creating service instance {{.ServiceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",

--- a/cf/commands/service/create_service.go
+++ b/cf/commands/service/create_service.go
@@ -71,7 +71,7 @@ func (cmd CreateService) Run(c *cli.Context) {
 	paramsMap := make(map[string]interface{})
 	err := json.Unmarshal([]byte(params), &paramsMap)
 	if err != nil && params != "" {
-		cmd.ui.Failed("Invalid JSON provided in parameters argument")
+		cmd.ui.Failed(T("Invalid JSON provided in parameters argument"))
 	}
 
 	cmd.ui.Say(T("Creating service instance {{.ServiceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",

--- a/cf/commands/service/create_service_test.go
+++ b/cf/commands/service/create_service_test.go
@@ -96,6 +96,29 @@ var _ = Describe("create-service command", func() {
 		Expect(serviceRepo.CreateServiceInstanceArgs.PlanGuid).To(Equal("cleardb-spark-guid"))
 	})
 
+	Context("when passing arbitrary params", func() {
+		It("successfully creates a service and passes the params as a json string", func() {
+			callCreateService([]string{"cleardb", "spark", "my-cleardb-service", "-c", `{"foo": "bar"}`})
+
+			Expect(ui.Outputs).To(ContainSubstrings(
+				[]string{"Creating service instance", "my-cleardb-service", "my-org", "my-space", "my-user"},
+				[]string{"OK"},
+			))
+			Expect(serviceRepo.CreateServiceInstanceArgs.Params).To(Equal(map[string]interface{}{"foo": "bar"}))
+		})
+
+		Context("that are not valid json", func() {
+			It("returns an error to the UI", func() {
+				callCreateService([]string{"cleardb", "spark", "my-cleardb-service", "-c", `bad-json`})
+
+				Expect(ui.Outputs).To(ContainSubstrings(
+					[]string{"FAILED"},
+					[]string{"Invalid JSON provided in parameters argument"},
+				))
+			})
+		})
+	})
+
 	Context("when service creation is asynchronous", func() {
 		var serviceInstance models.ServiceInstance
 

--- a/cf/commands/service/create_service_test.go
+++ b/cf/commands/service/create_service_test.go
@@ -113,7 +113,7 @@ var _ = Describe("create-service command", func() {
 
 				Expect(ui.Outputs).To(ContainSubstrings(
 					[]string{"FAILED"},
-					[]string{"Invalid JSON provided in parameters argument"},
+					[]string{"Invalid JSON provided in -c argument"},
 				))
 			})
 		})

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -5328,5 +5328,10 @@
       "id": "service key",
       "translation": "service key",
       "modified": false
+   },
+   {
+      "id": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
+      "translation": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -5333,5 +5333,10 @@
       "id": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
       "translation": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
       "modified": false
+   },
+   {
+      "id": "Invalid JSON provided in -c argument",
+      "translation": "Invalid JSON provided in -c argument",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -5328,5 +5328,10 @@
       "id": "service key",
       "translation": "service key",
       "modified": false
+   },
+   {
+      "id": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
+      "translation": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -5333,5 +5333,10 @@
       "id": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
       "translation": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
       "modified": false
+   },
+   {
+      "id": "Invalid JSON provided in -c argument",
+      "translation": "Invalid JSON provided in -c argument",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -5328,5 +5328,10 @@
       "id": "service key",
       "translation": "service key",
       "modified": false
+   },
+   {
+      "id": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
+      "translation": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -5333,5 +5333,10 @@
       "id": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
       "translation": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
       "modified": false
+   },
+   {
+      "id": "Invalid JSON provided in -c argument",
+      "translation": "Invalid JSON provided in -c argument",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -5323,5 +5323,10 @@
       "id": "service key",
       "translation": "clef de service",
       "modified": false
+   },
+   {
+      "id": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
+      "translation": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -5326,7 +5326,7 @@
    },
    {
       "id": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
-      "translation": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
+      "translation": "Objet JSON valide contenant les paramètres de configuration spécifiques au service, fourni soit en ligne ou dans un fichier. Pour une liste des paramètres de configuration valide, voir la documentation de l'offre de service particulier.",
       "modified": false
    }
 ]

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -5328,5 +5328,10 @@
       "id": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
       "translation": "Objet JSON valide contenant les paramètres de configuration spécifiques au service, fourni soit en ligne ou dans un fichier. Pour une liste des paramètres de configuration valide, voir la documentation de l'offre de service particulier.",
       "modified": false
+   },
+   {
+      "id": "Invalid JSON provided in -c argument",
+      "translation": "Invalid JSON provided in -c argument",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -5328,5 +5328,10 @@
       "id": "service key",
       "translation": "service key",
       "modified": false
+   },
+   {
+      "id": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
+      "translation": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -5333,5 +5333,10 @@
       "id": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
       "translation": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
       "modified": false
+   },
+   {
+      "id": "Invalid JSON provided in -c argument",
+      "translation": "Invalid JSON provided in -c argument",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -5328,5 +5328,10 @@
       "id": "service key",
       "translation": "service key",
       "modified": false
+   },
+   {
+      "id": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
+      "translation": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -5333,5 +5333,10 @@
       "id": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
       "translation": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
       "modified": false
+   },
+   {
+      "id": "Invalid JSON provided in -c argument",
+      "translation": "Invalid JSON provided in -c argument",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -5328,5 +5328,10 @@
       "id": "service key",
       "translation": "service key",
       "modified": false
+   },
+   {
+      "id": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
+      "translation": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -5333,5 +5333,10 @@
       "id": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
       "translation": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
       "modified": false
+   },
+   {
+      "id": "Invalid JSON provided in -c argument",
+      "translation": "Invalid JSON provided in -c argument",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -5328,5 +5328,10 @@
       "id": "service key",
       "translation": "服务密钥",
       "modified": false
+   },
+   {
+      "id": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
+      "translation": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -5333,5 +5333,10 @@
       "id": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
       "translation": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
       "modified": false
+   },
+   {
+      "id": "Invalid JSON provided in -c argument",
+      "translation": "Invalid JSON provided in -c argument",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -5328,5 +5328,10 @@
       "id": "service key",
       "translation": "service key",
       "modified": false
+   },
+   {
+      "id": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
+      "translation": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -5333,5 +5333,10 @@
       "id": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
       "translation": "Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.",
       "modified": false
+   },
+   {
+      "id": "Invalid JSON provided in -c argument",
+      "translation": "Invalid JSON provided in -c argument",
+      "modified": false
    }
 ]

--- a/cf/models/service_instance.go
+++ b/cf/models/service_instance.go
@@ -6,6 +6,13 @@ type LastOperationFields struct {
 	Description string
 }
 
+type ServiceInstanceRequest struct {
+	Name      string                 `json:"name"`
+	SpaceGuid string                 `json:"space_guid"`
+	PlanGuid  string                 `json:"service_plan_guid"`
+	Params    map[string]interface{} `json:"parameters,omitempty"`
+}
+
 type ServiceInstanceFields struct {
 	Guid             string
 	Name             string


### PR DESCRIPTION
Also includes a fix to a different bug where `async: true` was mistakenly being sent in the post body.