### PR TITLE
Add cf router-groups command

### DIFF
--- a/cf/api/endpoints.go
+++ b/cf/api/endpoints.go
@@ -25,6 +25,7 @@ type endpointResource struct {
 	LoggregatorEndpoint      string `json:"logging_endpoint"`
 	MinCliVersion            string `json:"min_cli_version"`
 	MinRecommendedCliVersion string `json:"min_recommended_cli_version"`
+	RoutingApiEndpoint       string `json:"routing_endpoint"`
 }
 
 func NewEndpointRepository(config core_config.ReadWriter, gateway net.Gateway) EndpointRepository {
@@ -90,6 +91,7 @@ func (repo RemoteEndpointRepository) attemptUpdate(endpoint string) error {
 	//* 3/5/15: loggregator endpoint will be renamed to doppler eventually,
 	//          we just have to use the loggregator endpoint as doppler for now
 	repo.config.SetDopplerEndpoint(strings.Replace(repo.config.LoggregatorEndpoint(), "loggregator", "doppler", 1))
+	repo.config.SetRoutingApiEndpoint(serverResponse.RoutingApiEndpoint)
 
 	return nil
 }

--- a/cf/api/endpoints_test.go
+++ b/cf/api/endpoints_test.go
@@ -34,6 +34,7 @@ func validApiInfoEndpoint(w http.ResponseWriter, r *http.Request) {
   "description": "Cloud Foundry sponsored by Pivotal",
   "authorization_endpoint": "https://login.example.com",
   "logging_endpoint": "wss://loggregator.foo.example.org:4443",
+  "routing_endpoint": "http://api.example.com/routing",
   "api_version": "42.0.0",
 	"min_cli_version": "6.5.0",
 	"min_recommended_cli_version": "6.7.0"
@@ -51,6 +52,7 @@ func apiInfoEndpointWithoutLogURL(w http.ResponseWriter, r *http.Request) {
   "name": "vcap",
   "build": "2222",
   "support": "http://support.cloudfoundry.com",
+  "routing_endpoint": "http://api.example.com/routing",
   "version": 2,
   "description": "Cloud Foundry sponsored by Pivotal",
   "authorization_endpoint": "https://login.example.com",
@@ -112,6 +114,7 @@ var _ = Describe("Endpoints Repository", func() {
 				Expect(config.HasSpace()).To(BeFalse())
 				Expect(config.MinCliVersion()).To(Equal("6.5.0"))
 				Expect(config.MinRecommendedCliVersion()).To(Equal("6.7.0"))
+				Expect(config.RoutingApiEndpoint()).To(Equal("http://api.example.com/routing"))
 			})
 
 			Context("when the api endpoint does not change", func() {

--- a/cf/api/fakes/fake_routing_api.go
+++ b/cf/api/fakes/fake_routing_api.go
@@ -1,0 +1,26 @@
+package fakes
+
+import (
+	"errors"
+
+	"github.com/cloudfoundry/cli/cf/models"
+)
+
+type FakeRoutingApiRepository struct {
+	RouterGroups models.RouterGroups
+	ListError    bool
+}
+
+func (fake *FakeRoutingApiRepository) ListRouterGroups(cb func(models.RouterGroup) bool) (apiErr error) {
+	if fake.ListError {
+		apiErr = errors.New("Error in FakeRoutingApiRepository")
+		return
+	}
+
+	for _, routerGroup := range fake.RouterGroups {
+		if !cb(routerGroup) {
+			break
+		}
+	}
+	return
+}

--- a/cf/api/repository_locator.go
+++ b/cf/api/repository_locator.go
@@ -48,6 +48,7 @@ type RepositoryLocator struct {
 	appFilesRepo                    api_app_files.AppFilesRepository
 	domainRepo                      DomainRepository
 	routeRepo                       RouteRepository
+	routingApiRepo                  RoutingApiRepository
 	stackRepo                       stacks.StackRepository
 	serviceRepo                     ServiceRepository
 	serviceKeyRepo                  ServiceKeyRepository
@@ -110,6 +111,7 @@ func NewRepositoryLocator(config core_config.ReadWriter, gatewaysByName map[stri
 	loc.passwordRepo = password.NewCloudControllerPasswordRepository(config, uaaGateway)
 	loc.quotaRepo = quotas.NewCloudControllerQuotaRepository(config, cloudControllerGateway)
 	loc.routeRepo = NewCloudControllerRouteRepository(config, cloudControllerGateway)
+	loc.routingApiRepo = NewRoutingApiRepository(config, cloudControllerGateway)
 	loc.stackRepo = stacks.NewCloudControllerStackRepository(config, cloudControllerGateway)
 	loc.serviceRepo = NewCloudControllerServiceRepository(config, cloudControllerGateway)
 	loc.serviceKeyRepo = NewCloudControllerServiceKeyRepository(config, cloudControllerGateway)
@@ -253,6 +255,15 @@ func (locator RepositoryLocator) GetDomainRepository() DomainRepository {
 
 func (locator RepositoryLocator) SetRouteRepository(repo RouteRepository) RepositoryLocator {
 	locator.routeRepo = repo
+	return locator
+}
+
+func (locator RepositoryLocator) GetRoutingApiRepository() RoutingApiRepository {
+	return locator.routingApiRepo
+}
+
+func (locator RepositoryLocator) SetRoutingApiRepository(repo RoutingApiRepository) RepositoryLocator {
+	locator.routingApiRepo = repo
 	return locator
 }
 

--- a/cf/api/routing_api.go
+++ b/cf/api/routing_api.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"fmt"
+
+	"github.com/cloudfoundry/cli/cf/configuration/core_config"
+	"github.com/cloudfoundry/cli/cf/models"
+	"github.com/cloudfoundry/cli/cf/net"
+)
+
+type routingApiRepository struct {
+	config  core_config.Reader
+	gateway net.Gateway
+}
+
+type RoutingApiRepository interface {
+	ListRouterGroups(cb func(models.RouterGroup) bool) (apiErr error)
+}
+
+func NewRoutingApiRepository(config core_config.Reader, gateway net.Gateway) RoutingApiRepository {
+	return routingApiRepository{
+		config:  config,
+		gateway: gateway,
+	}
+}
+
+func (r routingApiRepository) ListRouterGroups(cb func(models.RouterGroup) bool) (apiErr error) {
+	routerGroups := models.RouterGroups{}
+	endpoint := fmt.Sprintf("%s/v1/router_groups", r.config.RoutingApiEndpoint())
+	apiErr = r.gateway.GetResource(endpoint, &routerGroups)
+	if apiErr != nil {
+		return apiErr
+	}
+
+	for _, router := range routerGroups {
+		if cb(router) == false {
+			return
+		}
+	}
+	return
+}

--- a/cf/api/routing_api_test.go
+++ b/cf/api/routing_api_test.go
@@ -1,0 +1,118 @@
+package api_test
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/cloudfoundry/cli/cf/api"
+	"github.com/cloudfoundry/cli/cf/configuration/core_config"
+	"github.com/cloudfoundry/cli/cf/models"
+	"github.com/cloudfoundry/cli/cf/net"
+	testconfig "github.com/cloudfoundry/cli/testhelpers/configuration"
+	testterm "github.com/cloudfoundry/cli/testhelpers/terminal"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+)
+
+var _ = Describe("RoutingApi", func() {
+
+	var (
+		repo             api.RoutingApiRepository
+		configRepo       core_config.Repository
+		routingApiServer *ghttp.Server
+	)
+
+	BeforeEach(func() {
+		configRepo = testconfig.NewRepositoryWithDefaults()
+		gateway := net.NewCloudControllerGateway(configRepo, time.Now, &testterm.FakeUI{})
+
+		repo = api.NewRoutingApiRepository(configRepo, gateway)
+	})
+
+	AfterEach(func() {
+		routingApiServer.Close()
+	})
+
+	Describe("ListRouterGroups", func() {
+
+		Context("when routing api return router groups", func() {
+			BeforeEach(func() {
+				routingApiServer = ghttp.NewServer()
+				routingApiServer.RouteToHandler("GET", "/v1/router_groups",
+					func(w http.ResponseWriter, req *http.Request) {
+						responseBody := []byte(`[
+			{
+				  "guid": "bad25cff-9332-48a6-8603-b619858e7992",
+					"name": "default-tcp",
+					"type": "tcp"
+			}]`)
+						w.Header().Set("Content-Length", strconv.Itoa(len(responseBody)))
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						w.Write(responseBody)
+					})
+				configRepo.SetRoutingApiEndpoint(routingApiServer.URL())
+			})
+
+			It("lists routing groups", func() {
+				cb := func(grp models.RouterGroup) bool {
+					Expect(grp).To(Equal(models.RouterGroup{
+						Guid: "bad25cff-9332-48a6-8603-b619858e7992",
+						Name: "default-tcp",
+						Type: "tcp",
+					}))
+					return true
+				}
+				err := repo.ListRouterGroups(cb)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when routing api returns an empty response ", func() {
+			BeforeEach(func() {
+				routingApiServer = ghttp.NewServer()
+				routingApiServer.RouteToHandler("GET", "/v1/router_groups",
+					func(w http.ResponseWriter, req *http.Request) {
+						responseBody := []byte("[]")
+						w.Header().Set("Content-Length", strconv.Itoa(len(responseBody)))
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						w.Write(responseBody)
+					})
+				configRepo.SetRoutingApiEndpoint(routingApiServer.URL())
+			})
+
+			It("doesn't list any router groups", func() {
+				cb := func(grp models.RouterGroup) bool {
+					Fail(fmt.Sprintf("Not expected to receive callback for router group:%#v", grp))
+					return false
+				}
+				err := repo.ListRouterGroups(cb)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when routing api returns an error ", func() {
+			BeforeEach(func() {
+				routingApiServer = ghttp.NewServer()
+				routingApiServer.RouteToHandler("GET", "/v1/router_groups",
+					func(w http.ResponseWriter, req *http.Request) {
+						w.WriteHeader(http.StatusInternalServerError)
+					})
+				configRepo.SetRoutingApiEndpoint(routingApiServer.URL())
+			})
+
+			It("doesn't list any router groups", func() {
+				cb := func(grp models.RouterGroup) bool {
+					Fail(fmt.Sprintf("Not expected to receive callback for router group:%#v", grp))
+					return false
+				}
+				err := repo.ListRouterGroups(cb)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+})

--- a/cf/commands/routergroups/router_groups.go
+++ b/cf/commands/routergroups/router_groups.go
@@ -1,0 +1,73 @@
+package routergroups
+
+import (
+	"github.com/cloudfoundry/cli/cf/api"
+	"github.com/cloudfoundry/cli/cf/command_registry"
+	"github.com/cloudfoundry/cli/cf/configuration/core_config"
+	. "github.com/cloudfoundry/cli/cf/i18n"
+	"github.com/cloudfoundry/cli/cf/models"
+	"github.com/cloudfoundry/cli/cf/requirements"
+	"github.com/cloudfoundry/cli/cf/terminal"
+	"github.com/cloudfoundry/cli/flags"
+)
+
+type RouterGroups struct {
+	ui             terminal.UI
+	routingApiRepo api.RoutingApiRepository
+	config         core_config.Reader
+}
+
+func init() {
+	command_registry.Register(&RouterGroups{})
+}
+
+func (cmd *RouterGroups) MetaData() command_registry.CommandMetadata {
+	return command_registry.CommandMetadata{
+		Name:        "router-groups",
+		Description: T("List router-groups"),
+		Usage:       "CF_NAME router-groups",
+	}
+}
+
+func (cmd *RouterGroups) Requirements(requirementsFactory requirements.Factory, fc flags.FlagContext) ([]requirements.Requirement, error) {
+	if len(fc.Args()) != 0 {
+		cmd.ui.Failed(T("Incorrect Usage. No argument required\n\n") + command_registry.Commands.CommandUsage("router-groups"))
+	}
+
+	return []requirements.Requirement{
+		requirementsFactory.NewLoginRequirement(),
+	}, nil
+}
+
+func (cmd *RouterGroups) SetDependency(deps command_registry.Dependency, pluginCall bool) command_registry.Command {
+	cmd.ui = deps.Ui
+	cmd.config = deps.Config
+	cmd.routingApiRepo = deps.RepoLocator.GetRoutingApiRepository()
+	return cmd
+}
+
+func (cmd *RouterGroups) Execute(c flags.FlagContext) {
+	cmd.ui.Say(T("Getting router groups as {{.Username}} ...\n",
+		map[string]interface{}{"Username": terminal.EntityNameColor(cmd.config.Username())}))
+
+	table := cmd.ui.Table([]string{T("name"), T("type")})
+
+	noRouterGroups := true
+	cb := func(group models.RouterGroup) bool {
+		noRouterGroups = false
+		table.Add(group.Name, group.Type)
+		return true
+	}
+
+	apiErr := cmd.routingApiRepo.ListRouterGroups(cb)
+	if apiErr != nil {
+		cmd.ui.Failed(T("Failed fetching router groups.\n{{.Err}}", map[string]interface{}{"Err": apiErr.Error()}))
+		return
+	}
+
+	if noRouterGroups {
+		cmd.ui.Say(T("No router groups found"))
+	}
+
+	table.Print()
+}

--- a/cf/commands/routergroups/router_groups_test.go
+++ b/cf/commands/routergroups/router_groups_test.go
@@ -1,0 +1,111 @@
+package routergroups_test
+
+import (
+	testapi "github.com/cloudfoundry/cli/cf/api/fakes"
+	"github.com/cloudfoundry/cli/cf/command_registry"
+	"github.com/cloudfoundry/cli/cf/configuration/core_config"
+	"github.com/cloudfoundry/cli/cf/models"
+	testcmd "github.com/cloudfoundry/cli/testhelpers/commands"
+	testconfig "github.com/cloudfoundry/cli/testhelpers/configuration"
+	testreq "github.com/cloudfoundry/cli/testhelpers/requirements"
+	testterm "github.com/cloudfoundry/cli/testhelpers/terminal"
+
+	. "github.com/cloudfoundry/cli/testhelpers/matchers"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("RouterGroups", func() {
+
+	var (
+		ui                  *testterm.FakeUI
+		routingApiRepo      *testapi.FakeRoutingApiRepository
+		configRepo          core_config.Repository
+		requirementsFactory *testreq.FakeReqFactory
+		deps                command_registry.Dependency
+	)
+
+	updateCommandDependency := func(pluginCall bool) {
+		deps.Ui = ui
+		deps.RepoLocator = deps.RepoLocator.SetRoutingApiRepository(routingApiRepo)
+		deps.Config = configRepo
+		command_registry.Commands.SetCommand(command_registry.Commands.FindCommand("router-groups").SetDependency(deps, pluginCall))
+	}
+
+	BeforeEach(func() {
+		ui = &testterm.FakeUI{}
+		configRepo = testconfig.NewRepositoryWithDefaults()
+		requirementsFactory = &testreq.FakeReqFactory{
+			LoginSuccess: true,
+		}
+		routingApiRepo = &testapi.FakeRoutingApiRepository{}
+	})
+
+	runCommand := func(args ...string) bool {
+		return testcmd.RunCliCommand("router-groups", args, requirementsFactory, updateCommandDependency, false)
+	}
+
+	Describe("login requirements", func() {
+		It("fails if the user is not logged in", func() {
+			requirementsFactory.LoginSuccess = false
+			Expect(runCommand()).To(BeFalse())
+		})
+
+		It("should fail with usage when provided any arguments", func() {
+			requirementsFactory.LoginSuccess = true
+			Expect(runCommand("notrequired-option")).To(BeFalse())
+			Expect(ui.Outputs).To(ContainSubstrings(
+				[]string{"Incorrect Usage", "No argument required"},
+			))
+		})
+	})
+
+	Context("when there are router groups", func() {
+		BeforeEach(func() {
+			routingApiRepo.RouterGroups = models.RouterGroups{
+				models.RouterGroup{
+					Guid: "guid-0001",
+					Name: "default-router-group",
+					Type: "tcp",
+				},
+			}
+		})
+
+		It("lists router groups", func() {
+			runCommand()
+
+			Expect(ui.Outputs).To(ContainSubstrings(
+				[]string{"Getting router groups", "my-user"},
+				[]string{"name", "type"},
+				[]string{"default-router-group", "tcp"},
+			))
+		})
+	})
+
+	Context("when there are no router groups", func() {
+		It("tells the user when no router groups were found", func() {
+			runCommand()
+
+			Expect(ui.Outputs).To(ContainSubstrings(
+				[]string{"Getting router groups"},
+				[]string{"No router groups found"},
+			))
+		})
+	})
+
+	Context("when there is an error listing router groups", func() {
+		BeforeEach(func() {
+			routingApiRepo.ListError = true
+		})
+
+		It("returns an error to the user", func() {
+			runCommand()
+
+			Expect(ui.Outputs).To(ContainSubstrings(
+				[]string{"Getting router groups"},
+				[]string{"Failed fetching router groups"},
+			))
+		})
+	})
+
+})

--- a/cf/commands/routergroups/routergroups_suite_test.go
+++ b/cf/commands/routergroups/routergroups_suite_test.go
@@ -1,0 +1,19 @@
+package routergroups_test
+
+import (
+	"github.com/cloudfoundry/cli/cf/i18n"
+	"github.com/cloudfoundry/cli/cf/i18n/detection"
+	"github.com/cloudfoundry/cli/testhelpers/configuration"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestRoutergroups(t *testing.T) {
+	config := configuration.NewRepositoryWithDefaults()
+	i18n.T = i18n.Init(config, &detection.JibberJabberDetector{})
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Routergroups Suite")
+}

--- a/cf/configuration/core_config/config_data.go
+++ b/cf/configuration/core_config/config_data.go
@@ -26,6 +26,7 @@ type Data struct {
 	LoggregatorEndPoint      string
 	DopplerEndPoint          string
 	UaaEndpoint              string
+	RoutingApiEndpoint       string
 	AccessToken              string
 	RefreshToken             string
 	OrganizationFields       models.OrganizationFields

--- a/cf/configuration/core_config/config_data_test.go
+++ b/cf/configuration/core_config/config_data_test.go
@@ -18,6 +18,7 @@ var exampleJSON = `
 	"LoggregatorEndPoint": "loggregator.example.com",
 	"DopplerEndPoint": "doppler.example.com",
 	"UaaEndpoint": "uaa.example.com",
+	"RoutingApiEndpoint": "routing-api.example.com",
 	"AccessToken": "the-access-token",
 	"RefreshToken": "the-refresh-token",
 	"OrganizationFields": {
@@ -56,6 +57,7 @@ var exampleData = &Data{
 	ApiVersion:               "3",
 	AuthorizationEndpoint:    "auth.example.com",
 	LoggregatorEndPoint:      "loggregator.example.com",
+	RoutingApiEndpoint:       "routing-api.example.com",
 	DopplerEndPoint:          "doppler.example.com",
 	UaaEndpoint:              "uaa.example.com",
 	AccessToken:              "the-access-token",

--- a/cf/configuration/core_config/config_repository.go
+++ b/cf/configuration/core_config/config_repository.go
@@ -52,6 +52,7 @@ type Reader interface {
 	LoggregatorEndpoint() string
 	DopplerEndpoint() string
 	UaaEndpoint() string
+	RoutingApiEndpoint() string
 	AccessToken() string
 	RefreshToken() string
 
@@ -92,6 +93,7 @@ type ReadWriter interface {
 	SetLoggregatorEndpoint(string)
 	SetDopplerEndpoint(string)
 	SetUaaEndpoint(string)
+	SetRoutingApiEndpoint(string)
 	SetAccessToken(string)
 	SetRefreshToken(string)
 	SetOrganizationFields(models.OrganizationFields)
@@ -190,6 +192,13 @@ func (c *ConfigRepository) DopplerEndpoint() (logEndpoint string) {
 func (c *ConfigRepository) UaaEndpoint() (uaaEndpoint string) {
 	c.read(func() {
 		uaaEndpoint = c.data.UaaEndpoint
+	})
+	return
+}
+
+func (c *ConfigRepository) RoutingApiEndpoint() (routingApiEndpoint string) {
+	c.read(func() {
+		routingApiEndpoint = c.data.RoutingApiEndpoint
 	})
 	return
 }
@@ -420,6 +429,12 @@ func (c *ConfigRepository) SetDopplerEndpoint(endpoint string) {
 func (c *ConfigRepository) SetUaaEndpoint(uaaEndpoint string) {
 	c.write(func() {
 		c.data.UaaEndpoint = uaaEndpoint
+	})
+}
+
+func (c *ConfigRepository) SetRoutingApiEndpoint(routingApiEndpoint string) {
+	c.write(func() {
+		c.data.RoutingApiEndpoint = routingApiEndpoint
 	})
 }
 

--- a/cf/help/help.go
+++ b/cf/help/help.go
@@ -225,6 +225,13 @@ func newAppPresenter() (presenter appPresenter) {
 				},
 			},
 		}, {
+			Name: T("ROUTER GROUPS"),
+			CommandSubGroups: [][]cmdPresenter{
+				{
+					presentNonCodegangstaCommand("router-groups"),
+				},
+			},
+		}, {
 			Name: T("BUILDPACKS"),
 			CommandSubGroups: [][]cmdPresenter{
 				{

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -2270,6 +2270,11 @@
       "modified": false
    },
    {
+      "id": "Failed fetching router groups.\n{{.Err}}",
+      "translation": "Failed fetching router groups.\n{{.Err}}",
+      "modified": false
+   },
+   {
       "id": "Failed fetching routes.\n{{.Err}}",
       "translation": "Failed fetching routes.\n{{.Err}}",
       "modified": false
@@ -2452,6 +2457,11 @@
    {
       "id": "Getting quotas as {{.Username}}...",
       "translation": "Getting quotas as {{.Username}}...",
+      "modified": false
+   },
+   {
+      "id": "Getting router groups as {{.Username}} ...\n",
+      "translation": "Getting router groups as {{.Username}} ...\n",
       "modified": false
    },
    {
@@ -3050,6 +3060,11 @@
       "modified": false
    },
    {
+      "id": "List router-groups",
+      "translation": "List router-groups",
+      "modified": false
+   },
+   {
       "id": "List security groups in the set of security groups for running applications",
       "translation": "List security groups in the set of security groups for running applications",
       "modified": false
@@ -3282,6 +3297,11 @@
    {
       "id": "No orgs found",
       "translation": "No orgs found",
+      "modified": false
+   },
+   {
+      "id": "No router groups found",
+      "translation": "No router groups found",
       "modified": false
    },
    {
@@ -3667,6 +3687,11 @@
    {
       "id": "ROLES:\n",
       "translation": "ROLES:\n",
+      "modified": false
+   },
+   {
+      "id": "ROUTER GROUPS",
+      "translation": "ROUTER GROUPS",
       "modified": false
    },
    {
@@ -5388,6 +5413,11 @@
       "id": "total memory limit",
       "translation": "memory limit",
       "modified": true
+   },
+   {
+      "id": "type",
+      "translation": "type",
+      "modified": false
    },
    {
       "id": "unknown authority",

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -2270,6 +2270,11 @@
       "modified": false
    },
    {
+      "id": "Failed fetching router groups.\n{{.Err}}",
+      "translation": "Failed fetching router groups.\n{{.Err}}",
+      "modified": false
+   },
+   {
       "id": "Failed fetching routes.\n{{.Err}}",
       "translation": "Failed fetching routes.\n{{.Err}}",
       "modified": false
@@ -2452,6 +2457,11 @@
    {
       "id": "Getting quotas as {{.Username}}...",
       "translation": "Getting quotas as {{.Username}}...",
+      "modified": false
+   },
+   {
+      "id": "Getting router groups as {{.Username}} ...\n",
+      "translation": "Getting router groups as {{.Username}} ...\n",
       "modified": false
    },
    {
@@ -3050,6 +3060,11 @@
       "modified": false
    },
    {
+      "id": "List router-groups",
+      "translation": "List router-groups",
+      "modified": false
+   },
+   {
       "id": "List security groups in the set of security groups for running applications",
       "translation": "List security groups in the set of security groups for running applications",
       "modified": false
@@ -3282,6 +3297,11 @@
    {
       "id": "No orgs found",
       "translation": "No orgs found",
+      "modified": false
+   },
+   {
+      "id": "No router groups found",
+      "translation": "No router groups found",
       "modified": false
    },
    {
@@ -3667,6 +3687,11 @@
    {
       "id": "ROLES:\n",
       "translation": "ROLES:\n",
+      "modified": false
+   },
+   {
+      "id": "ROUTER GROUPS",
+      "translation": "ROUTER GROUPS",
       "modified": false
    },
    {
@@ -5387,6 +5412,11 @@
    {
       "id": "total memory limit",
       "translation": "total memory limit",
+      "modified": false
+   },
+   {
+      "id": "type",
+      "translation": "type",
       "modified": false
    },
    {

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -2270,6 +2270,11 @@
       "modified": false
    },
    {
+      "id": "Failed fetching router groups.\n{{.Err}}",
+      "translation": "Failed fetching router groups.\n{{.Err}}",
+      "modified": false
+   },
+   {
       "id": "Failed fetching routes.\n{{.Err}}",
       "translation": "Fallo trayendo rutas.\n{{.Err}}",
       "modified": false
@@ -2452,6 +2457,11 @@
    {
       "id": "Getting quotas as {{.Username}}...",
       "translation": "Obteniendo cuotas como {{.Username}}...",
+      "modified": false
+   },
+   {
+      "id": "Getting router groups as {{.Username}} ...\n",
+      "translation": "Getting router groups as {{.Username}} ...\n",
       "modified": false
    },
    {
@@ -3050,6 +3060,11 @@
       "modified": false
    },
    {
+      "id": "List router-groups",
+      "translation": "List router-groups",
+      "modified": false
+   },
+   {
       "id": "List security groups in the set of security groups for running applications",
       "translation": "List security groups in the set of security groups for running applications",
       "modified": false
@@ -3282,6 +3297,11 @@
    {
       "id": "No orgs found",
       "translation": "No se encontraron orgs",
+      "modified": false
+   },
+   {
+      "id": "No router groups found",
+      "translation": "No router groups found",
       "modified": false
    },
    {
@@ -3667,6 +3687,11 @@
    {
       "id": "ROLES:\n",
       "translation": "ROLES:\n",
+      "modified": false
+   },
+   {
+      "id": "ROUTER GROUPS",
+      "translation": "ROUTER GROUPS",
       "modified": false
    },
    {
@@ -5388,6 +5413,11 @@
       "id": "total memory limit",
       "translation": "limite de memoria",
       "modified": true
+   },
+   {
+      "id": "type",
+      "translation": "type",
+      "modified": false
    },
    {
       "id": "unknown authority",

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -2270,6 +2270,11 @@
       "modified": false
    },
    {
+      "id": "Failed fetching router groups.\n{{.Err}}",
+      "translation": "Failed fetching router groups.\n{{.Err}}",
+      "modified": false
+   },
+   {
       "id": "Failed fetching routes.\n{{.Err}}",
       "translation": "Échec aller chercher routes.\n{{.Err}}",
       "modified": false
@@ -2452,6 +2457,11 @@
    {
       "id": "Getting quotas as {{.Username}}...",
       "translation": "Récupération des quotas en tant que {{.Username}}...",
+      "modified": false
+   },
+   {
+      "id": "Getting router groups as {{.Username}} ...\n",
+      "translation": "Getting router groups as {{.Username}} ...\n",
       "modified": false
    },
    {
@@ -3050,6 +3060,11 @@
       "modified": false
    },
    {
+      "id": "List router-groups",
+      "translation": "List router-groups",
+      "modified": false
+   },
+   {
       "id": "List security groups in the set of security groups for running applications",
       "translation": "List security groups in the set of security groups for running applications",
       "modified": false
@@ -3282,6 +3297,11 @@
    {
       "id": "No orgs found",
       "translation": "Aucune Org trouvée",
+      "modified": false
+   },
+   {
+      "id": "No router groups found",
+      "translation": "No router groups found",
       "modified": false
    },
    {
@@ -3667,6 +3687,11 @@
    {
       "id": "ROLES:\n",
       "translation": "RÔLES:\n",
+      "modified": false
+   },
+   {
+      "id": "ROUTER GROUPS",
+      "translation": "ROUTER GROUPS",
       "modified": false
    },
    {
@@ -5388,6 +5413,11 @@
       "id": "total memory limit",
       "translation": "limite de memoire",
       "modified": true
+   },
+   {
+      "id": "type",
+      "translation": "type",
+      "modified": false
    },
    {
       "id": "unknown authority",

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -2270,6 +2270,11 @@
       "modified": false
    },
    {
+      "id": "Failed fetching router groups.\n{{.Err}}",
+      "translation": "Failed fetching router groups.\n{{.Err}}",
+      "modified": false
+   },
+   {
       "id": "Failed fetching routes.\n{{.Err}}",
       "translation": "Failed fetching routes.\n{{.Err}}",
       "modified": false
@@ -2452,6 +2457,11 @@
    {
       "id": "Getting quotas as {{.Username}}...",
       "translation": "Getting quotas as {{.Username}}...",
+      "modified": false
+   },
+   {
+      "id": "Getting router groups as {{.Username}} ...\n",
+      "translation": "Getting router groups as {{.Username}} ...\n",
       "modified": false
    },
    {
@@ -3050,6 +3060,11 @@
       "modified": false
    },
    {
+      "id": "List router-groups",
+      "translation": "List router-groups",
+      "modified": false
+   },
+   {
       "id": "List security groups in the set of security groups for running applications",
       "translation": "List security groups in the set of security groups for running applications",
       "modified": false
@@ -3282,6 +3297,11 @@
    {
       "id": "No orgs found",
       "translation": "No orgs found",
+      "modified": false
+   },
+   {
+      "id": "No router groups found",
+      "translation": "No router groups found",
       "modified": false
    },
    {
@@ -3667,6 +3687,11 @@
    {
       "id": "ROLES:\n",
       "translation": "ROLES:\n",
+      "modified": false
+   },
+   {
+      "id": "ROUTER GROUPS",
+      "translation": "ROUTER GROUPS",
       "modified": false
    },
    {
@@ -5388,6 +5413,11 @@
       "id": "total memory limit",
       "translation": "memory limit",
       "modified": true
+   },
+   {
+      "id": "type",
+      "translation": "type",
+      "modified": false
    },
    {
       "id": "unknown authority",

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -2270,6 +2270,11 @@
       "modified": false
    },
    {
+      "id": "Failed fetching router groups.\n{{.Err}}",
+      "translation": "Failed fetching router groups.\n{{.Err}}",
+      "modified": false
+   },
+   {
       "id": "Failed fetching routes.\n{{.Err}}",
       "translation": "Failed fetching routes.\n{{.Err}}",
       "modified": false
@@ -2452,6 +2457,11 @@
    {
       "id": "Getting quotas as {{.Username}}...",
       "translation": "Getting quotas as {{.Username}}...",
+      "modified": false
+   },
+   {
+      "id": "Getting router groups as {{.Username}} ...\n",
+      "translation": "Getting router groups as {{.Username}} ...\n",
       "modified": false
    },
    {
@@ -3050,6 +3060,11 @@
       "modified": false
    },
    {
+      "id": "List router-groups",
+      "translation": "List router-groups",
+      "modified": false
+   },
+   {
       "id": "List security groups in the set of security groups for running applications",
       "translation": "List security groups in the set of security groups for running applications",
       "modified": false
@@ -3282,6 +3297,11 @@
    {
       "id": "No orgs found",
       "translation": "No orgs found",
+      "modified": false
+   },
+   {
+      "id": "No router groups found",
+      "translation": "No router groups found",
       "modified": false
    },
    {
@@ -3667,6 +3687,11 @@
    {
       "id": "ROLES:\n",
       "translation": "ROLES:\n",
+      "modified": false
+   },
+   {
+      "id": "ROUTER GROUPS",
+      "translation": "ROUTER GROUPS",
       "modified": false
    },
    {
@@ -5388,6 +5413,11 @@
       "id": "total memory limit",
       "translation": "memory limit",
       "modified": true
+   },
+   {
+      "id": "type",
+      "translation": "type",
+      "modified": false
    },
    {
       "id": "unknown authority",

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -2270,6 +2270,11 @@
       "modified": false
    },
    {
+      "id": "Failed fetching router groups.\n{{.Err}}",
+      "translation": "Failed fetching router groups.\n{{.Err}}",
+      "modified": false
+   },
+   {
       "id": "Failed fetching routes.\n{{.Err}}",
       "translation": "Falha ao obter rotas.\n{{.Err}}",
       "modified": false
@@ -2452,6 +2457,11 @@
    {
       "id": "Getting quotas as {{.Username}}...",
       "translation": "Obtendo cotas como {{.Username}}...",
+      "modified": false
+   },
+   {
+      "id": "Getting router groups as {{.Username}} ...\n",
+      "translation": "Getting router groups as {{.Username}} ...\n",
       "modified": false
    },
    {
@@ -3050,6 +3060,11 @@
       "modified": false
    },
    {
+      "id": "List router-groups",
+      "translation": "List router-groups",
+      "modified": false
+   },
+   {
       "id": "List security groups in the set of security groups for running applications",
       "translation": "Exibir grupos de segurança nos padões de execução",
       "modified": false
@@ -3282,6 +3297,11 @@
    {
       "id": "No orgs found",
       "translation": "Nenhuma organização encontrada",
+      "modified": false
+   },
+   {
+      "id": "No router groups found",
+      "translation": "No router groups found",
       "modified": false
    },
    {
@@ -3667,6 +3687,11 @@
    {
       "id": "ROLES:\n",
       "translation": "FUNÇÕES:\n",
+      "modified": false
+   },
+   {
+      "id": "ROUTER GROUPS",
+      "translation": "ROUTER GROUPS",
       "modified": false
    },
    {
@@ -5387,6 +5412,11 @@
    {
       "id": "total memory limit",
       "translation": "total memory limit",
+      "modified": false
+   },
+   {
+      "id": "type",
+      "translation": "type",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -2270,6 +2270,11 @@
       "modified": false
    },
    {
+      "id": "Failed fetching router groups.\n{{.Err}}",
+      "translation": "Failed fetching router groups.\n{{.Err}}",
+      "modified": false
+   },
+   {
       "id": "Failed fetching routes.\n{{.Err}}",
       "translation": "Failed fetching routes.\n{{.Err}}",
       "modified": false
@@ -2452,6 +2457,11 @@
    {
       "id": "Getting quotas as {{.Username}}...",
       "translation": "Getting quotas as {{.Username}}...",
+      "modified": false
+   },
+   {
+      "id": "Getting router groups as {{.Username}} ...\n",
+      "translation": "Getting router groups as {{.Username}} ...\n",
       "modified": false
    },
    {
@@ -3050,6 +3060,11 @@
       "modified": false
    },
    {
+      "id": "List router-groups",
+      "translation": "List router-groups",
+      "modified": false
+   },
+   {
       "id": "List security groups in the set of security groups for running applications",
       "translation": "List security groups in the set of security groups for running applications",
       "modified": false
@@ -3282,6 +3297,11 @@
    {
       "id": "No orgs found",
       "translation": "没有找到任何组织",
+      "modified": false
+   },
+   {
+      "id": "No router groups found",
+      "translation": "No router groups found",
       "modified": false
    },
    {
@@ -3667,6 +3687,11 @@
    {
       "id": "ROLES:\n",
       "translation": "角色:\n",
+      "modified": false
+   },
+   {
+      "id": "ROUTER GROUPS",
+      "translation": "ROUTER GROUPS",
       "modified": false
    },
    {
@@ -5388,6 +5413,11 @@
       "id": "total memory limit",
       "translation": "memory limit",
       "modified": true
+   },
+   {
+      "id": "type",
+      "translation": "type",
+      "modified": false
    },
    {
       "id": "unknown authority",

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -2270,6 +2270,11 @@
       "modified": false
    },
    {
+      "id": "Failed fetching router groups.\n{{.Err}}",
+      "translation": "Failed fetching router groups.\n{{.Err}}",
+      "modified": false
+   },
+   {
       "id": "Failed fetching routes.\n{{.Err}}",
       "translation": "Failed fetching routes.\n{{.Err}}",
       "modified": false
@@ -2452,6 +2457,11 @@
    {
       "id": "Getting quotas as {{.Username}}...",
       "translation": "Getting quotas as {{.Username}}...",
+      "modified": false
+   },
+   {
+      "id": "Getting router groups as {{.Username}} ...\n",
+      "translation": "Getting router groups as {{.Username}} ...\n",
       "modified": false
    },
    {
@@ -3050,6 +3060,11 @@
       "modified": false
    },
    {
+      "id": "List router-groups",
+      "translation": "List router-groups",
+      "modified": false
+   },
+   {
       "id": "List security groups in the set of security groups for running applications",
       "translation": "List security groups in the set of security groups for running applications",
       "modified": false
@@ -3282,6 +3297,11 @@
    {
       "id": "No orgs found",
       "translation": "No orgs found",
+      "modified": false
+   },
+   {
+      "id": "No router groups found",
+      "translation": "No router groups found",
       "modified": false
    },
    {
@@ -3667,6 +3687,11 @@
    {
       "id": "ROLES:\n",
       "translation": "ROLES:\n",
+      "modified": false
+   },
+   {
+      "id": "ROUTER GROUPS",
+      "translation": "ROUTER GROUPS",
       "modified": false
    },
    {
@@ -5388,6 +5413,11 @@
       "id": "total memory limit",
       "translation": "memory limit",
       "modified": true
+   },
+   {
+      "id": "type",
+      "translation": "type",
+      "modified": false
    },
    {
       "id": "unknown authority",

--- a/cf/models/router_group.go
+++ b/cf/models/router_group.go
@@ -1,0 +1,9 @@
+package models
+
+type RouterGroups []RouterGroup
+
+type RouterGroup struct {
+	Guid string `json:"guid"`
+	Name string `json:"name"`
+	Type string `json:"type"`
+}

--- a/commands_loader/commands_loader.go
+++ b/commands_loader/commands_loader.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cloudfoundry/cli/cf/commands/plugin_repo"
 	"github.com/cloudfoundry/cli/cf/commands/quota"
 	"github.com/cloudfoundry/cli/cf/commands/route"
+	"github.com/cloudfoundry/cli/cf/commands/routergroups"
 	"github.com/cloudfoundry/cli/cf/commands/securitygroup"
 	"github.com/cloudfoundry/cli/cf/commands/service"
 	"github.com/cloudfoundry/cli/cf/commands/serviceaccess"
@@ -43,6 +44,7 @@ func Load() {
 	_ = plugin_repo.RepoPlugins{}
 	_ = quota.CreateQuota{}
 	_ = route.CreateRoute{}
+	_ = routergroups.RouterGroups{}
 	_ = securitygroup.ShowSecurityGroup{}
 	_ = service.ShowService{}
 	_ = serviceauthtoken.ListServiceAuthTokens{}


### PR DESCRIPTION
This PR is to add `cf router-groups` command to CF CLI. This command lets user list router groups.

This is first in the list of stories scheduled for supporting tcp routes in CF. Pivotal tracker story link for this PR: https://www.pivotaltracker.com/story/show/100975070

(Required OAuth scopes for CF CLI client are added to cf-release.)

Regards,
@atulkc and @fordaz
(CF Routing team)