### PR TITLE
Add support for port in create_route command

### DIFF
--- a/cf/api/fakes/fake_route_repo.go
+++ b/cf/api/fakes/fake_route_repo.go
@@ -16,15 +16,27 @@ type FakeRouteRepository struct {
 		Error error
 	}
 
+	FindByHostDomainAndPortCalledWith struct {
+		Host   string
+		Port   string
+		Domain models.DomainFields
+	}
+
+	FindByHostDomainAndPortReturns struct {
+		Route models.Route
+		Error error
+	}
+
 	CreatedHost       string
 	CreatedDomainGuid string
 	CreatedRoute      models.Route
 
 	CreateInSpaceHost         string
+	CreateInSpacePort         string
 	CreateInSpaceDomainGuid   string
 	CreateInSpaceSpaceGuid    string
 	CreateInSpaceCreatedRoute models.Route
-	CreateInSpaceErr          bool
+	CreateInSpaceErr          error
 
 	CheckIfExistsFound bool
 	CheckIfExistsError error
@@ -69,6 +81,19 @@ func (repo *FakeRouteRepository) ListAllRoutes(cb func(models.Route) bool) (apiE
 	return
 }
 
+func (repo *FakeRouteRepository) FindByHostDomainAndPort(host, port string, domain models.DomainFields) (route models.Route, apiErr error) {
+	repo.FindByHostDomainAndPortCalledWith.Host = host
+	repo.FindByHostDomainAndPortCalledWith.Domain = domain
+	repo.FindByHostDomainAndPortCalledWith.Port = port
+
+	if repo.FindByHostDomainAndPortReturns.Error != nil {
+		apiErr = repo.FindByHostDomainAndPortReturns.Error
+	}
+
+	route = repo.FindByHostDomainAndPortReturns.Route
+	return
+}
+
 func (repo *FakeRouteRepository) FindByHostAndDomain(host string, domain models.DomainFields) (route models.Route, apiErr error) {
 	repo.FindByHostAndDomainCalledWith.Host = host
 	repo.FindByHostAndDomainCalledWith.Domain = domain
@@ -104,13 +129,14 @@ func (repo *FakeRouteRepository) CheckIfExists(host string, domain models.Domain
 	}
 	return
 }
-func (repo *FakeRouteRepository) CreateInSpace(host, domainGuid, spaceGuid string) (createdRoute models.Route, apiErr error) {
+func (repo *FakeRouteRepository) CreateInSpace(host, port, domainGuid, spaceGuid string) (createdRoute models.Route, apiErr error) {
 	repo.CreateInSpaceHost = host
 	repo.CreateInSpaceDomainGuid = domainGuid
 	repo.CreateInSpaceSpaceGuid = spaceGuid
+	repo.CreateInSpacePort = port
 
-	if repo.CreateInSpaceErr {
-		apiErr = errors.New("Error")
+	if repo.CreateInSpaceErr != nil {
+		apiErr = repo.CreateInSpaceErr
 	} else {
 		createdRoute = repo.CreateInSpaceCreatedRoute
 	}

--- a/cf/api/resources/routes.go
+++ b/cf/api/resources/routes.go
@@ -9,6 +9,7 @@ type RouteResource struct {
 
 type RouteEntity struct {
 	Host   string
+	Port   int
 	Domain DomainResource
 	Space  SpaceResource
 	Apps   []ApplicationResource
@@ -21,6 +22,7 @@ func (resource RouteResource) ToFields() (fields models.Route) {
 }
 func (resource RouteResource) ToModel() (route models.Route) {
 	route.Host = resource.Entity.Host
+	route.Port = resource.Entity.Port
 	route.Guid = resource.Metadata.Guid
 	route.Domain = resource.Entity.Domain.ToFields()
 	route.Space = resource.Entity.Space.ToFields()

--- a/cf/api/routes.go
+++ b/cf/api/routes.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"fmt"
 	"net/url"
 	"strings"
@@ -16,9 +17,10 @@ type RouteRepository interface {
 	ListRoutes(cb func(models.Route) bool) (apiErr error)
 	ListAllRoutes(cb func(models.Route) bool) (apiErr error)
 	FindByHostAndDomain(host string, domain models.DomainFields) (route models.Route, apiErr error)
+	FindByHostDomainAndPort(host, port string, domain models.DomainFields) (route models.Route, apiErr error)
 	Create(host string, domain models.DomainFields) (createdRoute models.Route, apiErr error)
 	CheckIfExists(host string, domain models.DomainFields) (found bool, apiErr error)
-	CreateInSpace(host, domainGuid, spaceGuid string) (createdRoute models.Route, apiErr error)
+	CreateInSpace(host, port, domainGuid, spaceGuid string) (createdRoute models.Route, apiErr error)
 	Bind(routeGuid, appGuid string) (apiErr error)
 	Unbind(routeGuid, appGuid string) (apiErr error)
 	Delete(routeGuid string) (apiErr error)
@@ -54,11 +56,22 @@ func (repo CloudControllerRouteRepository) ListAllRoutes(cb func(models.Route) b
 			return cb(resource.(resources.RouteResource).ToModel())
 		})
 }
+
 func (repo CloudControllerRouteRepository) FindByHostAndDomain(host string, domain models.DomainFields) (route models.Route, apiErr error) {
+	return repo.FindByHostDomainAndPort(host, "", domain)
+}
+
+func (repo CloudControllerRouteRepository) FindByHostDomainAndPort(host, port string, domain models.DomainFields) (route models.Route, apiErr error) {
 	found := false
+	var endpointURL string
+	if port == "" {
+		endpointURL = fmt.Sprintf("/v2/routes?inline-relations-depth=1&q=%s", url.QueryEscape("host:"+host+";domain_guid:"+domain.Guid))
+	} else {
+		endpointURL = fmt.Sprintf("/v2/routes?inline-relations-depth=1&q=%s", url.QueryEscape("host:"+host+";domain_guid:"+domain.Guid+";port:"+port))
+	}
 	apiErr = repo.gateway.ListPaginatedResources(
 		repo.config.ApiEndpoint(),
-		fmt.Sprintf("/v2/routes?inline-relations-depth=1&q=%s", url.QueryEscape("host:"+host+";domain_guid:"+domain.Guid)),
+		endpointURL,
 		resources.RouteResource{},
 		func(resource interface{}) bool {
 			route = resource.(resources.RouteResource).ToModel()
@@ -74,7 +87,7 @@ func (repo CloudControllerRouteRepository) FindByHostAndDomain(host string, doma
 }
 
 func (repo CloudControllerRouteRepository) Create(host string, domain models.DomainFields) (createdRoute models.Route, apiErr error) {
-	return repo.CreateInSpace(host, domain.Guid, repo.config.SpaceFields().Guid)
+	return repo.CreateInSpace(host, "", domain.Guid, repo.config.SpaceFields().Guid)
 }
 
 func (repo CloudControllerRouteRepository) CheckIfExists(host string, domain models.DomainFields) (found bool, apiErr error) {
@@ -93,11 +106,20 @@ func (repo CloudControllerRouteRepository) CheckIfExists(host string, domain mod
 	return
 }
 
-func (repo CloudControllerRouteRepository) CreateInSpace(host, domainGuid, spaceGuid string) (createdRoute models.Route, apiErr error) {
-	data := fmt.Sprintf(`{"host":"%s","domain_guid":"%s","space_guid":"%s"}`, host, domainGuid, spaceGuid)
+func (repo CloudControllerRouteRepository) CreateInSpace(host string, port string, domainGuid, spaceGuid string) (createdRoute models.Route, apiErr error) {
+	var buffer bytes.Buffer
+
+	buffer.WriteString("{")
+	buffer.WriteString(fmt.Sprintf(`"host":"%s","domain_guid":"%s","space_guid":"%s"`, host, domainGuid, spaceGuid))
+	if port != "" {
+		buffer.WriteString(fmt.Sprintf(`,"port":%s`, port))
+	}
+	buffer.WriteString("}")
+
+	requestPayload := buffer.String()
 
 	resource := new(resources.RouteResource)
-	apiErr = repo.gateway.CreateResource(repo.config.ApiEndpoint(), "/v2/routes?inline-relations-depth=1", strings.NewReader(data), resource)
+	apiErr = repo.gateway.CreateResource(repo.config.ApiEndpoint(), "/v2/routes?inline-relations-depth=1", strings.NewReader(requestPayload), resource)
 	if apiErr != nil {
 		return
 	}

--- a/cf/commands/route/create_route.go
+++ b/cf/commands/route/create_route.go
@@ -1,9 +1,12 @@
 package route
 
 import (
+	"strconv"
+
 	"github.com/cloudfoundry/cli/cf/api"
 	"github.com/cloudfoundry/cli/cf/command_registry"
 	"github.com/cloudfoundry/cli/cf/configuration/core_config"
+	"github.com/cloudfoundry/cli/cf/errors"
 	. "github.com/cloudfoundry/cli/cf/i18n"
 	"github.com/cloudfoundry/cli/cf/models"
 	"github.com/cloudfoundry/cli/cf/requirements"
@@ -13,7 +16,7 @@ import (
 )
 
 type RouteCreator interface {
-	CreateRoute(hostName string, domain models.DomainFields, space models.SpaceFields) (route models.Route, apiErr error)
+	CreateRoute(hostName, port string, domain models.DomainFields, space models.SpaceFields) (route models.Route, apiErr error)
 }
 
 type CreateRoute struct {
@@ -31,11 +34,12 @@ func init() {
 func (cmd *CreateRoute) MetaData() command_registry.CommandMetadata {
 	fs := make(map[string]flags.FlagSet)
 	fs["n"] = &cliFlags.StringFlag{Name: "n", Usage: T("Hostname")}
+	fs["p"] = &cliFlags.IntFlag{Name: "p", Usage: T("Port used to create a TCP route. E.g. where domain is example.com and port is 50000, the resulting route is example.com:50000.")}
 
 	return command_registry.CommandMetadata{
 		Name:        "create-route",
 		Description: T("Create a url route in a space for later use"),
-		Usage:       T("CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]"),
+		Usage:       T("CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]"),
 		Flags:       fs,
 	}
 }
@@ -68,30 +72,49 @@ func (cmd *CreateRoute) SetDependency(deps command_registry.Dependency, pluginCa
 
 func (cmd *CreateRoute) Execute(c flags.FlagContext) {
 	hostName := c.String("n")
+
+	portStr := ""
+	if c.IsSet("p") {
+		portStr = strconv.Itoa(c.Int("p"))
+	}
+
 	space := cmd.spaceReq.GetSpace()
 	domain := cmd.domainReq.GetDomain()
 
-	_, apiErr := cmd.CreateRoute(hostName, domain, space.SpaceFields)
+	_, apiErr := cmd.CreateRoute(hostName, portStr, domain, space.SpaceFields)
 	if apiErr != nil {
 		cmd.ui.Failed(apiErr.Error())
 		return
 	}
 }
 
-func (cmd *CreateRoute) CreateRoute(hostName string, domain models.DomainFields, space models.SpaceFields) (route models.Route, apiErr error) {
-	cmd.ui.Say(T("Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+func (cmd *CreateRoute) CreateRoute(hostName, port string, domain models.DomainFields, space models.SpaceFields) (route models.Route, apiErr error) {
+	uiArgMap :=
 		map[string]interface{}{
 			"Hostname":  terminal.EntityNameColor(domain.UrlForHost(hostName)),
 			"OrgName":   terminal.EntityNameColor(cmd.config.OrganizationFields().Name),
 			"SpaceName": terminal.EntityNameColor(space.Name),
-			"Username":  terminal.EntityNameColor(cmd.config.Username())}))
+			"Username":  terminal.EntityNameColor(cmd.config.Username()),
+		}
 
-	route, apiErr = cmd.routeRepo.CreateInSpace(hostName, domain.Guid, space.Guid)
+	if port == "" {
+		cmd.ui.Say(T("Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...", uiArgMap))
+	} else {
+		uiArgMap["Port"] = terminal.EntityNameColor(port)
+		cmd.ui.Say(T("Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...", uiArgMap))
+	}
+
+	route, apiErr = cmd.routeRepo.CreateInSpace(hostName, port, domain.Guid, space.Guid)
+
 	if apiErr != nil {
-		var findApiResponse error
-		route, findApiResponse = cmd.routeRepo.FindByHostAndDomain(hostName, domain)
+		httpErr, isHttpError := apiErr.(errors.HttpError)
+		if !isHttpError || (httpErr.ErrorCode() != errors.PORT_TAKEN && httpErr.ErrorCode() != errors.HOST_TAKEN) {
+			return
+		}
 
-		if findApiResponse != nil ||
+		var err error
+		route, err = cmd.routeRepo.FindByHostDomainAndPort(hostName, port, domain)
+		if err != nil ||
 			route.Space.Guid != space.Guid ||
 			route.Domain.Guid != domain.Guid {
 			return

--- a/cf/commands/route/create_route_test.go
+++ b/cf/commands/route/create_route_test.go
@@ -3,6 +3,7 @@ package route_test
 import (
 	testapi "github.com/cloudfoundry/cli/cf/api/fakes"
 	"github.com/cloudfoundry/cli/cf/configuration/core_config"
+	"github.com/cloudfoundry/cli/cf/errors"
 	"github.com/cloudfoundry/cli/cf/models"
 	testcmd "github.com/cloudfoundry/cli/testhelpers/commands"
 	testconfig "github.com/cloudfoundry/cli/testhelpers/configuration"
@@ -81,46 +82,199 @@ var _ = Describe("create-route command", func() {
 			}}
 		})
 
-		It("creates routes, obviously", func() {
-			runCommand("-n", "host", "my-space", "example.com")
+		Context("when creating http routes", func() {
+			It("creates routes, obviously", func() {
+				runCommand("-n", "host", "my-space", "example.com")
 
-			Expect(ui.Outputs).To(ContainSubstrings(
-				[]string{"Creating route", "host.example.com", "my-org", "my-space", "my-user"},
-				[]string{"OK"},
-			))
+				Expect(ui.Outputs).To(ContainSubstrings(
+					[]string{"Creating route", "host.example.com", "my-org", "my-space", "my-user"},
+					[]string{"OK"},
+				))
 
-			Expect(routeRepo.CreateInSpaceHost).To(Equal("host"))
-			Expect(routeRepo.CreateInSpaceDomainGuid).To(Equal("domain-guid"))
-			Expect(routeRepo.CreateInSpaceSpaceGuid).To(Equal("my-space-guid"))
+				Expect(routeRepo.CreateInSpaceHost).To(Equal("host"))
+				Expect(routeRepo.CreateInSpaceDomainGuid).To(Equal("domain-guid"))
+				Expect(routeRepo.CreateInSpaceSpaceGuid).To(Equal("my-space-guid"))
+			})
+
+			It("is idempotent", func() {
+				routeRepo.CreateInSpaceErr = errors.NewHttpError(400, errors.HOST_TAKEN, "host already exists")
+				routeRepo.FindByHostDomainAndPortReturns.Route = models.Route{
+					Space:  requirementsFactory.Space.SpaceFields,
+					Guid:   "my-route-guid",
+					Host:   "host",
+					Domain: requirementsFactory.Domain,
+				}
+
+				runCommand("-n", "host", "my-space", "example.com")
+
+				Expect(routeRepo.FindByHostDomainAndPortCalledWith.Host).To(Equal("host"))
+				Expect(routeRepo.FindByHostDomainAndPortCalledWith.Domain.Guid).To(Equal(requirementsFactory.Domain.Guid))
+				Expect(routeRepo.FindByHostDomainAndPortCalledWith.Port).To(Equal(""))
+
+				Expect(ui.Outputs).To(ContainSubstrings(
+					[]string{"Creating route"},
+					[]string{"OK"},
+					[]string{"host.example.com", "already exists"},
+				))
+
+				Expect(routeRepo.CreateInSpaceHost).To(Equal("host"))
+				Expect(routeRepo.CreateInSpaceDomainGuid).To(Equal("domain-guid"))
+				Expect(routeRepo.CreateInSpaceSpaceGuid).To(Equal("my-space-guid"))
+			})
+
+			Context("when route repo returns error in createInSpace", func() {
+				It("displays that error", func() {
+					routeRepo.CreateInSpaceErr = errors.NewHttpError(400, "220023", "Some other error")
+					routeRepo.FindByHostDomainAndPortReturns.Route = models.Route{
+						Space: requirementsFactory.Space.SpaceFields,
+						Guid:  "my-route-guid",
+						Host:  "host",
+						Domain: models.DomainFields{
+							Guid: "some-other-guid",
+						},
+					}
+
+					runCommand("-n", "host", "my-space", "example.com")
+
+					Expect(ui.Outputs).To(ContainSubstrings(
+						[]string{"Creating route"},
+						[]string{"FAILED"},
+						[]string{"400"},
+						[]string{"220023"},
+						[]string{"Some other error"},
+					))
+
+					Expect(routeRepo.CreateInSpaceHost).To(Equal("host"))
+					Expect(routeRepo.CreateInSpaceDomainGuid).To(Equal("domain-guid"))
+					Expect(routeRepo.CreateInSpaceSpaceGuid).To(Equal("my-space-guid"))
+				})
+			})
+
+			Context("when route repo returns non-HTTP error", func() {
+				It("displays that error", func() {
+					routeRepo.CreateInSpaceErr = errors.New("some non-HTTP error")
+
+					routeRepo.FindByHostDomainAndPortReturns.Route = models.Route{
+						Space: requirementsFactory.Space.SpaceFields,
+						Guid:  "my-route-guid",
+						Host:  "host",
+						Domain: models.DomainFields{
+							Guid: "some-other-guid",
+						},
+					}
+
+					runCommand("-n", "host", "my-space", "example.com")
+
+					Expect(ui.Outputs).To(ContainSubstrings(
+						[]string{"Creating route"},
+						[]string{"FAILED"},
+						[]string{"some non-HTTP error"},
+					))
+
+					Expect(routeRepo.CreateInSpaceHost).To(Equal("host"))
+					Expect(routeRepo.CreateInSpaceDomainGuid).To(Equal("domain-guid"))
+					Expect(routeRepo.CreateInSpaceSpaceGuid).To(Equal("my-space-guid"))
+				})
+			})
 		})
 
-		It("is idempotent", func() {
-			routeRepo.CreateInSpaceErr = true
-			routeRepo.FindByHostAndDomainReturns.Route = models.Route{
-				Space:  requirementsFactory.Space.SpaceFields,
-				Guid:   "my-route-guid",
-				Host:   "host",
-				Domain: requirementsFactory.Domain,
-			}
+		Context("when creating tcp routes", func() {
+			It("creates routes, obviously", func() {
+				runCommand("my-space", "example.com", "-p", "8080")
 
-			runCommand("-n", "host", "my-space", "example.com")
+				Expect(ui.Outputs).To(ContainSubstrings(
+					[]string{"Creating route", "example.com:8080", "my-org", "my-space", "my-user"},
+					[]string{"OK"},
+				))
 
-			Expect(ui.Outputs).To(ContainSubstrings(
-				[]string{"Creating route"},
-				[]string{"OK"},
-				[]string{"host.example.com", "already exists"},
-			))
+				Expect(routeRepo.CreateInSpaceDomainGuid).To(Equal("domain-guid"))
+				Expect(routeRepo.CreateInSpaceSpaceGuid).To(Equal("my-space-guid"))
+				Expect(routeRepo.CreateInSpacePort).To(Equal("8080"))
+			})
 
-			Expect(routeRepo.CreateInSpaceHost).To(Equal("host"))
-			Expect(routeRepo.CreateInSpaceDomainGuid).To(Equal("domain-guid"))
-			Expect(routeRepo.CreateInSpaceSpaceGuid).To(Equal("my-space-guid"))
+			It("is idempotent", func() {
+				routeRepo.CreateInSpaceErr = errors.NewHttpError(400, errors.PORT_TAKEN, "port 8080 already taken")
+				routeRepo.FindByHostDomainAndPortReturns.Route = models.Route{
+					Space:  requirementsFactory.Space.SpaceFields,
+					Guid:   "my-route-guid",
+					Port:   8080,
+					Domain: requirementsFactory.Domain,
+				}
+
+				runCommand("-p", "8080", "my-space", "example.com")
+
+				Expect(ui.Outputs).To(ContainSubstrings(
+					[]string{"Creating route"},
+					[]string{"OK"},
+					[]string{"example.com:8080", "already exists"},
+				))
+
+				Expect(routeRepo.CreateInSpaceHost).To(Equal(""))
+				Expect(routeRepo.CreateInSpaceDomainGuid).To(Equal("domain-guid"))
+				Expect(routeRepo.CreateInSpaceSpaceGuid).To(Equal("my-space-guid"))
+				Expect(routeRepo.CreateInSpacePort).To(Equal("8080"))
+			})
+
+			Context("when route repo returns error in CreateInSpace", func() {
+				It("displays that error", func() {
+					routeRepo.CreateInSpaceErr = errors.NewHttpError(400, "158952", "some other error")
+					routeRepo.FindByHostDomainAndPortReturns.Route = models.Route{
+						Space: requirementsFactory.Space.SpaceFields,
+						Guid:  "my-route-guid",
+						Port:  8080,
+						Domain: models.DomainFields{
+							Guid: "some-other-guid",
+						},
+					}
+
+					runCommand("my-space", "example.com")
+
+					Expect(ui.Outputs).To(ContainSubstrings(
+						[]string{"Creating route"},
+						[]string{"FAILED"},
+						[]string{"158952"},
+						[]string{"some other error"},
+					))
+
+					Expect(routeRepo.CreateInSpaceHost).To(Equal(""))
+					Expect(routeRepo.CreateInSpacePort).To(Equal(""))
+					Expect(routeRepo.CreateInSpaceDomainGuid).To(Equal("domain-guid"))
+					Expect(routeRepo.CreateInSpaceSpaceGuid).To(Equal("my-space-guid"))
+				})
+			})
+
+			Context("when route repo returns non-HTTP error", func() {
+				It("displays that error", func() {
+					routeRepo.CreateInSpaceErr = errors.New("some non-HTTP error")
+
+					routeRepo.FindByHostDomainAndPortReturns.Route = models.Route{
+						Space: requirementsFactory.Space.SpaceFields,
+						Guid:  "my-route-guid",
+						Host:  "host",
+						Domain: models.DomainFields{
+							Guid: "some-other-guid",
+						},
+					}
+
+					runCommand("-p", "5095", "my-space", "example.com")
+
+					Expect(ui.Outputs).To(ContainSubstrings(
+						[]string{"Creating route"},
+						[]string{"FAILED"},
+						[]string{"some non-HTTP error"},
+					))
+
+					Expect(routeRepo.CreateInSpaceHost).To(Equal(""))
+					Expect(routeRepo.CreateInSpacePort).To(Equal("5095"))
+					Expect(routeRepo.CreateInSpaceDomainGuid).To(Equal("domain-guid"))
+					Expect(routeRepo.CreateInSpaceSpaceGuid).To(Equal("my-space-guid"))
+				})
+			})
 		})
 
 		Describe("RouteCreator interface", func() {
-			It("creates a route, given a domain and space", func() {
+			It("creates a HTTP route, given a domain and space, specify host", func() {
 				createdRoute := models.Route{}
-				createdRoute.Host = "my-host"
-				createdRoute.Guid = "my-route-guid"
 				routeRepo = &testapi.FakeRouteRepository{
 					CreateInSpaceCreatedRoute: createdRoute,
 				}
@@ -128,7 +282,7 @@ var _ = Describe("create-route command", func() {
 				updateCommandDependency(false)
 				c := command_registry.Commands.FindCommand("create-route")
 				cmd := c.(RouteCreator)
-				route, apiErr := cmd.CreateRoute("my-host", requirementsFactory.Domain, requirementsFactory.Space.SpaceFields)
+				route, apiErr := cmd.CreateRoute("my-host", "", requirementsFactory.Domain, requirementsFactory.Space.SpaceFields)
 
 				Expect(apiErr).NotTo(HaveOccurred())
 				Expect(route.Guid).To(Equal(createdRoute.Guid))
@@ -138,6 +292,29 @@ var _ = Describe("create-route command", func() {
 				))
 
 				Expect(routeRepo.CreateInSpaceHost).To(Equal("my-host"))
+				Expect(routeRepo.CreateInSpaceDomainGuid).To(Equal("domain-guid"))
+				Expect(routeRepo.CreateInSpaceSpaceGuid).To(Equal("my-space-guid"))
+			})
+
+			It("creates a TCP route, given a domain and space, specify port", func() {
+				createdRoute := models.Route{}
+				routeRepo = &testapi.FakeRouteRepository{
+					CreateInSpaceCreatedRoute: createdRoute,
+				}
+
+				updateCommandDependency(false)
+				c := command_registry.Commands.FindCommand("create-route")
+				cmd := c.(RouteCreator)
+				route, apiErr := cmd.CreateRoute("", "10011", requirementsFactory.Domain, requirementsFactory.Space.SpaceFields)
+
+				Expect(apiErr).NotTo(HaveOccurred())
+				Expect(route.Guid).To(Equal(createdRoute.Guid))
+				Expect(ui.Outputs).To(ContainSubstrings(
+					[]string{"Creating route", "example.com", "my-org", "my-space", "my-user", "10011"},
+					[]string{"OK"},
+				))
+
+				Expect(routeRepo.CreateInSpacePort).To(Equal("10011"))
 				Expect(routeRepo.CreateInSpaceDomainGuid).To(Equal("domain-guid"))
 				Expect(routeRepo.CreateInSpaceSpaceGuid).To(Equal("my-space-guid"))
 			})

--- a/cf/commands/route/map_route.go
+++ b/cf/commands/route/map_route.go
@@ -73,7 +73,7 @@ func (cmd *MapRoute) Execute(c flags.FlagContext) {
 	domain := cmd.domainReq.GetDomain()
 	app := cmd.appReq.GetApplication()
 
-	route, apiErr := cmd.routeCreator.CreateRoute(hostName, domain, cmd.config.SpaceFields())
+	route, apiErr := cmd.routeCreator.CreateRoute(hostName, "", domain, cmd.config.SpaceFields())
 	if apiErr != nil {
 		cmd.ui.Failed(T("Error resolving route:\n{{.Err}}", map[string]interface{}{"Err": apiErr.Error()}))
 	}

--- a/cf/errors/known_error_codes.go
+++ b/cf/errors/known_error_codes.go
@@ -18,4 +18,6 @@ const (
 	SECURITY_GROUP_EXISTS       = "300005"
 	APP_ALREADY_BOUND           = "90003"
 	UNBINDABLE_SERVICE          = "90005"
+	PORT_TAKEN                  = "210005"
+	HOST_TAKEN                  = "210003"
 )

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -685,8 +685,8 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
-      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
+      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
       "modified": false
    },
    {
@@ -1587,6 +1587,11 @@
    {
       "id": "Creating route {{.Hostname}}...",
       "translation": "Creating route {{.Hostname}}...",
+      "modified": false
+   },
+   {
+      "id": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3843,6 +3848,11 @@
       "id": "Plugin {{.PluginName}} v{{.Version}} successfully installed.",
       "translation": "Plugin {{.PluginName}} successfully installed.",
       "modified": true
+   },
+   {
+      "id": "Port used to create a TCP route. E.g. where domain is example.com and port is 50000, the resulting route is example.com:50000.",
+      "translation": "Port used to create a TCP route. E.g. where domain is example.com and port is 50000, the resulting route is example.com:50000.",
+      "modified": false
    },
    {
       "id": "Print API request diagnostics to stdout",

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -685,8 +685,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
-      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
+      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
       "modified": false
    },
    {
@@ -1587,6 +1587,11 @@
    {
       "id": "Creating route {{.Hostname}}...",
       "translation": "Creating route {{.Hostname}}...",
+      "modified": false
+   },
+   {
+      "id": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3842,6 +3847,11 @@
    {
       "id": "Plugin {{.PluginName}} v{{.Version}} successfully installed.",
       "translation": "Plugin {{.PluginName}} v{{.Version}} successfully installed.",
+      "modified": false
+   },
+   {
+      "id": "Port used to create a TCP route. E.g. where domain is example.com and port is 50000, the resulting route is example.com:50000.",
+      "translation": "Port used to create a TCP route. E.g. where domain is example.com and port is 50000, the resulting route is example.com:50000.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -685,8 +685,8 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
-      "translation": "CF_NAME create-route SPACE DOMINIO [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
+      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
       "modified": false
    },
    {
@@ -1587,6 +1587,11 @@
    {
       "id": "Creating route {{.Hostname}}...",
       "translation": "Creando ruta {{.Hostname}}...",
+      "modified": false
+   },
+   {
+      "id": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3843,6 +3848,11 @@
       "id": "Plugin {{.PluginName}} v{{.Version}} successfully installed.",
       "translation": "Plugin {{.PluginName}} successfully installed.",
       "modified": true
+   },
+   {
+      "id": "Port used to create a TCP route. E.g. where domain is example.com and port is 50000, the resulting route is example.com:50000.",
+      "translation": "Port used to create a TCP route. E.g. where domain is example.com and port is 50000, the resulting route is example.com:50000.",
+      "modified": false
    },
    {
       "id": "Print API request diagnostics to stdout",

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -685,8 +685,8 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
-      "translation": "CF_NAME create-route ESPACE DOMAINE [-n HÔTE]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
+      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
       "modified": false
    },
    {
@@ -1587,6 +1587,11 @@
    {
       "id": "Creating route {{.Hostname}}...",
       "translation": "Création de la route {{.Hostname}}...",
+      "modified": false
+   },
+   {
+      "id": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3843,6 +3848,11 @@
       "id": "Plugin {{.PluginName}} v{{.Version}} successfully installed.",
       "translation": "Plugin {{.PluginName}} successfully installed.",
       "modified": true
+   },
+   {
+      "id": "Port used to create a TCP route. E.g. where domain is example.com and port is 50000, the resulting route is example.com:50000.",
+      "translation": "Port used to create a TCP route. E.g. where domain is example.com and port is 50000, the resulting route is example.com:50000.",
+      "modified": false
    },
    {
       "id": "Print API request diagnostics to stdout",

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -685,8 +685,8 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
-      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
+      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
       "modified": false
    },
    {
@@ -1587,6 +1587,11 @@
    {
       "id": "Creating route {{.Hostname}}...",
       "translation": "Creating route {{.Hostname}}...",
+      "modified": false
+   },
+   {
+      "id": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3843,6 +3848,11 @@
       "id": "Plugin {{.PluginName}} v{{.Version}} successfully installed.",
       "translation": "Plugin {{.PluginName}} successfully installed.",
       "modified": true
+   },
+   {
+      "id": "Port used to create a TCP route. E.g. where domain is example.com and port is 50000, the resulting route is example.com:50000.",
+      "translation": "Port used to create a TCP route. E.g. where domain is example.com and port is 50000, the resulting route is example.com:50000.",
+      "modified": false
    },
    {
       "id": "Print API request diagnostics to stdout",

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -685,8 +685,8 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
-      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
+      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
       "modified": false
    },
    {
@@ -1587,6 +1587,11 @@
    {
       "id": "Creating route {{.Hostname}}...",
       "translation": "Creating route {{.Hostname}}...",
+      "modified": false
+   },
+   {
+      "id": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3843,6 +3848,11 @@
       "id": "Plugin {{.PluginName}} v{{.Version}} successfully installed.",
       "translation": "Plugin {{.PluginName}} successfully installed.",
       "modified": true
+   },
+   {
+      "id": "Port used to create a TCP route. E.g. where domain is example.com and port is 50000, the resulting route is example.com:50000.",
+      "translation": "Port used to create a TCP route. E.g. where domain is example.com and port is 50000, the resulting route is example.com:50000.",
+      "modified": false
    },
    {
       "id": "Print API request diagnostics to stdout",

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -685,8 +685,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
-      "translation": "CF_NAME create-route ESPAÇO DOMÍNIO [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
+      "translation": "CF_NAME create-route ESPAÇO DOMÍNIO [-n HOSTNAME | -p PORT]",
       "modified": false
    },
    {
@@ -1587,6 +1587,11 @@
    {
       "id": "Creating route {{.Hostname}}...",
       "translation": "Criando rota {{.Hostname}}...",
+      "modified": false
+   },
+   {
+      "id": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3843,6 +3848,11 @@
       "id": "Plugin {{.PluginName}} v{{.Version}} successfully installed.",
       "translation": "Plugin {{.PluginName}} successfully installed.",
       "modified": true
+   },
+   {
+      "id": "Port used to create a TCP route. E.g. where domain is example.com and port is 50000, the resulting route is example.com:50000.",
+      "translation": "Port used to create a TCP route. E.g. where domain is example.com and port is 50000, the resulting route is example.com:50000.",
+      "modified": false
    },
    {
       "id": "Print API request diagnostics to stdout",

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -685,8 +685,8 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
-      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
+      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
       "modified": false
    },
    {
@@ -1587,6 +1587,11 @@
    {
       "id": "Creating route {{.Hostname}}...",
       "translation": "创建路由 {{.Hostname}}...",
+      "modified": false
+   },
+   {
+      "id": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3843,6 +3848,11 @@
       "id": "Plugin {{.PluginName}} v{{.Version}} successfully installed.",
       "translation": "Plugin {{.PluginName}} successfully installed.",
       "modified": true
+   },
+   {
+      "id": "Port used to create a TCP route. E.g. where domain is example.com and port is 50000, the resulting route is example.com:50000.",
+      "translation": "Port used to create a TCP route. E.g. where domain is example.com and port is 50000, the resulting route is example.com:50000.",
+      "modified": false
    },
    {
       "id": "Print API request diagnostics to stdout",

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -685,8 +685,8 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
-      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
+      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME | -p PORT]",
       "modified": false
    },
    {
@@ -1587,6 +1587,11 @@
    {
       "id": "Creating route {{.Hostname}}...",
       "translation": "Creating route {{.Hostname}}...",
+      "modified": false
+   },
+   {
+      "id": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.Hostname}}:{{.Port}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3843,6 +3848,11 @@
       "id": "Plugin {{.PluginName}} v{{.Version}} successfully installed.",
       "translation": "Plugin {{.PluginName}} successfully installed.",
       "modified": true
+   },
+   {
+      "id": "Port used to create a TCP route. E.g. where domain is example.com and port is 50000, the resulting route is example.com:50000.",
+      "translation": "Port used to create a TCP route. E.g. where domain is example.com and port is 50000, the resulting route is example.com:50000.",
+      "modified": false
    },
    {
       "id": "Print API request diagnostics to stdout",

--- a/cf/models/route.go
+++ b/cf/models/route.go
@@ -5,6 +5,7 @@ import "fmt"
 type Route struct {
 	Guid   string
 	Host   string
+	Port   int
 	Domain DomainFields
 
 	Space SpaceFields
@@ -12,10 +13,16 @@ type Route struct {
 }
 
 func (route Route) URL() string {
-	if route.Host == "" {
+	if route.Host == "" && route.Port == 0 {
 		return route.Domain.Name
 	}
-	return fmt.Sprintf("%s.%s", route.Host, route.Domain.Name)
+	if route.Port == 0 {
+		return fmt.Sprintf("%s.%s", route.Host, route.Domain.Name)
+	}
+	if route.Host == "" {
+		return fmt.Sprintf("%s:%d", route.Domain.Name, route.Port)
+	}
+	return fmt.Sprintf("%s.%s:%d", route.Host, route.Domain.Name, route.Port)
 }
 
 type RouteSummary struct {

--- a/testhelpers/commands/fake_route_creator.go
+++ b/testhelpers/commands/fake_route_creator.go
@@ -9,13 +9,15 @@ import (
 
 type FakeRouteCreator struct {
 	CreateRouteHostname     string
+	CreateRoutePort         string
 	CreateRouteDomainFields models.DomainFields
 	CreateRouteSpaceFields  models.SpaceFields
 	ReservedRoute           models.Route
 }
 
-func (cmd *FakeRouteCreator) CreateRoute(hostName string, domain models.DomainFields, space models.SpaceFields) (reservedRoute models.Route, apiErr error) {
+func (cmd *FakeRouteCreator) CreateRoute(hostName, port string, domain models.DomainFields, space models.SpaceFields) (reservedRoute models.Route, apiErr error) {
 	cmd.CreateRouteHostname = hostName
+	cmd.CreateRoutePort = port
 	cmd.CreateRouteDomainFields = domain
 	cmd.CreateRouteSpaceFields = space
 	reservedRoute = cmd.ReservedRoute


### PR DESCRIPTION
Add port flag "-p" to the create route command to be able to create a route with a given external port mapping. 

The story about the PR: https://www.pivotaltracker.com/story/show/100992242
 
Thanks,
@yuzhangcmu @fordaz