### PR TITLE
Add purge-service-instance command

### DIFF
--- a/cf/api/fakes/fake_service_repo.go
+++ b/cf/api/fakes/fake_service_repo.go
@@ -60,9 +60,14 @@ type FakeServiceRepo struct {
 	FindInstanceByNameName            string
 	FindInstanceByNameServiceInstance models.ServiceInstance
 	FindInstanceByNameErr             bool
+	FindInstanceByNameCalled          bool
 	FindInstanceByNameNotFound        bool
 
 	FindInstanceByNameMap generic.Map
+
+	PurgedServiceInstance           models.ServiceInstance
+	PurgeServiceInstanceCalled      bool
+	PurgeServiceInstanceApiResponse error
 
 	DeleteServiceServiceInstance models.ServiceInstance
 
@@ -132,6 +137,12 @@ func (repo *FakeServiceRepo) PurgeServiceOffering(offering models.ServiceOfferin
 	return repo.PurgeServiceOfferingApiResponse
 }
 
+func (repo *FakeServiceRepo) PurgeServiceInstance(instance models.ServiceInstance) (apiErr error) {
+	repo.PurgedServiceInstance = instance
+	repo.PurgeServiceInstanceCalled = true
+	return repo.PurgeServiceInstanceApiResponse
+}
+
 func (repo *FakeServiceRepo) FindServiceOfferingByLabelAndProvider(name, provider string) (offering models.ServiceOffering, apiErr error) {
 	repo.FindServiceOfferingByLabelAndProviderCalled = true
 	repo.FindServiceOfferingByLabelAndProviderName = name
@@ -174,6 +185,7 @@ func (repo *FakeServiceRepo) UpdateServiceInstance(instanceGuid, planGuid string
 
 func (repo *FakeServiceRepo) FindInstanceByName(name string) (instance models.ServiceInstance, apiErr error) {
 	repo.FindInstanceByNameName = name
+	repo.FindInstanceByNameCalled = true
 
 	if repo.FindInstanceByNameMap != nil && repo.FindInstanceByNameMap.Has(name) {
 		instance = repo.FindInstanceByNameMap.Get(name).(models.ServiceInstance)

--- a/cf/api/services.go
+++ b/cf/api/services.go
@@ -25,6 +25,7 @@ type ServiceRepository interface {
 	GetAllServiceOfferings() (offerings models.ServiceOfferings, apiErr error)
 	GetServiceOfferingsForSpace(spaceGuid string) (offerings models.ServiceOfferings, apiErr error)
 	FindInstanceByName(name string) (instance models.ServiceInstance, apiErr error)
+	PurgeServiceInstance(instance models.ServiceInstance) error
 	CreateServiceInstance(name, planGuid string, params map[string]interface{}, tags []string) (apiErr error)
 	UpdateServiceInstance(instanceGuid, planGuid string, params map[string]interface{}, tags []string) (apiErr error)
 	RenameService(instance models.ServiceInstance, newName string) (apiErr error)
@@ -201,6 +202,11 @@ func (repo CloudControllerServiceRepository) DeleteService(instance models.Servi
 
 func (repo CloudControllerServiceRepository) PurgeServiceOffering(offering models.ServiceOffering) error {
 	url := fmt.Sprintf("/v2/services/%s?purge=true", offering.Guid)
+	return repo.gateway.DeleteResource(repo.config.ApiEndpoint(), url)
+}
+
+func (repo CloudControllerServiceRepository) PurgeServiceInstance(instance models.ServiceInstance) error {
+	url := fmt.Sprintf("/v2/service_instances/%s?purge=true", instance.Guid)
 	return repo.gateway.DeleteResource(repo.config.ApiEndpoint(), url)
 }
 

--- a/cf/api/services_test.go
+++ b/cf/api/services_test.go
@@ -913,6 +913,24 @@ var _ = Describe("Services Repo", func() {
 		})
 	})
 
+	Describe("PurgeServiceInstance", func() {
+		It("purges service instances", func() {
+			setupTestServer(testnet.TestRequest{
+				Method: "DELETE",
+				Path:   "/v2/service_instances/instance-guid?purge=true",
+				Response: testnet.TestResponse{
+					Status: 204,
+				}})
+
+			instance := maker.NewServiceInstance("schrodinger")
+			instance.Guid = "instance-guid"
+
+			err := repo.PurgeServiceInstance(instance)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(testHandler).To(HaveAllRequestsCalled())
+		})
+	})
+
 	Describe("getting the count of service instances for a service plan", func() {
 		var planGuid = "abc123"
 

--- a/cf/commands/service/purge_service_instance.go
+++ b/cf/commands/service/purge_service_instance.go
@@ -1,0 +1,88 @@
+package service
+
+import (
+	"github.com/cloudfoundry/cli/cf/api"
+	"github.com/cloudfoundry/cli/cf/command_registry"
+	"github.com/cloudfoundry/cli/cf/errors"
+	. "github.com/cloudfoundry/cli/cf/i18n"
+	"github.com/cloudfoundry/cli/cf/requirements"
+	"github.com/cloudfoundry/cli/cf/terminal"
+	"github.com/simonleung8/flags"
+	"github.com/simonleung8/flags/flag"
+)
+
+type PurgeServiceInstance struct {
+	ui          terminal.UI
+	serviceRepo api.ServiceRepository
+}
+
+func init() {
+	command_registry.Register(&PurgeServiceInstance{})
+}
+
+func (cmd *PurgeServiceInstance) MetaData() command_registry.CommandMetadata {
+	fs := make(map[string]flags.FlagSet)
+	fs["f"] = &cliFlags.BoolFlag{Name: "f", Usage: T("Force deletion without confirmation")}
+
+	return command_registry.CommandMetadata{
+		Name:        "purge-service-instance",
+		Description: T("Recursively remove a service instance and child objects from Cloud Foundry database without making requests to a service broker"),
+		Usage:       T("CF_NAME purge-service-instance SERVICE_INSTANCE") + "\n\n" + cmd.scaryWarningMessage(),
+		Flags:       fs,
+	}
+}
+
+func (cmd *PurgeServiceInstance) Requirements(requirementsFactory requirements.Factory, fc flags.FlagContext) (reqs []requirements.Requirement, err error) {
+	if len(fc.Args()) != 1 {
+		cmd.ui.Failed(T("Incorrect Usage. Requires an argument\n\n") + command_registry.Commands.CommandUsage("purge-service-instance"))
+	}
+
+	reqs = []requirements.Requirement{requirementsFactory.NewLoginRequirement()}
+	return
+}
+
+func (cmd *PurgeServiceInstance) SetDependency(deps command_registry.Dependency, pluginCall bool) command_registry.Command {
+	cmd.ui = deps.Ui
+	cmd.serviceRepo = deps.RepoLocator.GetServiceRepository()
+	return cmd
+}
+
+func (cmd *PurgeServiceInstance) scaryWarningMessage() string {
+	return T(`WARNING: This operation assumes that the service broker responsible for this service instance is no longer available or is not responding with a 200 or 410, and the service instance has been deleted, leaving orphan records in Cloud Foundry's database. All knowledge of the service instance will be removed from Cloud Foundry, including service bindings and service keys.`)
+}
+
+func (cmd *PurgeServiceInstance) Execute(c flags.FlagContext) {
+	instanceName := c.Args()[0]
+
+	instance, apiErr := cmd.serviceRepo.FindInstanceByName(instanceName)
+
+	switch apiErr.(type) {
+	case nil:
+	case *errors.ModelNotFoundError:
+		cmd.ui.Warn(T("Service instance {{.InstanceName}} not found",
+			map[string]interface{}{"InstanceName": instanceName},
+		))
+		return
+	default:
+		cmd.ui.Failed(apiErr.Error())
+	}
+
+	confirmed := c.Bool("f")
+	if !confirmed {
+		cmd.ui.Warn(cmd.scaryWarningMessage())
+		confirmed = cmd.ui.Confirm(T("Really purge service instance {{.InstanceName}} from Cloud Foundry?",
+			map[string]interface{}{"InstanceName": instanceName},
+		))
+	}
+
+	if !confirmed {
+		return
+	}
+	cmd.ui.Say(T("Purging service {{.InstanceName}}...", map[string]interface{}{"InstanceName": instanceName}))
+	err := cmd.serviceRepo.PurgeServiceInstance(instance)
+	if err != nil {
+		cmd.ui.Failed(err.Error())
+	}
+
+	cmd.ui.Ok()
+}

--- a/cf/commands/service/purge_service_instance_test.go
+++ b/cf/commands/service/purge_service_instance_test.go
@@ -1,0 +1,130 @@
+package service_test
+
+import (
+	testapi "github.com/cloudfoundry/cli/cf/api/fakes"
+	"github.com/cloudfoundry/cli/cf/command_registry"
+	"github.com/cloudfoundry/cli/cf/configuration/core_config"
+	cferrors "github.com/cloudfoundry/cli/cf/errors"
+	testcmd "github.com/cloudfoundry/cli/testhelpers/commands"
+	testconfig "github.com/cloudfoundry/cli/testhelpers/configuration"
+	"github.com/cloudfoundry/cli/testhelpers/maker"
+	testreq "github.com/cloudfoundry/cli/testhelpers/requirements"
+	testterm "github.com/cloudfoundry/cli/testhelpers/terminal"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/cloudfoundry/cli/testhelpers/matchers"
+)
+
+var _ = Describe("purge-service-instance command", func() {
+	var (
+		requirementsFactory *testreq.FakeReqFactory
+		config              core_config.Repository
+		ui                  *testterm.FakeUI
+		serviceRepo         *testapi.FakeServiceRepo
+		deps                command_registry.Dependency
+	)
+
+	updateCommandDependency := func(pluginCall bool) {
+		deps.Ui = ui
+		deps.RepoLocator = deps.RepoLocator.SetServiceRepository(serviceRepo)
+		deps.Config = config
+		command_registry.Commands.SetCommand(command_registry.Commands.FindCommand("purge-service-instance").SetDependency(deps, pluginCall))
+	}
+
+	runCommand := func(args []string) bool {
+		return testcmd.RunCliCommand("purge-service-instance", args, requirementsFactory, updateCommandDependency, false)
+	}
+
+	BeforeEach(func() {
+		ui = &testterm.FakeUI{}
+		config = testconfig.NewRepositoryWithDefaults()
+		serviceRepo = &testapi.FakeServiceRepo{}
+		requirementsFactory = &testreq.FakeReqFactory{LoginSuccess: true, TargetedSpaceSuccess: true}
+	})
+
+	Describe("requirements", func() {
+		It("fails when not logged in", func() {
+			requirementsFactory.LoginSuccess = false
+
+			passed := runCommand([]string{"-f", "whatever"})
+
+			Expect(passed).To(BeFalse())
+		})
+
+		It("fails when called without exactly one arg", func() {
+			requirementsFactory.LoginSuccess = true
+
+			passed := runCommand([]string{})
+
+			Expect(passed).To(BeFalse())
+			Expect(ui.Outputs).To(ContainSubstrings(
+				[]string{"Incorrect Usage", "Requires", "argument"},
+			))
+		})
+	})
+
+	It("exits when the user does not acknowledge the confirmation", func() {
+		ui.Inputs = []string{"no"}
+
+		runCommand([]string{"the-service-name"})
+
+		Expect(serviceRepo.FindInstanceByNameCalled).To(Equal(true))
+		Expect(serviceRepo.PurgeServiceInstanceCalled).To(Equal(false))
+	})
+
+	It("does not prompt with confirmation when -f is passed", func() {
+		instance := maker.NewServiceInstance("the-service-name")
+		serviceRepo.FindInstanceByNameServiceInstance = instance
+
+		runCommand(
+			[]string{"-f", "the-service-name"},
+		)
+
+		Expect(len(ui.Prompts)).To(Equal(0))
+		Expect(serviceRepo.PurgedServiceInstance).To(Equal(instance))
+		Expect(serviceRepo.PurgeServiceInstanceCalled).To(Equal(true))
+	})
+
+	It("fails with an error message when finding the instance fails", func() {
+		serviceRepo.FindInstanceByNameErr = true
+
+		runCommand(
+			[]string{"-f", "the-service-name"},
+		)
+
+		Expect(ui.Outputs).To(ContainSubstrings(
+			[]string{"FAILED"},
+			[]string{"Error finding instance"},
+		))
+	})
+
+	It("fails with an error message when the purging request fails", func() {
+		serviceRepo.PurgeServiceInstanceApiResponse = cferrors.New("crumpets insufficiently buttered")
+
+		runCommand(
+			[]string{"-f", "the-service-name"},
+		)
+
+		Expect(ui.Outputs).To(ContainSubstrings(
+			[]string{"FAILED"},
+			[]string{"crumpets insufficiently buttered"},
+		))
+	})
+
+	It("indicates when a service doesn't exist", func() {
+		serviceRepo.FindInstanceByNameNotFound = true
+
+		ui.Inputs = []string{"yes"}
+
+		runCommand(
+			[]string{"nonexistent-service"},
+		)
+
+		Expect(ui.Outputs).To(ContainSubstrings([]string{"Service instance", "nonexistent-service", "not found"}))
+		Expect(ui.Outputs).ToNot(ContainSubstrings([]string{"WARNING"}))
+		Expect(ui.Outputs).ToNot(ContainSubstrings([]string{"Ok"}))
+
+		Expect(serviceRepo.PurgeServiceInstanceCalled).To(Equal(false))
+	})
+})

--- a/cf/commands/service/purge_service_offering_test.go
+++ b/cf/commands/service/purge_service_offering_test.go
@@ -18,7 +18,7 @@ import (
 	. "github.com/cloudfoundry/cli/testhelpers/matchers"
 )
 
-var _ = Describe("purge-service command", func() {
+var _ = Describe("purge-service-offering command", func() {
 	var (
 		requirementsFactory *testreq.FakeReqFactory
 		config              core_config.Repository

--- a/cf/help/help.go
+++ b/cf/help/help.go
@@ -309,6 +309,7 @@ func newAppPresenter() (presenter appPresenter) {
 				}, {
 					presentNonCodegangstaCommand("migrate-service-instances"),
 					presentNonCodegangstaCommand("purge-service-offering"),
+					presentNonCodegangstaCommand("purge-service-instance"),
 				}, {
 					presentNonCodegangstaCommand("service-access"),
 					presentNonCodegangstaCommand("enable-service-access"),

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -945,6 +945,11 @@
       "modified": false
    },
    {
+      "id": "CF_NAME purge-service-instance SERVICE_INSTANCE",
+      "translation": "CF_NAME purge-service-instance SERVICE_INSTANCE",
+      "modified": false
+   },
+   {
       "id": "CF_NAME purge-service-offering SERVICE [-p PROVIDER]",
       "translation": "CF_NAME purge-service-offering SERVICE [-p PROVIDER]",
       "modified": false
@@ -3855,6 +3860,11 @@
       "modified": false
    },
    {
+      "id": "Purging service {{.InstanceName}}...",
+      "translation": "Purging service {{.InstanceName}}...",
+      "modified": false
+   },
+   {
       "id": "Purging service {{.ServiceName}}...",
       "translation": "Purging service {{.ServiceName}}...",
       "modified": false
@@ -3930,6 +3940,11 @@
       "modified": false
    },
    {
+      "id": "Really purge service instance {{.InstanceName}} from Cloud Foundry?",
+      "translation": "Really purge service instance {{.InstanceName}} from Cloud Foundry?",
+      "modified": false
+   },
+   {
       "id": "Really purge service offering {{.ServiceName}} from Cloud Foundry?",
       "translation": "Really purge service offering {{.ServiceName}} from Cloud Foundry?",
       "modified": false
@@ -3942,6 +3957,11 @@
    {
       "id": "Recursively remove a service and child objects from Cloud Foundry database without making requests to a service broker",
       "translation": "Recursively remove a service and child objects from Cloud Foundry database without making requests to a service broker",
+      "modified": false
+   },
+   {
+      "id": "Recursively remove a service instance and child objects from Cloud Foundry database without making requests to a service broker",
+      "translation": "Recursively remove a service instance and child objects from Cloud Foundry database without making requests to a service broker",
       "modified": false
    },
    {
@@ -4317,6 +4337,11 @@
    {
       "id": "Service Instance is not user provided",
       "translation": "Service Instance is not user provided",
+      "modified": false
+   },
+   {
+      "id": "Service instance {{.InstanceName}} not found",
+      "translation": "Service instance {{.InstanceName}} not found",
       "modified": false
    },
    {
@@ -5137,6 +5162,11 @@
    {
       "id": "WARNING:\n   Providing your password as a command line option is highly discouraged\n   Your password may be visible to others and may be recorded in your shell history\n\n",
       "translation": "WARNING:\n   Providing your password as a command line option is highly discouraged\n   Your password may be visible to others and may be recorded in your shell history\n\n",
+      "modified": false
+   },
+   {
+      "id": "WARNING: This operation assumes that the service broker responsible for this service instance is no longer available or is not responding with a 200 or 410, and the service instance has been deleted, leaving orphan records in Cloud Foundry's database. All knowledge of the service instance will be removed from Cloud Foundry, including service bindings and service keys.",
+      "translation": "WARNING: This operation assumes that the service broker responsible for this service instance is no longer available or is not responding with a 200 or 410, and the service instance has been deleted, leaving orphan records in Cloud Foundry's database. All knowledge of the service instance will be removed from Cloud Foundry, including service bindings and service keys.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -945,6 +945,11 @@
       "modified": false
    },
    {
+      "id": "CF_NAME purge-service-instance SERVICE_INSTANCE",
+      "translation": "CF_NAME purge-service-instance SERVICE_INSTANCE",
+      "modified": false
+   },
+   {
       "id": "CF_NAME purge-service-offering SERVICE [-p PROVIDER]",
       "translation": "CF_NAME purge-service-offering SERVICE [-p PROVIDER]",
       "modified": false
@@ -3855,6 +3860,11 @@
       "modified": false
    },
    {
+      "id": "Purging service {{.InstanceName}}...",
+      "translation": "Purging service {{.InstanceName}}...",
+      "modified": false
+   },
+   {
       "id": "Purging service {{.ServiceName}}...",
       "translation": "Purging service {{.ServiceName}}...",
       "modified": false
@@ -3930,6 +3940,11 @@
       "modified": false
    },
    {
+      "id": "Really purge service instance {{.InstanceName}} from Cloud Foundry?",
+      "translation": "Really purge service instance {{.InstanceName}} from Cloud Foundry?",
+      "modified": false
+   },
+   {
       "id": "Really purge service offering {{.ServiceName}} from Cloud Foundry?",
       "translation": "Really purge service offering {{.ServiceName}} from Cloud Foundry?",
       "modified": false
@@ -3942,6 +3957,11 @@
    {
       "id": "Recursively remove a service and child objects from Cloud Foundry database without making requests to a service broker",
       "translation": "Recursively remove a service and child objects from Cloud Foundry database without making requests to a service broker",
+      "modified": false
+   },
+   {
+      "id": "Recursively remove a service instance and child objects from Cloud Foundry database without making requests to a service broker",
+      "translation": "Recursively remove a service instance and child objects from Cloud Foundry database without making requests to a service broker",
       "modified": false
    },
    {
@@ -4317,6 +4337,11 @@
    {
       "id": "Service Instance is not user provided",
       "translation": "Service Instance is not user provided",
+      "modified": false
+   },
+   {
+      "id": "Service instance {{.InstanceName}} not found",
+      "translation": "Service instance {{.InstanceName}} not found",
       "modified": false
    },
    {
@@ -5137,6 +5162,11 @@
    {
       "id": "WARNING:\n   Providing your password as a command line option is highly discouraged\n   Your password may be visible to others and may be recorded in your shell history\n\n",
       "translation": "WARNING:\n   Providing your password as a command line option is highly discouraged\n   Your password may be visible to others and may be recorded in your shell history\n\n",
+      "modified": false
+   },
+   {
+      "id": "WARNING: This operation assumes that the service broker responsible for this service instance is no longer available or is not responding with a 200 or 410, and the service instance has been deleted, leaving orphan records in Cloud Foundry's database. All knowledge of the service instance will be removed from Cloud Foundry, including service bindings and service keys.",
+      "translation": "WARNING: This operation assumes that the service broker responsible for this service instance is no longer available or is not responding with a 200 or 410, and the service instance has been deleted, leaving orphan records in Cloud Foundry's database. All knowledge of the service instance will be removed from Cloud Foundry, including service bindings and service keys.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -945,6 +945,11 @@
       "modified": false
    },
    {
+      "id": "CF_NAME purge-service-instance SERVICE_INSTANCE",
+      "translation": "CF_NAME purge-service-instance SERVICE_INSTANCE",
+      "modified": false
+   },
+   {
       "id": "CF_NAME purge-service-offering SERVICE [-p PROVIDER]",
       "translation": "CF_NAME purge-service-offering SERVICE [-p PROVIDER]",
       "modified": false
@@ -3855,6 +3860,11 @@
       "modified": false
    },
    {
+      "id": "Purging service {{.InstanceName}}...",
+      "translation": "Purging service {{.InstanceName}}...",
+      "modified": false
+   },
+   {
       "id": "Purging service {{.ServiceName}}...",
       "translation": "Purging service {{.ServiceName}}...",
       "modified": false
@@ -3930,6 +3940,11 @@
       "modified": false
    },
    {
+      "id": "Really purge service instance {{.InstanceName}} from Cloud Foundry?",
+      "translation": "Really purge service instance {{.InstanceName}} from Cloud Foundry?",
+      "modified": false
+   },
+   {
       "id": "Really purge service offering {{.ServiceName}} from Cloud Foundry?",
       "translation": "Purgar realmente la oferta del servicio {{.ServiceName}} de Cloud Foundry?",
       "modified": false
@@ -3942,6 +3957,11 @@
    {
       "id": "Recursively remove a service and child objects from Cloud Foundry database without making requests to a service broker",
       "translation": "Recursively remove a service and child objects from Cloud Foundry database without making requests to a service broker",
+      "modified": false
+   },
+   {
+      "id": "Recursively remove a service instance and child objects from Cloud Foundry database without making requests to a service broker",
+      "translation": "Recursively remove a service instance and child objects from Cloud Foundry database without making requests to a service broker",
       "modified": false
    },
    {
@@ -4317,6 +4337,11 @@
    {
       "id": "Service Instance is not user provided",
       "translation": "Service Instance is not user provided",
+      "modified": false
+   },
+   {
+      "id": "Service instance {{.InstanceName}} not found",
+      "translation": "Service instance {{.InstanceName}} not found",
       "modified": false
    },
    {
@@ -5137,6 +5162,11 @@
    {
       "id": "WARNING:\n   Providing your password as a command line option is highly discouraged\n   Your password may be visible to others and may be recorded in your shell history\n\n",
       "translation": "ADVERTENCIA:\n   Proporcionar tu clave como una opción de línea de comando es desaconsejable\n   Tu clave puede ser visible por otros y ser grabada de el historial del shell\n\n",
+      "modified": false
+   },
+   {
+      "id": "WARNING: This operation assumes that the service broker responsible for this service instance is no longer available or is not responding with a 200 or 410, and the service instance has been deleted, leaving orphan records in Cloud Foundry's database. All knowledge of the service instance will be removed from Cloud Foundry, including service bindings and service keys.",
+      "translation": "WARNING: This operation assumes that the service broker responsible for this service instance is no longer available or is not responding with a 200 or 410, and the service instance has been deleted, leaving orphan records in Cloud Foundry's database. All knowledge of the service instance will be removed from Cloud Foundry, including service bindings and service keys.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -945,6 +945,11 @@
       "modified": false
    },
    {
+      "id": "CF_NAME purge-service-instance SERVICE_INSTANCE",
+      "translation": "CF_NAME purge-service-instance SERVICE_INSTANCE",
+      "modified": false
+   },
+   {
       "id": "CF_NAME purge-service-offering SERVICE [-p PROVIDER]",
       "translation": "CF_NAME purge-service-offering SERVICE [-p PROVIDER]",
       "modified": false
@@ -3855,6 +3860,11 @@
       "modified": false
    },
    {
+      "id": "Purging service {{.InstanceName}}...",
+      "translation": "Purging service {{.InstanceName}}...",
+      "modified": false
+   },
+   {
       "id": "Purging service {{.ServiceName}}...",
       "translation": "Purgé le service {{.ServiceName}}...",
       "modified": false
@@ -3930,6 +3940,11 @@
       "modified": false
    },
    {
+      "id": "Really purge service instance {{.InstanceName}} from Cloud Foundry?",
+      "translation": "Really purge service instance {{.InstanceName}} from Cloud Foundry?",
+      "modified": false
+   },
+   {
       "id": "Really purge service offering {{.ServiceName}} from Cloud Foundry?",
       "translation": "Vraiment purger offre de service {{.ServiceName}} de Cloud Foundry?",
       "modified": false
@@ -3942,6 +3957,11 @@
    {
       "id": "Recursively remove a service and child objects from Cloud Foundry database without making requests to a service broker",
       "translation": "Effacer de façon récursive un service et des objets enfants base de données Cloud Foundry sans faire des demandes à un courtier de service",
+      "modified": false
+   },
+   {
+      "id": "Recursively remove a service instance and child objects from Cloud Foundry database without making requests to a service broker",
+      "translation": "Recursively remove a service instance and child objects from Cloud Foundry database without making requests to a service broker",
       "modified": false
    },
    {
@@ -4317,6 +4337,11 @@
    {
       "id": "Service Instance is not user provided",
       "translation": "Instance de service n'est pas fourni par l'utilisateur",
+      "modified": false
+   },
+   {
+      "id": "Service instance {{.InstanceName}} not found",
+      "translation": "Service instance {{.InstanceName}} not found",
       "modified": false
    },
    {
@@ -5137,6 +5162,11 @@
    {
       "id": "WARNING:\n   Providing your password as a command line option is highly discouraged\n   Your password may be visible to others and may be recorded in your shell history\n\n",
       "translation": "AVERTISSEMENT:\n   Fournir votre mot de passe comme une option de ligne de commande est fortement déconseillée.\n   Votre mot de passe peut être visible par les autres et peut être enregistré dans votre historique du shell\n\n",
+      "modified": false
+   },
+   {
+      "id": "WARNING: This operation assumes that the service broker responsible for this service instance is no longer available or is not responding with a 200 or 410, and the service instance has been deleted, leaving orphan records in Cloud Foundry's database. All knowledge of the service instance will be removed from Cloud Foundry, including service bindings and service keys.",
+      "translation": "WARNING: This operation assumes that the service broker responsible for this service instance is no longer available or is not responding with a 200 or 410, and the service instance has been deleted, leaving orphan records in Cloud Foundry's database. All knowledge of the service instance will be removed from Cloud Foundry, including service bindings and service keys.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -945,6 +945,11 @@
       "modified": false
    },
    {
+      "id": "CF_NAME purge-service-instance SERVICE_INSTANCE",
+      "translation": "CF_NAME purge-service-instance SERVICE_INSTANCE",
+      "modified": false
+   },
+   {
       "id": "CF_NAME purge-service-offering SERVICE [-p PROVIDER]",
       "translation": "CF_NAME purge-service-offering SERVICE [-p PROVIDER]",
       "modified": false
@@ -3855,6 +3860,11 @@
       "modified": false
    },
    {
+      "id": "Purging service {{.InstanceName}}...",
+      "translation": "Purging service {{.InstanceName}}...",
+      "modified": false
+   },
+   {
       "id": "Purging service {{.ServiceName}}...",
       "translation": "Purging service {{.ServiceName}}...",
       "modified": false
@@ -3930,6 +3940,11 @@
       "modified": false
    },
    {
+      "id": "Really purge service instance {{.InstanceName}} from Cloud Foundry?",
+      "translation": "Really purge service instance {{.InstanceName}} from Cloud Foundry?",
+      "modified": false
+   },
+   {
       "id": "Really purge service offering {{.ServiceName}} from Cloud Foundry?",
       "translation": "Really purge service offering {{.ServiceName}} from Cloud Foundry?",
       "modified": false
@@ -3942,6 +3957,11 @@
    {
       "id": "Recursively remove a service and child objects from Cloud Foundry database without making requests to a service broker",
       "translation": "Recursively remove a service and child objects from Cloud Foundry database without making requests to a service broker",
+      "modified": false
+   },
+   {
+      "id": "Recursively remove a service instance and child objects from Cloud Foundry database without making requests to a service broker",
+      "translation": "Recursively remove a service instance and child objects from Cloud Foundry database without making requests to a service broker",
       "modified": false
    },
    {
@@ -4317,6 +4337,11 @@
    {
       "id": "Service Instance is not user provided",
       "translation": "Service Instance is not user provided",
+      "modified": false
+   },
+   {
+      "id": "Service instance {{.InstanceName}} not found",
+      "translation": "Service instance {{.InstanceName}} not found",
       "modified": false
    },
    {
@@ -5137,6 +5162,11 @@
    {
       "id": "WARNING:\n   Providing your password as a command line option is highly discouraged\n   Your password may be visible to others and may be recorded in your shell history\n\n",
       "translation": "WARNING:\n   Providing your password as a command line option is highly discouraged\n   Your password may be visible to others and may be recorded in your shell history\n\n",
+      "modified": false
+   },
+   {
+      "id": "WARNING: This operation assumes that the service broker responsible for this service instance is no longer available or is not responding with a 200 or 410, and the service instance has been deleted, leaving orphan records in Cloud Foundry's database. All knowledge of the service instance will be removed from Cloud Foundry, including service bindings and service keys.",
+      "translation": "WARNING: This operation assumes that the service broker responsible for this service instance is no longer available or is not responding with a 200 or 410, and the service instance has been deleted, leaving orphan records in Cloud Foundry's database. All knowledge of the service instance will be removed from Cloud Foundry, including service bindings and service keys.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -945,6 +945,11 @@
       "modified": false
    },
    {
+      "id": "CF_NAME purge-service-instance SERVICE_INSTANCE",
+      "translation": "CF_NAME purge-service-instance SERVICE_INSTANCE",
+      "modified": false
+   },
+   {
       "id": "CF_NAME purge-service-offering SERVICE [-p PROVIDER]",
       "translation": "CF_NAME purge-service-offering SERVICE [-p PROVIDER]",
       "modified": false
@@ -3855,6 +3860,11 @@
       "modified": false
    },
    {
+      "id": "Purging service {{.InstanceName}}...",
+      "translation": "Purging service {{.InstanceName}}...",
+      "modified": false
+   },
+   {
       "id": "Purging service {{.ServiceName}}...",
       "translation": "Purging service {{.ServiceName}}...",
       "modified": false
@@ -3930,6 +3940,11 @@
       "modified": false
    },
    {
+      "id": "Really purge service instance {{.InstanceName}} from Cloud Foundry?",
+      "translation": "Really purge service instance {{.InstanceName}} from Cloud Foundry?",
+      "modified": false
+   },
+   {
       "id": "Really purge service offering {{.ServiceName}} from Cloud Foundry?",
       "translation": "Really purge service offering {{.ServiceName}} from Cloud Foundry?",
       "modified": false
@@ -3942,6 +3957,11 @@
    {
       "id": "Recursively remove a service and child objects from Cloud Foundry database without making requests to a service broker",
       "translation": "Recursively remove a service and child objects from Cloud Foundry database without making requests to a service broker",
+      "modified": false
+   },
+   {
+      "id": "Recursively remove a service instance and child objects from Cloud Foundry database without making requests to a service broker",
+      "translation": "Recursively remove a service instance and child objects from Cloud Foundry database without making requests to a service broker",
       "modified": false
    },
    {
@@ -4317,6 +4337,11 @@
    {
       "id": "Service Instance is not user provided",
       "translation": "Service Instance is not user provided",
+      "modified": false
+   },
+   {
+      "id": "Service instance {{.InstanceName}} not found",
+      "translation": "Service instance {{.InstanceName}} not found",
       "modified": false
    },
    {
@@ -5137,6 +5162,11 @@
    {
       "id": "WARNING:\n   Providing your password as a command line option is highly discouraged\n   Your password may be visible to others and may be recorded in your shell history\n\n",
       "translation": "WARNING:\n   Providing your password as a command line option is highly discouraged\n   Your password may be visible to others and may be recorded in your shell history\n\n",
+      "modified": false
+   },
+   {
+      "id": "WARNING: This operation assumes that the service broker responsible for this service instance is no longer available or is not responding with a 200 or 410, and the service instance has been deleted, leaving orphan records in Cloud Foundry's database. All knowledge of the service instance will be removed from Cloud Foundry, including service bindings and service keys.",
+      "translation": "WARNING: This operation assumes that the service broker responsible for this service instance is no longer available or is not responding with a 200 or 410, and the service instance has been deleted, leaving orphan records in Cloud Foundry's database. All knowledge of the service instance will be removed from Cloud Foundry, including service bindings and service keys.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -945,6 +945,11 @@
       "modified": false
    },
    {
+      "id": "CF_NAME purge-service-instance SERVICE_INSTANCE",
+      "translation": "CF_NAME purge-service-instance SERVICE_INSTANCE",
+      "modified": false
+   },
+   {
       "id": "CF_NAME purge-service-offering SERVICE [-p PROVIDER]",
       "translation": "CF_NAME purge-service-offering SERVICE [-p PROVEDOR]",
       "modified": false
@@ -3855,6 +3860,11 @@
       "modified": false
    },
    {
+      "id": "Purging service {{.InstanceName}}...",
+      "translation": "Purging service {{.InstanceName}}...",
+      "modified": false
+   },
+   {
       "id": "Purging service {{.ServiceName}}...",
       "translation": "Removendo serviço {{.ServiceName}}...",
       "modified": false
@@ -3930,6 +3940,11 @@
       "modified": false
    },
    {
+      "id": "Really purge service instance {{.InstanceName}} from Cloud Foundry?",
+      "translation": "Really purge service instance {{.InstanceName}} from Cloud Foundry?",
+      "modified": false
+   },
+   {
       "id": "Really purge service offering {{.ServiceName}} from Cloud Foundry?",
       "translation": "Deseja realmente remover oferta de serviço {{.ServiceName}} de Cloud Foundry?",
       "modified": false
@@ -3942,6 +3957,11 @@
    {
       "id": "Recursively remove a service and child objects from Cloud Foundry database without making requests to a service broker",
       "translation": "Remover recursivamente um serviço e seus objetos filhos do banco de dados do Cloud Foundry, sem fazer contato com o corretor de serviços",
+      "modified": false
+   },
+   {
+      "id": "Recursively remove a service instance and child objects from Cloud Foundry database without making requests to a service broker",
+      "translation": "Recursively remove a service instance and child objects from Cloud Foundry database without making requests to a service broker",
       "modified": false
    },
    {
@@ -4317,6 +4337,11 @@
    {
       "id": "Service Instance is not user provided",
       "translation": "Instância de serviço não é fornecida pelo usuário",
+      "modified": false
+   },
+   {
+      "id": "Service instance {{.InstanceName}} not found",
+      "translation": "Service instance {{.InstanceName}} not found",
       "modified": false
    },
    {
@@ -5137,6 +5162,11 @@
    {
       "id": "WARNING:\n   Providing your password as a command line option is highly discouraged\n   Your password may be visible to others and may be recorded in your shell history\n\n",
       "translation": "ATENÇÃO:\n   Fornecendo sua senha através da linha de comando é altamente desaconselhável\n   Sua senha poderá ficar visível para outros usuários do sistema, e pode ser salva como parte do seu histórico de shell\n\n",
+      "modified": false
+   },
+   {
+      "id": "WARNING: This operation assumes that the service broker responsible for this service instance is no longer available or is not responding with a 200 or 410, and the service instance has been deleted, leaving orphan records in Cloud Foundry's database. All knowledge of the service instance will be removed from Cloud Foundry, including service bindings and service keys.",
+      "translation": "WARNING: This operation assumes that the service broker responsible for this service instance is no longer available or is not responding with a 200 or 410, and the service instance has been deleted, leaving orphan records in Cloud Foundry's database. All knowledge of the service instance will be removed from Cloud Foundry, including service bindings and service keys.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -945,6 +945,11 @@
       "modified": false
    },
    {
+      "id": "CF_NAME purge-service-instance SERVICE_INSTANCE",
+      "translation": "CF_NAME purge-service-instance SERVICE_INSTANCE",
+      "modified": false
+   },
+   {
       "id": "CF_NAME purge-service-offering SERVICE [-p PROVIDER]",
       "translation": "CF_NAME purge-service-offering 服务 [-p 提供者]",
       "modified": false
@@ -3855,6 +3860,11 @@
       "modified": false
    },
    {
+      "id": "Purging service {{.InstanceName}}...",
+      "translation": "Purging service {{.InstanceName}}...",
+      "modified": false
+   },
+   {
       "id": "Purging service {{.ServiceName}}...",
       "translation": "清理服务{{.ServiceName}}...",
       "modified": false
@@ -3930,6 +3940,11 @@
       "modified": false
    },
    {
+      "id": "Really purge service instance {{.InstanceName}} from Cloud Foundry?",
+      "translation": "Really purge service instance {{.InstanceName}} from Cloud Foundry?",
+      "modified": false
+   },
+   {
       "id": "Really purge service offering {{.ServiceName}} from Cloud Foundry?",
       "translation": "确定要从Cloud Foundry的清理服务{{.ServiceName}}吗?",
       "modified": false
@@ -3942,6 +3957,11 @@
    {
       "id": "Recursively remove a service and child objects from Cloud Foundry database without making requests to a service broker",
       "translation": "不经过请求服务令牌，递归地从Cloud Foundry的数据库中删除一个服务对象和子对象",
+      "modified": false
+   },
+   {
+      "id": "Recursively remove a service instance and child objects from Cloud Foundry database without making requests to a service broker",
+      "translation": "Recursively remove a service instance and child objects from Cloud Foundry database without making requests to a service broker",
       "modified": false
    },
    {
@@ -4317,6 +4337,11 @@
    {
       "id": "Service Instance is not user provided",
       "translation": "不是用户定义的服务实例",
+      "modified": false
+   },
+   {
+      "id": "Service instance {{.InstanceName}} not found",
+      "translation": "Service instance {{.InstanceName}} not found",
       "modified": false
    },
    {
@@ -5137,6 +5162,11 @@
    {
       "id": "WARNING:\n   Providing your password as a command line option is highly discouraged\n   Your password may be visible to others and may be recorded in your shell history\n\n",
       "translation": "警告:\n   强烈建议不要在命令行参数里指定密码，\n   以防他人读取或通过命令历史记录查找到密码\n\n",
+      "modified": false
+   },
+   {
+      "id": "WARNING: This operation assumes that the service broker responsible for this service instance is no longer available or is not responding with a 200 or 410, and the service instance has been deleted, leaving orphan records in Cloud Foundry's database. All knowledge of the service instance will be removed from Cloud Foundry, including service bindings and service keys.",
+      "translation": "WARNING: This operation assumes that the service broker responsible for this service instance is no longer available or is not responding with a 200 or 410, and the service instance has been deleted, leaving orphan records in Cloud Foundry's database. All knowledge of the service instance will be removed from Cloud Foundry, including service bindings and service keys.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -945,6 +945,11 @@
       "modified": false
    },
    {
+      "id": "CF_NAME purge-service-instance SERVICE_INSTANCE",
+      "translation": "CF_NAME purge-service-instance SERVICE_INSTANCE",
+      "modified": false
+   },
+   {
       "id": "CF_NAME purge-service-offering SERVICE [-p PROVIDER]",
       "translation": "CF_NAME purge-service-offering SERVICE [-p PROVIDER]",
       "modified": false
@@ -3855,6 +3860,11 @@
       "modified": false
    },
    {
+      "id": "Purging service {{.InstanceName}}...",
+      "translation": "Purging service {{.InstanceName}}...",
+      "modified": false
+   },
+   {
       "id": "Purging service {{.ServiceName}}...",
       "translation": "Purging service {{.ServiceName}}...",
       "modified": false
@@ -3930,6 +3940,11 @@
       "modified": false
    },
    {
+      "id": "Really purge service instance {{.InstanceName}} from Cloud Foundry?",
+      "translation": "Really purge service instance {{.InstanceName}} from Cloud Foundry?",
+      "modified": false
+   },
+   {
       "id": "Really purge service offering {{.ServiceName}} from Cloud Foundry?",
       "translation": "Really purge service offering {{.ServiceName}} from Cloud Foundry?",
       "modified": false
@@ -3942,6 +3957,11 @@
    {
       "id": "Recursively remove a service and child objects from Cloud Foundry database without making requests to a service broker",
       "translation": "Recursively remove a service and child objects from Cloud Foundry database without making requests to a service broker",
+      "modified": false
+   },
+   {
+      "id": "Recursively remove a service instance and child objects from Cloud Foundry database without making requests to a service broker",
+      "translation": "Recursively remove a service instance and child objects from Cloud Foundry database without making requests to a service broker",
       "modified": false
    },
    {
@@ -4317,6 +4337,11 @@
    {
       "id": "Service Instance is not user provided",
       "translation": "Service Instance is not user provided",
+      "modified": false
+   },
+   {
+      "id": "Service instance {{.InstanceName}} not found",
+      "translation": "Service instance {{.InstanceName}} not found",
       "modified": false
    },
    {
@@ -5137,6 +5162,11 @@
    {
       "id": "WARNING:\n   Providing your password as a command line option is highly discouraged\n   Your password may be visible to others and may be recorded in your shell history\n\n",
       "translation": "WARNING:\n   Providing your password as a command line option is highly discouraged\n   Your password may be visible to others and may be recorded in your shell history\n\n",
+      "modified": false
+   },
+   {
+      "id": "WARNING: This operation assumes that the service broker responsible for this service instance is no longer available or is not responding with a 200 or 410, and the service instance has been deleted, leaving orphan records in Cloud Foundry's database. All knowledge of the service instance will be removed from Cloud Foundry, including service bindings and service keys.",
+      "translation": "WARNING: This operation assumes that the service broker responsible for this service instance is no longer available or is not responding with a 200 or 410, and the service instance has been deleted, leaving orphan records in Cloud Foundry's database. All knowledge of the service instance will be removed from Cloud Foundry, including service bindings and service keys.",
       "modified": false
    },
    {

--- a/testhelpers/maker/service_instance.go
+++ b/testhelpers/maker/service_instance.go
@@ -9,7 +9,8 @@ func init() {
 }
 
 func NewServiceInstance(name string) (service models.ServiceInstance) {
-	service.Name = name
-	service.Guid = serviceInstanceGuid()
-	return
+	return models.ServiceInstance{ServiceInstanceFields: models.ServiceInstanceFields{
+		Name: name,
+		Guid: serviceInstanceGuid(),
+	}}
 }


### PR DESCRIPTION
Adds a `cf purge-service-instance` that will recursively delete a service instance, its keys and its service bindings.   

Tracker story is [here](https://www.pivotaltracker.com/story/show/102318490).

Best wishes,
@utako, CF CAPI Team