### PR TITLE
Add support for port in create_route command

### DIFF
--- a/cf/api/fakes/fake_route_repo.go
+++ b/cf/api/fakes/fake_route_repo.go
@@ -16,11 +16,23 @@ type FakeRouteRepository struct {
 		Error error
 	}
 
+	FindByHostDomainAndPortCalledWith struct {
+		Host   string
+		Port   string
+		Domain models.DomainFields
+	}
+
+	FindByHostDomainAndPortReturns struct {
+		Route models.Route
+		Error error
+	}
+
 	CreatedHost       string
 	CreatedDomainGuid string
 	CreatedRoute      models.Route
 
 	CreateInSpaceHost         string
+	CreateInSpacePort         string
 	CreateInSpaceDomainGuid   string
 	CreateInSpaceSpaceGuid    string
 	CreateInSpaceCreatedRoute models.Route
@@ -69,6 +81,19 @@ func (repo *FakeRouteRepository) ListAllRoutes(cb func(models.Route) bool) (apiE
 	return
 }
 
+func (repo *FakeRouteRepository) FindByHostDomainAndPort(host, port string, domain models.DomainFields) (route models.Route, apiErr error) {
+	repo.FindByHostDomainAndPortCalledWith.Host = host
+	repo.FindByHostDomainAndPortCalledWith.Domain = domain
+	repo.FindByHostDomainAndPortCalledWith.Port = port
+
+	if repo.FindByHostDomainAndPortReturns.Error != nil {
+		apiErr = repo.FindByHostDomainAndPortReturns.Error
+	}
+
+	route = repo.FindByHostDomainAndPortReturns.Route
+	return
+}
+
 func (repo *FakeRouteRepository) FindByHostAndDomain(host string, domain models.DomainFields) (route models.Route, apiErr error) {
 	repo.FindByHostAndDomainCalledWith.Host = host
 	repo.FindByHostAndDomainCalledWith.Domain = domain
@@ -104,10 +129,11 @@ func (repo *FakeRouteRepository) CheckIfExists(host string, domain models.Domain
 	}
 	return
 }
-func (repo *FakeRouteRepository) CreateInSpace(host, domainGuid, spaceGuid string) (createdRoute models.Route, apiErr error) {
+func (repo *FakeRouteRepository) CreateInSpace(host, port, domainGuid, spaceGuid string) (createdRoute models.Route, apiErr error) {
 	repo.CreateInSpaceHost = host
 	repo.CreateInSpaceDomainGuid = domainGuid
 	repo.CreateInSpaceSpaceGuid = spaceGuid
+	repo.CreateInSpacePort = port
 
 	if repo.CreateInSpaceErr {
 		apiErr = errors.New("Error")

--- a/cf/api/resources/routes.go
+++ b/cf/api/resources/routes.go
@@ -9,6 +9,7 @@ type RouteResource struct {
 
 type RouteEntity struct {
 	Host   string
+	Port   int
 	Domain DomainResource
 	Space  SpaceResource
 	Apps   []ApplicationResource
@@ -21,6 +22,7 @@ func (resource RouteResource) ToFields() (fields models.Route) {
 }
 func (resource RouteResource) ToModel() (route models.Route) {
 	route.Host = resource.Entity.Host
+	route.Port = resource.Entity.Port
 	route.Guid = resource.Metadata.Guid
 	route.Domain = resource.Entity.Domain.ToFields()
 	route.Space = resource.Entity.Space.ToFields()

--- a/cf/commands/route/map_route.go
+++ b/cf/commands/route/map_route.go
@@ -73,7 +73,7 @@ func (cmd *MapRoute) Execute(c flags.FlagContext) {
 	domain := cmd.domainReq.GetDomain()
 	app := cmd.appReq.GetApplication()
 
-	route, apiErr := cmd.routeCreator.CreateRoute(hostName, domain, cmd.config.SpaceFields())
+	route, apiErr := cmd.routeCreator.CreateRoute(hostName, "", domain, cmd.config.SpaceFields())
 	if apiErr != nil {
 		cmd.ui.Failed(T("Error resolving route:\n{{.Err}}", map[string]interface{}{"Err": apiErr.Error()}))
 	}

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -685,8 +685,8 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
-      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
+      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
       "modified": false
    },
    {
@@ -1587,6 +1587,11 @@
    {
       "id": "Creating route {{.Hostname}}...",
       "translation": "Creating route {{.Hostname}}...",
+      "modified": false
+   },
+   {
+      "id": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3005,11 +3010,6 @@
       "modified": false
    },
    {
-      "id": "Incorrect Usage. Requires stack name as argument\n\n",
-      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
-      "modified": false
-   },
-   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false
@@ -3047,6 +3047,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {
@@ -3842,6 +3847,11 @@
    {
       "id": "Plugin {{.PluginName}} v{{.Version}} successfully installed.",
       "translation": "Plugin {{.PluginName}} successfully installed.",
+      "modified": true
+   },
+   {
+      "id": "Port used to create a TCP route. E.g. where domain is example.com and port is 50000, the resulting route is example.com:50000.",
+      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
       "modified": true
    },
    {

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -685,8 +685,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
-      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
+      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
       "modified": false
    },
    {
@@ -1587,6 +1587,11 @@
    {
       "id": "Creating route {{.Hostname}}...",
       "translation": "Creating route {{.Hostname}}...",
+      "modified": false
+   },
+   {
+      "id": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3005,11 +3010,6 @@
       "modified": false
    },
    {
-      "id": "Incorrect Usage. Requires stack name as argument\n\n",
-      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
-      "modified": false
-   },
-   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false
@@ -3047,6 +3047,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {
@@ -3842,6 +3847,11 @@
    {
       "id": "Plugin {{.PluginName}} v{{.Version}} successfully installed.",
       "translation": "Plugin {{.PluginName}} v{{.Version}} successfully installed.",
+      "modified": false
+   },
+   {
+      "id": "Port used to create a TCP route. E.g. where domain is example.com and port is 50000, the resulting route is example.com:50000.",
+      "translation": "Port used to create a TCP route. E.g. where domain is example.com and port is 50000, the resulting route is example.com:50000.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -685,8 +685,8 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
-      "translation": "CF_NAME create-route SPACE DOMINIO [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
+      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
       "modified": false
    },
    {
@@ -1587,6 +1587,11 @@
    {
       "id": "Creating route {{.Hostname}}...",
       "translation": "Creando ruta {{.Hostname}}...",
+      "modified": false
+   },
+   {
+      "id": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3005,11 +3010,6 @@
       "modified": false
    },
    {
-      "id": "Incorrect Usage. Requires stack name as argument\n\n",
-      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
-      "modified": false
-   },
-   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false
@@ -3047,6 +3047,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {
@@ -3842,6 +3847,11 @@
    {
       "id": "Plugin {{.PluginName}} v{{.Version}} successfully installed.",
       "translation": "Plugin {{.PluginName}} successfully installed.",
+      "modified": true
+   },
+   {
+      "id": "Port used to create a TCP route. E.g. where domain is example.com and port is 50000, the resulting route is example.com:50000.",
+      "translation": "CF_NAME create-route SPACE DOMINIO [-n HOSTNAME]",
       "modified": true
    },
    {

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -685,8 +685,8 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
-      "translation": "CF_NAME create-route ESPACE DOMAINE [-n HÔTE]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
+      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
       "modified": false
    },
    {
@@ -1587,6 +1587,11 @@
    {
       "id": "Creating route {{.Hostname}}...",
       "translation": "Création de la route {{.Hostname}}...",
+      "modified": false
+   },
+   {
+      "id": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3005,11 +3010,6 @@
       "modified": false
    },
    {
-      "id": "Incorrect Usage. Requires stack name as argument\n\n",
-      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
-      "modified": false
-   },
-   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false
@@ -3047,6 +3047,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {
@@ -3842,6 +3847,11 @@
    {
       "id": "Plugin {{.PluginName}} v{{.Version}} successfully installed.",
       "translation": "Plugin {{.PluginName}} successfully installed.",
+      "modified": true
+   },
+   {
+      "id": "Port used to create a TCP route. E.g. where domain is example.com and port is 50000, the resulting route is example.com:50000.",
+      "translation": "CF_NAME create-route ESPACE DOMAINE [-n HÔTE]",
       "modified": true
    },
    {

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -685,8 +685,8 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
-      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
+      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
       "modified": false
    },
    {
@@ -1587,6 +1587,11 @@
    {
       "id": "Creating route {{.Hostname}}...",
       "translation": "Creating route {{.Hostname}}...",
+      "modified": false
+   },
+   {
+      "id": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3005,11 +3010,6 @@
       "modified": false
    },
    {
-      "id": "Incorrect Usage. Requires stack name as argument\n\n",
-      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
-      "modified": false
-   },
-   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false
@@ -3047,6 +3047,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {
@@ -3842,6 +3847,11 @@
    {
       "id": "Plugin {{.PluginName}} v{{.Version}} successfully installed.",
       "translation": "Plugin {{.PluginName}} successfully installed.",
+      "modified": true
+   },
+   {
+      "id": "Port used to create a TCP route. E.g. where domain is example.com and port is 50000, the resulting route is example.com:50000.",
+      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
       "modified": true
    },
    {

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -685,8 +685,8 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
-      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
+      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
       "modified": false
    },
    {
@@ -1587,6 +1587,11 @@
    {
       "id": "Creating route {{.Hostname}}...",
       "translation": "Creating route {{.Hostname}}...",
+      "modified": false
+   },
+   {
+      "id": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3005,11 +3010,6 @@
       "modified": false
    },
    {
-      "id": "Incorrect Usage. Requires stack name as argument\n\n",
-      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
-      "modified": false
-   },
-   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false
@@ -3047,6 +3047,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {
@@ -3842,6 +3847,11 @@
    {
       "id": "Plugin {{.PluginName}} v{{.Version}} successfully installed.",
       "translation": "Plugin {{.PluginName}} successfully installed.",
+      "modified": true
+   },
+   {
+      "id": "Port used to create a TCP route. E.g. where domain is example.com and port is 50000, the resulting route is example.com:50000.",
+      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
       "modified": true
    },
    {

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -685,8 +685,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
-      "translation": "CF_NAME create-route ESPAÇO DOMÍNIO [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
+      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
       "modified": false
    },
    {
@@ -1587,6 +1587,11 @@
    {
       "id": "Creating route {{.Hostname}}...",
       "translation": "Criando rota {{.Hostname}}...",
+      "modified": false
+   },
+   {
+      "id": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3005,11 +3010,6 @@
       "modified": false
    },
    {
-      "id": "Incorrect Usage. Requires stack name as argument\n\n",
-      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
-      "modified": false
-   },
-   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false
@@ -3047,6 +3047,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {
@@ -3842,6 +3847,11 @@
    {
       "id": "Plugin {{.PluginName}} v{{.Version}} successfully installed.",
       "translation": "Plugin {{.PluginName}} successfully installed.",
+      "modified": true
+   },
+   {
+      "id": "Port used to create a TCP route. E.g. where domain is example.com and port is 50000, the resulting route is example.com:50000.",
+      "translation": "CF_NAME create-route ESPAÇO DOMÍNIO [-n HOSTNAME]",
       "modified": true
    },
    {

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -685,8 +685,8 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
-      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
+      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
       "modified": false
    },
    {
@@ -1587,6 +1587,11 @@
    {
       "id": "Creating route {{.Hostname}}...",
       "translation": "创建路由 {{.Hostname}}...",
+      "modified": false
+   },
+   {
+      "id": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3005,11 +3010,6 @@
       "modified": false
    },
    {
-      "id": "Incorrect Usage. Requires stack name as argument\n\n",
-      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
-      "modified": false
-   },
-   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false
@@ -3047,6 +3047,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {
@@ -3842,6 +3847,11 @@
    {
       "id": "Plugin {{.PluginName}} v{{.Version}} successfully installed.",
       "translation": "Plugin {{.PluginName}} successfully installed.",
+      "modified": true
+   },
+   {
+      "id": "Port used to create a TCP route. E.g. where domain is example.com and port is 50000, the resulting route is example.com:50000.",
+      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
       "modified": true
    },
    {

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -685,8 +685,8 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
-      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
+      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
       "modified": false
    },
    {
@@ -1587,6 +1587,11 @@
    {
       "id": "Creating route {{.Hostname}}...",
       "translation": "Creating route {{.Hostname}}...",
+      "modified": false
+   },
+   {
+      "id": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3005,11 +3010,6 @@
       "modified": false
    },
    {
-      "id": "Incorrect Usage. Requires stack name as argument\n\n",
-      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
-      "modified": false
-   },
-   {
       "id": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "translation": "Incorrect Usage. Requires app_name, domain_name as arguments\n\n",
       "modified": false
@@ -3047,6 +3047,11 @@
    {
       "id": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
       "translation": "Incorrect Usage. Requires service, service plan, service instance as arguments\n\n",
+      "modified": false
+   },
+   {
+      "id": "Incorrect Usage. Requires stack name as argument\n\n",
+      "translation": "Incorrect Usage. Requires stack name as argument\n\n",
       "modified": false
    },
    {
@@ -3842,6 +3847,11 @@
    {
       "id": "Plugin {{.PluginName}} v{{.Version}} successfully installed.",
       "translation": "Plugin {{.PluginName}} successfully installed.",
+      "modified": true
+   },
+   {
+      "id": "Port used to create a TCP route. E.g. where domain is example.com and port is 50000, the resulting route is example.com:50000.",
+      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
       "modified": true
    },
    {

--- a/cf/models/route.go
+++ b/cf/models/route.go
@@ -5,6 +5,7 @@ import "fmt"
 type Route struct {
 	Guid   string
 	Host   string
+	Port   int
 	Domain DomainFields
 
 	Space SpaceFields
@@ -12,10 +13,16 @@ type Route struct {
 }
 
 func (route Route) URL() string {
-	if route.Host == "" {
+	if route.Host == "" && route.Port == 0 {
 		return route.Domain.Name
 	}
-	return fmt.Sprintf("%s.%s", route.Host, route.Domain.Name)
+	if route.Port == 0 {
+		return fmt.Sprintf("%s.%s", route.Host, route.Domain.Name)
+	}
+	if route.Host == "" {
+		return fmt.Sprintf("%s:%d", route.Domain.Name, route.Port)
+	}
+	return fmt.Sprintf("%s.%s:%d", route.Host, route.Domain.Name, route.Port)
 }
 
 type RouteSummary struct {

--- a/testhelpers/commands/fake_route_creator.go
+++ b/testhelpers/commands/fake_route_creator.go
@@ -9,13 +9,15 @@ import (
 
 type FakeRouteCreator struct {
 	CreateRouteHostname     string
+	CreateRoutePort         string
 	CreateRouteDomainFields models.DomainFields
 	CreateRouteSpaceFields  models.SpaceFields
 	ReservedRoute           models.Route
 }
 
-func (cmd *FakeRouteCreator) CreateRoute(hostName string, domain models.DomainFields, space models.SpaceFields) (reservedRoute models.Route, apiErr error) {
+func (cmd *FakeRouteCreator) CreateRoute(hostName, port string, domain models.DomainFields, space models.SpaceFields) (reservedRoute models.Route, apiErr error) {
 	cmd.CreateRouteHostname = hostName
+	cmd.CreateRoutePort = port
 	cmd.CreateRouteDomainFields = domain
 	cmd.CreateRouteSpaceFields = space
 	reservedRoute = cmd.ReservedRoute


### PR DESCRIPTION
This PR is to support port in `create-route` command. This is required for tcp routes.

Regards,
@atulkc and @yuzhangcmu
(CF Routing team)
Pivotal tracker story: https://www.pivotaltracker.com/story/show/100992242