### PR TITLE
List domains with router group

### DIFF
--- a/cf/api/resources/domains.go
+++ b/cf/api/resources/domains.go
@@ -11,6 +11,7 @@ type DomainEntity struct {
 	Name                   string `json:"name"`
 	OwningOrganizationGuid string `json:"owning_organization_guid,omitempty"`
 	SharedOrganizationsUrl string `json:"shared_organizations_url,omitempty"`
+	RouterGroupGuid        string `json:"router_group_guid,omitempty"`
 	Wildcard               bool   `json:"wildcard"`
 }
 
@@ -21,5 +22,6 @@ func (resource DomainResource) ToFields() models.DomainFields {
 		Guid: resource.Metadata.Guid,
 		OwningOrganizationGuid: resource.Entity.OwningOrganizationGuid,
 		Shared:                 !privateDomain,
+		RouterGroupGuid:        resource.Entity.RouterGroupGuid,
 	}
 }

--- a/cf/commands/domain/domains_test.go
+++ b/cf/commands/domain/domains_test.go
@@ -111,7 +111,7 @@ var _ = Describe("domains command", func() {
 					Expect(ui.Outputs).To(ContainSubstrings(
 						[]string{"Getting domains in org", "my-org", "my-user"},
 						[]string{"FAILED"},
-						[]string{"Failed fetching router groups"},
+						[]string{"Invalid router group guid"},
 					))
 				})
 			})

--- a/cf/commands/routergroups/router_groups_test.go
+++ b/cf/commands/routergroups/router_groups_test.go
@@ -112,5 +112,4 @@ var _ = Describe("RouterGroups", func() {
 			))
 		})
 	})
-
 })

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -3195,6 +3195,11 @@
       "modified": false
    },
    {
+      "id": "Invalid router group guid: {{.Guid}}",
+      "translation": "Invalid router group guid: {{.Guid}}",
+      "modified": false
+   },
+   {
       "id": "Invalid timeout param: {{.Timeout}}\n{{.Err}}",
       "translation": "Invalid timeout param: {{.Timeout}}\n{{.Err}}",
       "modified": false
@@ -5692,6 +5697,11 @@
    {
       "id": "routes",
       "translation": "routes",
+      "modified": false
+   },
+   {
+      "id": "routing",
+      "translation": "routing",
       "modified": false
    },
    {

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -3195,6 +3195,11 @@
       "modified": false
    },
    {
+      "id": "Invalid router group guid: {{.Guid}}",
+      "translation": "Invalid router group guid: {{.Guid}}",
+      "modified": false
+   },
+   {
       "id": "Invalid timeout param: {{.Timeout}}\n{{.Err}}",
       "translation": "Invalid timeout param: {{.Timeout}}\n{{.Err}}",
       "modified": false
@@ -5692,6 +5697,11 @@
    {
       "id": "routes",
       "translation": "routes",
+      "modified": false
+   },
+   {
+      "id": "routing",
+      "translation": "routing",
       "modified": false
    },
    {

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -3195,6 +3195,11 @@
       "modified": false
    },
    {
+      "id": "Invalid router group guid: {{.Guid}}",
+      "translation": "Invalid router group guid: {{.Guid}}",
+      "modified": false
+   },
+   {
       "id": "Invalid timeout param: {{.Timeout}}\n{{.Err}}",
       "translation": "Parametro de timeout invalido: {{.Timeout}}\n{{.Err}}",
       "modified": false
@@ -5692,6 +5697,11 @@
    {
       "id": "routes",
       "translation": "rutas",
+      "modified": false
+   },
+   {
+      "id": "routing",
+      "translation": "routing",
       "modified": false
    },
    {

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -3195,6 +3195,11 @@
       "modified": false
    },
    {
+      "id": "Invalid router group guid: {{.Guid}}",
+      "translation": "Invalid router group guid: {{.Guid}}",
+      "modified": false
+   },
+   {
       "id": "Invalid timeout param: {{.Timeout}}\n{{.Err}}",
       "translation": "Invalid délai param: {{.Timeout}}\n{{.Err}}",
       "modified": false
@@ -5692,6 +5697,11 @@
    {
       "id": "routes",
       "translation": "routes",
+      "modified": false
+   },
+   {
+      "id": "routing",
+      "translation": "routing",
       "modified": false
    },
    {

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -3195,6 +3195,11 @@
       "modified": false
    },
    {
+      "id": "Invalid router group guid: {{.Guid}}",
+      "translation": "Invalid router group guid: {{.Guid}}",
+      "modified": false
+   },
+   {
       "id": "Invalid timeout param: {{.Timeout}}\n{{.Err}}",
       "translation": "Invalid timeout param: {{.Timeout}}\n{{.Err}}",
       "modified": false
@@ -5692,6 +5697,11 @@
    {
       "id": "routes",
       "translation": "routes",
+      "modified": false
+   },
+   {
+      "id": "routing",
+      "translation": "routing",
       "modified": false
    },
    {

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -3195,6 +3195,11 @@
       "modified": false
    },
    {
+      "id": "Invalid router group guid: {{.Guid}}",
+      "translation": "Invalid router group guid: {{.Guid}}",
+      "modified": false
+   },
+   {
       "id": "Invalid timeout param: {{.Timeout}}\n{{.Err}}",
       "translation": "Invalid timeout param: {{.Timeout}}\n{{.Err}}",
       "modified": false
@@ -5692,6 +5697,11 @@
    {
       "id": "routes",
       "translation": "routes",
+      "modified": false
+   },
+   {
+      "id": "routing",
+      "translation": "routing",
       "modified": false
    },
    {

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -3195,6 +3195,11 @@
       "modified": false
    },
    {
+      "id": "Invalid router group guid: {{.Guid}}",
+      "translation": "Invalid router group guid: {{.Guid}}",
+      "modified": false
+   },
+   {
       "id": "Invalid timeout param: {{.Timeout}}\n{{.Err}}",
       "translation": "Parâmetro de tempo limite inválido: {{.Timeout}}\n{{.Err}}",
       "modified": false
@@ -5692,6 +5697,11 @@
    {
       "id": "routes",
       "translation": "rotas",
+      "modified": false
+   },
+   {
+      "id": "routing",
+      "translation": "routing",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -3195,6 +3195,11 @@
       "modified": false
    },
    {
+      "id": "Invalid router group guid: {{.Guid}}",
+      "translation": "Invalid router group guid: {{.Guid}}",
+      "modified": false
+   },
+   {
       "id": "Invalid timeout param: {{.Timeout}}\n{{.Err}}",
       "translation": "无效的超时参数设定: {{.Timeout}}\n{{.Err}}",
       "modified": false
@@ -5692,6 +5697,11 @@
    {
       "id": "routes",
       "translation": "routes",
+      "modified": false
+   },
+   {
+      "id": "routing",
+      "translation": "routing",
       "modified": false
    },
    {

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -3195,6 +3195,11 @@
       "modified": false
    },
    {
+      "id": "Invalid router group guid: {{.Guid}}",
+      "translation": "Invalid router group guid: {{.Guid}}",
+      "modified": false
+   },
+   {
       "id": "Invalid timeout param: {{.Timeout}}\n{{.Err}}",
       "translation": "Invalid timeout param: {{.Timeout}}\n{{.Err}}",
       "modified": false
@@ -5692,6 +5697,11 @@
    {
       "id": "routes",
       "translation": "routes",
+      "modified": false
+   },
+   {
+      "id": "routing",
+      "translation": "routing",
       "modified": false
    },
    {

--- a/cf/models/domain.go
+++ b/cf/models/domain.go
@@ -6,6 +6,7 @@ type DomainFields struct {
 	Guid                   string
 	Name                   string
 	OwningOrganizationGuid string
+	RouterGroupGuid        string
 	Shared                 bool
 }
 


### PR DESCRIPTION
@krishicks:
**This PR replaces PR #654** 
This displays the type of router group for domains associated with router groups.

In addition, this PR verifies that a routing api endpoint must be defined in the config when at least one shared-domain with a non-null router-group-guid is present.

Below is the story in the routing team's tracker:
https://www.pivotaltracker.com/story/show/100981770


@mdelillo @yuzhangcmu @msmykowski @markstgodard @fordaz