### PR TITLE
 'cf org'  orgs should be alphabetized for easier scanning

### DIFF
--- a/cf/commands/organization/orgs.go
+++ b/cf/commands/organization/orgs.go
@@ -5,9 +5,11 @@ import (
 	"github.com/cloudfoundry/cli/cf/command_metadata"
 	"github.com/cloudfoundry/cli/cf/configuration/core_config"
 	. "github.com/cloudfoundry/cli/cf/i18n"
+	"github.com/cloudfoundry/cli/cf/models"
 	"github.com/cloudfoundry/cli/cf/requirements"
 	"github.com/cloudfoundry/cli/cf/terminal"
 	"github.com/codegangsta/cli"
+	"sort"
 )
 
 type ListOrgs struct {
@@ -51,6 +53,9 @@ func (cmd ListOrgs) Run(c *cli.Context) {
 	table := cmd.ui.Table([]string{T("name")})
 
 	orgs, apiErr := cmd.orgRepo.ListOrgs()
+
+	sort.Sort(models.Organizations(orgs))
+
 	if apiErr != nil {
 		cmd.ui.Failed(apiErr.Error())
 	}

--- a/cf/models/organization.go
+++ b/cf/models/organization.go
@@ -12,3 +12,17 @@ type Organization struct {
 	Domains     []DomainFields
 	SpaceQuotas []SpaceQuota
 }
+
+type Organizations []Organization
+
+func (o Organizations) Len() int {
+	return len(o)
+}
+
+func (o Organizations) Swap(i, j int) {
+	o[i], o[j] = o[j], o[i]
+}
+
+func (o Organizations) Less(i, j int) bool {
+	return o[i].Name < o[j].Name
+}


### PR DESCRIPTION
Fixed this issue by implementing sort.Sort interface for organization models. 