### PR TITLE
Fix cf ssh with more than required args

### DIFF
--- a/cf/commands/application/ssh.go
+++ b/cf/commands/application/ssh.go
@@ -60,7 +60,7 @@ func (cmd *SSH) MetaData() command_registry.CommandMetadata {
 }
 
 func (cmd *SSH) Requirements(requirementsFactory requirements.Factory, fc flags.FlagContext) (reqs []requirements.Requirement, err error) {
-	if len(fc.Args()) == 0 {
+	if len(fc.Args()) != 1 {
 		cmd.ui.Failed(T("Incorrect Usage. Requires APP_NAME as argument") + "\n\n" + command_registry.Commands.CommandUsage("ssh"))
 	}
 

--- a/cf/commands/application/ssh_test.go
+++ b/cf/commands/application/ssh_test.go
@@ -76,7 +76,7 @@ var _ = Describe("SSH command", func() {
 	}
 
 	Describe("Requirements", func() {
-		It("fails with usage when called without enough arguments", func() {
+		It("fails with usage when not provided exactly one arg", func() {
 			requirementsFactory.LoginSuccess = true
 
 			runCommand()


### PR DESCRIPTION
Currently we are allowing the execution of command for more than required num of args , for example
cf ssh appname1  appname2  etc  by ignoring the other than one arg but considering other commands which supposed to make fail with invalid msg to user.

Any suggestions/commands are welcome.