### PR TITLE
Fixed misleading error when quotes are used to wrap json for cf curl -d 

### DIFF
--- a/cf/command_factory/factory.go
+++ b/cf/command_factory/factory.go
@@ -378,6 +378,8 @@ func (f concreteFactory) GetCommandFlags(command string) []string {
 			flags = append(flags, t.Name)
 		case flag_helpers.StringFlagWithNoDefault:
 			flags = append(flags, t.Name)
+		case cli.StringFlag:
+			flags = append(flags, t.Name)	
 		case cli.BoolFlag:
 			flags = append(flags, t.Name)
 		}

--- a/cf/command_factory/factory_test.go
+++ b/cf/command_factory/factory_test.go
@@ -124,8 +124,24 @@ var _ = Describe("factory", func() {
 			Expect(contains(flags, "c")).To(Equal(true))
 			Expect(contains(flags, "no-hostname")).To(Equal(true))
 		})
-	})
 
+		It("returns a list of flags for the curl command", func() {
+			flags := factory.GetCommandFlags("curl")
+			Expect(contains(flags, "i")).To(Equal(true))
+			Expect(contains(flags, "v")).To(Equal(true))
+			Expect(contains(flags, "X")).To(Equal(true))
+			Expect(contains(flags, "H")).To(Equal(true))
+			Expect(contains(flags, "d")).To(Equal(true))
+			Expect(contains(flags, "output")).To(Equal(true))
+
+		})
+
+		It("returns the total no of flags for the curl command", func() {
+			flags := factory.GetCommandFlags("curl")
+			Expect(len(flags)).To(Equal(6))
+		})
+	})
+	
 	Describe("GetCommandTotalArgs", func() {
 		It("returns the total number of argument required by the command ", func() {
 			totalArgs, err := factory.GetCommandTotalArgs("create-buildpack")


### PR DESCRIPTION
notice the error returned when single ticks are not used to wrap the argument for -d.

When I was debugging code, I realized that flag 'X' was missing in flags list. 

ALL Flags-----> [i v H d output]
 
Story details: https://www.pivotaltracker.com/n/projects/892938/stories/95206110