### PR TITLE
Show better error message when routing api endpoint is not defined.

### DIFF
--- a/cf/api/routing_api.go
+++ b/cf/api/routing_api.go
@@ -31,7 +31,7 @@ func (r routingApiRepository) ListRouterGroups(cb func(models.RouterGroup) bool)
 
 	routingApiEndpoint := r.config.RoutingApiEndpoint()
 	if routingApiEndpoint == "" {
-		apiErr = errors.New(T("Routing API not found. Please log in."))
+		apiErr = errors.New(T("Routing API uri missing. Please log in again and retry."))
 		return
 	}
 

--- a/cf/api/routing_api.go
+++ b/cf/api/routing_api.go
@@ -1,9 +1,11 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/cloudfoundry/cli/cf/configuration/core_config"
+	. "github.com/cloudfoundry/cli/cf/i18n"
 	"github.com/cloudfoundry/cli/cf/models"
 	"github.com/cloudfoundry/cli/cf/net"
 )
@@ -26,7 +28,15 @@ func NewRoutingApiRepository(config core_config.Reader, gateway net.Gateway) Rou
 
 func (r routingApiRepository) ListRouterGroups(cb func(models.RouterGroup) bool) (apiErr error) {
 	routerGroups := models.RouterGroups{}
-	endpoint := fmt.Sprintf("%s/v1/router_groups", r.config.RoutingApiEndpoint())
+
+	routingApiEndpoint := r.config.RoutingApiEndpoint()
+	if routingApiEndpoint == "" {
+		apiErr = errors.New(T("Routing API not found. Please log in."))
+		return
+	}
+
+	endpoint := fmt.Sprintf("%s/v1/router_groups", routingApiEndpoint)
+
 	apiErr = r.gateway.GetResource(endpoint, &routerGroups)
 	if apiErr != nil {
 		return apiErr

--- a/cf/api/routing_api_test.go
+++ b/cf/api/routing_api_test.go
@@ -135,7 +135,7 @@ var _ = Describe("RoutingApi", func() {
 
 				err := repo.ListRouterGroups(cb)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("Routing API not found. Please log in."))
+				Expect(err.Error()).To(ContainSubstring("Routing API uri missing. Please log in again and retry."))
 			})
 		})
 	})

--- a/cf/api/routing_api_test.go
+++ b/cf/api/routing_api_test.go
@@ -120,5 +120,23 @@ var _ = Describe("RoutingApi", func() {
 				Expect(err.(errors.HttpError).StatusCode()).To(Equal(http.StatusUnauthorized))
 			})
 		})
+
+		Context("when routing api endopoint is not configured", func() {
+			BeforeEach(func() {
+				routingApiServer = ghttp.NewServer()
+				configRepo.SetRoutingApiEndpoint("")
+			})
+
+			It("returns an error", func() {
+				cb := func(grp models.RouterGroup) bool {
+					Fail(fmt.Sprintf("Routing Api Endpoint Not defined. Not expected to receive callback for router group:%#v", grp))
+					return false
+				}
+
+				err := repo.ListRouterGroups(cb)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Routing API not found. Please log in."))
+			})
+		})
 	})
 })

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -4250,9 +4250,9 @@
       "modified": false
    },
    {
-      "id": "Routing API not found. Please log in.",
+      "id": "Routing API uri missing. Please log in again and retry.",
       "translation": "Routing API not found. Please log in.",
-      "modified": false
+      "modified": true
    },
    {
       "id": "Rules",

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -3005,11 +3005,6 @@
       "modified": false
    },
    {
-      "id": "Incorrect Usage. Requires stack name as argument\n\n",
-      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
-      "modified": false
-   },
-   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false
@@ -3047,6 +3042,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {
@@ -4247,6 +4247,11 @@
    {
       "id": "Routes",
       "translation": "Routes",
+      "modified": false
+   },
+   {
+      "id": "Routing API not found. Please log in.",
+      "translation": "Routing API not found. Please log in.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -4250,8 +4250,8 @@
       "modified": false
    },
    {
-      "id": "Routing API not found. Please log in.",
-      "translation": "Routing API not found. Please log in.",
+      "id": "Routing API uri missing. Please log in again and retry.",
+      "translation": "Routing API uri missing. Please log in again and retry.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -3005,11 +3005,6 @@
       "modified": false
    },
    {
-      "id": "Incorrect Usage. Requires stack name as argument\n\n",
-      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
-      "modified": false
-   },
-   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false
@@ -3047,6 +3042,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {
@@ -4247,6 +4247,11 @@
    {
       "id": "Routes",
       "translation": "Routes",
+      "modified": false
+   },
+   {
+      "id": "Routing API not found. Please log in.",
+      "translation": "Routing API not found. Please log in.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -3005,11 +3005,6 @@
       "modified": false
    },
    {
-      "id": "Incorrect Usage. Requires stack name as argument\n\n",
-      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
-      "modified": false
-   },
-   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false
@@ -3047,6 +3042,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {
@@ -4247,6 +4247,11 @@
    {
       "id": "Routes",
       "translation": "Rutas",
+      "modified": false
+   },
+   {
+      "id": "Routing API not found. Please log in.",
+      "translation": "Routing API not found. Please log in.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -4250,9 +4250,9 @@
       "modified": false
    },
    {
-      "id": "Routing API not found. Please log in.",
+      "id": "Routing API uri missing. Please log in again and retry.",
       "translation": "Routing API not found. Please log in.",
-      "modified": false
+      "modified": true
    },
    {
       "id": "Rules",

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -4250,9 +4250,9 @@
       "modified": false
    },
    {
-      "id": "Routing API not found. Please log in.",
+      "id": "Routing API uri missing. Please log in again and retry.",
       "translation": "Routing API not found. Please log in.",
-      "modified": false
+      "modified": true
    },
    {
       "id": "Rules",

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -3005,11 +3005,6 @@
       "modified": false
    },
    {
-      "id": "Incorrect Usage. Requires stack name as argument\n\n",
-      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
-      "modified": false
-   },
-   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false
@@ -3047,6 +3042,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {
@@ -4247,6 +4247,11 @@
    {
       "id": "Routes",
       "translation": "Routes",
+      "modified": false
+   },
+   {
+      "id": "Routing API not found. Please log in.",
+      "translation": "Routing API not found. Please log in.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -4250,9 +4250,9 @@
       "modified": false
    },
    {
-      "id": "Routing API not found. Please log in.",
+      "id": "Routing API uri missing. Please log in again and retry.",
       "translation": "Routing API not found. Please log in.",
-      "modified": false
+      "modified": true
    },
    {
       "id": "Rules",

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -3005,11 +3005,6 @@
       "modified": false
    },
    {
-      "id": "Incorrect Usage. Requires stack name as argument\n\n",
-      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
-      "modified": false
-   },
-   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false
@@ -3047,6 +3042,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {
@@ -4247,6 +4247,11 @@
    {
       "id": "Routes",
       "translation": "Routes",
+      "modified": false
+   },
+   {
+      "id": "Routing API not found. Please log in.",
+      "translation": "Routing API not found. Please log in.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -4250,9 +4250,9 @@
       "modified": false
    },
    {
-      "id": "Routing API not found. Please log in.",
+      "id": "Routing API uri missing. Please log in again and retry.",
       "translation": "Routing API not found. Please log in.",
-      "modified": false
+      "modified": true
    },
    {
       "id": "Rules",

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -3005,11 +3005,6 @@
       "modified": false
    },
    {
-      "id": "Incorrect Usage. Requires stack name as argument\n\n",
-      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
-      "modified": false
-   },
-   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false
@@ -3047,6 +3042,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {
@@ -4247,6 +4247,11 @@
    {
       "id": "Routes",
       "translation": "Routes",
+      "modified": false
+   },
+   {
+      "id": "Routing API not found. Please log in.",
+      "translation": "Routing API not found. Please log in.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -3005,11 +3005,6 @@
       "modified": false
    },
    {
-      "id": "Incorrect Usage. Requires stack name as argument\n\n",
-      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
-      "modified": false
-   },
-   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false
@@ -3047,6 +3042,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {
@@ -4247,6 +4247,11 @@
    {
       "id": "Routes",
       "translation": "Rotas",
+      "modified": false
+   },
+   {
+      "id": "Routing API not found. Please log in.",
+      "translation": "Routing API not found. Please log in.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -4250,9 +4250,9 @@
       "modified": false
    },
    {
-      "id": "Routing API not found. Please log in.",
+      "id": "Routing API uri missing. Please log in again and retry.",
       "translation": "Routing API not found. Please log in.",
-      "modified": false
+      "modified": true
    },
    {
       "id": "Rules",

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -4250,9 +4250,9 @@
       "modified": false
    },
    {
-      "id": "Routing API not found. Please log in.",
+      "id": "Routing API uri missing. Please log in again and retry.",
       "translation": "Routing API not found. Please log in.",
-      "modified": false
+      "modified": true
    },
    {
       "id": "Rules",

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -3005,11 +3005,6 @@
       "modified": false
    },
    {
-      "id": "Incorrect Usage. Requires stack name as argument\n\n",
-      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
-      "modified": false
-   },
-   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false
@@ -3047,6 +3042,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {
@@ -4247,6 +4247,11 @@
    {
       "id": "Routes",
       "translation": "Routes",
+      "modified": false
+   },
+   {
+      "id": "Routing API not found. Please log in.",
+      "translation": "Routing API not found. Please log in.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -4250,9 +4250,9 @@
       "modified": false
    },
    {
-      "id": "Routing API not found. Please log in.",
+      "id": "Routing API uri missing. Please log in again and retry.",
       "translation": "Routing API not found. Please log in.",
-      "modified": false
+      "modified": true
    },
    {
       "id": "Rules",

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -3005,11 +3005,6 @@
       "modified": false
    },
    {
-      "id": "Incorrect Usage. Requires stack name as argument\n\n",
-      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
-      "modified": false
-   },
-   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false
@@ -3047,6 +3042,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {
@@ -4247,6 +4247,11 @@
    {
       "id": "Routes",
       "translation": "Routes",
+      "modified": false
+   },
+   {
+      "id": "Routing API not found. Please log in.",
+      "translation": "Routing API not found. Please log in.",
       "modified": false
    },
    {


### PR DESCRIPTION
This PR adds a specific error message when trying to execute "cf router-groups" and the Routing Api Endpoint is not defined in the ".cf/config.json". The i18n resources have been updated as well. For more details please check [#100975070]

Thanks,
Fermin Ordaz, Mike Smykowski, Atul Kshirsagar