### PR TITLE
Add the type field to 'cf domains' command.

### DIFF
--- a/cf/api/resources/domains.go
+++ b/cf/api/resources/domains.go
@@ -11,6 +11,7 @@ type DomainEntity struct {
 	Name                   string `json:"name"`
 	OwningOrganizationGuid string `json:"owning_organization_guid,omitempty"`
 	SharedOrganizationsUrl string `json:"shared_organizations_url,omitempty"`
+	RouterGroupGuid        string `json:"router_group_guid,omitempty"`
 	Wildcard               bool   `json:"wildcard"`
 }
 
@@ -21,5 +22,6 @@ func (resource DomainResource) ToFields() models.DomainFields {
 		Guid: resource.Metadata.Guid,
 		OwningOrganizationGuid: resource.Entity.OwningOrganizationGuid,
 		Shared:                 !privateDomain,
+		RouterGroupGuid:        resource.Entity.RouterGroupGuid,
 	}
 }

--- a/cf/commands/domain/domains.go
+++ b/cf/commands/domain/domains.go
@@ -1,6 +1,8 @@
 package domain
 
 import (
+	"errors"
+
 	"github.com/cloudfoundry/cli/cf/api"
 	"github.com/cloudfoundry/cli/cf/command_registry"
 	"github.com/cloudfoundry/cli/cf/configuration/core_config"
@@ -12,10 +14,12 @@ import (
 )
 
 type ListDomains struct {
-	ui         terminal.UI
-	config     core_config.Reader
-	orgReq     requirements.TargetedOrgRequirement
-	domainRepo api.DomainRepository
+	ui              terminal.UI
+	config          core_config.Reader
+	orgReq          requirements.TargetedOrgRequirement
+	domainRepo      api.DomainRepository
+	routingApiRepo  api.RoutingApiRepository
+	routerGroupsMap map[string]models.RouterGroup
 }
 
 func init() {
@@ -47,6 +51,8 @@ func (cmd *ListDomains) SetDependency(deps command_registry.Dependency, pluginCa
 	cmd.ui = deps.Ui
 	cmd.config = deps.Config
 	cmd.domainRepo = deps.RepoLocator.GetDomainRepository()
+	cmd.routingApiRepo = deps.RepoLocator.GetRoutingApiRepository()
+
 	return cmd
 }
 
@@ -77,12 +83,45 @@ func (cmd *ListDomains) fetchAllDomains(orgGuid string) (domains []models.Domain
 	return
 }
 
+func (cmd *ListDomains) getRouterGroupTypeFromGuid(guid string) (string, error) {
+	if cmd.routerGroupsMap == nil {
+		cmd.routerGroupsMap = map[string]models.RouterGroup{}
+		cb := func(routerGroup models.RouterGroup) bool {
+			cmd.routerGroupsMap[routerGroup.Guid] = routerGroup
+			return true
+		}
+
+		apiErr := cmd.routingApiRepo.ListRouterGroups(cb)
+		if apiErr != nil {
+			return "", apiErr
+		}
+	}
+
+	routerGroup, ok := cmd.routerGroupsMap[guid]
+	if ok == false {
+		return "", errors.New(T("Invalid router group guid"))
+	}
+
+	return routerGroup.Type, nil
+}
+
 func (cmd *ListDomains) printDomainsTable(domains []models.DomainFields) {
-	table := cmd.ui.Table([]string{T("name"), T("status")})
+	table := cmd.ui.Table([]string{T("name"), T("status"), T("routing")})
+
+	cmd.routerGroupsMap = nil
 
 	for _, domain := range domains {
 		if domain.Shared {
-			table.Add(domain.Name, T("shared"))
+			if domain.RouterGroupGuid == "" {
+				table.Add(domain.Name, T("shared"))
+			} else {
+				routerGroupType, err := cmd.getRouterGroupTypeFromGuid(domain.RouterGroupGuid)
+				if err != nil {
+					cmd.ui.Failed(T("Failed fetching router groups.\n{{.Err}}", map[string]interface{}{"Err": err.Error()}))
+				}
+
+				table.Add(domain.Name, T("shared"), routerGroupType)
+			}
 		}
 	}
 

--- a/cf/commands/domain/domains_test.go
+++ b/cf/commands/domain/domains_test.go
@@ -111,7 +111,7 @@ var _ = Describe("domains command", func() {
 					Expect(ui.Outputs).To(ContainSubstrings(
 						[]string{"Getting domains in org", "my-org", "my-user"},
 						[]string{"FAILED"},
-						[]string{"Failed fetching router groups"},
+						[]string{"Invalid router group guid"},
 					))
 				})
 			})

--- a/cf/commands/routergroups/router_groups_test.go
+++ b/cf/commands/routergroups/router_groups_test.go
@@ -107,5 +107,4 @@ var _ = Describe("RouterGroups", func() {
 			))
 		})
 	})
-
 })

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -3185,6 +3185,11 @@
       "modified": false
    },
    {
+      "id": "Invalid router group guid",
+      "translation": "Invalid router group guid",
+      "modified": false
+   },
+   {
       "id": "Invalid timeout param: {{.Timeout}}\n{{.Err}}",
       "translation": "Invalid timeout param: {{.Timeout}}\n{{.Err}}",
       "modified": false
@@ -5662,6 +5667,11 @@
    {
       "id": "routes",
       "translation": "routes",
+      "modified": false
+   },
+   {
+      "id": "routing",
+      "translation": "routing",
       "modified": false
    },
    {

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -3005,11 +3005,6 @@
       "modified": false
    },
    {
-      "id": "Incorrect Usage. Requires stack name as argument\n\n",
-      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
-      "modified": false
-   },
-   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false
@@ -3047,6 +3042,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -3185,8 +3185,8 @@
       "modified": false
    },
    {
-      "id": "Invalid router group guid",
-      "translation": "Invalid router group guid",
+      "id": "Invalid router group guid: {{.Guid}}",
+      "translation": "Invalid router group guid: {{.Guid}}",
       "modified": false
    },
    {

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -3185,6 +3185,11 @@
       "modified": false
    },
    {
+      "id": "Invalid router group guid",
+      "translation": "Invalid router group guid",
+      "modified": false
+   },
+   {
       "id": "Invalid timeout param: {{.Timeout}}\n{{.Err}}",
       "translation": "Invalid timeout param: {{.Timeout}}\n{{.Err}}",
       "modified": false
@@ -5662,6 +5667,11 @@
    {
       "id": "routes",
       "translation": "routes",
+      "modified": false
+   },
+   {
+      "id": "routing",
+      "translation": "routing",
       "modified": false
    },
    {

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -3005,11 +3005,6 @@
       "modified": false
    },
    {
-      "id": "Incorrect Usage. Requires stack name as argument\n\n",
-      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
-      "modified": false
-   },
-   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false
@@ -3047,6 +3042,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -3185,8 +3185,8 @@
       "modified": false
    },
    {
-      "id": "Invalid router group guid",
-      "translation": "Invalid router group guid",
+      "id": "Invalid router group guid: {{.Guid}}",
+      "translation": "Invalid router group guid: {{.Guid}}",
       "modified": false
    },
    {

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -3005,11 +3005,6 @@
       "modified": false
    },
    {
-      "id": "Incorrect Usage. Requires stack name as argument\n\n",
-      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
-      "modified": false
-   },
-   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false
@@ -3047,6 +3042,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -3185,6 +3185,11 @@
       "modified": false
    },
    {
+      "id": "Invalid router group guid",
+      "translation": "Invalid router group guid",
+      "modified": false
+   },
+   {
       "id": "Invalid timeout param: {{.Timeout}}\n{{.Err}}",
       "translation": "Parametro de timeout invalido: {{.Timeout}}\n{{.Err}}",
       "modified": false
@@ -5662,6 +5667,11 @@
    {
       "id": "routes",
       "translation": "rutas",
+      "modified": false
+   },
+   {
+      "id": "routing",
+      "translation": "routing",
       "modified": false
    },
    {

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -3185,8 +3185,8 @@
       "modified": false
    },
    {
-      "id": "Invalid router group guid",
-      "translation": "Invalid router group guid",
+      "id": "Invalid router group guid: {{.Guid}}",
+      "translation": "Invalid router group guid: {{.Guid}}",
       "modified": false
    },
    {

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -3005,11 +3005,6 @@
       "modified": false
    },
    {
-      "id": "Incorrect Usage. Requires stack name as argument\n\n",
-      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
-      "modified": false
-   },
-   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false
@@ -3047,6 +3042,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -3185,8 +3185,8 @@
       "modified": false
    },
    {
-      "id": "Invalid router group guid",
-      "translation": "Invalid router group guid",
+      "id": "Invalid router group guid: {{.Guid}}",
+      "translation": "Invalid router group guid: {{.Guid}}",
       "modified": false
    },
    {

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -3185,6 +3185,11 @@
       "modified": false
    },
    {
+      "id": "Invalid router group guid",
+      "translation": "Invalid router group guid",
+      "modified": false
+   },
+   {
       "id": "Invalid timeout param: {{.Timeout}}\n{{.Err}}",
       "translation": "Invalid délai param: {{.Timeout}}\n{{.Err}}",
       "modified": false
@@ -5662,6 +5667,11 @@
    {
       "id": "routes",
       "translation": "routes",
+      "modified": false
+   },
+   {
+      "id": "routing",
+      "translation": "routing",
       "modified": false
    },
    {

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -3185,6 +3185,11 @@
       "modified": false
    },
    {
+      "id": "Invalid router group guid",
+      "translation": "Invalid router group guid",
+      "modified": false
+   },
+   {
       "id": "Invalid timeout param: {{.Timeout}}\n{{.Err}}",
       "translation": "Invalid timeout param: {{.Timeout}}\n{{.Err}}",
       "modified": false
@@ -5662,6 +5667,11 @@
    {
       "id": "routes",
       "translation": "routes",
+      "modified": false
+   },
+   {
+      "id": "routing",
+      "translation": "routing",
       "modified": false
    },
    {

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -3005,11 +3005,6 @@
       "modified": false
    },
    {
-      "id": "Incorrect Usage. Requires stack name as argument\n\n",
-      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
-      "modified": false
-   },
-   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false
@@ -3047,6 +3042,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -3185,8 +3185,8 @@
       "modified": false
    },
    {
-      "id": "Invalid router group guid",
-      "translation": "Invalid router group guid",
+      "id": "Invalid router group guid: {{.Guid}}",
+      "translation": "Invalid router group guid: {{.Guid}}",
       "modified": false
    },
    {

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -3185,6 +3185,11 @@
       "modified": false
    },
    {
+      "id": "Invalid router group guid",
+      "translation": "Invalid router group guid",
+      "modified": false
+   },
+   {
       "id": "Invalid timeout param: {{.Timeout}}\n{{.Err}}",
       "translation": "Invalid timeout param: {{.Timeout}}\n{{.Err}}",
       "modified": false
@@ -5662,6 +5667,11 @@
    {
       "id": "routes",
       "translation": "routes",
+      "modified": false
+   },
+   {
+      "id": "routing",
+      "translation": "routing",
       "modified": false
    },
    {

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -3005,11 +3005,6 @@
       "modified": false
    },
    {
-      "id": "Incorrect Usage. Requires stack name as argument\n\n",
-      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
-      "modified": false
-   },
-   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false
@@ -3047,6 +3042,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -3185,8 +3185,8 @@
       "modified": false
    },
    {
-      "id": "Invalid router group guid",
-      "translation": "Invalid router group guid",
+      "id": "Invalid router group guid: {{.Guid}}",
+      "translation": "Invalid router group guid: {{.Guid}}",
       "modified": false
    },
    {

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -3005,11 +3005,6 @@
       "modified": false
    },
    {
-      "id": "Incorrect Usage. Requires stack name as argument\n\n",
-      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
-      "modified": false
-   },
-   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false
@@ -3047,6 +3042,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -3185,8 +3185,8 @@
       "modified": false
    },
    {
-      "id": "Invalid router group guid",
-      "translation": "Invalid router group guid",
+      "id": "Invalid router group guid: {{.Guid}}",
+      "translation": "Invalid router group guid: {{.Guid}}",
       "modified": false
    },
    {

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -3185,6 +3185,11 @@
       "modified": false
    },
    {
+      "id": "Invalid router group guid",
+      "translation": "Invalid router group guid",
+      "modified": false
+   },
+   {
       "id": "Invalid timeout param: {{.Timeout}}\n{{.Err}}",
       "translation": "Parâmetro de tempo limite inválido: {{.Timeout}}\n{{.Err}}",
       "modified": false
@@ -5662,6 +5667,11 @@
    {
       "id": "routes",
       "translation": "rotas",
+      "modified": false
+   },
+   {
+      "id": "routing",
+      "translation": "routing",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -3005,11 +3005,6 @@
       "modified": false
    },
    {
-      "id": "Incorrect Usage. Requires stack name as argument\n\n",
-      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
-      "modified": false
-   },
-   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false
@@ -3047,6 +3042,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -3185,6 +3185,11 @@
       "modified": false
    },
    {
+      "id": "Invalid router group guid",
+      "translation": "Invalid router group guid",
+      "modified": false
+   },
+   {
       "id": "Invalid timeout param: {{.Timeout}}\n{{.Err}}",
       "translation": "无效的超时参数设定: {{.Timeout}}\n{{.Err}}",
       "modified": false
@@ -5662,6 +5667,11 @@
    {
       "id": "routes",
       "translation": "routes",
+      "modified": false
+   },
+   {
+      "id": "routing",
+      "translation": "routing",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -3185,8 +3185,8 @@
       "modified": false
    },
    {
-      "id": "Invalid router group guid",
-      "translation": "Invalid router group guid",
+      "id": "Invalid router group guid: {{.Guid}}",
+      "translation": "Invalid router group guid: {{.Guid}}",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -3185,6 +3185,11 @@
       "modified": false
    },
    {
+      "id": "Invalid router group guid",
+      "translation": "Invalid router group guid",
+      "modified": false
+   },
+   {
       "id": "Invalid timeout param: {{.Timeout}}\n{{.Err}}",
       "translation": "Invalid timeout param: {{.Timeout}}\n{{.Err}}",
       "modified": false
@@ -5662,6 +5667,11 @@
    {
       "id": "routes",
       "translation": "routes",
+      "modified": false
+   },
+   {
+      "id": "routing",
+      "translation": "routing",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -3005,11 +3005,6 @@
       "modified": false
    },
    {
-      "id": "Incorrect Usage. Requires stack name as argument\n\n",
-      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
-      "modified": false
-   },
-   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false
@@ -3047,6 +3042,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -3185,8 +3185,8 @@
       "modified": false
    },
    {
-      "id": "Invalid router group guid",
-      "translation": "Invalid router group guid",
+      "id": "Invalid router group guid: {{.Guid}}",
+      "translation": "Invalid router group guid: {{.Guid}}",
       "modified": false
    },
    {

--- a/cf/models/domain.go
+++ b/cf/models/domain.go
@@ -6,6 +6,7 @@ type DomainFields struct {
 	Guid                   string
 	Name                   string
 	OwningOrganizationGuid string
+	RouterGroupGuid        string
 	Shared                 bool
 }
 


### PR DESCRIPTION
@krishicks:
This displays the type of router group for domains associated with router groups.

Below is the story in the routing team's tracker:
https://www.pivotaltracker.com/story/show/100981770

As we don't have the permission to modify repo of @mdelillo in #627, we create a new PR here to replace the it, please close #627.

This PR contains all the changes in #627 and do the refactor:
1. We rebased the master branch as there is some test error if don't rebase.
2. Instead of put routerGroupsMap as a field of struct, now we just pass it as a parameter. Why we don't populating routerGroupsMap in the function "printDomainsTable" locally because if no domain has RoutergroupGuid, then we don't need to populate it. So we only populate it when necessary. So it is better to put it in the for loop and initialize it when necessary. And we make a function to do it to separate the logic. That is one function do only one thing.
3. Test case and the error message: We changed the test case and the code to display the right information.

@mdelillo @yuzhangcmu