### PR TITLE
Change api endpoint for listing service keys

### DIFF
--- a/cf/api/service_keys.go
+++ b/cf/api/service_keys.go
@@ -59,13 +59,13 @@ func (c CloudControllerServiceKeyRepository) CreateServiceKey(instanceGuid strin
 }
 
 func (c CloudControllerServiceKeyRepository) ListServiceKeys(instanceGuid string) ([]models.ServiceKey, error) {
-	path := fmt.Sprintf("/v2/service_keys?q=service_instance_guid:%s", instanceGuid)
+	path := fmt.Sprintf("/v2/service_instances/%s/service_keys", instanceGuid)
 
 	return c.listServiceKeys(path)
 }
 
-func (c CloudControllerServiceKeyRepository) GetServiceKey(instanceId string, keyName string) (models.ServiceKey, error) {
-	path := fmt.Sprintf("/v2/service_keys?q=%s", url.QueryEscape("service_instance_guid:"+instanceId+";name:"+keyName))
+func (c CloudControllerServiceKeyRepository) GetServiceKey(instanceGuid string, keyName string) (models.ServiceKey, error) {
+	path := fmt.Sprintf("/v2/service_instances/%s/service_keys?q=%s", instanceGuid, url.QueryEscape("name:"+keyName))
 
 	serviceKeys, err := c.listServiceKeys(path)
 	if err != nil || len(serviceKeys) == 0 {

--- a/cf/api/service_keys_test.go
+++ b/cf/api/service_keys_test.go
@@ -121,7 +121,7 @@ var _ = Describe("Service Keys Repo", func() {
 		It("returns empty result when no service key is found", func() {
 			setupTestServer(testapi.NewCloudControllerTestRequest(testnet.TestRequest{
 				Method:   "GET",
-				Path:     "/v2/service_keys?q=service_instance_guid:fake-instance-guid",
+				Path:     "/v2/service_instances/fake-instance-guid/service_keys",
 				Response: emptyServiceKeysResponse,
 			}))
 
@@ -134,7 +134,7 @@ var _ = Describe("Service Keys Repo", func() {
 		It("returns correctly when service keys are found", func() {
 			setupTestServer(testapi.NewCloudControllerTestRequest(testnet.TestRequest{
 				Method:   "GET",
-				Path:     "/v2/service_keys?q=service_instance_guid:fake-instance-guid",
+				Path:     "/v2/service_instances/fake-instance-guid/service_keys",
 				Response: serviceKeysResponse,
 			}))
 
@@ -175,7 +175,7 @@ var _ = Describe("Service Keys Repo", func() {
 		It("returns service key detail", func() {
 			setupTestServer(testapi.NewCloudControllerTestRequest(testnet.TestRequest{
 				Method:   "GET",
-				Path:     "/v2/service_keys?q=service_instance_guid:fake-instance-guid;name:fake-service-key-name",
+				Path:     "/v2/service_instances/fake-instance-guid/service_keys?q=name:fake-service-key-name",
 				Response: serviceKeyDetailResponse,
 			}))
 
@@ -200,7 +200,7 @@ var _ = Describe("Service Keys Repo", func() {
 		It("returns empty result when the service key is not found", func() {
 			setupTestServer(testapi.NewCloudControllerTestRequest(testnet.TestRequest{
 				Method:   "GET",
-				Path:     "/v2/service_keys?q=service_instance_guid:fake-instance-guid;name:non-exist-key-name",
+				Path:     "/v2/service_instances/fake-instance-guid/service_keys?q=name:non-exist-key-name",
 				Response: emptyServiceKeysResponse,
 			}))
 


### PR DESCRIPTION
CLI should use the endpoint `/v2/service_instances/:fake-guid/service_keys`
to list service keys instead of using endpoint `/v2/service_keys?q=service_instance_guid:fake-guid`

[#87481016]

Signed-off-by: Hua Zhang <zhuadl@cn.ibm.com>