### PR TITLE
modify error message of missing routing-api endpoint

### DIFF
--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -4250,8 +4250,8 @@
       "modified": false
    },
    {
-      "id": "Routing API URI missing. Please log in again to set the URI automatically.",
-      "translation": "Routing API URI missing. Please log in again to set the URI automatically.",
+      "id": "Routing API uri missing. Please log in again and retry.",
+      "translation": "Routing API uri missing. Please log in again and retry.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -4250,8 +4250,8 @@
       "modified": false
    },
    {
-      "id": "Routing API URI missing. Please log in again to set the URI automatically.",
-      "translation": "Routing API URI missing. Please log in again to set the URI automatically.",
+      "id": "Routing API uri missing. Please log in again and retry.",
+      "translation": "Routing API uri missing. Please log in again and retry.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -4250,8 +4250,8 @@
       "modified": false
    },
    {
-      "id": "Routing API URI missing. Please log in again to set the URI automatically.",
-      "translation": "Routing API URI missing. Please log in again to set the URI automatically.",
+      "id": "Routing API uri missing. Please log in again and retry.",
+      "translation": "Routing API uri missing. Please log in again and retry.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -4250,8 +4250,8 @@
       "modified": false
    },
    {
-      "id": "Routing API URI missing. Please log in again to set the URI automatically.",
-      "translation": "Routing API URI missing. Please log in again to set the URI automatically.",
+      "id": "Routing API uri missing. Please log in again and retry.",
+      "translation": "Routing API uri missing. Please log in again and retry.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -4250,8 +4250,8 @@
       "modified": false
    },
    {
-      "id": "Routing API URI missing. Please log in again to set the URI automatically.",
-      "translation": "Routing API URI missing. Please log in again to set the URI automatically.",
+      "id": "Routing API uri missing. Please log in again and retry.",
+      "translation": "Routing API uri missing. Please log in again and retry.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -4250,8 +4250,8 @@
       "modified": false
    },
    {
-      "id": "Routing API URI missing. Please log in again to set the URI automatically.",
-      "translation": "Routing API URI missing. Please log in again to set the URI automatically.",
+      "id": "Routing API uri missing. Please log in again and retry.",
+      "translation": "Routing API uri missing. Please log in again and retry.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -4250,8 +4250,8 @@
       "modified": false
    },
    {
-      "id": "Routing API URI missing. Please log in again to set the URI automatically.",
-      "translation": "Routing API URI missing. Please log in again to set the URI automatically.",
+      "id": "Routing API uri missing. Please log in again and retry.",
+      "translation": "Routing API uri missing. Please log in again and retry.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -4250,8 +4250,8 @@
       "modified": false
    },
    {
-      "id": "Routing API URI missing. Please log in again to set the URI automatically.",
-      "translation": "Routing API URI missing. Please log in again to set the URI automatically.",
+      "id": "Routing API uri missing. Please log in again and retry.",
+      "translation": "Routing API uri missing. Please log in again and retry.",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -4250,8 +4250,8 @@
       "modified": false
    },
    {
-      "id": "Routing API URI missing. Please log in again to set the URI automatically.",
-      "translation": "Routing API URI missing. Please log in again to set the URI automatically.",
+      "id": "Routing API uri missing. Please log in again and retry.",
+      "translation": "Routing API uri missing. Please log in again and retry.",
       "modified": false
    },
    {

--- a/cf/requirements/fakes/fake_factory.go
+++ b/cf/requirements/fakes/fake_factory.go
@@ -27,13 +27,13 @@ type FakeFactory struct {
 	NewLoginRequirementStub        func() requirements.Requirement
 	newLoginRequirementMutex       sync.RWMutex
 	newLoginRequirementArgsForCall []struct{}
-	newLoginRequirementReturns struct {
+	newLoginRequirementReturns     struct {
 		result1 requirements.Requirement
 	}
 	NewRoutingAPIRequirementStub        func() requirements.Requirement
 	newRoutingAPIRequirementMutex       sync.RWMutex
 	newRoutingAPIRequirementArgsForCall []struct{}
-	newRoutingAPIRequirementReturns struct {
+	newRoutingAPIRequirementReturns     struct {
 		result1 requirements.Requirement
 	}
 	NewSpaceRequirementStub        func(name string) requirements.SpaceRequirement
@@ -47,13 +47,13 @@ type FakeFactory struct {
 	NewTargetedSpaceRequirementStub        func() requirements.Requirement
 	newTargetedSpaceRequirementMutex       sync.RWMutex
 	newTargetedSpaceRequirementArgsForCall []struct{}
-	newTargetedSpaceRequirementReturns struct {
+	newTargetedSpaceRequirementReturns     struct {
 		result1 requirements.Requirement
 	}
 	NewTargetedOrgRequirementStub        func() requirements.TargetedOrgRequirement
 	newTargetedOrgRequirementMutex       sync.RWMutex
 	newTargetedOrgRequirementArgsForCall []struct{}
-	newTargetedOrgRequirementReturns struct {
+	newTargetedOrgRequirementReturns     struct {
 		result1 requirements.TargetedOrgRequirement
 	}
 	NewOrganizationRequirementStub        func(name string) requirements.OrganizationRequirement
@@ -92,7 +92,7 @@ type FakeFactory struct {
 	NewApiEndpointRequirementStub        func() requirements.Requirement
 	newApiEndpointRequirementMutex       sync.RWMutex
 	newApiEndpointRequirementArgsForCall []struct{}
-	newApiEndpointRequirementReturns struct {
+	newApiEndpointRequirementReturns     struct {
 		result1 requirements.Requirement
 	}
 	NewMinCCApiVersionRequirementStub        func(commandName string, major, minor, patch int) requirements.Requirement

--- a/cf/requirements/fakes/fake_organization_requirement.go
+++ b/cf/requirements/fakes/fake_organization_requirement.go
@@ -12,7 +12,7 @@ type FakeOrganizationRequirement struct {
 	ExecuteStub        func() (success bool)
 	executeMutex       sync.RWMutex
 	executeArgsForCall []struct{}
-	executeReturns struct {
+	executeReturns     struct {
 		result1 bool
 	}
 	SetOrganizationNameStub        func(string)
@@ -23,7 +23,7 @@ type FakeOrganizationRequirement struct {
 	GetOrganizationStub        func() models.Organization
 	getOrganizationMutex       sync.RWMutex
 	getOrganizationArgsForCall []struct{}
-	getOrganizationReturns struct {
+	getOrganizationReturns     struct {
 		result1 models.Organization
 	}
 }

--- a/cf/requirements/fakes/fake_user_requirement.go
+++ b/cf/requirements/fakes/fake_user_requirement.go
@@ -12,13 +12,13 @@ type FakeUserRequirement struct {
 	ExecuteStub        func() (success bool)
 	executeMutex       sync.RWMutex
 	executeArgsForCall []struct{}
-	executeReturns struct {
+	executeReturns     struct {
 		result1 bool
 	}
 	GetUserStub        func() models.UserFields
 	getUserMutex       sync.RWMutex
 	getUserArgsForCall []struct{}
-	getUserReturns struct {
+	getUserReturns     struct {
 		result1 models.UserFields
 	}
 }

--- a/cf/requirements/routing_api.go
+++ b/cf/requirements/routing_api.go
@@ -20,7 +20,7 @@ func NewRoutingAPIRequirement(ui terminal.UI, config core_config.Reader) Routing
 
 func (req RoutingAPIRequirement) Execute() bool {
 	if len(req.config.RoutingApiEndpoint()) == 0 {
-		req.ui.Failed(T("Routing API URI missing. Please log in again to set the URI automatically."))
+		req.ui.Failed(T("Routing API uri missing. Please log in again and retry."))
 		return false
 	}
 

--- a/cf/requirements/routing_api_test.go
+++ b/cf/requirements/routing_api_test.go
@@ -31,7 +31,7 @@ var _ = Describe("RoutingApi", func() {
 
 		It("panics and prints a failure message", func() {
 			Expect(func() { requirement.Execute() }).To(Panic())
-			Expect(ui.Outputs).To(ContainElement("Routing API URI missing. Please log in again to set the URI automatically."))
+			Expect(ui.Outputs).To(ContainElement("Routing API uri missing. Please log in again and retry."))
 		})
 	})
 


### PR DESCRIPTION
We are updating the error message of the story: https://www.pivotaltracker.com/story/show/100975070

The error message returned when routing api url is not found in config file:
current: "Routing API not found. Please log in.".
desired: "Routing API uri missing. Please log in again and retry."

@yuzhangcmu @fordaz

Thanks!