### PR TITLE
Fix 'cf stack' and 'cf stacks' to display accurate error message

### DIFF
--- a/cf/commands/stack.go
+++ b/cf/commands/stack.go
@@ -36,7 +36,7 @@ func (cmd *ListStack) MetaData() command_registry.CommandMetadata {
 
 func (cmd *ListStack) Requirements(requirementsFactory requirements.Factory, fc flags.FlagContext) (reqs []requirements.Requirement, err error) {
 	if len(fc.Args()) != 1 {
-		cmd.ui.Failed(T("Incorrect Usage. Requires app name as argument\n\n") + command_registry.Commands.CommandUsage("auth"))
+		cmd.ui.Failed(T("Incorrect Usage. Requires stack name as argument\n\n") + command_registry.Commands.CommandUsage("stack"))
 	}
 
 	reqs = append(reqs, requirementsFactory.NewLoginRequirement())

--- a/cf/commands/stacks.go
+++ b/cf/commands/stacks.go
@@ -30,7 +30,7 @@ func (cmd *ListStacks) MetaData() command_registry.CommandMetadata {
 
 func (cmd *ListStacks) Requirements(requirementsFactory requirements.Factory, fc flags.FlagContext) (reqs []requirements.Requirement, err error) {
 	if len(fc.Args()) != 0 {
-		cmd.ui.Failed(T("Incorrect Usage. Requires app name as argument\n\n") + command_registry.Commands.CommandUsage("stacks"))
+		cmd.ui.Failed(T("Incorrect Usage. Does not require an argument\n\n") + command_registry.Commands.CommandUsage("stacks"))
 	}
 
 	reqs = append(reqs, requirementsFactory.NewLoginRequirement())

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -2815,6 +2815,11 @@
       "modified": false
    },
    {
+      "id": "Incorrect Usage. Does not require an argument\n\n",
+      "translation": "Incorrect Usage. Does not require an argument\n\n",
+      "modified": false
+   },
+   {
       "id": "Incorrect Usage. HEALTH_CHECK_TYPE must be \"port\" or \"none\"\\n\\n",
       "translation": "Incorrect Usage. HEALTH_CHECK_TYPE must be \"port\" or \"none\"\\n\\n",
       "modified": false
@@ -3027,6 +3032,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -2815,6 +2815,11 @@
       "modified": false
    },
    {
+      "id": "Incorrect Usage. Does not require an argument\n\n",
+      "translation": "Incorrect Usage. Does not require an argument\n\n",
+      "modified": false
+   },
+   {
       "id": "Incorrect Usage. HEALTH_CHECK_TYPE must be \"port\" or \"none\"\\n\\n",
       "translation": "Incorrect Usage. HEALTH_CHECK_TYPE must be \"port\" or \"none\"\\n\\n",
       "modified": false
@@ -3027,6 +3032,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -2815,6 +2815,11 @@
       "modified": false
    },
    {
+      "id": "Incorrect Usage. Does not require an argument\n\n",
+      "translation": "Incorrect Usage. Does not require an argument\n\n",
+      "modified": false
+   },
+   {
       "id": "Incorrect Usage. HEALTH_CHECK_TYPE must be \"port\" or \"none\"\\n\\n",
       "translation": "Incorrect Usage. HEALTH_CHECK_TYPE must be \"port\" or \"none\"\\n\\n",
       "modified": false
@@ -3027,6 +3032,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -2815,6 +2815,11 @@
       "modified": false
    },
    {
+      "id": "Incorrect Usage. Does not require an argument\n\n",
+      "translation": "Incorrect Usage. Does not require an argument\n\n",
+      "modified": false
+   },
+   {
       "id": "Incorrect Usage. HEALTH_CHECK_TYPE must be \"port\" or \"none\"\\n\\n",
       "translation": "Incorrect Usage. HEALTH_CHECK_TYPE must be \"port\" or \"none\"\\n\\n",
       "modified": false
@@ -3027,6 +3032,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -2815,6 +2815,11 @@
       "modified": false
    },
    {
+      "id": "Incorrect Usage. Does not require an argument\n\n",
+      "translation": "Incorrect Usage. Does not require an argument\n\n",
+      "modified": false
+   },
+   {
       "id": "Incorrect Usage. HEALTH_CHECK_TYPE must be \"port\" or \"none\"\\n\\n",
       "translation": "Incorrect Usage. HEALTH_CHECK_TYPE must be \"port\" or \"none\"\\n\\n",
       "modified": false
@@ -3027,6 +3032,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -2815,6 +2815,11 @@
       "modified": false
    },
    {
+      "id": "Incorrect Usage. Does not require an argument\n\n",
+      "translation": "Incorrect Usage. Does not require an argument\n\n",
+      "modified": false
+   },
+   {
       "id": "Incorrect Usage. HEALTH_CHECK_TYPE must be \"port\" or \"none\"\\n\\n",
       "translation": "Incorrect Usage. HEALTH_CHECK_TYPE must be \"port\" or \"none\"\\n\\n",
       "modified": false
@@ -3027,6 +3032,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -2815,6 +2815,11 @@
       "modified": false
    },
    {
+      "id": "Incorrect Usage. Does not require an argument\n\n",
+      "translation": "Incorrect Usage. Does not require an argument\n\n",
+      "modified": false
+   },
+   {
       "id": "Incorrect Usage. HEALTH_CHECK_TYPE must be \"port\" or \"none\"\\n\\n",
       "translation": "Incorrect Usage. HEALTH_CHECK_TYPE must be \"port\" or \"none\"\\n\\n",
       "modified": false
@@ -3027,6 +3032,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -2815,6 +2815,11 @@
       "modified": false
    },
    {
+      "id": "Incorrect Usage. Does not require an argument\n\n",
+      "translation": "Incorrect Usage. Does not require an argument\n\n",
+      "modified": false
+   },
+   {
       "id": "Incorrect Usage. HEALTH_CHECK_TYPE must be \"port\" or \"none\"\\n\\n",
       "translation": "Incorrect Usage. HEALTH_CHECK_TYPE must be \"port\" or \"none\"\\n\\n",
       "modified": false
@@ -3027,6 +3032,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -2815,6 +2815,11 @@
       "modified": false
    },
    {
+      "id": "Incorrect Usage. Does not require an argument\n\n",
+      "translation": "Incorrect Usage. Does not require an argument\n\n",
+      "modified": false
+   },
+   {
       "id": "Incorrect Usage. HEALTH_CHECK_TYPE must be \"port\" or \"none\"\\n\\n",
       "translation": "Incorrect Usage. HEALTH_CHECK_TYPE must be \"port\" or \"none\"\\n\\n",
       "modified": false
@@ -3027,6 +3032,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {


### PR DESCRIPTION
#### Fix 'cf stack' and 'cf stacks' to display accurate error message

##### Before Fix
```
➜  cli git:(master) ✗ cf stack
FAILED
Incorrect Usage. Requires app name as argument

NAME:
   auth - Authenticate user non-interactively

USAGE:
   cf auth USERNAME PASSWORD

WARNING:
   Providing your password as a command line option is highly discouraged
   Your password may be visible to others and may be recorded in your shell history

EXAMPLE:
   cf auth name@example.com "my password" (use quotes for passwords with a space)
   cf auth name@example.com "\"password\"" (escape quotes if used in password)
```
```
➜  cli git:(master) ✗ cf stacks 1   
FAILED
Incorrect Usage. Requires app name as argument

NAME:
   stacks - List all stacks (a stack is a pre-built file system, including an operating system, that can run apps)

USAGE:
   cf stacks
```
##### After Fix
```
➜  cli git:(master) ✗ ./out/cf stack
FAILED
Incorrect Usage. Requires stack name as argument

NAME:
   stack - Show information for a stack (a stack is a pre-built file system, including an operating system, that can run apps)

USAGE:
   cf stack STACK_NAME

OPTIONS:
   --guid      Retrieve and display the given stack's guid. All other output for the stack is suppressed.
```

```
➜  cli git:(master) ✗ ./out/cf stacks 1
FAILED
Incorrect Usage. Does not require an argument

NAME:
   stacks - List all stacks (a stack is a pre-built file system, including an operating system, that can run apps)

USAGE:
   cf stacks
```