### PR TITLE
Tip for listening on CF port when app start timeout

### DIFF
--- a/cf/commands/application/start.go
+++ b/cf/commands/application/start.go
@@ -311,9 +311,10 @@ func (cmd *Start) waitForOneRunningInstance(app models.Application) {
 
 	for {
 		if time.Since(startupStartTime) > cmd.StartupTimeout {
-			cmd.ui.Failed(fmt.Sprintf(T("Start app timeout\n\nTIP: use '{{.Command}}' for more information",
-				map[string]interface{}{
-					"Command": terminal.CommandColor(fmt.Sprintf("%s logs %s --recent", cf.Name(), app.Name))})))
+			tipMsg := T("Start app timeout\n\nTIP: Application must be listening on the right port. Instead of hard coding the port, use the $PORT environment variable.") + "\n\n"
+			tipMsg += T("Use '{{.Command}}' for more information", map[string]interface{}{"Command": terminal.CommandColor(fmt.Sprintf("%s logs %s --recent", cf.Name(), app.Name))})
+
+			cmd.ui.Failed(tipMsg)
 			return
 		}
 

--- a/cf/commands/application/start_test.go
+++ b/cf/commands/application/start_test.go
@@ -168,7 +168,7 @@ var _ = Describe("start command", func() {
 		return testcmd.RunCliCommandWithoutDependency("start", args, requirementsFactory)
 	}
 
-	callStartWithTimeout := func(args []string) (ui *testterm.FakeUI) {
+	callStartWithLoggingTimeout := func(args []string) (ui *testterm.FakeUI) {
 
 		oldLogsRepoWithTimeout := &testapi.FakeOldLogsRepositoryWithTimeout{}
 
@@ -362,7 +362,7 @@ var _ = Describe("start command", func() {
 			}
 			appRepo.ReadReturns.App = defaultAppForStart
 
-			callStartWithTimeout([]string{"my-app"})
+			callStartWithLoggingTimeout([]string{"my-app"})
 			Expect(ui.Outputs).To(ContainSubstrings(
 				[]string{"timeout connecting to log server"},
 			))
@@ -487,6 +487,29 @@ var _ = Describe("start command", func() {
 				[]string{"my-app"},
 				[]string{"FAILED"},
 				[]string{"is executed from within the directory"},
+			))
+		})
+
+		It("Display a TIP when starting the app timeout", func() {
+			appInstance := models.AppInstanceFields{}
+			appInstance.State = models.InstanceStarting
+			appInstance2 := models.AppInstanceFields{}
+			appInstance2.State = models.InstanceStarting
+			appInstance3 := models.AppInstanceFields{}
+			appInstance3.State = models.InstanceStarting
+			appInstance4 := models.AppInstanceFields{}
+			appInstance4.State = models.InstanceStarting
+			defaultInstanceResponses = [][]models.AppInstanceFields{
+				[]models.AppInstanceFields{appInstance, appInstance2},
+				[]models.AppInstanceFields{appInstance3, appInstance4},
+			}
+
+			defaultInstanceErrorCodes = []string{"", ""}
+
+			ui, _, _ := startAppWithInstancesAndErrors(displayApp, defaultAppForStart, requirementsFactory)
+
+			Expect(ui.Outputs).To(ContainSubstrings(
+				[]string{"TIP: Application must be listening on the right port."},
 			))
 		})
 

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -4310,9 +4310,9 @@
       "modified": false
    },
    {
-      "id": "Start app timeout\n\nTIP: use '{{.Command}}' for more information",
-      "translation": "Start app timeout\n\nTIP: use '{{.Command}}' for more information",
-      "modified": false
+      "id": "Start app timeout\n\nTIP: Application must be listening on the right port. Instead of hard coding the port, use the $PORT environment variable.",
+      "translation": "Start app timeout\n\nTIP: Application must be listening on the right port.\n     Instead of hard coding the port, use the $PORT environment variable.",
+      "modified": true
    },
    {
       "id": "Start unsuccessful\n\nTIP: use '{{.Command}}' for more information",
@@ -4788,6 +4788,11 @@
       "id": "Url",
       "translation": "Url",
       "modified": false
+   },
+   {
+      "id": "Use '{{.Command}}' for more information",
+      "translation": "Start app timeout\n\nTIP: use '{{.Command}}' for more information",
+      "modified": true
    },
    {
       "id": "Use '{{.Name}}' to view or set your target org and space",

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -4310,8 +4310,8 @@
       "modified": false
    },
    {
-      "id": "Start app timeout\n\nTIP: use '{{.Command}}' for more information",
-      "translation": "Start app timeout\n\nTIP: use '{{.Command}}' for more information",
+      "id": "Start app timeout\n\nTIP: Application must be listening on the right port. Instead of hard coding the port, use the $PORT environment variable.",
+      "translation": "Start app timeout\n\nTIP: Application must be listening on the right port. Instead of hard coding the port, use the $PORT environment variable.",
       "modified": false
    },
    {
@@ -4787,6 +4787,11 @@
    {
       "id": "Url",
       "translation": "Url",
+      "modified": false
+   },
+   {
+      "id": "Use '{{.Command}}' for more information",
+      "translation": "Use '{{.Command}}' for more information",
       "modified": false
    },
    {

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -4310,9 +4310,9 @@
       "modified": false
    },
    {
-      "id": "Start app timeout\n\nTIP: use '{{.Command}}' for more information",
-      "translation": "Tiempo de espera para comienzo de app\n\nTIP: usar '{{.Command}}' para mas informacion",
-      "modified": false
+      "id": "Start app timeout\n\nTIP: Application must be listening on the right port. Instead of hard coding the port, use the $PORT environment variable.",
+      "translation": "Start app timeout\n\nTIP: Application must be listening on the right port.\n     Instead of hard coding the port, use the $PORT environment variable.",
+      "modified": true
    },
    {
       "id": "Start unsuccessful\n\nTIP: use '{{.Command}}' for more information",
@@ -4788,6 +4788,11 @@
       "id": "Url",
       "translation": "Url",
       "modified": false
+   },
+   {
+      "id": "Use '{{.Command}}' for more information",
+      "translation": "Tiempo de espera para comienzo de app\n\nTIP: usar '{{.Command}}' para mas informacion",
+      "modified": true
    },
    {
       "id": "Use '{{.Name}}' to view or set your target org and space",

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -4310,9 +4310,9 @@
       "modified": false
    },
    {
-      "id": "Start app timeout\n\nTIP: use '{{.Command}}' for more information",
-      "translation": "Lancer l'application délai\n\nTIP: utiliser '{{.Command}}' pour plus d'informations",
-      "modified": false
+      "id": "Start app timeout\n\nTIP: Application must be listening on the right port. Instead of hard coding the port, use the $PORT environment variable.",
+      "translation": "Start app timeout\n\nTIP: Application must be listening on the right port.\n     Instead of hard coding the port, use the $PORT environment variable.",
+      "modified": true
    },
    {
       "id": "Start unsuccessful\n\nTIP: use '{{.Command}}' for more information",
@@ -4788,6 +4788,11 @@
       "id": "Url",
       "translation": "Url",
       "modified": false
+   },
+   {
+      "id": "Use '{{.Command}}' for more information",
+      "translation": "Lancer l'application délai\n\nTIP: utiliser '{{.Command}}' pour plus d'informations",
+      "modified": true
    },
    {
       "id": "Use '{{.Name}}' to view or set your target org and space",

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -4310,9 +4310,9 @@
       "modified": false
    },
    {
-      "id": "Start app timeout\n\nTIP: use '{{.Command}}' for more information",
-      "translation": "Start app timeout\n\nTIP: use '{{.Command}}' for more information",
-      "modified": false
+      "id": "Start app timeout\n\nTIP: Application must be listening on the right port. Instead of hard coding the port, use the $PORT environment variable.",
+      "translation": "Start app timeout\n\nTIP: Application must be listening on the right port.\n     Instead of hard coding the port, use the $PORT environment variable.",
+      "modified": true
    },
    {
       "id": "Start unsuccessful\n\nTIP: use '{{.Command}}' for more information",
@@ -4788,6 +4788,11 @@
       "id": "Url",
       "translation": "Url",
       "modified": false
+   },
+   {
+      "id": "Use '{{.Command}}' for more information",
+      "translation": "Start app timeout\n\nTIP: use '{{.Command}}' for more information",
+      "modified": true
    },
    {
       "id": "Use '{{.Name}}' to view or set your target org and space",

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -4310,9 +4310,9 @@
       "modified": false
    },
    {
-      "id": "Start app timeout\n\nTIP: use '{{.Command}}' for more information",
-      "translation": "Start app timeout\n\nTIP: use '{{.Command}}' for more information",
-      "modified": false
+      "id": "Start app timeout\n\nTIP: Application must be listening on the right port. Instead of hard coding the port, use the $PORT environment variable.",
+      "translation": "Start app timeout\n\nTIP: Application must be listening on the right port.\n     Instead of hard coding the port, use the $PORT environment variable.",
+      "modified": true
    },
    {
       "id": "Start unsuccessful\n\nTIP: use '{{.Command}}' for more information",
@@ -4788,6 +4788,11 @@
       "id": "Url",
       "translation": "Url",
       "modified": false
+   },
+   {
+      "id": "Use '{{.Command}}' for more information",
+      "translation": "Start app timeout\n\nTIP: use '{{.Command}}' for more information",
+      "modified": true
    },
    {
       "id": "Use '{{.Name}}' to view or set your target org and space",

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -4310,9 +4310,9 @@
       "modified": false
    },
    {
-      "id": "Start app timeout\n\nTIP: use '{{.Command}}' for more information",
-      "translation": "Tempo de inicialização limite para aplicativo\n\nDICA: utilize '{{.Command}}' para maiores informações",
-      "modified": false
+      "id": "Start app timeout\n\nTIP: Application must be listening on the right port. Instead of hard coding the port, use the $PORT environment variable.",
+      "translation": "Start app timeout\n\nTIP: Application must be listening on the right port.\n     Instead of hard coding the port, use the $PORT environment variable.",
+      "modified": true
    },
    {
       "id": "Start unsuccessful\n\nTIP: use '{{.Command}}' for more information",
@@ -4788,6 +4788,11 @@
       "id": "Url",
       "translation": "Url",
       "modified": false
+   },
+   {
+      "id": "Use '{{.Command}}' for more information",
+      "translation": "Tempo de inicialização limite para aplicativo\n\nDICA: utilize '{{.Command}}' para maiores informações",
+      "modified": true
    },
    {
       "id": "Use '{{.Name}}' to view or set your target org and space",

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -4310,9 +4310,9 @@
       "modified": false
    },
    {
-      "id": "Start app timeout\n\nTIP: use '{{.Command}}' for more information",
-      "translation": "启动应用程序超时\n\n小贴士: 使用'{{.Command}}'以获取更多信息",
-      "modified": false
+      "id": "Start app timeout\n\nTIP: Application must be listening on the right port. Instead of hard coding the port, use the $PORT environment variable.",
+      "translation": "Start app timeout\n\nTIP: Application must be listening on the right port.\n     Instead of hard coding the port, use the $PORT environment variable.",
+      "modified": true
    },
    {
       "id": "Start unsuccessful\n\nTIP: use '{{.Command}}' for more information",
@@ -4788,6 +4788,11 @@
       "id": "Url",
       "translation": "Url",
       "modified": false
+   },
+   {
+      "id": "Use '{{.Command}}' for more information",
+      "translation": "启动应用程序超时\n\n小贴士: 使用'{{.Command}}'以获取更多信息",
+      "modified": true
    },
    {
       "id": "Use '{{.Name}}' to view or set your target org and space",

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -4310,9 +4310,9 @@
       "modified": false
    },
    {
-      "id": "Start app timeout\n\nTIP: use '{{.Command}}' for more information",
-      "translation": "Start app timeout\n\nTIP: use '{{.Command}}' for more information",
-      "modified": false
+      "id": "Start app timeout\n\nTIP: Application must be listening on the right port. Instead of hard coding the port, use the $PORT environment variable.",
+      "translation": "Start app timeout\n\nTIP: Application must be listening on the right port.\n     Instead of hard coding the port, use the $PORT environment variable.",
+      "modified": true
    },
    {
       "id": "Start unsuccessful\n\nTIP: use '{{.Command}}' for more information",
@@ -4788,6 +4788,11 @@
       "id": "Url",
       "translation": "Url",
       "modified": false
+   },
+   {
+      "id": "Use '{{.Command}}' for more information",
+      "translation": "Start app timeout\n\nTIP: use '{{.Command}}' for more information",
+      "modified": true
    },
    {
       "id": "Use '{{.Name}}' to view or set your target org and space",


### PR DESCRIPTION
This PR addresses the tracker story [#97340332](https://www.pivotaltracker.com/story/show/97340332)

A friendly 'TIP' is shown when start app timeout.

example output

```
Starting app demo-app in org test / space test as admin...

0 of 1 instances running, 1 starting
0 of 1 instances running, 1 starting
0 of 1 instances running, 1 starting
0 of 1 instances running, 1 starting
0 of 1 instances running, 1 down
FAILED
Start app timeout

TIP: Application must be listening on the right port. Instead of hard coding the port, use the $PORT environment variable.

Use 'cf logs demo-app --recent' for more information
```