### PR TITLE
Fix the Getting running or staging environment variable groups panics

### DIFF
--- a/cf/api/environment_variable_groups/environment_variable_groups.go
+++ b/cf/api/environment_variable_groups/environment_variable_groups.go
@@ -70,6 +70,11 @@ func (repo CloudControllerEnvironmentVariableGroupsRepository) SetRunning(runnin
 
 func (repo CloudControllerEnvironmentVariableGroupsRepository) marshalToEnvironmentVariables(raw_response interface{}) ([]models.EnvironmentVariable, error) {
 	var variables []models.EnvironmentVariable
+
+	if raw_response == nil {
+		return nil, errors.New(fmt.Sprintf("Response body is not valid"))
+	}
+
 	for key, value := range raw_response.(map[string]interface{}) {
 		stringvalue, err := repo.convertValueToString(value)
 		if err != nil {

--- a/cf/api/environment_variable_groups/environment_variable_groups_test.go
+++ b/cf/api/environment_variable_groups/environment_variable_groups_test.go
@@ -58,6 +58,21 @@ var _ = Describe("CloudControllerEnvironmentVariableGroupsRepository", func() {
 				models.EnvironmentVariable{Name: "do-re-mi", Value: "fa-sol-la-ti"},
 			}))
 		})
+
+		Context("With invalid response", func() {
+			BeforeEach(func() {
+				setupTestServer(listRunningReqRspBodyNil)
+			})
+
+			It("fails on null running environment group", func() {
+				envVars, err := repo.ListRunning()
+
+				Expect(err).To(HaveOccurred())
+				Expect(envVars).To(BeNil())
+				Expect(err).To(MatchError("Response body is not valid"))
+
+			})
+		})
 	})
 
 	Describe("ListStaging", func() {
@@ -74,6 +89,21 @@ var _ = Describe("CloudControllerEnvironmentVariableGroupsRepository", func() {
 				models.EnvironmentVariable{Name: "abc", Value: "123"},
 				models.EnvironmentVariable{Name: "do-re-mi", Value: "fa-sol-la-ti"},
 			}))
+		})
+
+		Context("With invalid response", func() {
+			BeforeEach(func() {
+				setupTestServer(listStagingReqRspBodyNil)
+			})
+
+			It("fails on null staging environment group", func() {
+				envVars, err := repo.ListStaging()
+
+				Expect(err).To(HaveOccurred())
+				Expect(envVars).To(BeNil())
+				Expect(err).To(MatchError("Response body is not valid"))
+
+			})
 		})
 	})
 
@@ -125,6 +155,24 @@ var listStagingRequest = testapi.NewCloudControllerTestRequest(testnet.TestReque
   "abc": 123,
   "do-re-mi": "fa-sol-la-ti"
 }`,
+	},
+})
+
+var listRunningReqRspBodyNil = testapi.NewCloudControllerTestRequest(testnet.TestRequest{
+	Method: "GET",
+	Path:   "/v2/config/environment_variable_groups/running",
+	Response: testnet.TestResponse{
+		Status: http.StatusOK,
+		Body:   `null`,
+	},
+})
+
+var listStagingReqRspBodyNil = testapi.NewCloudControllerTestRequest(testnet.TestRequest{
+	Method: "GET",
+	Path:   "/v2/config/environment_variable_groups/staging",
+	Response: testnet.TestResponse{
+		Status: http.StatusOK,
+		Body:   `null`,
 	},
 })
 


### PR DESCRIPTION
story ID: https://www.pivotaltracker.com/story/show/100589546

After Fix:
~# ./out/cf set-staging-environment-variable-group 'null'
Setting the contents of the staging environment variable group as admin...
OK
~# ./out/cf staging-environment-variable-group
Retrieving the contents of the staging environment variable group as admin...
FAILED
Response Body is not valid
~# ./out/cf set-running-environment-variable-group 'null'
Setting the contents of the running environment variable group as admin...
OK
~# ./out/cf running-environment-variable-group
Retrieving the contents of the running environment variable group as admin...
FAILED
Response Body is not valid