### PR TITLE
remove inappropriate error message

### DIFF
--- a/cf/i18n/init.go
+++ b/cf/i18n/init.go
@@ -102,7 +102,7 @@ func mustLoadDefaultLocale() string {
 
 	err := loadFromAsset(DEFAULT_LOCALE)
 	if err != nil {
-		panic("Could not load en_US language files. God save the queen. \n" + err.Error() + "\n\n")
+		panic("Could not load en_US language files. \n" + err.Error() + "\n\n")
 	}
 
 	return userLocale


### PR DESCRIPTION
Remove a joke that could be at best confusing, and at worst culturally insensitive.

I've just seen this error message occur for a user whose first language was not English (making debugging harder for them), and who lives and works in a country that was once under British colonial rule: between 200,000 and 500,000 people died in the independence movement.