### PR TITLE
cf service-access performance

### DIFF
--- a/cf/actors/broker_builder/broker_builder_test.go
+++ b/cf/actors/broker_builder/broker_builder_test.go
@@ -181,7 +181,7 @@ var _ = Describe("Broker Builder", func() {
 
 		It("returns an error if we cannot list the services for a broker", func() {
 			brokerRepo.ServiceBrokers = []models.ServiceBroker{serviceBroker1}
-			serviceBuilder.GetServicesForBrokerReturns(nil, errors.New("Cannot find services"))
+			serviceBuilder.GetServicesForManyBrokersReturns(nil, errors.New("Cannot find services"))
 
 			_, err := brokerBuilder.GetAllServiceBrokers()
 			Expect(err).To(HaveOccurred())
@@ -189,7 +189,7 @@ var _ = Describe("Broker Builder", func() {
 
 		It("returns all service brokers populated with their services", func() {
 			brokerRepo.ServiceBrokers = []models.ServiceBroker{serviceBroker1}
-			serviceBuilder.GetServicesForBrokerReturns(services, nil)
+			serviceBuilder.GetServicesForManyBrokersReturns(services, nil)
 
 			brokers, err := brokerBuilder.GetAllServiceBrokers()
 			Expect(err).NotTo(HaveOccurred())

--- a/cf/actors/plan_builder/fakes/fake_plan_builder.go
+++ b/cf/actors/plan_builder/fakes/fake_plan_builder.go
@@ -2,9 +2,10 @@
 package fakes
 
 import (
-	. "github.com/cloudfoundry/cli/cf/actors/plan_builder"
-	"github.com/cloudfoundry/cli/cf/models"
 	"sync"
+
+	"github.com/cloudfoundry/cli/cf/actors/plan_builder"
+	"github.com/cloudfoundry/cli/cf/models"
 )
 
 type FakePlanBuilder struct {
@@ -46,6 +47,15 @@ type FakePlanBuilder struct {
 		result1 []models.ServicePlanFields
 		result2 error
 	}
+	GetPlansForManyServicesWithOrgsStub        func([]string) ([]models.ServicePlanFields, error)
+	getPlansForManyServicesWithOrgsMutex       sync.RWMutex
+	getPlansForManyServicesWithOrgsArgsForCall []struct {
+		arg1 []string
+	}
+	getPlansForManyServicesWithOrgsReturns struct {
+		result1 []models.ServicePlanFields
+		result2 error
+	}
 	GetPlansForServiceStub        func(string) ([]models.ServicePlanFields, error)
 	getPlansForServiceMutex       sync.RWMutex
 	getPlansForServiceArgsForCall []struct {
@@ -68,10 +78,10 @@ type FakePlanBuilder struct {
 
 func (fake *FakePlanBuilder) AttachOrgsToPlans(arg1 []models.ServicePlanFields) ([]models.ServicePlanFields, error) {
 	fake.attachOrgsToPlansMutex.Lock()
-	defer fake.attachOrgsToPlansMutex.Unlock()
 	fake.attachOrgsToPlansArgsForCall = append(fake.attachOrgsToPlansArgsForCall, struct {
 		arg1 []models.ServicePlanFields
 	}{arg1})
+	fake.attachOrgsToPlansMutex.Unlock()
 	if fake.AttachOrgsToPlansStub != nil {
 		return fake.AttachOrgsToPlansStub(arg1)
 	} else {
@@ -92,6 +102,7 @@ func (fake *FakePlanBuilder) AttachOrgsToPlansArgsForCall(i int) []models.Servic
 }
 
 func (fake *FakePlanBuilder) AttachOrgsToPlansReturns(result1 []models.ServicePlanFields, result2 error) {
+	fake.AttachOrgsToPlansStub = nil
 	fake.attachOrgsToPlansReturns = struct {
 		result1 []models.ServicePlanFields
 		result2 error
@@ -100,11 +111,11 @@ func (fake *FakePlanBuilder) AttachOrgsToPlansReturns(result1 []models.ServicePl
 
 func (fake *FakePlanBuilder) AttachOrgToPlans(arg1 []models.ServicePlanFields, arg2 string) ([]models.ServicePlanFields, error) {
 	fake.attachOrgToPlansMutex.Lock()
-	defer fake.attachOrgToPlansMutex.Unlock()
 	fake.attachOrgToPlansArgsForCall = append(fake.attachOrgToPlansArgsForCall, struct {
 		arg1 []models.ServicePlanFields
 		arg2 string
 	}{arg1, arg2})
+	fake.attachOrgToPlansMutex.Unlock()
 	if fake.AttachOrgToPlansStub != nil {
 		return fake.AttachOrgToPlansStub(arg1, arg2)
 	} else {
@@ -125,6 +136,7 @@ func (fake *FakePlanBuilder) AttachOrgToPlansArgsForCall(i int) ([]models.Servic
 }
 
 func (fake *FakePlanBuilder) AttachOrgToPlansReturns(result1 []models.ServicePlanFields, result2 error) {
+	fake.AttachOrgToPlansStub = nil
 	fake.attachOrgToPlansReturns = struct {
 		result1 []models.ServicePlanFields
 		result2 error
@@ -133,11 +145,11 @@ func (fake *FakePlanBuilder) AttachOrgToPlansReturns(result1 []models.ServicePla
 
 func (fake *FakePlanBuilder) GetPlansForServiceForOrg(arg1 string, arg2 string) ([]models.ServicePlanFields, error) {
 	fake.getPlansForServiceForOrgMutex.Lock()
-	defer fake.getPlansForServiceForOrgMutex.Unlock()
 	fake.getPlansForServiceForOrgArgsForCall = append(fake.getPlansForServiceForOrgArgsForCall, struct {
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	fake.getPlansForServiceForOrgMutex.Unlock()
 	if fake.GetPlansForServiceForOrgStub != nil {
 		return fake.GetPlansForServiceForOrgStub(arg1, arg2)
 	} else {
@@ -158,6 +170,7 @@ func (fake *FakePlanBuilder) GetPlansForServiceForOrgArgsForCall(i int) (string,
 }
 
 func (fake *FakePlanBuilder) GetPlansForServiceForOrgReturns(result1 []models.ServicePlanFields, result2 error) {
+	fake.GetPlansForServiceForOrgStub = nil
 	fake.getPlansForServiceForOrgReturns = struct {
 		result1 []models.ServicePlanFields
 		result2 error
@@ -166,10 +179,10 @@ func (fake *FakePlanBuilder) GetPlansForServiceForOrgReturns(result1 []models.Se
 
 func (fake *FakePlanBuilder) GetPlansForServiceWithOrgs(arg1 string) ([]models.ServicePlanFields, error) {
 	fake.getPlansForServiceWithOrgsMutex.Lock()
-	defer fake.getPlansForServiceWithOrgsMutex.Unlock()
 	fake.getPlansForServiceWithOrgsArgsForCall = append(fake.getPlansForServiceWithOrgsArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	fake.getPlansForServiceWithOrgsMutex.Unlock()
 	if fake.GetPlansForServiceWithOrgsStub != nil {
 		return fake.GetPlansForServiceWithOrgsStub(arg1)
 	} else {
@@ -190,7 +203,41 @@ func (fake *FakePlanBuilder) GetPlansForServiceWithOrgsArgsForCall(i int) string
 }
 
 func (fake *FakePlanBuilder) GetPlansForServiceWithOrgsReturns(result1 []models.ServicePlanFields, result2 error) {
+	fake.GetPlansForServiceWithOrgsStub = nil
 	fake.getPlansForServiceWithOrgsReturns = struct {
+		result1 []models.ServicePlanFields
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakePlanBuilder) GetPlansForManyServicesWithOrgs(arg1 []string) ([]models.ServicePlanFields, error) {
+	fake.getPlansForManyServicesWithOrgsMutex.Lock()
+	fake.getPlansForManyServicesWithOrgsArgsForCall = append(fake.getPlansForManyServicesWithOrgsArgsForCall, struct {
+		arg1 []string
+	}{arg1})
+	fake.getPlansForManyServicesWithOrgsMutex.Unlock()
+	if fake.GetPlansForManyServicesWithOrgsStub != nil {
+		return fake.GetPlansForManyServicesWithOrgsStub(arg1)
+	} else {
+		return fake.getPlansForManyServicesWithOrgsReturns.result1, fake.getPlansForManyServicesWithOrgsReturns.result2
+	}
+}
+
+func (fake *FakePlanBuilder) GetPlansForManyServicesWithOrgsCallCount() int {
+	fake.getPlansForManyServicesWithOrgsMutex.RLock()
+	defer fake.getPlansForManyServicesWithOrgsMutex.RUnlock()
+	return len(fake.getPlansForManyServicesWithOrgsArgsForCall)
+}
+
+func (fake *FakePlanBuilder) GetPlansForManyServicesWithOrgsArgsForCall(i int) []string {
+	fake.getPlansForManyServicesWithOrgsMutex.RLock()
+	defer fake.getPlansForManyServicesWithOrgsMutex.RUnlock()
+	return fake.getPlansForManyServicesWithOrgsArgsForCall[i].arg1
+}
+
+func (fake *FakePlanBuilder) GetPlansForManyServicesWithOrgsReturns(result1 []models.ServicePlanFields, result2 error) {
+	fake.GetPlansForManyServicesWithOrgsStub = nil
+	fake.getPlansForManyServicesWithOrgsReturns = struct {
 		result1 []models.ServicePlanFields
 		result2 error
 	}{result1, result2}
@@ -198,10 +245,10 @@ func (fake *FakePlanBuilder) GetPlansForServiceWithOrgsReturns(result1 []models.
 
 func (fake *FakePlanBuilder) GetPlansForService(arg1 string) ([]models.ServicePlanFields, error) {
 	fake.getPlansForServiceMutex.Lock()
-	defer fake.getPlansForServiceMutex.Unlock()
 	fake.getPlansForServiceArgsForCall = append(fake.getPlansForServiceArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	fake.getPlansForServiceMutex.Unlock()
 	if fake.GetPlansForServiceStub != nil {
 		return fake.GetPlansForServiceStub(arg1)
 	} else {
@@ -222,6 +269,7 @@ func (fake *FakePlanBuilder) GetPlansForServiceArgsForCall(i int) string {
 }
 
 func (fake *FakePlanBuilder) GetPlansForServiceReturns(result1 []models.ServicePlanFields, result2 error) {
+	fake.GetPlansForServiceStub = nil
 	fake.getPlansForServiceReturns = struct {
 		result1 []models.ServicePlanFields
 		result2 error
@@ -230,10 +278,10 @@ func (fake *FakePlanBuilder) GetPlansForServiceReturns(result1 []models.ServiceP
 
 func (fake *FakePlanBuilder) GetPlansVisibleToOrg(arg1 string) ([]models.ServicePlanFields, error) {
 	fake.getPlansVisibleToOrgMutex.Lock()
-	defer fake.getPlansVisibleToOrgMutex.Unlock()
 	fake.getPlansVisibleToOrgArgsForCall = append(fake.getPlansVisibleToOrgArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	fake.getPlansVisibleToOrgMutex.Unlock()
 	if fake.GetPlansVisibleToOrgStub != nil {
 		return fake.GetPlansVisibleToOrgStub(arg1)
 	} else {
@@ -254,10 +302,11 @@ func (fake *FakePlanBuilder) GetPlansVisibleToOrgArgsForCall(i int) string {
 }
 
 func (fake *FakePlanBuilder) GetPlansVisibleToOrgReturns(result1 []models.ServicePlanFields, result2 error) {
+	fake.GetPlansVisibleToOrgStub = nil
 	fake.getPlansVisibleToOrgReturns = struct {
 		result1 []models.ServicePlanFields
 		result2 error
 	}{result1, result2}
 }
 
-var _ PlanBuilder = new(FakePlanBuilder)
+var _ plan_builder.PlanBuilder = new(FakePlanBuilder)

--- a/cf/actors/plan_builder/plan_builder.go
+++ b/cf/actors/plan_builder/plan_builder.go
@@ -11,6 +11,7 @@ type PlanBuilder interface {
 	AttachOrgToPlans([]models.ServicePlanFields, string) ([]models.ServicePlanFields, error)
 	GetPlansForServiceForOrg(string, string) ([]models.ServicePlanFields, error)
 	GetPlansForServiceWithOrgs(string) ([]models.ServicePlanFields, error)
+	GetPlansForManyServicesWithOrgs([]string) ([]models.ServicePlanFields, error)
 	GetPlansForService(string) ([]models.ServicePlanFields, error)
 	GetPlansVisibleToOrg(string) ([]models.ServicePlanFields, error)
 }
@@ -83,6 +84,19 @@ func (builder Builder) GetPlansForService(serviceGuid string) ([]models.ServiceP
 
 func (builder Builder) GetPlansForServiceWithOrgs(serviceGuid string) ([]models.ServicePlanFields, error) {
 	plans, err := builder.GetPlansForService(serviceGuid)
+	if err != nil {
+		return nil, err
+	}
+
+	plans, err = builder.AttachOrgsToPlans(plans)
+	if err != nil {
+		return nil, err
+	}
+	return plans, nil
+}
+
+func (builder Builder) GetPlansForManyServicesWithOrgs(serviceGuids []string) ([]models.ServicePlanFields, error) {
+	plans, err := builder.servicePlanRepo.ListPlansFromManyServices(serviceGuids)
 	if err != nil {
 		return nil, err
 	}

--- a/cf/actors/plan_builder/plan_builder_test.go
+++ b/cf/actors/plan_builder/plan_builder_test.go
@@ -1,6 +1,8 @@
 package plan_builder_test
 
 import (
+	"errors"
+
 	"github.com/cloudfoundry/cli/cf/actors/plan_builder"
 	"github.com/cloudfoundry/cli/cf/api/fakes"
 	testorg "github.com/cloudfoundry/cli/cf/api/organizations/fakes"
@@ -35,12 +37,12 @@ var _ = Describe("Plan builder", func() {
 			Guid:                "service-plan1-guid",
 			ServiceOfferingGuid: "service-guid1",
 		}
-
 		plan2 = models.ServicePlanFields{
 			Name:                "service-plan2",
 			Guid:                "service-plan2-guid",
 			ServiceOfferingGuid: "service-guid1",
 		}
+
 		planRepo.SearchReturns = map[string][]models.ServicePlanFields{
 			"service-guid1": []models.ServicePlanFields{plan1, plan2},
 		}
@@ -90,6 +92,29 @@ var _ = Describe("Plan builder", func() {
 			Expect(plans[0].Name).To(Equal("service-plan1"))
 			Expect(plans[0].OrgNames).To(Equal([]string{"org1", "org2"}))
 			Expect(plans[1].Name).To(Equal("service-plan2"))
+		})
+	})
+
+	Describe(".GetPlansForManyServicesWithOrgs", func() {
+		It("returns all the plans for all service in a list of guids", func() {
+			planRepo.ListPlansFromManyServicesReturns = []models.ServicePlanFields{
+				plan1, plan2,
+			}
+			serviceGuids := []string{"service-guid1", "service-guid2"}
+			plans, err := builder.GetPlansForManyServicesWithOrgs(serviceGuids)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(len(plans)).To(Equal(2))
+			Expect(plans[0].Name).To(Equal("service-plan1"))
+			Expect(plans[0].OrgNames).To(Equal([]string{"org1", "org2"}))
+			Expect(plans[1].Name).To(Equal("service-plan2"))
+		})
+
+		It("returns errors from the service plan repo", func() {
+			planRepo.ListPlansFromManyServicesError = errors.New("Error")
+			serviceGuids := []string{"service-guid1", "service-guid2"}
+			_, err := builder.GetPlansForManyServicesWithOrgs(serviceGuids)
+			Expect(err).To(HaveOccurred())
 		})
 	})
 

--- a/cf/actors/service_builder/fakes/fake_service_builder.go
+++ b/cf/actors/service_builder/fakes/fake_service_builder.go
@@ -2,9 +2,10 @@
 package fakes
 
 import (
+	"sync"
+
 	. "github.com/cloudfoundry/cli/cf/actors/service_builder"
 	"github.com/cloudfoundry/cli/cf/models"
-	"sync"
 )
 
 type FakeServiceBuilder struct {
@@ -80,6 +81,16 @@ type FakeServiceBuilder struct {
 		result1 models.ServiceOffering
 		result2 error
 	}
+	GetServicesForManyBrokersStub        func([]string) ([]models.ServiceOffering, error)
+	getServicesForManyBrokersMutex       sync.RWMutex
+	getServicesForManyBrokersArgsForCall []struct {
+		arg1 []string
+	}
+	getServicesForManyBrokersReturns struct {
+		result1 []models.ServiceOffering
+		result2 error
+	}
+
 	GetServicesForBrokerStub        func(string) ([]models.ServiceOffering, error)
 	getServicesForBrokerMutex       sync.RWMutex
 	getServicesForBrokerArgsForCall []struct {
@@ -372,6 +383,19 @@ func (fake *FakeServiceBuilder) GetServiceByNameForOrgReturns(result1 models.Ser
 	}{result1, result2}
 }
 
+func (fake *FakeServiceBuilder) GetServicesForManyBrokers(arg1 []string) ([]models.ServiceOffering, error) {
+	fake.getServicesForManyBrokersMutex.Lock()
+	defer fake.getServicesForManyBrokersMutex.Unlock()
+	fake.getServicesForManyBrokersArgsForCall = append(fake.getServicesForManyBrokersArgsForCall, struct {
+		arg1 []string
+	}{arg1})
+	if fake.GetServicesForManyBrokersStub != nil {
+		return fake.GetServicesForManyBrokersStub(arg1)
+	} else {
+		return fake.getServicesForManyBrokersReturns.result1, fake.getServicesForManyBrokersReturns.result2
+	}
+}
+
 func (fake *FakeServiceBuilder) GetServicesForBroker(arg1 string) ([]models.ServiceOffering, error) {
 	fake.getServicesForBrokerMutex.Lock()
 	defer fake.getServicesForBrokerMutex.Unlock()
@@ -395,6 +419,13 @@ func (fake *FakeServiceBuilder) GetServicesForBrokerArgsForCall(i int) string {
 	fake.getServicesForBrokerMutex.RLock()
 	defer fake.getServicesForBrokerMutex.RUnlock()
 	return fake.getServicesForBrokerArgsForCall[i].arg1
+}
+
+func (fake *FakeServiceBuilder) GetServicesForManyBrokersReturns(result1 []models.ServiceOffering, result2 error) {
+	fake.getServicesForManyBrokersReturns = struct {
+		result1 []models.ServiceOffering
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeServiceBuilder) GetServicesForBrokerReturns(result1 []models.ServiceOffering, result2 error) {

--- a/cf/actors/service_builder/service_builder_test.go
+++ b/cf/actors/service_builder/service_builder_test.go
@@ -1,6 +1,8 @@
 package service_builder_test
 
 import (
+	"errors"
+
 	plan_builder_fakes "github.com/cloudfoundry/cli/cf/actors/plan_builder/fakes"
 	"github.com/cloudfoundry/cli/cf/actors/service_builder"
 	testapi "github.com/cloudfoundry/cli/cf/api/fakes"
@@ -17,6 +19,7 @@ var _ = Describe("Service Builder", func() {
 		serviceBuilder  service_builder.ServiceBuilder
 		serviceRepo     *testapi.FakeServiceRepo
 		service1        models.ServiceOffering
+		service2        models.ServiceOffering
 		v1Service       models.ServiceOffering
 		planWithoutOrgs models.ServicePlanFields
 		plan1           models.ServicePlanFields
@@ -36,6 +39,14 @@ var _ = Describe("Service Builder", func() {
 			},
 		}
 
+		service2 = models.ServiceOffering{
+			ServiceOfferingFields: models.ServiceOfferingFields{
+				Label:      "my-service2",
+				Guid:       "service-guid2",
+				BrokerGuid: "my-service-broker-guid2",
+			},
+		}
+
 		v1Service = models.ServiceOffering{
 			ServiceOfferingFields: models.ServiceOfferingFields{
 				Label:      "v1Service",
@@ -46,7 +57,8 @@ var _ = Describe("Service Builder", func() {
 		}
 
 		serviceRepo.FindServiceOfferingsByLabelName = "my-service1"
-		serviceRepo.FindServiceOfferingsByLabelServiceOfferings = models.ServiceOfferings([]models.ServiceOffering{service1, v1Service})
+		serviceRepo.FindServiceOfferingsByLabelServiceOfferings =
+			models.ServiceOfferings([]models.ServiceOffering{service1, v1Service})
 
 		serviceRepo.GetServiceOfferingByGuidReturns = struct {
 			ServiceOffering models.ServiceOffering
@@ -58,6 +70,10 @@ var _ = Describe("Service Builder", func() {
 
 		serviceRepo.ListServicesFromBrokerReturns = map[string][]models.ServiceOffering{
 			"my-service-broker-guid1": []models.ServiceOffering{service1},
+		}
+
+		serviceRepo.ListServicesFromManyBrokersReturns = map[string][]models.ServiceOffering{
+			"my-service-broker-guid1,my-service-broker-guid2": []models.ServiceOffering{service1, service2},
 		}
 
 		plan1 = models.ServicePlanFields{
@@ -371,6 +387,37 @@ var _ = Describe("Service Builder", func() {
 			Expect(service.Plans[0].Name).To(Equal("service-plan1"))
 			Expect(service.Plans[1].Name).To(Equal("service-plan2"))
 			Expect(service.Plans[0].OrgNames).To(Equal([]string{"org1", "org2"}))
+		})
+	})
+
+	Describe(".GetServicesForManyBrokers", func() {
+		It("returns all the services for an array of broker guids, fully populated", func() {
+			brokerGuids := []string{"my-service-broker-guid1", "my-service-broker-guid2"}
+			services, err := serviceBuilder.GetServicesForManyBrokers(brokerGuids)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(services).To(HaveLen(2))
+
+			broker_service := services[0]
+			Expect(broker_service.Label).To(Equal("my-service1"))
+			Expect(len(broker_service.Plans)).To(Equal(2))
+			Expect(broker_service.Plans[0].Name).To(Equal("service-plan1"))
+			Expect(broker_service.Plans[1].Name).To(Equal("service-plan2"))
+			Expect(broker_service.Plans[0].OrgNames).To(Equal([]string{"org1", "org2"}))
+
+			broker_service2 := services[1]
+			Expect(broker_service2.Label).To(Equal("my-service2"))
+			Expect(len(broker_service2.Plans)).To(Equal(2))
+			Expect(broker_service.Plans[0].Name).To(Equal("service-plan1"))
+			Expect(broker_service.Plans[1].Name).To(Equal("service-plan2"))
+			Expect(broker_service.Plans[0].OrgNames).To(Equal([]string{"org1", "org2"}))
+		})
+
+		It("raises errors from the service repo", func() {
+			serviceRepo.ListServicesFromManyBrokersErr = errors.New("error")
+			brokerGuids := []string{"my-service-broker-guid1", "my-service-broker-guid2"}
+			_, err := serviceBuilder.GetServicesForManyBrokers(brokerGuids)
+			Expect(err).To(HaveOccurred())
 		})
 	})
 

--- a/cf/api/fakes/fake_service_plan_repo.go
+++ b/cf/api/fakes/fake_service_plan_repo.go
@@ -22,6 +22,20 @@ type FakeServicePlanRepo struct {
 	updateReturns struct {
 		result1 error
 	}
+
+	ListPlansFromManyServicesReturns []models.ServicePlanFields
+	ListPlansFromManyServicesError   error
+}
+
+func (fake *FakeServicePlanRepo) ListPlansFromManyServices(serviceGuids []string) (plans []models.ServicePlanFields, err error) {
+	if fake.ListPlansFromManyServicesError != nil {
+		return nil, fake.ListPlansFromManyServicesError
+	}
+
+	if fake.ListPlansFromManyServicesReturns != nil {
+		return fake.ListPlansFromManyServicesReturns, nil
+	}
+	return []models.ServicePlanFields{}, nil
 }
 
 func (fake *FakeServicePlanRepo) Search(queryParams map[string]string) ([]models.ServicePlanFields, error) {

--- a/cf/api/fakes/fake_service_repo.go
+++ b/cf/api/fakes/fake_service_repo.go
@@ -1,6 +1,8 @@
 package fakes
 
 import (
+	"strings"
+
 	"github.com/cloudfoundry/cli/cf/api/resources"
 	"github.com/cloudfoundry/cli/cf/errors"
 	"github.com/cloudfoundry/cli/cf/models"
@@ -81,6 +83,9 @@ type FakeServiceRepo struct {
 	FindServiceOfferingsByLabelServiceOfferings models.ServiceOfferings
 	FindServiceOfferingsByLabelApiResponse      error
 	FindServiceOfferingsByLabelCalled           bool
+
+	ListServicesFromManyBrokersReturns map[string][]models.ServiceOffering
+	ListServicesFromManyBrokersErr     error
 
 	ListServicesFromBrokerReturns map[string][]models.ServiceOffering
 	ListServicesFromBrokerErr     error
@@ -211,6 +216,19 @@ func (repo *FakeServiceRepo) FindServicePlanByDescription(planDescription resour
 	}
 	repo.findServicePlanByDescriptionCallCount += 1
 	return
+}
+
+func (repo *FakeServiceRepo) ListServicesFromManyBrokers(brokerGuids []string) ([]models.ServiceOffering, error) {
+	if repo.ListServicesFromManyBrokersErr != nil {
+		return nil, repo.ListServicesFromManyBrokersErr
+	}
+
+	key := strings.Join(brokerGuids, ",")
+	if repo.ListServicesFromManyBrokersReturns[key] != nil {
+		return repo.ListServicesFromManyBrokersReturns[key], nil
+	}
+
+	return []models.ServiceOffering{}, nil
 }
 
 func (repo *FakeServiceRepo) ListServicesFromBroker(brokerGuid string) ([]models.ServiceOffering, error) {

--- a/cf/api/organizations/fakes/fake_organization_repository.go
+++ b/cf/api/organizations/fakes/fake_organization_repository.go
@@ -16,6 +16,15 @@ type FakeOrganizationRepository struct {
 		result1 []models.Organization
 		result2 error
 	}
+	GetManyOrgsByGuidStub        func(orgGuids []string) (orgs []models.Organization, apiErr error)
+	getManyOrgsByGuidMutex       sync.RWMutex
+	getManyOrgsByGuidArgsForCall []struct {
+		orgGuids []string
+	}
+	getManyOrgsByGuidReturns struct {
+		result1 []models.Organization
+		result2 error
+	}
 	FindByNameStub        func(name string) (org models.Organization, apiErr error)
 	findByNameMutex       sync.RWMutex
 	findByNameArgsForCall []struct {
@@ -90,6 +99,39 @@ func (fake *FakeOrganizationRepository) ListOrgsCallCount() int {
 func (fake *FakeOrganizationRepository) ListOrgsReturns(result1 []models.Organization, result2 error) {
 	fake.ListOrgsStub = nil
 	fake.listOrgsReturns = struct {
+		result1 []models.Organization
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeOrganizationRepository) GetManyOrgsByGuid(orgGuids []string) (orgs []models.Organization, apiErr error) {
+	fake.getManyOrgsByGuidMutex.Lock()
+	fake.getManyOrgsByGuidArgsForCall = append(fake.getManyOrgsByGuidArgsForCall, struct {
+		orgGuids []string
+	}{orgGuids})
+	fake.getManyOrgsByGuidMutex.Unlock()
+	if fake.GetManyOrgsByGuidStub != nil {
+		return fake.GetManyOrgsByGuidStub(orgGuids)
+	} else {
+		return fake.getManyOrgsByGuidReturns.result1, fake.getManyOrgsByGuidReturns.result2
+	}
+}
+
+func (fake *FakeOrganizationRepository) GetManyOrgsByGuidCallCount() int {
+	fake.getManyOrgsByGuidMutex.RLock()
+	defer fake.getManyOrgsByGuidMutex.RUnlock()
+	return len(fake.getManyOrgsByGuidArgsForCall)
+}
+
+func (fake *FakeOrganizationRepository) GetManyOrgsByGuidArgsForCall(i int) []string {
+	fake.getManyOrgsByGuidMutex.RLock()
+	defer fake.getManyOrgsByGuidMutex.RUnlock()
+	return fake.getManyOrgsByGuidArgsForCall[i].orgGuids
+}
+
+func (fake *FakeOrganizationRepository) GetManyOrgsByGuidReturns(result1 []models.Organization, result2 error) {
+	fake.GetManyOrgsByGuidStub = nil
+	fake.getManyOrgsByGuidReturns = struct {
 		result1 []models.Organization
 		result2 error
 	}{result1, result2}

--- a/cf/api/organizations/organizations.go
+++ b/cf/api/organizations/organizations.go
@@ -15,6 +15,7 @@ import (
 //go:generate counterfeiter -o fakes/fake_organization_repository.go . OrganizationRepository
 type OrganizationRepository interface {
 	ListOrgs() (orgs []models.Organization, apiErr error)
+	GetManyOrgsByGuid(orgGuids []string) (orgs []models.Organization, apiErr error)
 	FindByName(name string) (org models.Organization, apiErr error)
 	Create(org models.Organization) (apiErr error)
 	Rename(orgGuid string, name string) (apiErr error)
@@ -50,6 +51,20 @@ func (repo CloudControllerOrganizationRepository) ListOrgs() ([]models.Organizat
 			}
 		})
 	return orgs, err
+}
+
+func (repo CloudControllerOrganizationRepository) GetManyOrgsByGuid(orgGuids []string) (orgs []models.Organization, err error) {
+	for _, orgGuid := range orgGuids {
+		url := fmt.Sprintf("%s/v2/organizations/%s", repo.config.ApiEndpoint(), orgGuid)
+		orgResource := resources.OrganizationResource{}
+		err = repo.gateway.GetResource(url, &orgResource)
+		if err != nil {
+			return nil, err
+		} else {
+			orgs = append(orgs, orgResource.ToModel())
+		}
+	}
+	return
 }
 
 func (repo CloudControllerOrganizationRepository) FindByName(name string) (org models.Organization, apiErr error) {

--- a/cf/api/organizations/organizations_test.go
+++ b/cf/api/organizations/organizations_test.go
@@ -81,6 +81,38 @@ var _ = Describe("Organization Repository", func() {
 		})
 	})
 
+	Describe(".GetManyOrgsByGuid", func() {
+		It("requests each org", func() {
+			firstOrgRequest := testapi.NewCloudControllerTestRequest(testnet.TestRequest{
+				Method: "GET",
+				Path:   "/v2/organizations/org1-guid",
+				Response: testnet.TestResponse{Status: http.StatusOK, Body: `{
+		  "metadata": { "guid": "org1-guid" },
+		  "entity": { "name": "Org1" }
+		}`},
+			})
+			secondOrgRequest := testapi.NewCloudControllerTestRequest(testnet.TestRequest{
+				Method: "GET",
+				Path:   "/v2/organizations/org2-guid",
+				Response: testnet.TestResponse{Status: http.StatusOK, Body: `{
+			"metadata": { "guid": "org2-guid" },
+		  "entity": { "name": "Org2" }
+	  }`},
+			})
+			testserver, handler, repo := createOrganizationRepo(firstOrgRequest, secondOrgRequest)
+			defer testserver.Close()
+
+			orgGuids := []string{"org1-guid", "org2-guid"}
+			orgs, err := repo.GetManyOrgsByGuid(orgGuids)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(handler).To(HaveAllRequestsCalled())
+			Expect(len(orgs)).To(Equal(2))
+			Expect(orgs[0].Guid).To(Equal("org1-guid"))
+			Expect(orgs[1].Guid).To(Equal("org2-guid"))
+		})
+	})
+
 	Describe("finding organizations by name", func() {
 		It("returns the org with that name", func() {
 			req := testapi.NewCloudControllerTestRequest(testnet.TestRequest{

--- a/cf/api/service_plan.go
+++ b/cf/api/service_plan.go
@@ -44,10 +44,11 @@ func (repo CloudControllerServicePlanRepository) Update(servicePlan models.Servi
 	return repo.gateway.UpdateResource(repo.config.ApiEndpoint(), url, strings.NewReader(body))
 }
 
-func (repo CloudControllerServicePlanRepository) ListPlansFromManyServices(serviceGuids []string) (plans []models.ServicePlanFields, err error) {
+func (repo CloudControllerServicePlanRepository) ListPlansFromManyServices(serviceGuids []string) ([]models.ServicePlanFields, error) {
 	serviceGuidsString := strings.Join(serviceGuids, ",")
+	plans := []models.ServicePlanFields{}
 
-	err = repo.gateway.ListPaginatedResources(
+	err := repo.gateway.ListPaginatedResources(
 		repo.config.ApiEndpoint(),
 		fmt.Sprintf("/v2/service_plans?q=%s", url.QueryEscape("service_guid IN "+serviceGuidsString)),
 		resources.ServicePlanResource{},
@@ -57,7 +58,7 @@ func (repo CloudControllerServicePlanRepository) ListPlansFromManyServices(servi
 			}
 			return true
 		})
-	return
+	return plans, err
 }
 
 func (repo CloudControllerServicePlanRepository) Search(queryParams map[string]string) (plans []models.ServicePlanFields, err error) {

--- a/cf/api/service_plan.go
+++ b/cf/api/service_plan.go
@@ -14,6 +14,7 @@ import (
 type ServicePlanRepository interface {
 	Search(searchParameters map[string]string) ([]models.ServicePlanFields, error)
 	Update(models.ServicePlanFields, string, bool) error
+	ListPlansFromManyServices(serviceGuids []string) ([]models.ServicePlanFields, error)
 }
 
 type CloudControllerServicePlanRepository struct {
@@ -41,6 +42,22 @@ func (repo CloudControllerServicePlanRepository) Update(servicePlan models.Servi
 
 	url := fmt.Sprintf("/v2/service_plans/%s", servicePlan.Guid)
 	return repo.gateway.UpdateResource(repo.config.ApiEndpoint(), url, strings.NewReader(body))
+}
+
+func (repo CloudControllerServicePlanRepository) ListPlansFromManyServices(serviceGuids []string) (plans []models.ServicePlanFields, err error) {
+	serviceGuidsString := strings.Join(serviceGuids, ",")
+
+	err = repo.gateway.ListPaginatedResources(
+		repo.config.ApiEndpoint(),
+		fmt.Sprintf("/v2/service_plans?q=%s", url.QueryEscape("service_guid IN "+serviceGuidsString)),
+		resources.ServicePlanResource{},
+		func(resource interface{}) bool {
+			if plan, ok := resource.(resources.ServicePlanResource); ok {
+				plans = append(plans, plan.ToFields())
+			}
+			return true
+		})
+	return
 }
 
 func (repo CloudControllerServicePlanRepository) Search(queryParams map[string]string) (plans []models.ServicePlanFields, err error) {

--- a/cf/api/services.go
+++ b/cf/api/services.go
@@ -256,10 +256,11 @@ func (repo CloudControllerServiceRepository) FindServicePlanByDescription(planDe
 	return planGuid, apiErr
 }
 
-func (repo CloudControllerServiceRepository) ListServicesFromManyBrokers(brokerGuids []string) (services []models.ServiceOffering, err error) {
+func (repo CloudControllerServiceRepository) ListServicesFromManyBrokers(brokerGuids []string) ([]models.ServiceOffering, error) {
 	brokerGuidsString := strings.Join(brokerGuids, ",")
+	services := []models.ServiceOffering{}
 
-	err = repo.gateway.ListPaginatedResources(
+	err := repo.gateway.ListPaginatedResources(
 		repo.config.ApiEndpoint(),
 		fmt.Sprintf("/v2/services?q=%s", url.QueryEscape("service_broker_guid IN "+brokerGuidsString)),
 		resources.ServiceOfferingResource{},
@@ -269,7 +270,7 @@ func (repo CloudControllerServiceRepository) ListServicesFromManyBrokers(brokerG
 			}
 			return true
 		})
-	return
+	return services, err
 }
 
 func (repo CloudControllerServiceRepository) ListServicesFromBroker(brokerGuid string) (offerings []models.ServiceOffering, err error) {

--- a/cf/api/services_test.go
+++ b/cf/api/services_test.go
@@ -194,6 +194,81 @@ var _ = Describe("Services Repo", func() {
 		})
 	})
 
+	Describe("returning services for many brokers", func() {
+		path1 := "/v2/services?q=service_broker_guid%20IN%20my-service-broker-guid,my-service-broker-guid2"
+		body1 := `
+{
+   "total_results": 2,
+   "total_pages": 2,
+   "prev_url": null,
+	 "next_url": "/v2/services?q=service_broker_guid%20IN%20my-service-broker-guid,my-service-broker-guid2&page=2",
+   "resources": [
+     {
+         "metadata": {
+            "guid": "my-service-guid"
+         },
+         "entity": {
+            "label": "my-service",
+            "provider": "androsterone-ensphere",
+            "description": "Dummy addon that is cool",
+            "version": "damageableness-preheat",
+            "documentation_url": "YESWECAN.com"
+         }
+			 }
+   ]
+}`
+		path2 := "/v2/services?q=service_broker_guid%20IN%20my-service-broker-guid,my-service-broker-guid2&page=2"
+		body2 := `
+{
+   "total_results": 2,
+   "total_pages": 2,
+   "prev_url": "/v2/services?q=service_broker_guid%20IN%20my-service-broker-guid,my-service-broker-guid2",
+	 "next_url": null,
+   "resources": [
+      {
+         "metadata": {
+            "guid": "my-service-guid2"
+         },
+         "entity": {
+            "label": "my-service2",
+            "provider": "androsterone-ensphere",
+            "description": "Dummy addon that is cool",
+            "version": "damageableness-preheat",
+            "documentation_url": "YESWECAN.com"
+         }
+      }
+   ]
+}`
+		BeforeEach(func() {
+			setupTestServer(
+				testapi.NewCloudControllerTestRequest(
+					testnet.TestRequest{
+						Method:   "GET",
+						Path:     path1,
+						Response: testnet.TestResponse{Status: http.StatusOK, Body: body1},
+					}),
+				testapi.NewCloudControllerTestRequest(
+					testnet.TestRequest{
+						Method:   "GET",
+						Path:     path2,
+						Response: testnet.TestResponse{Status: http.StatusOK, Body: body2},
+					}),
+			)
+		})
+
+		It("returns the service brokers services", func() {
+			brokerGuids := []string{"my-service-broker-guid", "my-service-broker-guid2"}
+			services, err := repo.ListServicesFromManyBrokers(brokerGuids)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(testHandler).To(HaveAllRequestsCalled())
+			Expect(len(services)).To(Equal(2))
+
+			Expect(services[0].Guid).To(Equal("my-service-guid"))
+			Expect(services[1].Guid).To(Equal("my-service-guid2"))
+		})
+	})
+
 	Describe("creating a service instance", func() {
 		It("makes the right request", func() {
 			setupTestServer(testapi.NewCloudControllerTestRequest(testnet.TestRequest{


### PR DESCRIPTION
To improve performance of the `service access` command we changed the way that we:
1. Get service offerings for brokers
2. Get service plans for service offerings
3. Get organization names for service plan visibilities

Each change has its own commit with further details in the commit message. Let us know if you have any questions about our changes.

Tracker Story: https://www.pivotaltracker.com/story/show/96912380