### PR TITLE
Fix router-groups command error handling

### DIFF
--- a/cf/api/repository_locator.go
+++ b/cf/api/repository_locator.go
@@ -80,6 +80,7 @@ func NewRepositoryLocator(config core_config.ReadWriter, gatewaysByName map[stri
 
 	authGateway := gatewaysByName["auth"]
 	cloudControllerGateway := gatewaysByName["cloud-controller"]
+	routingApiGateway := gatewaysByName["routing-api"]
 	uaaGateway := gatewaysByName["uaa"]
 	loc.authRepo = authentication.NewUAAAuthenticationRepository(authGateway, config)
 
@@ -111,7 +112,7 @@ func NewRepositoryLocator(config core_config.ReadWriter, gatewaysByName map[stri
 	loc.passwordRepo = password.NewCloudControllerPasswordRepository(config, uaaGateway)
 	loc.quotaRepo = quotas.NewCloudControllerQuotaRepository(config, cloudControllerGateway)
 	loc.routeRepo = NewCloudControllerRouteRepository(config, cloudControllerGateway)
-	loc.routingApiRepo = NewRoutingApiRepository(config, cloudControllerGateway)
+	loc.routingApiRepo = NewRoutingApiRepository(config, routingApiGateway)
 	loc.stackRepo = stacks.NewCloudControllerStackRepository(config, cloudControllerGateway)
 	loc.serviceRepo = NewCloudControllerServiceRepository(config, cloudControllerGateway)
 	loc.serviceKeyRepo = NewCloudControllerServiceKeyRepository(config, cloudControllerGateway)

--- a/cf/command_registry/dependency.go
+++ b/cf/command_registry/dependency.go
@@ -93,6 +93,7 @@ func NewDependency() Dependency {
 		"auth":             net.NewUAAGateway(deps.Config, deps.Ui),
 		"cloud-controller": net.NewCloudControllerGateway(deps.Config, time.Now, deps.Ui),
 		"uaa":              net.NewUAAGateway(deps.Config, deps.Ui),
+		"routing-api":      net.NewRoutingApiGateway(deps.Config, time.Now, deps.Ui),
 	}
 	deps.RepoLocator = api.NewRepositoryLocator(deps.Config, deps.Gateways)
 

--- a/cf/net/routing_api_gateway.go
+++ b/cf/net/routing_api_gateway.go
@@ -1,0 +1,33 @@
+package net
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/cloudfoundry/cli/cf/configuration/core_config"
+	"github.com/cloudfoundry/cli/cf/errors"
+	"github.com/cloudfoundry/cli/cf/terminal"
+)
+
+type errorResponse struct {
+	Name    string
+	Message string
+}
+
+func errorHandler(statusCode int, body []byte) error {
+	response := errorResponse{}
+	err := json.Unmarshal(body, &response)
+	if err != nil {
+		return errors.NewHttpError(http.StatusInternalServerError, "", "")
+	}
+
+	return errors.NewHttpError(statusCode, response.Name, response.Message)
+}
+
+func NewRoutingApiGateway(config core_config.Reader, clock func() time.Time, ui terminal.UI) Gateway {
+	gateway := newGateway(errorHandler, config, ui)
+	gateway.Clock = clock
+	gateway.PollingEnabled = true
+	return gateway
+}

--- a/cf/net/routing_api_gateway_test.go
+++ b/cf/net/routing_api_gateway_test.go
@@ -1,0 +1,85 @@
+package net_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/cloudfoundry/cli/cf/configuration/core_config"
+	"github.com/cloudfoundry/cli/cf/errors"
+	. "github.com/cloudfoundry/cli/cf/net"
+	testconfig "github.com/cloudfoundry/cli/testhelpers/configuration"
+	testterm "github.com/cloudfoundry/cli/testhelpers/terminal"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var failingRoutingApiRequest = func(writer http.ResponseWriter, request *http.Request) {
+	writer.WriteHeader(http.StatusBadRequest)
+	jsonResponse := `{ "name": "some-error", "message": "The host is taken: test1" }`
+	fmt.Fprintln(writer, jsonResponse)
+}
+
+var invalidTokenRoutingApiRequest = func(writer http.ResponseWriter, request *http.Request) {
+	writer.WriteHeader(http.StatusUnauthorized)
+	jsonResponse := `{ "name": "UnauthorizedError", "message": "bad token!" }`
+	fmt.Fprintln(writer, jsonResponse)
+}
+
+var _ = Describe("Routing Api Gateway", func() {
+	var gateway Gateway
+	var config core_config.Reader
+
+	BeforeEach(func() {
+		config = testconfig.NewRepository()
+		gateway = NewRoutingApiGateway(config, time.Now, &testterm.FakeUI{})
+	})
+
+	It("parses error responses", func() {
+		ts := httptest.NewTLSServer(http.HandlerFunc(failingRoutingApiRequest))
+		defer ts.Close()
+		gateway.SetTrustedCerts(ts.TLS.Certificates)
+
+		request, apiErr := gateway.NewRequest("GET", ts.URL, "TOKEN", nil)
+		_, apiErr = gateway.PerformRequest(request)
+
+		Expect(apiErr).NotTo(BeNil())
+		Expect(apiErr.Error()).To(ContainSubstring("The host is taken: test1"))
+		Expect(apiErr.(errors.HttpError).ErrorCode()).To(ContainSubstring("some-error"))
+	})
+
+	It("parses invalid token responses", func() {
+		ts := httptest.NewTLSServer(http.HandlerFunc(invalidTokenRoutingApiRequest))
+		defer ts.Close()
+		gateway.SetTrustedCerts(ts.TLS.Certificates)
+
+		request, apiErr := gateway.NewRequest("GET", ts.URL, "TOKEN", nil)
+		_, apiErr = gateway.PerformRequest(request)
+
+		Expect(apiErr).NotTo(BeNil())
+		Expect(apiErr.Error()).To(ContainSubstring("bad token"))
+		Expect(apiErr.(errors.HttpError)).To(HaveOccurred())
+	})
+
+	Context("when the Routing API returns a invalid Json", func() {
+		var invalidJsonResponse = func(writer http.ResponseWriter, request *http.Request) {
+			writer.WriteHeader(http.StatusUnauthorized)
+			jsonResponse := `¯\_(ツ)_/¯`
+			fmt.Fprintln(writer, jsonResponse)
+		}
+
+		It("returns a 500 http error", func() {
+			ts := httptest.NewTLSServer(http.HandlerFunc(invalidJsonResponse))
+			defer ts.Close()
+			gateway.SetTrustedCerts(ts.TLS.Certificates)
+
+			request, apiErr := gateway.NewRequest("GET", ts.URL, "TOKEN", nil)
+			_, apiErr = gateway.PerformRequest(request)
+
+			Expect(apiErr).NotTo(BeNil())
+			Expect(apiErr.(errors.HttpError)).To(HaveOccurred())
+			Expect(apiErr.(errors.HttpError).StatusCode()).To(Equal(http.StatusInternalServerError))
+		})
+	})
+})


### PR DESCRIPTION
This PR is to fix the error handling of `cf router-groups` command.

The Routing API Repository was using the Cloud Controller Gateway and error messages returned by the Routing API were ignored.  Created Routing API Gateway and changed the Routing API Repository to use the newly created gateway.

Pivotal tracker story: https://www.pivotaltracker.com/story/show/100975070

Thanks,
@leochu and @yuzhangcmu
(CF Routing Team)