### PR TITLE
Fix for serviceaccess help

### DIFF
--- a/cf/commands/serviceaccess/service_access.go
+++ b/cf/commands/serviceaccess/service_access.go
@@ -30,7 +30,7 @@ func init() {
 func (cmd *ServiceAccess) MetaData() command_registry.CommandMetadata {
 	fs := make(map[string]flags.FlagSet)
 	fs["b"] = &cliFlags.StringFlag{Name: "b", Usage: T("access for plans of a particular broker")}
-	fs["e"] = &cliFlags.StringFlag{Name: "e", Usage: T("access for plans of a particular service offering")}
+	fs["e"] = &cliFlags.StringFlag{Name: "e", Usage: T("access for service name of a particular service offering")}
 	fs["o"] = &cliFlags.StringFlag{Name: "o", Usage: T("plans accessible by a particular organization")}
 
 	return command_registry.CommandMetadata{

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -4960,8 +4960,8 @@
       "modified": true
    },
    {
-      "id": "access for plans of a particular service offering",
-      "translation": "settings for a specific broker",
+      "id": "access for service name of a particular service offering",
+      "translation": "access for service name of a particular service offering",
       "modified": true
    },
    {

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -4960,8 +4960,8 @@
       "modified": false
    },
    {
-      "id": "access for plans of a particular service offering",
-      "translation": "access for plans of a particular service offering",
+      "id": "access for service name of a particular service offering",
+      "translation": "access for service name of a particular service offering",
       "modified": false
    },
    {

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -4960,8 +4960,8 @@
       "modified": true
    },
    {
-      "id": "access for plans of a particular service offering",
-      "translation": "settings for a specific broker",
+      "id": "access for service name of a particular service offering",
+      "translation": "access for service name of a particular service offering",
       "modified": true
    },
    {

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -4960,8 +4960,8 @@
       "modified": true
    },
    {
-      "id": "access for plans of a particular service offering",
-      "translation": "settings for a specific broker",
+      "id": "access for service name of a particular service offering",
+      "translation": "access for service name of a particular service offering",
       "modified": true
    },
    {

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -4960,8 +4960,8 @@
       "modified": true
    },
    {
-      "id": "access for plans of a particular service offering",
-      "translation": "settings for a specific broker",
+      "id": "access for service name of a particular service offering",
+      "translation": "access for service name of a particular service offering",
       "modified": true
    },
    {

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -4960,8 +4960,8 @@
       "modified": true
    },
    {
-      "id": "access for plans of a particular service offering",
-      "translation": "settings for a specific broker",
+      "id": "access for service name of a particular service offering",
+      "translation": "access for service name of a particular service offering",
       "modified": true
    },
    {

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -4960,8 +4960,8 @@
       "modified": true
    },
    {
-      "id": "access for plans of a particular service offering",
-      "translation": "configurações de planos específicas à uma oferta de serviço",
+      "id": "access for service name of a particular service offering",
+      "translation": "acesso para o nome de uma oferta de servi?o determinado servi?o",
       "modified": true
    },
    {

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -4960,8 +4960,8 @@
       "modified": true
    },
    {
-      "id": "access for plans of a particular service offering",
-      "translation": "settings for a specific broker",
+      "id": "access for service name of a particular service offering",
+      "translation": "access for service name of a particular service offering",
       "modified": true
    },
    {

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -4960,8 +4960,8 @@
       "modified": true
    },
    {
-      "id": "access for plans of a particular service offering",
-      "translation": "settings for a specific broker",
+      "id": "access for service name of a particular service offering",
+      "translation": "access for service name of a particular service offering",
       "modified": true
    },
    {


### PR DESCRIPTION
Fix the service-access help
https://www.pivotaltracker.com/story/show/100663714
Before Fix:

# cf help service-access
NAME:
   service-access - List service access settings

USAGE:
   cf service-access [-b BROKER] [-e SERVICE] [-o ORG]

OPTIONS:
   -b       access for plans of a particular broker
   -e       access for plans of a particular service offering
   -o       plans accessible by a particular organization

After Fix:

./out/cf help service-access
NAME:
   service-access - List service access settings

USAGE:
   cf service-access [-b BROKER] [-e SERVICE] [-o ORG]

OPTIONS:
   -b       access for plans of a particular broker
   -e       access for service name of a particular service offering
   -o       plans accessible by a particular organization