### PR TITLE
Reduce API calls when CRU operations of service keys

### DIFF
--- a/cf/commands/servicekey/create_service_key_test.go
+++ b/cf/commands/servicekey/create_service_key_test.go
@@ -26,7 +26,7 @@ var _ = Describe("create-service-key command", func() {
 	var (
 		ui                  *testterm.FakeUI
 		config              core_config.Repository
-		cmd                 CreateServiceKey
+		cmd                 *CreateServiceKey
 		requirementsFactory *testreq.FakeReqFactory
 		serviceRepo         *testapi.FakeServiceRepo
 		serviceKeyRepo      *testapi.FakeServiceKeyRepo
@@ -38,11 +38,13 @@ var _ = Describe("create-service-key command", func() {
 		serviceRepo = &testapi.FakeServiceRepo{}
 		serviceInstance := models.ServiceInstance{}
 		serviceInstance.Guid = "fake-instance-guid"
+		serviceInstance.Name = "fake-service-instance"
 		serviceRepo.FindInstanceByNameMap = generic.NewMap()
 		serviceRepo.FindInstanceByNameMap.Set("fake-service-instance", serviceInstance)
 		serviceKeyRepo = testapi.NewFakeServiceKeyRepo()
 		cmd = NewCreateServiceKey(ui, config, serviceRepo, serviceKeyRepo)
 		requirementsFactory = &testreq.FakeReqFactory{LoginSuccess: true, TargetedSpaceSuccess: true, ServiceInstanceNotFound: false}
+		requirementsFactory.ServiceInstance = serviceInstance
 	})
 
 	var callCreateService = func(args []string) bool {

--- a/cf/commands/servicekey/delete_service_key.go
+++ b/cf/commands/servicekey/delete_service_key.go
@@ -18,8 +18,8 @@ type DeleteServiceKey struct {
 	serviceKeyRepo api.ServiceKeyRepository
 }
 
-func NewDeleteServiceKey(ui terminal.UI, config core_config.Reader, serviceRepo api.ServiceRepository, serviceKeyRepo api.ServiceKeyRepository) (cmd DeleteServiceKey) {
-	return DeleteServiceKey{
+func NewDeleteServiceKey(ui terminal.UI, config core_config.Reader, serviceRepo api.ServiceRepository, serviceKeyRepo api.ServiceKeyRepository) (cmd *DeleteServiceKey) {
+	return &DeleteServiceKey{
 		ui:             ui,
 		config:         config,
 		serviceRepo:    serviceRepo,
@@ -27,7 +27,7 @@ func NewDeleteServiceKey(ui terminal.UI, config core_config.Reader, serviceRepo 
 	}
 }
 
-func (cmd DeleteServiceKey) Metadata() command_metadata.CommandMetadata {
+func (cmd *DeleteServiceKey) Metadata() command_metadata.CommandMetadata {
 	return command_metadata.CommandMetadata{
 		Name:        "delete-service-key",
 		ShortName:   "dsk",
@@ -42,21 +42,20 @@ EXAMPLE:
 	}
 }
 
-func (cmd DeleteServiceKey) GetRequirements(requirementsFactory requirements.Factory, c *cli.Context) (reqs []requirements.Requirement, err error) {
+func (cmd *DeleteServiceKey) GetRequirements(requirementsFactory requirements.Factory, c *cli.Context) (reqs []requirements.Requirement, err error) {
 	if len(c.Args()) != 2 {
 		cmd.ui.FailWithUsage(c)
 	}
 
 	loginRequirement := requirementsFactory.NewLoginRequirement()
-	serviceInstanceRequirement := requirementsFactory.NewServiceInstanceRequirement(c.Args()[0])
 	targetSpaceRequirement := requirementsFactory.NewTargetedSpaceRequirement()
 
-	reqs = []requirements.Requirement{loginRequirement, serviceInstanceRequirement, targetSpaceRequirement}
+	reqs = []requirements.Requirement{loginRequirement, targetSpaceRequirement}
 
 	return reqs, nil
 }
 
-func (cmd DeleteServiceKey) Run(c *cli.Context) {
+func (cmd *DeleteServiceKey) Run(c *cli.Context) {
 	serviceInstanceName := c.Args()[0]
 	serviceKeyName := c.Args()[1]
 

--- a/cf/commands/servicekey/delete_service_key_test.go
+++ b/cf/commands/servicekey/delete_service_key_test.go
@@ -23,7 +23,7 @@ var _ = Describe("delete-service-key command", func() {
 	var (
 		ui                  *testterm.FakeUI
 		config              core_config.Repository
-		cmd                 DeleteServiceKey
+		cmd                 *DeleteServiceKey
 		requirementsFactory *testreq.FakeReqFactory
 		serviceRepo         *testapi.FakeServiceRepo
 		serviceKeyRepo      *testapi.FakeServiceKeyRepo
@@ -39,7 +39,7 @@ var _ = Describe("delete-service-key command", func() {
 		serviceRepo.FindInstanceByNameMap.Set("fake-service-instance", serviceInstance)
 		serviceKeyRepo = testapi.NewFakeServiceKeyRepo()
 		cmd = NewDeleteServiceKey(ui, config, serviceRepo, serviceKeyRepo)
-		requirementsFactory = &testreq.FakeReqFactory{LoginSuccess: true, TargetedSpaceSuccess: true, ServiceInstanceNotFound: false}
+		requirementsFactory = &testreq.FakeReqFactory{LoginSuccess: true, TargetedSpaceSuccess: true}
 	})
 
 	var callDeleteServiceKey = func(args []string) bool {
@@ -56,11 +56,6 @@ var _ = Describe("delete-service-key command", func() {
 			Expect(callDeleteServiceKey([]string{})).To(BeFalse())
 			Expect(callDeleteServiceKey([]string{"fake-arg-one"})).To(BeFalse())
 			Expect(callDeleteServiceKey([]string{"fake-arg-one", "fake-arg-two", "fake-arg-three"})).To(BeFalse())
-		})
-
-		It("fails when service instance is not found", func() {
-			requirementsFactory = &testreq.FakeReqFactory{LoginSuccess: true, ServiceInstanceNotFound: true}
-			Expect(callDeleteServiceKey([]string{"non-exist-service-instance"})).To(BeFalse())
 		})
 
 		It("fails when space is not targetted", func() {
@@ -92,7 +87,7 @@ var _ = Describe("delete-service-key command", func() {
 			})
 
 			It("deletes service key successfully when '-f' option is provided", func() {
-				requirementsFactory = &testreq.FakeReqFactory{LoginSuccess: true, ServiceInstanceNotFound: false, TargetedSpaceSuccess: true}
+				requirementsFactory = &testreq.FakeReqFactory{LoginSuccess: true, TargetedSpaceSuccess: true}
 
 				Expect(callDeleteServiceKey([]string{"fake-service-instance", "fake-service-key", "-f"})).To(BeTrue())
 				Expect(ui.Outputs).To(ContainSubstrings(
@@ -101,7 +96,7 @@ var _ = Describe("delete-service-key command", func() {
 			})
 
 			It("deletes service key successfully when '-f' option is not provided and confirmed 'yes'", func() {
-				requirementsFactory = &testreq.FakeReqFactory{LoginSuccess: true, ServiceInstanceNotFound: false, TargetedSpaceSuccess: true}
+				requirementsFactory = &testreq.FakeReqFactory{LoginSuccess: true, TargetedSpaceSuccess: true}
 				ui.Inputs = append(ui.Inputs, "yes")
 
 				Expect(callDeleteServiceKey([]string{"fake-service-instance", "fake-service-key"})).To(BeTrue())
@@ -112,7 +107,7 @@ var _ = Describe("delete-service-key command", func() {
 			})
 
 			It("skips to delete service key when '-f' option is not provided and confirmed 'no'", func() {
-				requirementsFactory = &testreq.FakeReqFactory{LoginSuccess: true, ServiceInstanceNotFound: false, TargetedSpaceSuccess: true}
+				requirementsFactory = &testreq.FakeReqFactory{LoginSuccess: true, TargetedSpaceSuccess: true}
 				ui.Inputs = append(ui.Inputs, "no")
 
 				Expect(callDeleteServiceKey([]string{"fake-service-instance", "fake-service-key"})).To(BeTrue())

--- a/cf/commands/servicekey/service_key_test.go
+++ b/cf/commands/servicekey/service_key_test.go
@@ -22,7 +22,7 @@ var _ = Describe("service-key command", func() {
 	var (
 		ui                  *testterm.FakeUI
 		config              core_config.Repository
-		cmd                 ServiceKey
+		cmd                 *ServiceKey
 		requirementsFactory *testreq.FakeReqFactory
 		serviceRepo         *testapi.FakeServiceRepo
 		serviceKeyRepo      *testapi.FakeServiceKeyRepo
@@ -34,11 +34,13 @@ var _ = Describe("service-key command", func() {
 		serviceRepo = &testapi.FakeServiceRepo{}
 		serviceInstance := models.ServiceInstance{}
 		serviceInstance.Guid = "fake-service-instance-guid"
+		serviceInstance.Name = "fake-service-instance"
 		serviceRepo.FindInstanceByNameMap = generic.NewMap()
 		serviceRepo.FindInstanceByNameMap.Set("fake-service-instance", serviceInstance)
 		serviceKeyRepo = testapi.NewFakeServiceKeyRepo()
 		cmd = NewGetServiceKey(ui, config, serviceRepo, serviceKeyRepo)
 		requirementsFactory = &testreq.FakeReqFactory{LoginSuccess: true, TargetedSpaceSuccess: true, ServiceInstanceNotFound: false}
+		requirementsFactory.ServiceInstance = serviceInstance
 	})
 
 	var callGetServiceKey = func(args []string) bool {

--- a/cf/commands/servicekey/service_keys_test.go
+++ b/cf/commands/servicekey/service_keys_test.go
@@ -22,7 +22,7 @@ var _ = Describe("service-keys command", func() {
 	var (
 		ui                  *testterm.FakeUI
 		config              core_config.Repository
-		cmd                 ServiceKeys
+		cmd                 *ServiceKeys
 		requirementsFactory *testreq.FakeReqFactory
 		serviceRepo         *testapi.FakeServiceRepo
 		serviceKeyRepo      *testapi.FakeServiceKeyRepo
@@ -34,11 +34,13 @@ var _ = Describe("service-keys command", func() {
 		serviceRepo = &testapi.FakeServiceRepo{}
 		serviceInstance := models.ServiceInstance{}
 		serviceInstance.Guid = "fake-instance-guid"
+		serviceInstance.Name = "fake-service-instance"
 		serviceRepo.FindInstanceByNameMap = generic.NewMap()
 		serviceRepo.FindInstanceByNameMap.Set("fake-service-instance", serviceInstance)
 		serviceKeyRepo = testapi.NewFakeServiceKeyRepo()
 		cmd = NewListServiceKeys(ui, config, serviceRepo, serviceKeyRepo)
 		requirementsFactory = &testreq.FakeReqFactory{LoginSuccess: true, TargetedSpaceSuccess: true, ServiceInstanceNotFound: false}
+		requirementsFactory.ServiceInstance = serviceInstance
 	})
 
 	var callListServiceKeys = func(args []string) bool {
@@ -98,16 +100,6 @@ var _ = Describe("service-keys command", func() {
 			Expect(ui.Outputs).To(ContainSubstrings(
 				[]string{"Getting keys for service instance", "fake-service-instance", "as", "my-user"},
 				[]string{"No service key for service instance", "fake-service-instance"},
-			))
-		})
-
-		It("fails when service instance is not found", func() {
-			serviceRepo.FindInstanceByNameNotFound = true
-			callListServiceKeys([]string{"non-exist-service-instance"})
-			Expect(ui.Outputs).To(ContainSubstrings(
-				[]string{"Getting keys for service instance", "non-exist-service-instance", "as", "my-user"},
-				[]string{"FAILED"},
-				[]string{"Service instance", "non-exist-service-instance", "not found"},
 			))
 		})
 	})


### PR DESCRIPTION
Leveraging existing API calls in ServiceInstanceRequirement to find service
instance info by name so that no need to send the same request twice.

[#93578300]

Signed-off-by: Hua Zhang <zhuadl@cn.ibm.com>