### PR TITLE
Diego property can now be set in manifest

### DIFF
--- a/cf/api/applications/applications_test.go
+++ b/cf/api/applications/applications_test.go
@@ -261,6 +261,7 @@ var _ = Describe("ApplicationsRepository", func() {
 			app.SpaceGuid = "some-space-guid"
 			app.State = "started"
 			app.DiskQuota = 512
+			app.Diego = true
 			Expect(app.EnvironmentVars).To(BeNil())
 
 			updatedApp, apiErr := repo.Update(app.Guid, app.ToParams())
@@ -271,6 +272,7 @@ var _ = Describe("ApplicationsRepository", func() {
 			Expect(updatedApp.DetectedStartCommand).To(Equal("detected command"))
 			Expect(updatedApp.Name).To(Equal("my-cool-app"))
 			Expect(updatedApp.Guid).To(Equal("my-cool-app-guid"))
+			Expect(updatedApp.Diego).To(Equal(true))
 		})
 
 		It("sets environment variables", func() {
@@ -491,14 +493,15 @@ var updateApplicationResponse = `
     "entity": {
         "name": "my-cool-app",
 				"command": "some-command",
-				"detected_start_command": "detected command"
+				"detected_start_command": "detected command",
+				"diego": true
     }
 }`
 
 var updateApplicationRequest = testapi.NewCloudControllerTestRequest(testnet.TestRequest{
 	Method:  "PUT",
 	Path:    "/v2/apps/my-app-guid?inline-relations-depth=1",
-	Matcher: testnet.RequestBodyMatcher(`{"name":"my-cool-app","instances":3,"buildpack":"buildpack-url","memory":2048,"disk_quota":512,"space_guid":"some-space-guid","state":"STARTED","stack_guid":"some-stack-guid","command":"some-command"}`),
+	Matcher: testnet.RequestBodyMatcher(`{"name":"my-cool-app","instances":3,"buildpack":"buildpack-url","memory":2048,"disk_quota":512,"space_guid":"some-space-guid","state":"STARTED","stack_guid":"some-stack-guid","command":"some-command","diego":true}`),
 	Response: testnet.TestResponse{
 		Status: http.StatusOK,
 		Body:   updateApplicationResponse},

--- a/cf/api/resources/applications.go
+++ b/cf/api/resources/applications.go
@@ -54,7 +54,7 @@ type ApplicationEntity struct {
 	HealthCheckTimeout   *int                    `json:"health_check_timeout,omitempty"`
 	PackageState         *string                 `json:"package_state,omitempty"`
 	StagingFailedReason  *string                 `json:"staging_failed_reason,omitempty"`
-	Diego                bool                    `json:"diego,omitempty"`
+	Diego                *bool                   `json:"diego,omitempty"`
 }
 
 func (resource AppRouteResource) ToFields() (route models.RouteSummary) {
@@ -78,6 +78,7 @@ func NewApplicationEntityFromAppParams(app models.AppParams) ApplicationEntity {
 		SpaceGuid:          app.SpaceGuid,
 		Instances:          app.InstanceCount,
 		Memory:             app.Memory,
+		Diego:              app.Diego,
 		DiskQuota:          app.DiskQuota,
 		StackGuid:          app.StackGuid,
 		Command:            app.Command,
@@ -136,8 +137,9 @@ func (resource ApplicationResource) ToFields() (app models.ApplicationFields) {
 	if entity.DetectedBuildpack != nil {
 		app.DetectedBuildpack = *entity.DetectedBuildpack
 	}
-
-	app.Diego = entity.Diego
+	if entity.Diego != nil {
+		app.Diego = *entity.Diego
+	}
 
 	return
 }

--- a/cf/manifest/manifest_test.go
+++ b/cf/manifest/manifest_test.go
@@ -256,6 +256,7 @@ var _ = Describe("Manifests", func() {
 					"no-route":     true,
 					"no-hostname":  true,
 					"random-route": true,
+					"diego":        true,
 				},
 			},
 		}))
@@ -276,6 +277,7 @@ var _ = Describe("Manifests", func() {
 		Expect(apps[0].NoRoute).To(BeTrue())
 		Expect(apps[0].NoHostname).To(BeTrue())
 		Expect(apps[0].UseRandomHostname).To(BeTrue())
+		Expect(*apps[0].Diego).To(BeTrue())
 	})
 
 	It("removes duplicated values in 'hosts' and 'domains'", func() {
@@ -383,6 +385,18 @@ var _ = Describe("Manifests", func() {
 		apps, err := m.Applications()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(apps[0].Command).To(BeNil())
+	})
+
+	It("does not set diego when the manifest doesn't have the 'diego' key", func() {
+		m := NewManifest("/some/path/manifest.yml", generic.NewMap(map[interface{}]interface{}{
+			"applications": []interface{}{
+				map[interface{}]interface{}{},
+			},
+		}))
+
+		apps, err := m.Applications()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(apps[0].Diego).To(BeNil())
 	})
 
 	It("can build the applications multiple times", func() {

--- a/cf/models/application.go
+++ b/cf/models/application.go
@@ -32,6 +32,7 @@ func (model Application) ToParams() (params AppParams) {
 		DiskQuota:       &model.DiskQuota,
 		InstanceCount:   &model.InstanceCount,
 		Memory:          &model.Memory,
+		Diego:           &model.Diego,
 		State:           &state,
 		SpaceGuid:       &model.SpaceGuid,
 		EnvironmentVars: &model.EnvironmentVars,
@@ -77,6 +78,7 @@ type AppParams struct {
 	Hosts              *[]string
 	InstanceCount      *int
 	Memory             *int64
+	Diego              *bool
 	Name               *string
 	NoHostname         bool
 	NoRoute            bool
@@ -143,6 +145,9 @@ func (app *AppParams) Merge(other *AppParams) {
 	}
 	if other.State != nil {
 		app.State = other.State
+	}
+	if other.Diego != nil {
+		app.Diego = other.Diego
 	}
 
 	app.NoRoute = app.NoRoute || other.NoRoute


### PR DESCRIPTION
Manifest now correctly handles diego: true and whether it is omitted.

:shipit:
Signed-off-by: Evan Farrar <efarrar@pivotal.io>