### PR TITLE
create-route command now takes optional context path

### DIFF
--- a/cf/api/fakes/fake_route_repo.go
+++ b/cf/api/fakes/fake_route_repo.go
@@ -21,6 +21,7 @@ type FakeRouteRepository struct {
 	CreatedRoute      models.Route
 
 	CreateInSpaceHost         string
+	CreateInSpacePath         string
 	CreateInSpaceDomainGuid   string
 	CreateInSpaceSpaceGuid    string
 	CreateInSpaceCreatedRoute models.Route
@@ -104,10 +105,11 @@ func (repo *FakeRouteRepository) CheckIfExists(host string, domain models.Domain
 	}
 	return
 }
-func (repo *FakeRouteRepository) CreateInSpace(host, domainGuid, spaceGuid string) (createdRoute models.Route, apiErr error) {
+func (repo *FakeRouteRepository) CreateInSpace(host, path, domainGuid, spaceGuid string) (createdRoute models.Route, apiErr error) {
 	repo.CreateInSpaceHost = host
 	repo.CreateInSpaceDomainGuid = domainGuid
 	repo.CreateInSpaceSpaceGuid = spaceGuid
+	repo.CreateInSpacePath = path
 
 	if repo.CreateInSpaceErr {
 		apiErr = errors.New("Error")

--- a/cf/api/resources/routes.go
+++ b/cf/api/resources/routes.go
@@ -9,6 +9,7 @@ type RouteResource struct {
 
 type RouteEntity struct {
 	Host   string
+	Path   string
 	Domain DomainResource
 	Space  SpaceResource
 	Apps   []ApplicationResource
@@ -19,8 +20,10 @@ func (resource RouteResource) ToFields() (fields models.Route) {
 	fields.Host = resource.Entity.Host
 	return
 }
+
 func (resource RouteResource) ToModel() (route models.Route) {
 	route.Host = resource.Entity.Host
+	route.Path = resource.Entity.Path
 	route.Guid = resource.Metadata.Guid
 	route.Domain = resource.Entity.Domain.ToFields()
 	route.Space = resource.Entity.Space.ToFields()

--- a/cf/api/routes.go
+++ b/cf/api/routes.go
@@ -18,7 +18,7 @@ type RouteRepository interface {
 	FindByHostAndDomain(host string, domain models.DomainFields) (route models.Route, apiErr error)
 	Create(host string, domain models.DomainFields) (createdRoute models.Route, apiErr error)
 	CheckIfExists(host string, domain models.DomainFields) (found bool, apiErr error)
-	CreateInSpace(host, domainGuid, spaceGuid string) (createdRoute models.Route, apiErr error)
+	CreateInSpace(host, path, domainGuid, spaceGuid string) (createdRoute models.Route, apiErr error)
 	Bind(routeGuid, appGuid string) (apiErr error)
 	Unbind(routeGuid, appGuid string) (apiErr error)
 	Delete(routeGuid string) (apiErr error)
@@ -74,7 +74,7 @@ func (repo CloudControllerRouteRepository) FindByHostAndDomain(host string, doma
 }
 
 func (repo CloudControllerRouteRepository) Create(host string, domain models.DomainFields) (createdRoute models.Route, apiErr error) {
-	return repo.CreateInSpace(host, domain.Guid, repo.config.SpaceFields().Guid)
+	return repo.CreateInSpace(host, "", domain.Guid, repo.config.SpaceFields().Guid)
 }
 
 func (repo CloudControllerRouteRepository) CheckIfExists(host string, domain models.DomainFields) (found bool, apiErr error) {
@@ -93,8 +93,8 @@ func (repo CloudControllerRouteRepository) CheckIfExists(host string, domain mod
 	return
 }
 
-func (repo CloudControllerRouteRepository) CreateInSpace(host, domainGuid, spaceGuid string) (createdRoute models.Route, apiErr error) {
-	data := fmt.Sprintf(`{"host":"%s","domain_guid":"%s","space_guid":"%s"}`, host, domainGuid, spaceGuid)
+func (repo CloudControllerRouteRepository) CreateInSpace(host, path, domainGuid, spaceGuid string) (createdRoute models.Route, apiErr error) {
+	data := fmt.Sprintf(`{"host":"%s","path":"%s","domain_guid":"%s","space_guid":"%s"}`, host, path, domainGuid, spaceGuid)
 
 	resource := new(resources.RouteResource)
 	apiErr = repo.gateway.CreateResource(repo.config.ApiEndpoint(), "/v2/routes?inline-relations-depth=1", strings.NewReader(data), resource)

--- a/cf/commands/route/map_route.go
+++ b/cf/commands/route/map_route.go
@@ -73,7 +73,7 @@ func (cmd *MapRoute) Execute(c flags.FlagContext) {
 	domain := cmd.domainReq.GetDomain()
 	app := cmd.appReq.GetApplication()
 
-	route, apiErr := cmd.routeCreator.CreateRoute(hostName, domain, cmd.config.SpaceFields())
+	route, apiErr := cmd.routeCreator.CreateRoute(hostName, "", domain, cmd.config.SpaceFields())
 	if apiErr != nil {
 		cmd.ui.Failed(T("Error resolving route:\n{{.Err}}", map[string]interface{}{"Err": apiErr.Error()}))
 	}

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -685,9 +685,9 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]",
       "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
-      "modified": false
+      "modified": true
    },
    {
       "id": "CF_NAME create-security-group SECURITY_GROUP PATH_TO_JSON_RULES_FILE",
@@ -1580,13 +1580,13 @@
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
-      "translation": "Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "id": "Creating route {{.Hostname}}...",
+      "translation": "Creating route {{.Hostname}}...",
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}}...",
-      "translation": "Creating route {{.Hostname}}...",
+      "id": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3668,6 +3668,16 @@
       "id": "ORGS",
       "translation": "ORGS",
       "modified": false
+   },
+   {
+      "id": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
+      "translation": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped. Requests received with a trailing slash will match.",
+      "modified": true
+   },
+   {
+      "id": "Optional hostname",
+      "translation": "Optional hostname",
+      "modified": true
    },
    {
       "id": "Org",

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -685,8 +685,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
-      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]",
+      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]",
       "modified": false
    },
    {
@@ -1580,13 +1580,13 @@
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
-      "translation": "Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "id": "Creating route {{.Hostname}}...",
+      "translation": "Creating route {{.Hostname}}...",
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}}...",
-      "translation": "Creating route {{.Hostname}}...",
+      "id": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3667,6 +3667,16 @@
    {
       "id": "ORGS",
       "translation": "ORGS",
+      "modified": false
+   },
+   {
+      "id": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
+      "translation": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
+      "modified": false
+   },
+   {
+      "id": "Optional hostname",
+      "translation": "Optional hostname",
       "modified": false
    },
    {

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -685,9 +685,9 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]",
       "translation": "CF_NAME create-route SPACE DOMINIO [-n HOSTNAME]",
-      "modified": false
+      "modified": true
    },
    {
       "id": "CF_NAME create-security-group SECURITY_GROUP PATH_TO_JSON_RULES_FILE",
@@ -1580,13 +1580,13 @@
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
-      "translation": "Creando ruta {{.Hostname}} en org {{.OrgName}} / space {{.SpaceName}} como {{.Username}}...",
+      "id": "Creating route {{.Hostname}}...",
+      "translation": "Creando ruta {{.Hostname}}...",
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}}...",
-      "translation": "Creando ruta {{.Hostname}}...",
+      "id": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3668,6 +3668,16 @@
       "id": "ORGS",
       "translation": "ORGS",
       "modified": false
+   },
+   {
+      "id": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
+      "translation": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped. Requests received with a trailing slash will match.",
+      "modified": true
+   },
+   {
+      "id": "Optional hostname",
+      "translation": "Optional hostname",
+      "modified": true
    },
    {
       "id": "Org",

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -685,9 +685,9 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]",
       "translation": "CF_NAME create-route ESPACE DOMAINE [-n HÔTE]",
-      "modified": false
+      "modified": true
    },
    {
       "id": "CF_NAME create-security-group SECURITY_GROUP PATH_TO_JSON_RULES_FILE",
@@ -1580,13 +1580,13 @@
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
-      "translation": "Création de la route {{.Hostname}} pour l'org {{.OrgName}} / {{.SpaceName}} en tant que {{.Username}}...",
+      "id": "Creating route {{.Hostname}}...",
+      "translation": "Création de la route {{.Hostname}}...",
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}}...",
-      "translation": "Création de la route {{.Hostname}}...",
+      "id": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3668,6 +3668,16 @@
       "id": "ORGS",
       "translation": "ORGS",
       "modified": false
+   },
+   {
+      "id": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
+      "translation": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped. Requests received with a trailing slash will match.",
+      "modified": true
+   },
+   {
+      "id": "Optional hostname",
+      "translation": "Optional hostname",
+      "modified": true
    },
    {
       "id": "Org",

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -685,9 +685,9 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]",
       "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
-      "modified": false
+      "modified": true
    },
    {
       "id": "CF_NAME create-security-group SECURITY_GROUP PATH_TO_JSON_RULES_FILE",
@@ -1580,13 +1580,13 @@
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
-      "translation": "Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "id": "Creating route {{.Hostname}}...",
+      "translation": "Creating route {{.Hostname}}...",
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}}...",
-      "translation": "Creating route {{.Hostname}}...",
+      "id": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3668,6 +3668,16 @@
       "id": "ORGS",
       "translation": "ORGS",
       "modified": false
+   },
+   {
+      "id": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
+      "translation": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped. Requests received with a trailing slash will match.",
+      "modified": true
+   },
+   {
+      "id": "Optional hostname",
+      "translation": "Optional hostname",
+      "modified": true
    },
    {
       "id": "Org",

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -685,9 +685,9 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]",
       "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
-      "modified": false
+      "modified": true
    },
    {
       "id": "CF_NAME create-security-group SECURITY_GROUP PATH_TO_JSON_RULES_FILE",
@@ -1580,13 +1580,13 @@
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
-      "translation": "Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "id": "Creating route {{.Hostname}}...",
+      "translation": "Creating route {{.Hostname}}...",
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}}...",
-      "translation": "Creating route {{.Hostname}}...",
+      "id": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3668,6 +3668,16 @@
       "id": "ORGS",
       "translation": "ORGS",
       "modified": false
+   },
+   {
+      "id": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
+      "translation": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped. Requests received with a trailing slash will match.",
+      "modified": true
+   },
+   {
+      "id": "Optional hostname",
+      "translation": "Optional hostname",
+      "modified": true
    },
    {
       "id": "Org",

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -685,9 +685,9 @@
       "modified": false
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]",
       "translation": "CF_NAME create-route ESPAÇO DOMÍNIO [-n HOSTNAME]",
-      "modified": false
+      "modified": true
    },
    {
       "id": "CF_NAME create-security-group SECURITY_GROUP PATH_TO_JSON_RULES_FILE",
@@ -1580,13 +1580,13 @@
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
-      "translation": "Criando rota {{.Hostname}} para org {{.OrgName}} / espaço {{.SpaceName}} como {{.Username}}...",
+      "id": "Creating route {{.Hostname}}...",
+      "translation": "Criando rota {{.Hostname}}...",
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}}...",
-      "translation": "Criando rota {{.Hostname}}...",
+      "id": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3668,6 +3668,16 @@
       "id": "ORGS",
       "translation": "ORGS",
       "modified": false
+   },
+   {
+      "id": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
+      "translation": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped. Requests received with a trailing slash will match.",
+      "modified": true
+   },
+   {
+      "id": "Optional hostname",
+      "translation": "Optional hostname",
+      "modified": true
    },
    {
       "id": "Org",

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -685,9 +685,9 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]",
       "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
-      "modified": false
+      "modified": true
    },
    {
       "id": "CF_NAME create-security-group SECURITY_GROUP PATH_TO_JSON_RULES_FILE",
@@ -1580,13 +1580,13 @@
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
-      "translation": "Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "id": "Creating route {{.Hostname}}...",
+      "translation": "创建路由 {{.Hostname}}...",
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}}...",
-      "translation": "创建路由 {{.Hostname}}...",
+      "id": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3668,6 +3668,16 @@
       "id": "ORGS",
       "translation": "组织",
       "modified": false
+   },
+   {
+      "id": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
+      "translation": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped. Requests received with a trailing slash will match.",
+      "modified": true
+   },
+   {
+      "id": "Optional hostname",
+      "translation": "Optional hostname",
+      "modified": true
    },
    {
       "id": "Org",

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -685,9 +685,9 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]",
       "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
-      "modified": false
+      "modified": true
    },
    {
       "id": "CF_NAME create-security-group SECURITY_GROUP PATH_TO_JSON_RULES_FILE",
@@ -1580,13 +1580,13 @@
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
-      "translation": "Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "id": "Creating route {{.Hostname}}...",
+      "translation": "Creating route {{.Hostname}}...",
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}}...",
-      "translation": "Creating route {{.Hostname}}...",
+      "id": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3668,6 +3668,16 @@
       "id": "ORGS",
       "translation": "ORGS",
       "modified": false
+   },
+   {
+      "id": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
+      "translation": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped. Requests received with a trailing slash will match.",
+      "modified": true
+   },
+   {
+      "id": "Optional hostname",
+      "translation": "Optional hostname",
+      "modified": true
    },
    {
       "id": "Org",

--- a/cf/models/route.go
+++ b/cf/models/route.go
@@ -6,27 +6,28 @@ type Route struct {
 	Guid   string
 	Host   string
 	Domain DomainFields
-
-	Space SpaceFields
-	Apps  []ApplicationFields
+	Path   string
+	Space  SpaceFields
+	Apps   []ApplicationFields
 }
 
 func (route Route) URL() string {
 	if route.Host == "" {
 		return route.Domain.Name
 	}
-	return fmt.Sprintf("%s.%s", route.Host, route.Domain.Name)
+	return fmt.Sprintf("%s.%s%s", route.Host, route.Domain.Name, route.Path)
 }
 
 type RouteSummary struct {
 	Guid   string
 	Host   string
 	Domain DomainFields
+	Path   string
 }
 
 func (model RouteSummary) URL() string {
 	if model.Host == "" {
 		return model.Domain.Name
 	}
-	return fmt.Sprintf("%s.%s", model.Host, model.Domain.Name)
+	return fmt.Sprintf("%s.%s%s", model.Host, model.Domain.Name, model.Path)
 }

--- a/testhelpers/commands/fake_route_creator.go
+++ b/testhelpers/commands/fake_route_creator.go
@@ -9,13 +9,15 @@ import (
 
 type FakeRouteCreator struct {
 	CreateRouteHostname     string
+	CreateRoutePath         string
 	CreateRouteDomainFields models.DomainFields
 	CreateRouteSpaceFields  models.SpaceFields
 	ReservedRoute           models.Route
 }
 
-func (cmd *FakeRouteCreator) CreateRoute(hostName string, domain models.DomainFields, space models.SpaceFields) (reservedRoute models.Route, apiErr error) {
+func (cmd *FakeRouteCreator) CreateRoute(hostName, path string, domain models.DomainFields, space models.SpaceFields) (reservedRoute models.Route, apiErr error) {
 	cmd.CreateRouteHostname = hostName
+	cmd.CreateRoutePath = path
 	cmd.CreateRouteDomainFields = domain
 	cmd.CreateRouteSpaceFields = space
 	reservedRoute = cmd.ReservedRoute


### PR DESCRIPTION
This PR adds an optional parameter, `-c`, to the `create-route` command in order to specify a context path for a route.

Notably, in this PR we are always sending the `path` key in the JSON request to the CC, by default an empty string. We also modify the `RouteCreator` interface to take in a new path parameter and send in the empty string for `map-route` at the current time.

[#104020104](https://www.pivotaltracker.com/story/show/104020104)