### PR TITLE
Last operation timestamps

### DIFF
--- a/cf/api/resources/service_instances.go
+++ b/cf/api/resources/service_instances.go
@@ -16,6 +16,8 @@ type LastOperation struct {
 	Type        string `json:"type"`
 	State       string `json:"state"`
 	Description string `json:"description"`
+	CreatedAt   string `json:"created_at"`
+	UpdatedAt   string `json:"updated_at"`
 }
 
 type ServiceInstanceEntity struct {
@@ -36,6 +38,8 @@ func (resource ServiceInstanceResource) ToFields() models.ServiceInstanceFields 
 			Type:        resource.Entity.LastOperation.Type,
 			State:       resource.Entity.LastOperation.State,
 			Description: resource.Entity.LastOperation.Description,
+			CreatedAt:   resource.Entity.LastOperation.CreatedAt,
+			UpdatedAt:   resource.Entity.LastOperation.UpdatedAt,
 		},
 	}
 }

--- a/cf/api/resources/service_instances_test.go
+++ b/cf/api/resources/service_instances_test.go
@@ -36,7 +36,9 @@ var _ = Describe("ServiceInstanceResource", func() {
         "last_operation": {
           "type": "create",
           "state": "in progress",
-          "description": "fake state description"
+          "description": "fake state description",
+          "created_at": "fake created at",
+          "updated_at": "fake updated at"
         },
         "service_plan": {
           "metadata": {
@@ -125,6 +127,8 @@ var _ = Describe("ServiceInstanceResource", func() {
 				Expect(fields.LastOperation.Type).To(Equal("create"))
 				Expect(fields.LastOperation.State).To(Equal("in progress"))
 				Expect(fields.LastOperation.Description).To(Equal("fake state description"))
+				Expect(fields.LastOperation.CreatedAt).To(Equal("fake created at"))
+				Expect(fields.LastOperation.UpdatedAt).To(Equal("fake updated at"))
 			})
 		})
 
@@ -138,6 +142,8 @@ var _ = Describe("ServiceInstanceResource", func() {
 				Expect(instance.ServiceInstanceFields.LastOperation.Type).To(Equal("create"))
 				Expect(instance.ServiceInstanceFields.LastOperation.State).To(Equal("in progress"))
 				Expect(instance.ServiceInstanceFields.LastOperation.Description).To(Equal("fake state description"))
+				Expect(instance.ServiceInstanceFields.LastOperation.CreatedAt).To(Equal("fake created at"))
+				Expect(instance.ServiceInstanceFields.LastOperation.UpdatedAt).To(Equal("fake updated at"))
 
 				Expect(instance.ServicePlan.Guid).To(Equal("fake-service-plan-guid"))
 				Expect(instance.ServicePlan.Free).To(BeTrue())

--- a/cf/api/resources/service_instances_test.go
+++ b/cf/api/resources/service_instances_test.go
@@ -130,6 +130,124 @@ var _ = Describe("ServiceInstanceResource", func() {
 				Expect(fields.LastOperation.CreatedAt).To(Equal("fake created at"))
 				Expect(fields.LastOperation.UpdatedAt).To(Equal("fake updated at"))
 			})
+
+			Context("When created_at is null", func() {
+				It("unmarshalls the service instance resource model", func() {
+					var resourceWithNullCreatedAt ServiceInstanceResource
+
+					err := json.Unmarshal([]byte(`
+						{
+							"metadata": {
+								"guid": "fake-guid",
+								"url": "/v2/service_instances/fake-guid",
+								"created_at": null,
+								"updated_at": "2015-01-13T18:52:08+00:00"
+							},
+							"entity": {
+								"name": "fake service name",
+								"credentials": {
+								},
+								"service_plan_guid": "fake-service-plan-guid",
+								"space_guid": "fake-space-guid",
+								"gateway_data": null,
+								"dashboard_url": "https://fake/dashboard/url",
+								"type": "managed_service_instance",
+								"space_url": "/v2/spaces/fake-space-guid",
+								"service_plan_url": "/v2/service_plans/fake-service-plan-guid",
+								"service_bindings_url": "/v2/service_instances/fake-guid/service_bindings",
+								"last_operation": {
+									"type": "create",
+									"state": "in progress",
+									"description": "fake state description",
+									"updated_at": "fake updated at"
+								},
+								"service_plan": {
+									"metadata": {
+										"guid": "fake-service-plan-guid"
+									},
+									"entity": {
+										"name": "fake-service-plan-name",
+										"free": true,
+										"description": "fake-description",
+										"public": true,
+										"active": true,
+										"service_guid": "fake-service-guid"
+									}
+								},
+								"service_bindings": [{
+									"metadata": {
+										"guid": "fake-service-binding-guid",
+										"url": "http://fake/url"
+									},
+									"entity": {
+										"app_guid": "fake-app-guid"
+									}
+								}]
+							}
+						}`), &resourceWithNullCreatedAt)
+
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
+			Context("When created_at is missing", func() {
+				It("unmarshalls the service instance resource model", func() {
+					var resourceWithMissingCreatedAt ServiceInstanceResource
+
+					err := json.Unmarshal([]byte(`
+						{
+							"metadata": {
+								"guid": "fake-guid",
+								"url": "/v2/service_instances/fake-guid",
+								"updated_at": "2015-01-13T18:52:08+00:00"
+							},
+							"entity": {
+								"name": "fake service name",
+								"credentials": {
+								},
+								"service_plan_guid": "fake-service-plan-guid",
+								"space_guid": "fake-space-guid",
+								"gateway_data": null,
+								"dashboard_url": "https://fake/dashboard/url",
+								"type": "managed_service_instance",
+								"space_url": "/v2/spaces/fake-space-guid",
+								"service_plan_url": "/v2/service_plans/fake-service-plan-guid",
+								"service_bindings_url": "/v2/service_instances/fake-guid/service_bindings",
+								"last_operation": {
+									"type": "create",
+									"state": "in progress",
+									"description": "fake state description",
+									"updated_at": "fake updated at"
+								},
+								"service_plan": {
+									"metadata": {
+										"guid": "fake-service-plan-guid"
+									},
+									"entity": {
+										"name": "fake-service-plan-name",
+										"free": true,
+										"description": "fake-description",
+										"public": true,
+										"active": true,
+										"service_guid": "fake-service-guid"
+									}
+								},
+								"service_bindings": [{
+									"metadata": {
+										"guid": "fake-service-binding-guid",
+										"url": "http://fake/url"
+									},
+									"entity": {
+										"app_guid": "fake-app-guid"
+									}
+								}]
+							}
+						}`), &resourceWithMissingCreatedAt)
+
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
 		})
 
 		Describe("#ToModel", func() {

--- a/cf/api/resources/service_instances_test.go
+++ b/cf/api/resources/service_instances_test.go
@@ -2,6 +2,7 @@ package resources_test
 
 import (
 	"encoding/json"
+	"fmt"
 
 	. "github.com/cloudfoundry/cli/cf/api/resources"
 
@@ -117,6 +118,56 @@ var _ = Describe("ServiceInstanceResource", func() {
 	})
 
 	Context("Async brokers", func() {
+		var instanceString string
+
+		BeforeEach(func() {
+			instanceString = `
+						{
+							%s,
+							"entity": {
+								"name": "fake service name",
+								"credentials": {
+								},
+								"service_plan_guid": "fake-service-plan-guid",
+								"space_guid": "fake-space-guid",
+								"gateway_data": null,
+								"dashboard_url": "https://fake/dashboard/url",
+								"type": "managed_service_instance",
+								"space_url": "/v2/spaces/fake-space-guid",
+								"service_plan_url": "/v2/service_plans/fake-service-plan-guid",
+								"service_bindings_url": "/v2/service_instances/fake-guid/service_bindings",
+								"last_operation": {
+									"type": "create",
+									"state": "in progress",
+									"description": "fake state description",
+									"updated_at": "fake updated at"
+								},
+								"service_plan": {
+									"metadata": {
+										"guid": "fake-service-plan-guid"
+									},
+									"entity": {
+										"name": "fake-service-plan-name",
+										"free": true,
+										"description": "fake-description",
+										"public": true,
+										"active": true,
+										"service_guid": "fake-service-guid"
+									}
+								},
+								"service_bindings": [{
+									"metadata": {
+										"guid": "fake-service-binding-guid",
+										"url": "http://fake/url"
+									},
+									"entity": {
+										"app_guid": "fake-app-guid"
+									}
+								}]
+							}
+						}`
+		})
+
 		Describe("#ToFields", func() {
 			It("unmarshalls the fields of a service instance resource", func() {
 				fields := resource.ToFields()
@@ -134,58 +185,15 @@ var _ = Describe("ServiceInstanceResource", func() {
 			Context("When created_at is null", func() {
 				It("unmarshalls the service instance resource model", func() {
 					var resourceWithNullCreatedAt ServiceInstanceResource
-
-					err := json.Unmarshal([]byte(`
-						{
-							"metadata": {
+					metadata := `"metadata": {
 								"guid": "fake-guid",
 								"url": "/v2/service_instances/fake-guid",
 								"created_at": null,
 								"updated_at": "2015-01-13T18:52:08+00:00"
-							},
-							"entity": {
-								"name": "fake service name",
-								"credentials": {
-								},
-								"service_plan_guid": "fake-service-plan-guid",
-								"space_guid": "fake-space-guid",
-								"gateway_data": null,
-								"dashboard_url": "https://fake/dashboard/url",
-								"type": "managed_service_instance",
-								"space_url": "/v2/spaces/fake-space-guid",
-								"service_plan_url": "/v2/service_plans/fake-service-plan-guid",
-								"service_bindings_url": "/v2/service_instances/fake-guid/service_bindings",
-								"last_operation": {
-									"type": "create",
-									"state": "in progress",
-									"description": "fake state description",
-									"updated_at": "fake updated at"
-								},
-								"service_plan": {
-									"metadata": {
-										"guid": "fake-service-plan-guid"
-									},
-									"entity": {
-										"name": "fake-service-plan-name",
-										"free": true,
-										"description": "fake-description",
-										"public": true,
-										"active": true,
-										"service_guid": "fake-service-guid"
-									}
-								},
-								"service_bindings": [{
-									"metadata": {
-										"guid": "fake-service-binding-guid",
-										"url": "http://fake/url"
-									},
-									"entity": {
-										"app_guid": "fake-app-guid"
-									}
-								}]
-							}
-						}`), &resourceWithNullCreatedAt)
+							}`
+					stringWithNullCreatedAt := fmt.Sprintf(instanceString, metadata)
 
+					err := json.Unmarshal([]byte(stringWithNullCreatedAt), &resourceWithNullCreatedAt)
 					Expect(err).ToNot(HaveOccurred())
 				})
 			})
@@ -194,60 +202,17 @@ var _ = Describe("ServiceInstanceResource", func() {
 				It("unmarshalls the service instance resource model", func() {
 					var resourceWithMissingCreatedAt ServiceInstanceResource
 
-					err := json.Unmarshal([]byte(`
-						{
-							"metadata": {
+					metadata := `"metadata": {
 								"guid": "fake-guid",
 								"url": "/v2/service_instances/fake-guid",
 								"updated_at": "2015-01-13T18:52:08+00:00"
-							},
-							"entity": {
-								"name": "fake service name",
-								"credentials": {
-								},
-								"service_plan_guid": "fake-service-plan-guid",
-								"space_guid": "fake-space-guid",
-								"gateway_data": null,
-								"dashboard_url": "https://fake/dashboard/url",
-								"type": "managed_service_instance",
-								"space_url": "/v2/spaces/fake-space-guid",
-								"service_plan_url": "/v2/service_plans/fake-service-plan-guid",
-								"service_bindings_url": "/v2/service_instances/fake-guid/service_bindings",
-								"last_operation": {
-									"type": "create",
-									"state": "in progress",
-									"description": "fake state description",
-									"updated_at": "fake updated at"
-								},
-								"service_plan": {
-									"metadata": {
-										"guid": "fake-service-plan-guid"
-									},
-									"entity": {
-										"name": "fake-service-plan-name",
-										"free": true,
-										"description": "fake-description",
-										"public": true,
-										"active": true,
-										"service_guid": "fake-service-guid"
-									}
-								},
-								"service_bindings": [{
-									"metadata": {
-										"guid": "fake-service-binding-guid",
-										"url": "http://fake/url"
-									},
-									"entity": {
-										"app_guid": "fake-app-guid"
-									}
-								}]
-							}
-						}`), &resourceWithMissingCreatedAt)
+							}`
+					stringWithMissingCreatedAt := fmt.Sprintf(instanceString, metadata)
 
+					err := json.Unmarshal([]byte(stringWithMissingCreatedAt), &resourceWithMissingCreatedAt)
 					Expect(err).ToNot(HaveOccurred())
 				})
 			})
-
 		})
 
 		Describe("#ToModel", func() {

--- a/cf/commands/service/service.go
+++ b/cf/commands/service/service.go
@@ -87,10 +87,12 @@ func (cmd *ShowService) Run(c *cli.Context) {
 				map[string]interface{}{
 					"Message": terminal.EntityNameColor(serviceInstance.LastOperation.Description),
 				}))
-			cmd.ui.Say(T("Started: {{.Started}}",
-				map[string]interface{}{
-					"Started": terminal.EntityNameColor(serviceInstance.LastOperation.CreatedAt),
-				}))
+			if "" != serviceInstance.LastOperation.CreatedAt {
+				cmd.ui.Say(T("Started: {{.Started}}",
+					map[string]interface{}{
+						"Started": terminal.EntityNameColor(serviceInstance.LastOperation.CreatedAt),
+					}))
+			}
 			cmd.ui.Say(T("Updated: {{.Updated}}",
 				map[string]interface{}{
 					"Updated": terminal.EntityNameColor(serviceInstance.LastOperation.UpdatedAt),

--- a/cf/commands/service/service.go
+++ b/cf/commands/service/service.go
@@ -87,6 +87,14 @@ func (cmd *ShowService) Run(c *cli.Context) {
 				map[string]interface{}{
 					"Message": terminal.EntityNameColor(serviceInstance.LastOperation.Description),
 				}))
+			cmd.ui.Say(T("Started: {{.Started}}",
+				map[string]interface{}{
+					"Started": terminal.EntityNameColor(serviceInstance.LastOperation.CreatedAt),
+				}))
+			cmd.ui.Say(T("Updated: {{.Updated}}",
+				map[string]interface{}{
+					"Updated": terminal.EntityNameColor(serviceInstance.LastOperation.UpdatedAt),
+				}))
 		}
 	}
 }

--- a/cf/commands/service/service_test.go
+++ b/cf/commands/service/service_test.go
@@ -70,6 +70,8 @@ var _ = Describe("service command", func() {
 				serviceInstance.ServiceOffering = offering
 				serviceInstance.DashboardUrl = "some-url"
 				serviceInstance.LastOperation.State = state
+				serviceInstance.LastOperation.CreatedAt = "created-date"
+				serviceInstance.LastOperation.UpdatedAt = "updated-date"
 				requirementsFactory.ServiceInstance = serviceInstance
 			}
 
@@ -91,6 +93,8 @@ var _ = Describe("service command", func() {
 					[]string{"Last Operation"},
 					[]string{"Status: ", "create in progress"},
 					[]string{"Message: ", "creating resource - step 1"},
+					[]string{"Started: ", "created-date"},
+					[]string{"Updated: ", "updated-date"},
 				))
 				Expect(requirementsFactory.ServiceInstanceName).To(Equal("service1"))
 			})

--- a/cf/commands/service/service_test.go
+++ b/cf/commands/service/service_test.go
@@ -99,6 +99,30 @@ var _ = Describe("service command", func() {
 				Expect(requirementsFactory.ServiceInstanceName).To(Equal("service1"))
 			})
 
+			Context("when the service instance CreatedAt is empty", func() {
+				It("does not output the Started line", func() {
+					createServiceInstanceWithState("in progress")
+					requirementsFactory.ServiceInstance.LastOperation.CreatedAt = ""
+					runCommand("service1")
+
+					Expect(ui.Outputs).To(ContainSubstrings(
+						[]string{"Service instance:", "service1"},
+						[]string{"Service: ", "mysql"},
+						[]string{"Plan: ", "plan-name"},
+						[]string{"Description: ", "the-description"},
+						[]string{"Documentation url: ", "http://documentation.url"},
+						[]string{"Dashboard: ", "some-url"},
+						[]string{"Last Operation"},
+						[]string{"Status: ", "create in progress"},
+						[]string{"Message: ", "creating resource - step 1"},
+						[]string{"Updated: ", "updated-date"},
+					))
+					Expect(ui.Outputs).ToNot(ContainSubstrings(
+						[]string{"Started: "},
+					))
+				})
+			})
+
 			Context("shows correct status information based on service instance state", func() {
 				It("shows status: `create in progress` when state is `in progress`", func() {
 					createServiceInstanceWithState("in progress")

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -4105,6 +4105,11 @@
       "modified": false
    },
    {
+      "id": "Started: {{.Started}}",
+      "translation": "Started: {{.Started}}",
+      "modified": false
+   },
+   {
       "id": "Starting app {{.AppName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
       "translation": "Starting app {{.AppName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
       "modified": false
@@ -4497,6 +4502,11 @@
    {
       "id": "Update user-provided service instance name value pairs",
       "translation": "Update user-provided service instance name value pairs",
+      "modified": false
+   },
+   {
+      "id": "Updated: {{.Updated}}",
+      "translation": "Updated: {{.Updated}}",
       "modified": false
    },
    {

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -4105,6 +4105,11 @@
       "modified": false
    },
    {
+      "id": "Started: {{.Started}}",
+      "translation": "Started: {{.Started}}",
+      "modified": false
+   },
+   {
       "id": "Starting app {{.AppName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
       "translation": "Starting app {{.AppName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
       "modified": false
@@ -4497,6 +4502,11 @@
    {
       "id": "Update user-provided service instance name value pairs",
       "translation": "Update user-provided service instance name value pairs",
+      "modified": false
+   },
+   {
+      "id": "Updated: {{.Updated}}",
+      "translation": "Updated: {{.Updated}}",
       "modified": false
    },
    {

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -4105,6 +4105,11 @@
       "modified": false
    },
    {
+      "id": "Started: {{.Started}}",
+      "translation": "Started: {{.Started}}",
+      "modified": false
+   },
+   {
       "id": "Starting app {{.AppName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
       "translation": "Comenzando app {{.AppName}} en la org {{.OrgName}} / space {{.SpaceName}} como {{.CurrentUser}}...",
       "modified": false
@@ -4497,6 +4502,11 @@
    {
       "id": "Update user-provided service instance name value pairs",
       "translation": "Update user-provided service instance name value pairs",
+      "modified": false
+   },
+   {
+      "id": "Updated: {{.Updated}}",
+      "translation": "Updated: {{.Updated}}",
       "modified": false
    },
    {

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -4105,6 +4105,11 @@
       "modified": false
    },
    {
+      "id": "Started: {{.Started}}",
+      "translation": "Started: {{.Started}}",
+      "modified": false
+   },
+   {
       "id": "Starting app {{.AppName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
       "translation": "À partir de l'application {{.AppName}} dans l'org {{.OrgName}} / espace {{.SpaceName}} en tant que {{.CurrentUser}}...",
       "modified": false
@@ -4497,6 +4502,11 @@
    {
       "id": "Update user-provided service instance name value pairs",
       "translation": "Mettre à jour les noms et valeurs d'un instance de service fournie par l'utilisateur",
+      "modified": false
+   },
+   {
+      "id": "Updated: {{.Updated}}",
+      "translation": "Updated: {{.Updated}}",
       "modified": false
    },
    {

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -4105,6 +4105,11 @@
       "modified": false
    },
    {
+      "id": "Started: {{.Started}}",
+      "translation": "Started: {{.Started}}",
+      "modified": false
+   },
+   {
       "id": "Starting app {{.AppName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
       "translation": "Starting app {{.AppName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
       "modified": false
@@ -4497,6 +4502,11 @@
    {
       "id": "Update user-provided service instance name value pairs",
       "translation": "Update user-provided service instance name value pairs",
+      "modified": false
+   },
+   {
+      "id": "Updated: {{.Updated}}",
+      "translation": "Updated: {{.Updated}}",
       "modified": false
    },
    {

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -4105,6 +4105,11 @@
       "modified": false
    },
    {
+      "id": "Started: {{.Started}}",
+      "translation": "Started: {{.Started}}",
+      "modified": false
+   },
+   {
       "id": "Starting app {{.AppName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
       "translation": "Starting app {{.AppName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
       "modified": false
@@ -4497,6 +4502,11 @@
    {
       "id": "Update user-provided service instance name value pairs",
       "translation": "Update user-provided service instance name value pairs",
+      "modified": false
+   },
+   {
+      "id": "Updated: {{.Updated}}",
+      "translation": "Updated: {{.Updated}}",
       "modified": false
    },
    {

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -4105,6 +4105,11 @@
       "modified": false
    },
    {
+      "id": "Started: {{.Started}}",
+      "translation": "Started: {{.Started}}",
+      "modified": false
+   },
+   {
       "id": "Starting app {{.AppName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
       "translation": "Inicializando app {{.AppName}} na org {{.OrgName}} / espaço {{.SpaceName}} como {{.CurrentUser}}...",
       "modified": false
@@ -4497,6 +4502,11 @@
    {
       "id": "Update user-provided service instance name value pairs",
       "translation": "Atualizar par de valores de nome de instância de serviço fornecido pelo usuário",
+      "modified": false
+   },
+   {
+      "id": "Updated: {{.Updated}}",
+      "translation": "Updated: {{.Updated}}",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -4105,6 +4105,11 @@
       "modified": false
    },
    {
+      "id": "Started: {{.Started}}",
+      "translation": "Started: {{.Started}}",
+      "modified": false
+   },
+   {
       "id": "Starting app {{.AppName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
       "translation": "作为用户{{.CurrentUser}}启动组织{{.OrgName}}/空间{{.SpaceName}}中的应用程序{{.AppName}}...",
       "modified": false
@@ -4497,6 +4502,11 @@
    {
       "id": "Update user-provided service instance name value pairs",
       "translation": "更新用户提供的服务实例名称值对",
+      "modified": false
+   },
+   {
+      "id": "Updated: {{.Updated}}",
+      "translation": "Updated: {{.Updated}}",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -4105,6 +4105,11 @@
       "modified": false
    },
    {
+      "id": "Started: {{.Started}}",
+      "translation": "Started: {{.Started}}",
+      "modified": false
+   },
+   {
       "id": "Starting app {{.AppName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
       "translation": "Starting app {{.AppName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}...",
       "modified": false
@@ -4497,6 +4502,11 @@
    {
       "id": "Update user-provided service instance name value pairs",
       "translation": "Update user-provided service instance name value pairs",
+      "modified": false
+   },
+   {
+      "id": "Updated: {{.Updated}}",
+      "translation": "Updated: {{.Updated}}",
       "modified": false
    },
    {

--- a/cf/models/service_instance.go
+++ b/cf/models/service_instance.go
@@ -4,6 +4,8 @@ type LastOperationFields struct {
 	Type        string
 	State       string
 	Description string
+	CreatedAt   string
+	UpdatedAt   string
 }
 
 type ServiceInstanceCreateRequest struct {


### PR DESCRIPTION
- Add started and updated timestamps to service instance operations
- Updated the CLI to not return a Started date if the service/operation does not have a CreatedAt in it's JSON.