### PR TITLE
Improve performance of disable-service-access

### DIFF
--- a/cf/api/service_plan_visibility.go
+++ b/cf/api/service_plan_visibility.go
@@ -51,7 +51,7 @@ func (repo CloudControllerServicePlanVisibilityRepository) List() (visibilities 
 
 func (repo CloudControllerServicePlanVisibilityRepository) Delete(servicePlanGuid string) error {
 	path := fmt.Sprintf("/v2/service_plan_visibilities/%s", servicePlanGuid)
-	return repo.gateway.DeleteResource(repo.config.ApiEndpoint(), path)
+	return repo.gateway.DeleteResourceSynchronously(repo.config.ApiEndpoint(), path)
 }
 
 func (repo CloudControllerServicePlanVisibilityRepository) Search(queryParams map[string]string) ([]models.ServicePlanVisibilityFields, error) {

--- a/cf/api/service_plan_visibility_test.go
+++ b/cf/api/service_plan_visibility_test.go
@@ -83,8 +83,9 @@ var _ = Describe("Service Plan Visibility Repository", func() {
 		It("deletes a service plan visibility", func() {
 			servicePlanVisibilityGuid := "the-service-plan-visibility-guid"
 			setupTestServer(testapi.NewCloudControllerTestRequest(testnet.TestRequest{
-				Method: "DELETE",
-				Path:   "/v2/service_plan_visibilities/" + servicePlanVisibilityGuid,
+				Method:  "DELETE",
+				Path:    "/v2/service_plan_visibilities/" + servicePlanVisibilityGuid,
+				Matcher: testnet.EmptyQueryParamMatcher(),
 				Response: testnet.TestResponse{
 					Status: http.StatusNoContent,
 				},

--- a/cf/net/gateway.go
+++ b/cf/net/gateway.go
@@ -130,6 +130,10 @@ func (gateway Gateway) UpdateResourceSync(endpoint, apiUrl string, body io.ReadS
 	return gateway.createUpdateOrDeleteResource("PUT", endpoint, apiUrl, body, true, resource...)
 }
 
+func (gateway Gateway) DeleteResourceSynchronously(endpoint, apiUrl string) (apiErr error) {
+	return gateway.createUpdateOrDeleteResource("DELETE", endpoint, apiUrl, nil, true, &AsyncResource{})
+}
+
 func (gateway Gateway) DeleteResource(endpoint, apiUrl string) (apiErr error) {
 	return gateway.createUpdateOrDeleteResource("DELETE", endpoint, apiUrl, nil, false, &AsyncResource{})
 }

--- a/cf/net/gateway_test.go
+++ b/cf/net/gateway_test.go
@@ -143,6 +143,27 @@ var _ = Describe("Gateway", func() {
 		Describe("Delete", func() {
 			var apiServer *httptest.Server
 
+			Describe("DeleteResourceSynchronously", func() {
+				var queryParams string
+				BeforeEach(func() {
+					apiServer = httptest.NewTLSServer(http.HandlerFunc(func(_ http.ResponseWriter, request *http.Request) {
+						queryParams = request.URL.RawQuery
+					}))
+					ccGateway.SetTrustedCerts(apiServer.TLS.Certificates)
+				})
+
+				It("does not send the async=true flag", func() {
+					err := ccGateway.DeleteResourceSynchronously(apiServer.URL, "/v2/foobars/SOME_GUID")
+					Expect(err).NotTo(HaveOccurred())
+					Expect(queryParams).ToNot(ContainSubstring("async=true"))
+				})
+
+				It("deletes a resource", func() {
+					err := ccGateway.DeleteResource(apiServer.URL, "/v2/foobars/SOME_GUID")
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
 			Context("when the config has an async timeout", func() {
 				BeforeEach(func() {
 					count := 0

--- a/testhelpers/net/request_matcher.go
+++ b/testhelpers/net/request_matcher.go
@@ -35,6 +35,13 @@ func bytesToInterface(jsonBytes []byte) (interface{}, error) {
 	return arrayResult, err
 }
 
+func EmptyQueryParamMatcher() RequestMatcher {
+	return func(request *http.Request) {
+		defer GinkgoRecover()
+		Expect(request.URL.RawQuery).To(Equal(""))
+	}
+}
+
 func RequestBodyMatcher(expectedBodyString string) RequestMatcher {
 	return func(request *http.Request) {
 		defer GinkgoRecover()


### PR DESCRIPTION
- It was making an `async=true` delete request for each
  service_plan_visibility. This meant each delete would take at least 5
  seconds due to polling.
- Deleting service plan visibilities does not interact with
  the broker and can be completed synchronously in ~.5s
- Add new http test matcher for testing empty query strings.

Tracker Story: https://www.pivotaltracker.com/story/show/96912324