### PR TITLE
download links are hard to work with

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Downloads
 | [Debian 32 bit](https://cli.run.pivotal.io/stable?release=debian32&source=github)
 | [Debian 64 bit](https://cli.run.pivotal.io/stable?release=debian64&source=github)
 
-**Note** When downloading from the command line, you may need to rename the file before untarring as the above urls are redirected. 
+**Note** When downloading from the command line, you may need to rename the file before untarring as the above links are redirected. 
 
 ```
 $ wget 'https://cli.run.pivotal.io/stable?release=linux64-binary&source=github' -O cf-darwin-amd64.tgz

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ Downloads
 | [Debian 32 bit](https://cli.run.pivotal.io/stable?release=debian32&source=github)
 | [Debian 64 bit](https://cli.run.pivotal.io/stable?release=debian64&source=github)
 
+**Note** When downloading from the command line, you may need to rename the file before untarring as the above urls are redirected. 
+
+```
+$ wget 'https://cli.run.pivotal.io/stable?release=linux64-binary&source=github' -O cf-darwin-amd64.tgz
+$ tar -xf cf-darwin-amd64.tgz
+```
 
 **Experimental:** Install CF for OSX through [Homebrew](http://brew.sh/) via the [pivotal's homebrew-tap](https://github.com/pivotal/homebrew-tap):
 


### PR DESCRIPTION
on ubuntu
```
 wget 'https://cli.run.pivotal.io/stable?release=linux64-binary&source=github'
--2015-10-08 22:33:56--  https://cli.run.pivotal.io/stable?release=linux64-binary&source=github
Resolving cli.run.pivotal.io (cli.run.pivotal.io)... 52.21.135.158, 52.2.163.125
Connecting to cli.run.pivotal.io (cli.run.pivotal.io)|52.21.135.158|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: http://go-cli.s3-website-us-east-1.amazonaws.com/releases/v6.12.4/cf-linux-amd64.tgz [following]
--2015-10-08 22:33:57--  http://go-cli.s3-website-us-east-1.amazonaws.com/releases/v6.12.4/cf-linux-amd64.tgz
Resolving go-cli.s3-website-us-east-1.amazonaws.com (go-cli.s3-website-us-east-1.amazonaws.com)... 54.231.97.226
Connecting to go-cli.s3-website-us-east-1.amazonaws.com (go-cli.s3-website-us-east-1.amazonaws.com)|54.231.97.226|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: 5012747 (4.8M) [application/gzip]
Saving to: ‘stable?release=linux64-binary&source=github’

100%[===========================================================================================================================================>] 5,012,747   2.02MB/s   in 2.4s

2015-10-08 22:33:59 (2.02 MB/s) - ‘stable?release=linux64-binary&source=github’ saved [5012747/5012747]
```

on osx
```
$ wget 'https://cli.run.pivotal.io/stable?release=macosx64-binary&source=github'
--2015-10-08 15:35:27--  https://cli.run.pivotal.io/stable?release=macosx64-binary&source=github
Resolving cli.run.pivotal.io... 52.21.135.158, 52.2.163.125
Connecting to cli.run.pivotal.io|52.21.135.158|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: http://go-cli.s3-website-us-east-1.amazonaws.com/releases/v6.12.4/cf-darwin-amd64.tgz [following]
--2015-10-08 15:35:27--  http://go-cli.s3-website-us-east-1.amazonaws.com/releases/v6.12.4/cf-darwin-amd64.tgz
Resolving go-cli.s3-website-us-east-1.amazonaws.com... 54.231.8.4
Connecting to go-cli.s3-website-us-east-1.amazonaws.com|54.231.8.4|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: 4702181 (4.5M) [application/gzip]
Saving to: 'stable?release=macosx64-binary&source=github'

stable?release=macosx64-binary&source=github  100%[================================================================================================>]   4.48M  1.32MB/s   in 3.6s

2015-10-08 15:35:31 (1.25 MB/s) - 'stable?release=macosx64-binary&source=github' saved [4702181/4702181]
```

the docs don't mention that the dl is a tarball. if the dl resulted in a .tgz file, users would know what to do next. but without instructions, it's not intuitive what to do with a file called `stable?release=macosx64-binary&source=github`.