### PR TITLE
Move to go 1.5.1 [#104131294]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.4.2
+  - 1.5.1
 install:
   - go get -v golang.org/x/tools/cmd/vet
   - go get -v github.com/tools/godep

--- a/cf/help/template.go
+++ b/cf/help/template.go
@@ -30,6 +30,7 @@ func GetHelpTemplate() string {
 
 {{.Title "` + T("GLOBAL OPTIONS:") + `"}}
    --version, -v                      ` + T("Print the version") + `
+   --build, -b                        ` + T("Print the version of Go the CLI was built against") + `
    --help, -h                         ` + T("Show help") + `
 
 `

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -3605,6 +3605,11 @@
       "modified": false
    },
    {
+      "id": "Print the version of Go the CLI was built against",
+      "translation": "Print the version of Go the CLI was built against",
+      "modified": false
+   },
+   {
       "id": "Problem removing downloaded binary in temp directory: ",
       "translation": "Problem removing downloaded binary in temp directory: ",
       "modified": false
@@ -5462,6 +5467,11 @@
    {
       "id": "{{.CFName}} login",
       "translation": "{{.CFName}} login",
+      "modified": false
+   },
+   {
+      "id": "{{.CFName}} was built with Go version: {{.GoVersion}}",
+      "translation": "{{.CFName}} was built with Go version: {{.GoVersion}}",
       "modified": false
    },
    {

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -3605,6 +3605,11 @@
       "modified": false
    },
    {
+      "id": "Print the version of Go the CLI was built against",
+      "translation": "Print the version of Go the CLI was built against",
+      "modified": false
+   },
+   {
       "id": "Problem removing downloaded binary in temp directory: ",
       "translation": "Problem removing downloaded binary in temp directory: ",
       "modified": false
@@ -5462,6 +5467,11 @@
    {
       "id": "{{.CFName}} login",
       "translation": "{{.CFName}} login",
+      "modified": false
+   },
+   {
+      "id": "{{.CFName}} was built with Go version: {{.GoVersion}}",
+      "translation": "{{.CFName}} was built with Go version: {{.GoVersion}}",
       "modified": false
    },
    {

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -3605,6 +3605,11 @@
       "modified": false
    },
    {
+      "id": "Print the version of Go the CLI was built against",
+      "translation": "Print the version of Go the CLI was built against",
+      "modified": false
+   },
+   {
       "id": "Problem removing downloaded binary in temp directory: ",
       "translation": "Problem removing downloaded binary in temp directory: ",
       "modified": false
@@ -5462,6 +5467,11 @@
    {
       "id": "{{.CFName}} login",
       "translation": "{{.CFName}} login",
+      "modified": false
+   },
+   {
+      "id": "{{.CFName}} was built with Go version: {{.GoVersion}}",
+      "translation": "{{.CFName}} was built with Go version: {{.GoVersion}}",
       "modified": false
    },
    {

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -3605,6 +3605,11 @@
       "modified": false
    },
    {
+      "id": "Print the version of Go the CLI was built against",
+      "translation": "Print the version of Go the CLI was built against",
+      "modified": false
+   },
+   {
       "id": "Problem removing downloaded binary in temp directory: ",
       "translation": "Problem removing downloaded binary in temp directory: ",
       "modified": false
@@ -5462,6 +5467,11 @@
    {
       "id": "{{.CFName}} login",
       "translation": "{{.CFName}} login",
+      "modified": false
+   },
+   {
+      "id": "{{.CFName}} was built with Go version: {{.GoVersion}}",
+      "translation": "{{.CFName}} was built with Go version: {{.GoVersion}}",
       "modified": false
    },
    {

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -3605,6 +3605,11 @@
       "modified": false
    },
    {
+      "id": "Print the version of Go the CLI was built against",
+      "translation": "Print the version of Go the CLI was built against",
+      "modified": false
+   },
+   {
       "id": "Problem removing downloaded binary in temp directory: ",
       "translation": "Problem removing downloaded binary in temp directory: ",
       "modified": false
@@ -5462,6 +5467,11 @@
    {
       "id": "{{.CFName}} login",
       "translation": "{{.CFName}} login",
+      "modified": false
+   },
+   {
+      "id": "{{.CFName}} was built with Go version: {{.GoVersion}}",
+      "translation": "{{.CFName}} was built with Go version: {{.GoVersion}}",
       "modified": false
    },
    {

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -3605,6 +3605,11 @@
       "modified": false
    },
    {
+      "id": "Print the version of Go the CLI was built against",
+      "translation": "Print the version of Go the CLI was built against",
+      "modified": false
+   },
+   {
       "id": "Problem removing downloaded binary in temp directory: ",
       "translation": "Problem removing downloaded binary in temp directory: ",
       "modified": false
@@ -5462,6 +5467,11 @@
    {
       "id": "{{.CFName}} login",
       "translation": "{{.CFName}} login",
+      "modified": false
+   },
+   {
+      "id": "{{.CFName}} was built with Go version: {{.GoVersion}}",
+      "translation": "{{.CFName}} was built with Go version: {{.GoVersion}}",
       "modified": false
    },
    {

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -3605,6 +3605,11 @@
       "modified": false
    },
    {
+      "id": "Print the version of Go the CLI was built against",
+      "translation": "Print the version of Go the CLI was built against",
+      "modified": false
+   },
+   {
       "id": "Problem removing downloaded binary in temp directory: ",
       "translation": "Problem removing downloaded binary in temp directory: ",
       "modified": false
@@ -5462,6 +5467,11 @@
    {
       "id": "{{.CFName}} login",
       "translation": "{{.CFName}} login",
+      "modified": false
+   },
+   {
+      "id": "{{.CFName}} was built with Go version: {{.GoVersion}}",
+      "translation": "{{.CFName}} was built with Go version: {{.GoVersion}}",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -3605,6 +3605,11 @@
       "modified": false
    },
    {
+      "id": "Print the version of Go the CLI was built against",
+      "translation": "Print the version of Go the CLI was built against",
+      "modified": false
+   },
+   {
       "id": "Problem removing downloaded binary in temp directory: ",
       "translation": "Problem removing downloaded binary in temp directory: ",
       "modified": false
@@ -5462,6 +5467,11 @@
    {
       "id": "{{.CFName}} login",
       "translation": "{{.CFName}} login",
+      "modified": false
+   },
+   {
+      "id": "{{.CFName}} was built with Go version: {{.GoVersion}}",
+      "translation": "{{.CFName}} was built with Go version: {{.GoVersion}}",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -3605,6 +3605,11 @@
       "modified": false
    },
    {
+      "id": "Print the version of Go the CLI was built against",
+      "translation": "Print the version of Go the CLI was built against",
+      "modified": false
+   },
+   {
       "id": "Problem removing downloaded binary in temp directory: ",
       "translation": "Problem removing downloaded binary in temp directory: ",
       "modified": false
@@ -5462,6 +5467,11 @@
    {
       "id": "{{.CFName}} login",
       "translation": "{{.CFName}} login",
+      "modified": false
+   },
+   {
+      "id": "{{.CFName}} was built with Go version: {{.GoVersion}}",
+      "translation": "{{.CFName}} was built with Go version: {{.GoVersion}}",
       "modified": false
    },
    {

--- a/main/main.go
+++ b/main/main.go
@@ -42,6 +42,16 @@ func main() {
 		os.Exit(0)
 	}
 
+	//handle `cf --build`
+	if len(os.Args) == 2 && (os.Args[1] == "--build" || os.Args[1] == "-b") {
+		deps.Ui.Say(T("{{.CFName}} was built with Go version: {{.GoVersion}}",
+			map[string]interface{}{
+				"CFName": os.Args[0],
+				"GoVersion": runtime.Version(),
+			}))
+		os.Exit(0)
+	}
+
 	//handles `cf [COMMAND] -h ...`
 	//rearrage args to `cf help COMMAND` and let `command help` to print out usage
 	if requestHelp(os.Args[2:]) {

--- a/main/main_test.go
+++ b/main/main_test.go
@@ -73,6 +73,28 @@ var _ = Describe("main", func() {
 		})
 	})
 
+	Describe("Shows debug information with -b or --build", func() {
+		It("prints the golang version if '--build' flag is provided", func() {
+			output := Cf("--build").Wait(1 * time.Second)
+			Eventually(output.Out.Contents).Should(ContainSubstring("was built with Go version:"))
+			Ω(output.ExitCode()).To(Equal(0))
+		})
+
+		It("prints the golang version if '-b' flag is provided", func() {
+			output := Cf("-b").Wait(1 * time.Second)
+			Eventually(output.Out.Contents).Should(ContainSubstring("was built with Go version:"))
+			Ω(output.ExitCode()).To(Equal(0))
+		})
+	})
+
+	Describe("Staying abreast of Security Vulerabilities", func() {
+		It("uses Go 1.5.1 as the most up to date Go compiler", func() {
+			output := Cf("--build").Wait(1 * time.Second)
+			Eventually(output.Out.Contents).Should(ContainSubstring("go1.5.1"))
+			Ω(output.ExitCode()).To(Equal(0))
+		})
+	})
+
 	Describe("Commands /w new non-codegangsta structure", func() {
 		It("prints usage help for all non-codegangsta commands by providing `help` flag", func() {
 			output := Cf("api", "-h").Wait(1 * time.Second)


### PR DESCRIPTION
* add a --build flag to allow us to prove the Go compiler of any packaged binary
* add a test to ensure we specify the Go compiler as a dependency
* add help for --build
* add translations for new --build flag