### PR TITLE
Improve performance of enable/disable service access

### DIFF
--- a/cf/actors/plan_builder/plan_builder.go
+++ b/cf/actors/plan_builder/plan_builder.go
@@ -82,7 +82,7 @@ func (builder Builder) GetPlansForService(serviceGuid string) ([]models.ServiceP
 }
 
 func (builder Builder) GetPlansForServiceWithOrgs(serviceGuid string) ([]models.ServicePlanFields, error) {
-	plans, err := builder.servicePlanRepo.Search(map[string]string{"service_guid": serviceGuid})
+	plans, err := builder.GetPlansForService(serviceGuid)
 	if err != nil {
 		return nil, err
 	}

--- a/cf/actors/services_plans.go
+++ b/cf/actors/services_plans.go
@@ -61,7 +61,7 @@ func NewServicePlanHandler(plan api.ServicePlanRepository, vis api.ServicePlanVi
 }
 
 func (actor ServicePlanHandler) UpdateAllPlansForService(serviceName string, setPlanVisibility bool) (bool, error) {
-	service, err := actor.serviceBuilder.GetServiceByNameWithPlansWithOrgNames(serviceName)
+	service, err := actor.serviceBuilder.GetServiceByNameWithPlans(serviceName)
 	if err != nil {
 		return false, err
 	}
@@ -160,7 +160,7 @@ func (actor ServicePlanHandler) UpdatePlanAndOrgForService(serviceName, planName
 }
 
 func (actor ServicePlanHandler) UpdateSinglePlanForService(serviceName string, planName string, setPlanVisibility bool) (PlanAccess, error) {
-	serviceOffering, err := actor.serviceBuilder.GetServiceByNameWithPlansWithOrgNames(serviceName)
+	serviceOffering, err := actor.serviceBuilder.GetServiceByNameWithPlans(serviceName)
 	if err != nil {
 		return PlanAccessError, err
 	}
@@ -170,10 +170,9 @@ func (actor ServicePlanHandler) UpdateSinglePlanForService(serviceName string, p
 func (actor ServicePlanHandler) updateSinglePlan(serviceOffering models.ServiceOffering, planName string, setPlanVisibility bool) (PlanAccess, error) {
 	var planToUpdate *models.ServicePlanFields
 
-	//find the service plan and set it as the only service plan for update
 	for _, servicePlan := range serviceOffering.Plans {
 		if servicePlan.Name == planName {
-			planToUpdate = &servicePlan //he has the orgs inside him!!!
+			planToUpdate = &servicePlan
 			break
 		}
 	}

--- a/cf/actors/services_plans_test.go
+++ b/cf/actors/services_plans_test.go
@@ -167,13 +167,13 @@ var _ = Describe("Service Plans", func() {
 		})
 
 		It("Returns an error if the service cannot be found", func() {
-			serviceBuilder.GetServiceByNameWithPlansWithOrgNamesReturns(models.ServiceOffering{}, errors.New("service was not found"))
+			serviceBuilder.GetServiceByNameWithPlansReturns(models.ServiceOffering{}, errors.New("service was not found"))
 			_, err := actor.UpdateAllPlansForService("not-a-service", true)
 			Expect(err.Error()).To(Equal("service was not found"))
 		})
 
 		It("Removes the service plan visibilities for any non-public service plans", func() {
-			serviceBuilder.GetServiceByNameWithPlansWithOrgNamesReturns(mixedService, nil)
+			serviceBuilder.GetServiceByNameWithPlansReturns(mixedService, nil)
 			_, err := actor.UpdateAllPlansForService("my-mixed-service", true)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -183,7 +183,7 @@ var _ = Describe("Service Plans", func() {
 
 		Context("when setting all plans to public", func() {
 			It("Sets all non-public service plans to public", func() {
-				serviceBuilder.GetServiceByNameWithPlansWithOrgNamesReturns(mixedService, nil)
+				serviceBuilder.GetServiceByNameWithPlansReturns(mixedService, nil)
 				_, err := actor.UpdateAllPlansForService("my-mixed-service", true)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -194,7 +194,7 @@ var _ = Describe("Service Plans", func() {
 			})
 
 			It("Returns true if all the plans were public", func() {
-				serviceBuilder.GetServiceByNameWithPlansWithOrgNamesReturns(publicService, nil)
+				serviceBuilder.GetServiceByNameWithPlansReturns(publicService, nil)
 
 				servicesOriginallyPublic, err := actor.UpdateAllPlansForService("my-public-service", true)
 				Expect(err).NotTo(HaveOccurred())
@@ -202,7 +202,7 @@ var _ = Describe("Service Plans", func() {
 			})
 
 			It("Returns false if any of the plans were not public", func() {
-				serviceBuilder.GetServiceByNameWithPlansWithOrgNamesReturns(mixedService, nil)
+				serviceBuilder.GetServiceByNameWithPlansReturns(mixedService, nil)
 
 				servicesOriginallyPublic, err := actor.UpdateAllPlansForService("my-mixed-service", true)
 				Expect(err).NotTo(HaveOccurred())
@@ -226,7 +226,7 @@ var _ = Describe("Service Plans", func() {
 
 		Context("when setting all plans to private", func() {
 			It("Sets all public service plans to private", func() {
-				serviceBuilder.GetServiceByNameWithPlansWithOrgNamesReturns(mixedService, nil)
+				serviceBuilder.GetServiceByNameWithPlansReturns(mixedService, nil)
 
 				_, err := actor.UpdateAllPlansForService("my-mixed-service", false)
 				Expect(err).ToNot(HaveOccurred())
@@ -238,7 +238,7 @@ var _ = Describe("Service Plans", func() {
 			})
 
 			It("Returns true if all plans were already private", func() {
-				serviceBuilder.GetServiceByNameWithPlansWithOrgNamesReturns(privateService, nil)
+				serviceBuilder.GetServiceByNameWithPlansReturns(privateService, nil)
 
 				allPlansAlreadyPrivate, err := actor.UpdateAllPlansForService("my-private-service", false)
 				Expect(err).NotTo(HaveOccurred())
@@ -246,7 +246,7 @@ var _ = Describe("Service Plans", func() {
 			})
 
 			It("Returns false if any of the plans were not private", func() {
-				serviceBuilder.GetServiceByNameWithPlansWithOrgNamesReturns(mixedService, nil)
+				serviceBuilder.GetServiceByNameWithPlansReturns(mixedService, nil)
 
 				allPlansAlreadyPrivate, err := actor.UpdateAllPlansForService("my-mixed-service", false)
 				Expect(err).NotTo(HaveOccurred())
@@ -254,7 +254,7 @@ var _ = Describe("Service Plans", func() {
 			})
 
 			It("Does not try to update service plans if they are all already private", func() {
-				serviceBuilder.GetServiceByNameWithPlansWithOrgNamesReturns(privateService, nil)
+				serviceBuilder.GetServiceByNameWithPlansReturns(privateService, nil)
 
 				_, err := actor.UpdateAllPlansForService("my-private-service", false)
 				Expect(err).ToNot(HaveOccurred())
@@ -352,34 +352,34 @@ var _ = Describe("Service Plans", func() {
 
 	Describe(".UpdateSinglePlanForService", func() {
 		It("Returns an error if the service cannot be found", func() {
-			serviceBuilder.GetServiceByNameWithPlansWithOrgNamesReturns(models.ServiceOffering{}, errors.New("service was not found"))
+			serviceBuilder.GetServiceByNameWithPlansReturns(models.ServiceOffering{}, errors.New("service was not found"))
 			_, err := actor.UpdateSinglePlanForService("not-a-service", "public-service-plan", true)
 			Expect(err.Error()).To(Equal("service was not found"))
 		})
 
 		It("Returns None if the original plan was private", func() {
-			serviceBuilder.GetServiceByNameWithPlansWithOrgNamesReturns(privateService, nil)
+			serviceBuilder.GetServiceByNameWithPlansReturns(privateService, nil)
 			originalAccessValue, err := actor.UpdateSinglePlanForService("my-mixed-service", "private-service-plan", true)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(originalAccessValue).To(Equal(actors.None))
 		})
 
 		It("Returns All if the original plan was public", func() {
-			serviceBuilder.GetServiceByNameWithPlansWithOrgNamesReturns(mixedService, nil)
+			serviceBuilder.GetServiceByNameWithPlansReturns(mixedService, nil)
 			originalAccessValue, err := actor.UpdateSinglePlanForService("my-mixed-service", "public-service-plan", true)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(originalAccessValue).To(Equal(actors.All))
 		})
 
 		It("Returns an error if the plan cannot be found", func() {
-			serviceBuilder.GetServiceByNameWithPlansWithOrgNamesReturns(mixedService, nil)
+			serviceBuilder.GetServiceByNameWithPlansReturns(mixedService, nil)
 			_, err := actor.UpdateSinglePlanForService("my-mixed-service", "not-a-service-plan", true)
 			Expect(err.Error()).To(Equal("The plan not-a-service-plan could not be found for service my-mixed-service"))
 		})
 
 		Context("when setting a public service plan to public", func() {
 			It("Does not try to update the service plan", func() {
-				serviceBuilder.GetServiceByNameWithPlansWithOrgNamesReturns(mixedService, nil)
+				serviceBuilder.GetServiceByNameWithPlansReturns(mixedService, nil)
 				_, err := actor.UpdateSinglePlanForService("my-mixed-service", "public-service-plan", true)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(servicePlanRepo.UpdateCallCount()).To(Equal(0))
@@ -393,7 +393,7 @@ var _ = Describe("Service Plans", func() {
 			})
 
 			It("removes the service plan visibilities for the service plan", func() {
-				serviceBuilder.GetServiceByNameWithPlansWithOrgNamesReturns(mixedService, nil)
+				serviceBuilder.GetServiceByNameWithPlansReturns(mixedService, nil)
 				_, err := actor.UpdateSinglePlanForService("my-mixed-service", "private-service-plan", true)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -402,7 +402,7 @@ var _ = Describe("Service Plans", func() {
 			})
 
 			It("sets a service plan to public", func() {
-				serviceBuilder.GetServiceByNameWithPlansWithOrgNamesReturns(mixedService, nil)
+				serviceBuilder.GetServiceByNameWithPlansReturns(mixedService, nil)
 				_, err := actor.UpdateSinglePlanForService("my-mixed-service", "private-service-plan", true)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -415,7 +415,7 @@ var _ = Describe("Service Plans", func() {
 
 		Context("when setting a private service plan to private", func() {
 			It("Does not try to update the service plan", func() {
-				serviceBuilder.GetServiceByNameWithPlansWithOrgNamesReturns(mixedService, nil)
+				serviceBuilder.GetServiceByNameWithPlansReturns(mixedService, nil)
 				_, err := actor.UpdateSinglePlanForService("my-mixed-service", "private-service-plan", false)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(servicePlanRepo.UpdateCallCount()).To(Equal(0))
@@ -429,7 +429,7 @@ var _ = Describe("Service Plans", func() {
 			})
 
 			It("removes the service plan visibilities for the service plan", func() {
-				serviceBuilder.GetServiceByNameWithPlansWithOrgNamesReturns(mixedService, nil)
+				serviceBuilder.GetServiceByNameWithPlansReturns(mixedService, nil)
 				_, err := actor.UpdateSinglePlanForService("my-mixed-service", "public-service-plan", false)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -438,7 +438,7 @@ var _ = Describe("Service Plans", func() {
 			})
 
 			It("sets the plan to private", func() {
-				serviceBuilder.GetServiceByNameWithPlansWithOrgNamesReturns(mixedService, nil)
+				serviceBuilder.GetServiceByNameWithPlansReturns(mixedService, nil)
 				_, err := actor.UpdateSinglePlanForService("my-mixed-service", "public-service-plan", false)
 				Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
Service access commands were embedding org names in service plans, but not using them. This resulted in calls to /v2/organizations, which would take a long time on environments with many orgs.

Tracker Story: https://www.pivotaltracker.com/story/show/95214984