### PR TITLE
Display correct error when deleting nonexistent service key

### DIFF
--- a/cf/commands/servicekey/delete_service_key.go
+++ b/cf/commands/servicekey/delete_service_key.go
@@ -86,7 +86,7 @@ func (cmd DeleteServiceKey) Run(c *cli.Context) {
 	}
 
 	serviceKey, err := cmd.serviceKeyRepo.GetServiceKey(serviceInstance.Guid, serviceKeyName)
-	if err != nil {
+	if err != nil || serviceKey.Fields.Guid == "" {
 		cmd.ui.Ok()
 
 		cmd.ui.Say(T("Service key {{.ServiceKeyName}} does not exist for service instance {{.ServiceInstanceName}}.",

--- a/cf/commands/servicekey/delete_service_key_test.go
+++ b/cf/commands/servicekey/delete_service_key_test.go
@@ -134,8 +134,19 @@ var _ = Describe("delete-service-key command", func() {
 				))
 			})
 
-			It("fails to delete service key when service key does not exist", func() {
+			It("fails to delete service key when the service key repository returns an error", func() {
 				serviceKeyRepo.GetServiceKeyMethod.Error = errors.New("")
+				callDeleteServiceKey([]string{"fake-service-instance", "non-exist-service-key", "-f"})
+
+				Expect(ui.Outputs).To(ContainSubstrings(
+					[]string{"Deleting key", "non-exist-service-key", "for service instance", "fake-service-instance", "as", "my-user..."},
+					[]string{"OK"},
+					[]string{"Service key", "non-exist-service-key", "does not exist for service instance", "fake-service-instance"},
+				))
+			})
+
+			It("fails to delete service key when service key does not exist", func() {
+				serviceKeyRepo.GetServiceKeyMethod.ServiceKey = models.ServiceKey{}
 				callDeleteServiceKey([]string{"fake-service-instance", "non-exist-service-key", "-f"})
 
 				Expect(ui.Outputs).To(ContainSubstrings(


### PR DESCRIPTION
Tracker story: https://www.pivotaltracker.com/story/show/94220156

The service key repository returns an empty struct when the key cannot be found, but the command was expecting an error.

Note that currently any error from serviceKeyRepo.GetServiceKey will result in a message to the user that the key is missing (and an 'OK' from the CLI). Not sure if this is intended.