### PR TITLE
Missing service key coloring message from dsk  now matches the coloring from ds

### DIFF
--- a/cf/commands/servicekey/delete_service_key.go
+++ b/cf/commands/servicekey/delete_service_key.go
@@ -89,10 +89,10 @@ func (cmd DeleteServiceKey) Run(c *cli.Context) {
 	if err != nil || serviceKey.Fields.Guid == "" {
 		cmd.ui.Ok()
 
-		cmd.ui.Say(T("Service key {{.ServiceKeyName}} does not exist for service instance {{.ServiceInstanceName}}.",
+		cmd.ui.Warn(T("Service key {{.ServiceKeyName}} does not exist for service instance {{.ServiceInstanceName}}.",
 			map[string]interface{}{
-				"ServiceKeyName":      terminal.EntityNameColor(serviceKeyName),
-				"ServiceInstanceName": terminal.EntityNameColor(serviceInstanceName),
+				"ServiceKeyName":      serviceKeyName,
+				"ServiceInstanceName": serviceInstanceName,
 			}))
 
 		return


### PR DESCRIPTION
- ui type is now `Warn` instead of `Say`
- Keyword highlight is now switched off

Tracker link: https://www.pivotaltracker.com/n/projects/1211680/stories/94220156