### PR TITLE
Fix to the delete-domain to fail early if domain is shared

### DIFF
--- a/cf/commands/domain/delete_domain.go
+++ b/cf/commands/domain/delete_domain.go
@@ -63,7 +63,13 @@ func (cmd *DeleteDomain) Execute(c flags.FlagContext) {
 	domain, apiErr := cmd.domainRepo.FindByNameInOrg(domainName, cmd.orgReq.GetOrganizationFields().Guid)
 
 	switch apiErr.(type) {
-	case nil: //do nothing
+	case nil:
+		if domain.Shared {
+			cmd.ui.Failed(T("domain {{.DomainName}} is not an owned domain",
+				map[string]interface{}{
+					"DomainName": domainName}))
+			return
+		}
 	case *errors.ModelNotFoundError:
 		cmd.ui.Ok()
 		cmd.ui.Warn(apiErr.Error())

--- a/cf/commands/domain/delete_domain_test.go
+++ b/cf/commands/domain/delete_domain_test.go
@@ -63,6 +63,29 @@ var _ = Describe("delete-domain command", func() {
 		})
 	})
 
+	Context("when the domain is shared", func() {
+		BeforeEach(func() {
+			domainRepo.FindByNameInOrgDomain = []models.DomainFields{
+				models.DomainFields{
+					Name:   "foo1.com",
+					Guid:   "foo1-guid",
+					Shared: true,
+				},
+			}
+		})
+		It("informs the user that the domain is shared", func() {
+			runCommand("foo1.com")
+
+			Expect(domainRepo.DeleteDomainGuid).To(Equal(""))
+			Expect(ui.Outputs).To(ContainSubstrings(
+				[]string{"FAILED"},
+				[]string{"domain"},
+				[]string{"foo1.com"},
+				[]string{"is not an owned domain"},
+			))
+
+		})
+	})
 	Context("when the domain exists", func() {
 		BeforeEach(func() {
 			domainRepo.FindByNameInOrgDomain = []models.DomainFields{

--- a/cf/commands/domain/delete_shared_domain.go
+++ b/cf/commands/domain/delete_shared_domain.go
@@ -70,6 +70,11 @@ func (cmd *DeleteSharedDomain) Execute(c flags.FlagContext) {
 	domain, apiErr := cmd.domainRepo.FindByNameInOrg(domainName, cmd.orgReq.GetOrganizationFields().Guid)
 	switch apiErr.(type) {
 	case nil:
+		if !domain.Shared {
+			cmd.ui.Failed(T("domain {{.DomainName}} is not a shared domain",
+				map[string]interface{}{"DomainName": domainName}))
+			return
+		}
 	case *errors.ModelNotFoundError:
 		cmd.ui.Ok()
 		cmd.ui.Warn(apiErr.Error())

--- a/cf/commands/domain/delete_shared_domain_test.go
+++ b/cf/commands/domain/delete_shared_domain_test.go
@@ -57,6 +57,30 @@ var _ = Describe("delete-shared-domain command", func() {
 		})
 	})
 
+	Context("when the domain is owned", func() {
+		BeforeEach(func() {
+			requirementsFactory.LoginSuccess = true
+			requirementsFactory.TargetedOrgSuccess = true
+			domainRepo.FindByNameInOrgDomain = []models.DomainFields{
+				models.DomainFields{
+					Name:   "foo1.com",
+					Guid:   "foo1-guid",
+					Shared: false,
+				},
+			}
+		})
+		It("informs the user that the domain is not shared", func() {
+			runCommand("foo1.com")
+
+			Expect(domainRepo.DeleteSharedDomainGuid).To(Equal(""))
+			Expect(ui.Outputs).To(ContainSubstrings(
+				[]string{"FAILED"},
+				[]string{"domain"},
+				[]string{"foo1.com"},
+				[]string{"is not a shared domain"},
+			))
+		})
+	})
 	Context("when logged in and targeted an organiztion", func() {
 		BeforeEach(func() {
 			requirementsFactory.LoginSuccess = true

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -5548,5 +5548,15 @@
       "id": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "translation": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "modified": false
+   },
+   {
+      "id": "domain {{.DomainName}} is not an owned domain",
+      "translation": "domain {{.DomainName}} is not an owned domain",
+      "modified": false
+   },
+  {
+      "id": "domain {{.DomainName}} is not a shared domain",
+      "translation": "domain {{.DomainName}} is not a shared domain",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -5548,5 +5548,15 @@
       "id": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "translation": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "modified": false
+   },
+   {
+      "id": "domain {{.DomainName}} is not an owned domain",
+      "translation": "domain {{.DomainName}} is not an owned domain",
+      "modified": false
+   },
+  {
+      "id": "domain {{.DomainName}} is not a shared domain",
+      "translation": "domain {{.DomainName}} is not a shared domain",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -5548,5 +5548,15 @@
       "id": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "translation": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instancias",
       "modified": false
+   },
+   {
+      "id": "domain {{.DomainName}} is not an owned domain",
+      "translation": "domain {{.DomainName}} is not an owned domain",
+      "modified": false
+   },
+  {
+      "id": "domain {{.DomainName}} is not a shared domain",
+      "translation": "domain {{.DomainName}} is not a shared domain",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -5548,5 +5548,15 @@
       "id": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "translation": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "modified": false
+   },
+   {
+      "id": "domain {{.DomainName}} is not an owned domain",
+      "translation": "domain {{.DomainName}} is not an owned domain",
+      "modified": false
+   },
+  {
+      "id": "domain {{.DomainName}} is not a shared domain",
+      "translation": "domain {{.DomainName}} is not a shared domain",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -5548,5 +5548,15 @@
       "id": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "translation": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "modified": false
+   },
+   {
+      "id": "domain {{.DomainName}} is not an owned domain",
+      "translation": "domain {{.DomainName}} is not an owned domain",
+      "modified": false
+   },
+  {
+      "id": "domain {{.DomainName}} is not a shared domain",
+      "translation": "domain {{.DomainName}} is not a shared domain",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -5548,5 +5548,15 @@
       "id": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "translation": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "modified": false
+   },
+   {
+      "id": "domain {{.DomainName}} is not an owned domain",
+      "translation": "domain {{.DomainName}} is not an owned domain",
+      "modified": false
+   },
+  {
+      "id": "domain {{.DomainName}} is not a shared domain",
+      "translation": "domain {{.DomainName}} is not a shared domain",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -5548,5 +5548,15 @@
       "id": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "translation": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instâncias",
       "modified": false
+   },
+   {
+      "id": "domain {{.DomainName}} is not an owned domain",
+      "translation": "domain {{.DomainName}} is not an owned domain",
+      "modified": false
+   },
+  {
+      "id": "domain {{.DomainName}} is not a shared domain",
+      "translation": "domain {{.DomainName}} is not a shared domain",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -5548,5 +5548,15 @@
       "id": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "translation": "{{.Usage}} {{.FormattedMemory}} 乘以 {{.InstanceCount}}实例数",
       "modified": false
+   },
+   {
+      "id": "domain {{.DomainName}} is not an owned domain",
+      "translation": "domain {{.DomainName}} is not an owned domain",
+      "modified": false
+   },
+  {
+      "id": "domain {{.DomainName}} is not a shared domain",
+      "translation": "domain {{.DomainName}} is not a shared domain",
+      "modified": false
    }
 ]

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -5548,5 +5548,15 @@
       "id": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "translation": "{{.Usage}} {{.FormattedMemory}} x {{.InstanceCount}} instances",
       "modified": false
+   },
+   {
+      "id": "domain {{.DomainName}} is not an owned domain",
+      "translation": "domain {{.DomainName}} is not an owned domain",
+      "modified": false
+   },
+  {
+      "id": "domain {{.DomainName}} is not a shared domain",
+      "translation": "domain {{.DomainName}} is not a shared domain",
+      "modified": false
    }
 ]


### PR DESCRIPTION
delete-domain command is not failing early if given name is a shared
domain and delete-shared-domain is not failing early if given name is
owned domain.

Modified the delete-domain and delete-shared-domain commands to check
the domain type and fail early based on domain type.

$ cf domains

Getting domains in org abc as admin...
name                 status
10.244.0.34.xip.io   shared
abc.shared.com       shared
abc.private.domain   owned

Before Fix :
 delete-domain abc.shared.com -f
Deleting domain abc.shared.com as admin...
FAILED
Error deleting domain abc.shared.com
Server error, status code: 404, error code: 130002, message: The domain could not be found: c42e00e4-0c72-4ba4-ba1c-cb4b59ff1bc0

$ cf delete-shared-domain abc.private.domain -f
Deleting domain abc.private.domain as admin...
FAILED
Error deleting domain abc.private.domain
Server error, status code: 404, error code: 130002, message: The domain could not be found: 51a6d739-5134-4dfd-8ed0-6e1d38c5a2e0

After Fix :
 $ ./out/cf delete-domain abc.shared.com
 domain abc.shared.com is not an owned domain

$ ./out/cf delete-shared-domain abc.private.domain
 Deleting domain abc.private.domain as admin...
 domain abc.private.domain is not a shared domain

[#68736518]