### PR TITLE
Fix 'cf stack' to display accurate error message for incorrect usage

### DIFF
--- a/cf/commands/stack.go
+++ b/cf/commands/stack.go
@@ -36,7 +36,7 @@ func (cmd *ListStack) MetaData() command_registry.CommandMetadata {
 
 func (cmd *ListStack) Requirements(requirementsFactory requirements.Factory, fc flags.FlagContext) (reqs []requirements.Requirement, err error) {
 	if len(fc.Args()) != 1 {
-		cmd.ui.Failed(T("Incorrect Usage. Requires app name as argument\n\n") + command_registry.Commands.CommandUsage("auth"))
+		cmd.ui.Failed(T("Incorrect Usage. Requires stack name as argument\n\n") + command_registry.Commands.CommandUsage("stack"))
 	}
 
 	reqs = append(reqs, requirementsFactory.NewLoginRequirement())


### PR DESCRIPTION
#### Fix 'cf stack' to display accurate error message for incorrect usage

##### Before fix:
```
➜  cli git:(master) cf stack
FAILED
Incorrect Usage. Requires app name as argument

NAME:
   auth - Authenticate user non-interactively

USAGE:
   cf auth USERNAME PASSWORD

WARNING:
   Providing your password as a command line option is highly discouraged
   Your password may be visible to others and may be recorded in your shell history

EXAMPLE:
   cf auth name@example.com "my password" (use quotes for passwords with a space)
   cf auth name@example.com "\"password\"" (escape quotes if used in password)
```
##### After fix:
```
➜  cli git:(master) cf stack
FAILED
Incorrect Usage. Requires stack name as argument

NAME:
   stack - Show information for a stack (a stack is a pre-built file system, including an operating system, that can run apps)

USAGE:
   cf stack STACK_NAME

OPTIONS:
   --guid      Retrieve and display the given stack's guid. All other output for the stack is suppressed.
```