### PR TITLE
Fix Admin should be able to list apps in any space of current org

### DIFF
--- a/cf/api/app_summary.go
+++ b/cf/api/app_summary.go
@@ -114,6 +114,7 @@ type DomainSummary struct {
 type AppSummaryRepository interface {
 	GetSummariesInCurrentSpace() (apps []models.Application, apiErr error)
 	GetSummary(appGuid string) (summary models.Application, apiErr error)
+	GetSpaceSummaries(spaceGuid string) (apps []models.Application, apiErr error)
 }
 
 type CloudControllerAppSummaryRepository struct {
@@ -152,5 +153,18 @@ func (repo CloudControllerAppSummaryRepository) GetSummary(appGuid string) (summ
 
 	summary = summaryResponse.ToModel()
 
+	return
+}
+
+func (repo CloudControllerAppSummaryRepository) GetSpaceSummaries(spaceGuid string) (apps []models.Application, apiErr error) {
+	resources := new(ApplicationSummaries)
+	path := fmt.Sprintf("%s/v2/spaces/%s/summary", repo.config.ApiEndpoint(), spaceGuid)
+	apiErr = repo.gateway.GetResource(path, resources)
+	if apiErr != nil {
+		return
+	}
+	for _, resource := range resources.Apps {
+		apps = append(apps, resource.ToModel())
+	}
 	return
 }

--- a/cf/api/fakes/fake_app_summary_repo.go
+++ b/cf/api/fakes/fake_app_summary_repo.go
@@ -8,9 +8,11 @@ import (
 type FakeAppSummaryRepo struct {
 	GetSummariesInCurrentSpaceApps []models.Application
 
-	GetSummaryErrorCode string
-	GetSummaryAppGuid   string
-	GetSummarySummary   models.Application
+	GetSummaryErrorCode   string
+	GetSummaryAppGuid     string
+	GetSummarySummary     models.Application
+	GetSpaceGuid          string
+	GetSpaceSummariesApps []models.Application
 }
 
 func (repo *FakeAppSummaryRepo) GetSummariesInCurrentSpace() (apps []models.Application, apiErr error) {
@@ -26,5 +28,10 @@ func (repo *FakeAppSummaryRepo) GetSummary(appGuid string) (summary models.Appli
 		apiErr = errors.NewHttpError(400, repo.GetSummaryErrorCode, "Error")
 	}
 
+	return
+}
+func (repo *FakeAppSummaryRepo) GetSpaceSummaries(spaceGuid string) (apps []models.Application, apiErr error) {
+	repo.GetSpaceGuid = spaceGuid
+	apps = repo.GetSpaceSummariesApps
 	return
 }

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -2960,8 +2960,18 @@
       "modified": false
    },
    {
-      "id": "List all apps in the target space",
-      "translation": "List all apps in the target space",
+      "id": "List all apps in a space of targeted organization",
+      "translation": "List all apps in a space of targeted organization",
+      "modified": false
+   },
+   {
+      "id": "Space name (list all apps in a specified space of current organization)",
+      "translation": "Space name (list all apps in a specified space of current organization)",
+      "modified": false
+   },
+   {
+      "id": "By default it will list all apps of current targeted space if '-s' flag is not provided.",
+      "translation": "By default it will list all apps of current targeted space if '-s' flag is not provided.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -2960,8 +2960,18 @@
       "modified": false
    },
    {
-      "id": "List all apps in the target space",
-      "translation": "List all apps in the target space",
+      "id": "List all apps in a space of targeted organization",
+      "translation": "List all apps in a space of targeted organization",
+      "modified": false
+   },
+   {
+      "id": "Space name (list all apps in a specified space of current organization)",
+      "translation": "Space name (list all apps in a specified space of current organization)",
+      "modified": false
+   },
+   {
+      "id": "By default it will list all apps of current targeted space if '-s' flag is not provided.",
+      "translation": "By default it will list all apps of current targeted space if '-s' flag is not provided.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -2960,8 +2960,18 @@
       "modified": false
    },
    {
-      "id": "List all apps in the target space",
-      "translation": "Lista todas las apps en el space seleccionado",
+      "id": "List all apps in a space of targeted organization",
+      "translation": "List all apps in a space of targeted organization",
+      "modified": false
+   },
+   {
+      "id": "Space name (list all apps in a specified space of current organization)",
+      "translation": "Space name (list all apps in a specified space of current organization)",
+      "modified": false
+   },
+   {
+      "id": "By default it will list all apps of current targeted space if '-s' flag is not provided.",
+      "translation": "By default it will list all apps of current targeted space if '-s' flag is not provided.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -2960,8 +2960,18 @@
       "modified": false
    },
    {
-      "id": "List all apps in the target space",
-      "translation": "Liste de toutes les applications dans l'espace ciblé",
+      "id": "List all apps in a space of targeted organization",
+      "translation": "Inscrivez toutes les applications dans un espace d'organisation cibl¨¦e",
+      "modified": false
+   },
+   {
+      "id": "Space name (list all apps in a specified space of current organization)",
+      "translation": "Space name (list all apps in a specified space of current organization)",
+      "modified": false
+   },
+   {
+      "id": "By default it will list all apps of current targeted space if '-s' flag is not provided.",
+      "translation": "En d¨¦fault toutes les logiciels seront lister pour l'espace cibl¨¦ si '-s' n'est pas fournit...",
       "modified": false
    },
    {

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -2960,8 +2960,18 @@
       "modified": false
    },
    {
-      "id": "List all apps in the target space",
-      "translation": "List all apps in the target space",
+      "id": "List all apps in a space of targeted organization",
+      "translation": "List all apps in a space of targeted organization",
+      "modified": false
+   },
+   {
+      "id": "Space name (list all apps in a specified space of current organization)",
+      "translation": "Space name (list all apps in a specified space of current organization)",
+      "modified": false
+   },
+   {
+      "id": "By default it will list all apps of current targeted space if '-s' flag is not provided.",
+      "translation": "By default it will list all apps of current targeted space if '-s' flag is not provided.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -2960,8 +2960,18 @@
       "modified": false
    },
    {
-      "id": "List all apps in the target space",
-      "translation": "List all apps in the target space",
+      "id": "List all apps in a space of targeted organization",
+      "translation": "List all apps in a space of targeted organization",
+      "modified": false
+   },
+   {
+      "id": "Space name (list all apps in a specified space of current organization)",
+      "translation": "Space name (list all apps in a specified space of current organization)",
+      "modified": false
+   },
+   {
+      "id": "By default it will list all apps of current targeted space if '-s' flag is not provided.",
+      "translation": "By default it will list all apps of current targeted space if '-s' flag is not provided.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -2960,8 +2960,18 @@
       "modified": false
    },
    {
-      "id": "List all apps in the target space",
-      "translation": "Exibir todos os aplicativos num determinado espaço",
+      "id": "List all apps in a space of targeted organization",
+      "translation": "List all apps in a space of targeted organization",
+      "modified": false
+   },
+   {
+      "id": "Space name (list all apps in a specified space of current organization)",
+      "translation": "Space name (list all apps in a specified space of current organization)",
+      "modified": false
+   },
+   {
+      "id": "By default it will list all apps of current targeted space if '-s' flag is not provided.",
+      "translation": "By default it will list all apps of current targeted space if '-s' flag is not provided.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -2960,8 +2960,18 @@
       "modified": false
    },
    {
-      "id": "List all apps in the target space",
-      "translation": "列出目标空间中的所有应用程序",
+      "id": "List all apps in a space of targeted organization",
+      "translation": "List all apps in a space of targeted organization",
+      "modified": false
+   },
+   {
+      "id": "Space name (list all apps in a specified space of current organization)",
+      "translation": "Space name (list all apps in a specified space of current organization)",
+      "modified": false
+   },
+   {
+      "id": "By default it will list all apps of current targeted space if '-s' flag is not provided.",
+      "translation": "By default it will list all apps of current targeted space if '-s' flag is not provided.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -2960,8 +2960,18 @@
       "modified": false
    },
    {
-      "id": "List all apps in the target space",
-      "translation": "List all apps in the target space",
+      "id": "List all apps in a space of targeted organization",
+      "translation": "List all apps in a space of targeted organization",
+      "modified": false
+   },
+   {
+      "id": "Space name (list all apps in a specified space of current organization)",
+      "translation": "Space name (list all apps in a specified space of current organization)",
+      "modified": false
+   },
+   {
+      "id": "By default it will list all apps of current targeted space if '-s' flag is not provided.",
+      "translation": "By default it will list all apps of current targeted space if '-s' flag is not provided.",
       "modified": false
    },
    {


### PR DESCRIPTION
Story in CLI [#91292742] for addition of the -s string flag in cf app……s command.

As of now this command lists only the apps in the currently targeted space. With this new flag, user can get the list of apps
in a space of current organization provided by the user.
Output after modification :
apps -s spaceName
Getting apps in org orgName / space spaceName as admin...
OK
name requested state instances memory disk urls
fib-cpu started 1/1 256M 1G fib-cpu.10.244.0.34.xip.io
