### PR TITLE
Fix issues in stacks and stack commands

### DIFF
--- a/cf/commands/stack.go
+++ b/cf/commands/stack.go
@@ -36,7 +36,7 @@ func (cmd *ListStack) MetaData() command_registry.CommandMetadata {
 
 func (cmd *ListStack) Requirements(requirementsFactory requirements.Factory, fc flags.FlagContext) (reqs []requirements.Requirement, err error) {
 	if len(fc.Args()) != 1 {
-		cmd.ui.Failed(T("Incorrect Usage. Requires app name as argument\n\n") + command_registry.Commands.CommandUsage("auth"))
+		cmd.ui.Failed(T("Incorrect Usage. Requires stack name as argument\n\n") + command_registry.Commands.CommandUsage("stack"))
 	}
 
 	reqs = append(reqs, requirementsFactory.NewLoginRequirement())

--- a/cf/commands/stack_test.go
+++ b/cf/commands/stack_test.go
@@ -53,7 +53,7 @@ var _ = Describe("stack command", func() {
 			Expect(testcmd.RunCliCommand("stack", []string{}, requirementsFactory, updateCommandDependency, false)).To(BeFalse())
 			Expect(ui.Outputs).To(ContainSubstrings(
 				[]string{"FAILED"},
-				[]string{"Incorrect Usage."},
+				[]string{"Incorrect Usage.", "Requires stack name as argument"},
 			))
 		})
 	})

--- a/cf/commands/stacks.go
+++ b/cf/commands/stacks.go
@@ -30,7 +30,7 @@ func (cmd *ListStacks) MetaData() command_registry.CommandMetadata {
 
 func (cmd *ListStacks) Requirements(requirementsFactory requirements.Factory, fc flags.FlagContext) (reqs []requirements.Requirement, err error) {
 	if len(fc.Args()) != 0 {
-		cmd.ui.Failed(T("Incorrect Usage. Requires app name as argument\n\n") + command_registry.Commands.CommandUsage("stacks"))
+		cmd.ui.Failed(T("Incorrect Usage. No argument required\n\n") + command_registry.Commands.CommandUsage("stacks"))
 	}
 
 	reqs = append(reqs, requirementsFactory.NewLoginRequirement())

--- a/cf/commands/stacks_test.go
+++ b/cf/commands/stacks_test.go
@@ -50,7 +50,7 @@ var _ = Describe("stacks command", func() {
 			Expect(testcmd.RunCliCommand("stacks", []string{"etcetc"}, requirementsFactory, updateCommandDependency, false)).To(BeFalse())
 			Expect(ui.Outputs).To(ContainSubstrings(
 				[]string{"FAILED"},
-				[]string{"Incorrect Usage."},
+				[]string{"Incorrect Usage", "No argument required"},
 			))
 		})
 	})

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -2990,6 +2990,11 @@
       "modified": false
    },
    {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
+      "modified": false
+   },
+   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -2990,6 +2990,11 @@
       "modified": false
    },
    {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
+      "modified": false
+   },
+   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -2990,6 +2990,11 @@
       "modified": false
    },
    {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
+      "modified": false
+   },
+   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -2990,6 +2990,11 @@
       "modified": false
    },
    {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
+      "modified": false
+   },
+   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -2990,6 +2990,11 @@
       "modified": false
    },
    {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
+      "modified": false
+   },
+   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -2990,6 +2990,11 @@
       "modified": false
    },
    {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
+      "modified": false
+   },
+   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -2990,6 +2990,11 @@
       "modified": false
    },
    {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
+      "modified": false
+   },
+   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -2990,6 +2990,11 @@
       "modified": false
    },
    {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
+      "modified": false
+   },
+   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -2990,6 +2990,11 @@
       "modified": false
    },
    {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
+      "modified": false
+   },
+   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false


### PR DESCRIPTION
Fix issues in stacks and stack commands

Before Fix:
# cf stacks aaa
FAILED
Incorrect Usage. Requires app name as argument
NAME:
   stacks - List all stacks (a stack is a pre-built file system, including an operating system, that can run apps)
USAGE:
   cf stacks

# cf stack
FAILED
Incorrect Usage. Requires app name as argument
NAME:
   auth - Authenticate user non-interactively
USAGE:
   cf auth USERNAME PASSWORD
WARNING:
   Providing your password as a command line option is highly discouraged
   Your password may be visible to others and may be recorded in your shell history
EXAMPLE:
   cf auth name@example.com "my password" (use quotes for passwords with a space)
   cf auth name@example.com "\"password\"" (escape quotes if used in password)



After Fix:

# ./out/cf stacks aaa
FAILED
Incorrect Usage. No argument required
NAME:
   stacks - List all stacks (a stack is a pre-built file system, including an operating system, that can run apps)
USAGE:
   cf stacks

# ./out/cf stack
FAILED
Incorrect Usage. Requires stack name as argument
NAME:
   stack - Show information for a stack (a stack is a pre-built file system, including an operating system, that can run apps)
USAGE:
   cf stack STACK_NAME
OPTIONS:
   --guid      Retrieve and display the given stack's guid. All other output for the stack is suppressed.


Any suggestions are comments are welcome.