### PR TITLE
Reduce API calls when creating,listing and getting details of service…

### DIFF
--- a/cf/commands/servicekey/create_service_key_test.go
+++ b/cf/commands/servicekey/create_service_key_test.go
@@ -26,7 +26,7 @@ var _ = Describe("create-service-key command", func() {
 	var (
 		ui                  *testterm.FakeUI
 		config              core_config.Repository
-		cmd                 CreateServiceKey
+		cmd                 *CreateServiceKey
 		requirementsFactory *testreq.FakeReqFactory
 		serviceRepo         *testapi.FakeServiceRepo
 		serviceKeyRepo      *testapi.FakeServiceKeyRepo
@@ -43,6 +43,7 @@ var _ = Describe("create-service-key command", func() {
 		serviceKeyRepo = testapi.NewFakeServiceKeyRepo()
 		cmd = NewCreateServiceKey(ui, config, serviceRepo, serviceKeyRepo)
 		requirementsFactory = &testreq.FakeReqFactory{LoginSuccess: true, TargetedSpaceSuccess: true, ServiceInstanceNotFound: false}
+		requirementsFactory.ServiceInstance = serviceInstance
 	})
 
 	var callCreateService = func(args []string) bool {

--- a/cf/commands/servicekey/service_key_test.go
+++ b/cf/commands/servicekey/service_key_test.go
@@ -22,7 +22,7 @@ var _ = Describe("service-key command", func() {
 	var (
 		ui                  *testterm.FakeUI
 		config              core_config.Repository
-		cmd                 ServiceKey
+		cmd                 *ServiceKey
 		requirementsFactory *testreq.FakeReqFactory
 		serviceRepo         *testapi.FakeServiceRepo
 		serviceKeyRepo      *testapi.FakeServiceKeyRepo
@@ -39,6 +39,7 @@ var _ = Describe("service-key command", func() {
 		serviceKeyRepo = testapi.NewFakeServiceKeyRepo()
 		cmd = NewGetServiceKey(ui, config, serviceRepo, serviceKeyRepo)
 		requirementsFactory = &testreq.FakeReqFactory{LoginSuccess: true, TargetedSpaceSuccess: true, ServiceInstanceNotFound: false}
+		requirementsFactory.ServiceInstance = serviceInstance
 	})
 
 	var callGetServiceKey = func(args []string) bool {

--- a/cf/commands/servicekey/service_keys_test.go
+++ b/cf/commands/servicekey/service_keys_test.go
@@ -22,7 +22,7 @@ var _ = Describe("service-keys command", func() {
 	var (
 		ui                  *testterm.FakeUI
 		config              core_config.Repository
-		cmd                 ServiceKeys
+		cmd                 *ServiceKeys
 		requirementsFactory *testreq.FakeReqFactory
 		serviceRepo         *testapi.FakeServiceRepo
 		serviceKeyRepo      *testapi.FakeServiceKeyRepo
@@ -39,6 +39,7 @@ var _ = Describe("service-keys command", func() {
 		serviceKeyRepo = testapi.NewFakeServiceKeyRepo()
 		cmd = NewListServiceKeys(ui, config, serviceRepo, serviceKeyRepo)
 		requirementsFactory = &testreq.FakeReqFactory{LoginSuccess: true, TargetedSpaceSuccess: true, ServiceInstanceNotFound: false}
+		requirementsFactory.ServiceInstance = serviceInstance
 	})
 
 	var callListServiceKeys = func(args []string) bool {
@@ -98,16 +99,6 @@ var _ = Describe("service-keys command", func() {
 			Expect(ui.Outputs).To(ContainSubstrings(
 				[]string{"Getting keys for service instance", "fake-service-instance", "as", "my-user"},
 				[]string{"No service key for service instance", "fake-service-instance"},
-			))
-		})
-
-		It("fails when service instance is not found", func() {
-			serviceRepo.FindInstanceByNameNotFound = true
-			callListServiceKeys([]string{"non-exist-service-instance"})
-			Expect(ui.Outputs).To(ContainSubstrings(
-				[]string{"Getting keys for service instance", "non-exist-service-instance", "as", "my-user"},
-				[]string{"FAILED"},
-				[]string{"Service instance", "non-exist-service-instance", "not found"},
 			))
 		})
 	})


### PR DESCRIPTION
… keys

Leveraging existing API calls in ServiceInstanceRequirement to find service
instance info by name so that no need to send the same request twice.

[#93578300]

Signed-off-by: Hua Zhang <zhuadl@cn.ibm.com>