### PR TITLE
Update `create-service` duplicate name error message

### DIFF
--- a/cf/api/services.go
+++ b/cf/api/services.go
@@ -152,9 +152,9 @@ func (repo CloudControllerServiceRepository) CreateServiceInstance(name, planGui
 	err = repo.gateway.CreateResource(repo.config.ApiEndpoint(), path, bytes.NewReader(jsonBytes))
 
 	if httpErr, ok := err.(errors.HttpError); ok && httpErr.ErrorCode() == errors.SERVICE_INSTANCE_NAME_TAKEN {
-		serviceInstance, findInstanceErr := repo.FindInstanceByName(name)
+		_, findInstanceErr := repo.FindInstanceByName(name)
 
-		if findInstanceErr == nil && serviceInstance.ServicePlan.Guid == planGuid {
+		if nil == findInstanceErr {
 			return errors.NewModelAlreadyExistsError("Service", name)
 		}
 	}

--- a/cf/commands/service/create_service_test.go
+++ b/cf/commands/service/create_service_test.go
@@ -252,6 +252,23 @@ var _ = Describe("create-service command", func() {
 		})
 	})
 
+	It("warns the user when the service name already exists no matter the service plan", func() {
+		serviceRepo.CreateServiceInstanceReturns.Error = errors.NewModelAlreadyExistsError("Service", "my-cleardb-service")
+
+		callCreateService([]string{"cleardb", "expensive", "my-cleardb-service"})
+
+		Expect(ui.Outputs).To(ContainSubstrings(
+			[]string{"Creating service instance", "my-cleardb-service"},
+			[]string{"OK"},
+			[]string{"Service my-cleardb-service already exists"},
+		), "Expected output did not match with ModelAlreadyExistsError")
+
+		Expect(serviceRepo.CreateServiceInstanceArgs.Name).To(Equal("my-cleardb-service"),
+			"name argument did not match")
+		Expect(serviceRepo.CreateServiceInstanceArgs.PlanGuid).To(Equal("luxury-guid"),
+			"plan argument did not match")
+	})
+
 	It("warns the user when the service already exists with the same service plan", func() {
 		serviceRepo.CreateServiceInstanceReturns.Error = errors.NewModelAlreadyExistsError("Service", "my-cleardb-service")
 


### PR DESCRIPTION
- Now checks only if the name is already taken in the space.
- It doesn't matter now if the plan is the same or not.
- It now returns an 'OK' and an error message if the name already exists

Tracker link: https://www.pivotaltracker.com/n/projects/1211680