### PR TITLE
Display route services in cf routes command

### DIFF
--- a/cf/api/resources/routes.go
+++ b/cf/api/resources/routes.go
@@ -8,10 +8,11 @@ type RouteResource struct {
 }
 
 type RouteEntity struct {
-	Host   string
-	Domain DomainResource
-	Space  SpaceResource
-	Apps   []ApplicationResource
+	Host            string                  `json:"host"`
+	Domain          DomainResource          `json:"domain"`
+	Space           SpaceResource           `json:"space"`
+	Apps            []ApplicationResource   `json:"apps"`
+	ServiceInstance ServiceInstanceResource `json:"service_instance"`
 }
 
 func (resource RouteResource) ToFields() (fields models.Route) {
@@ -24,6 +25,7 @@ func (resource RouteResource) ToModel() (route models.Route) {
 	route.Guid = resource.Metadata.Guid
 	route.Domain = resource.Entity.Domain.ToFields()
 	route.Space = resource.Entity.Space.ToFields()
+	route.ServiceInstance = resource.Entity.ServiceInstance.ToFields()
 	for _, appResource := range resource.Entity.Apps {
 		route.Apps = append(route.Apps, appResource.ToFields())
 	}

--- a/cf/api/routes_test.go
+++ b/cf/api/routes_test.go
@@ -67,6 +67,8 @@ var _ = Describe("route repository", func() {
 
 			Expect(len(routes)).To(Equal(2))
 			Expect(routes[0].Guid).To(Equal("route-1-guid"))
+			Expect(routes[0].ServiceInstance.Guid).To(Equal("service-guid"))
+			Expect(routes[0].ServiceInstance.Name).To(Equal("test-service"))
 			Expect(routes[1].Guid).To(Equal("route-2-guid"))
 			Expect(handler).To(HaveAllRequestsCalled())
 			Expect(apiErr).NotTo(HaveOccurred())
@@ -96,8 +98,11 @@ var _ = Describe("route repository", func() {
 			Expect(len(routes)).To(Equal(2))
 			Expect(routes[0].Guid).To(Equal("route-1-guid"))
 			Expect(routes[0].Space.Guid).To(Equal("space-1-guid"))
+			Expect(routes[0].ServiceInstance.Guid).To(Equal("service-guid"))
+			Expect(routes[0].ServiceInstance.Name).To(Equal("test-service"))
 			Expect(routes[1].Guid).To(Equal("route-2-guid"))
 			Expect(routes[1].Space.Guid).To(Equal("space-2-guid"))
+
 			Expect(handler).To(HaveAllRequestsCalled())
 			Expect(apiErr).NotTo(HaveOccurred())
 		})
@@ -344,7 +349,24 @@ var firstPageRoutesResponse = testnet.TestResponse{Status: http.StatusOK, Body: 
               "name": "app-1"
        	    }
        	  }
-        ]
+        ],
+         "service_instance_url": "/v2/service_instances/service-guid",
+        "service_instance": {
+           "metadata": {
+              "guid": "service-guid",
+              "url": "/v2/service_instances/service-guid"
+           },
+           "entity": {
+              "name": "test-service",
+              "credentials": {
+                 "username": "user",
+                 "password": "password"
+              },
+              "type": "managed_service_instance",
+              "route_service_url": "https://something.awesome.com",
+              "space_url": "/v2/spaces/space-1-guid"
+           }
+        }
       }
     }
   ]
@@ -450,7 +472,24 @@ var firstPageRoutesOrgLvlResponse = testnet.TestResponse{Status: http.StatusOK, 
               "name": "app-1"
             }
           }
-        ]
+        ],
+        "service_instance_url": "/v2/service_instances/service-guid",
+        "service_instance": {
+           "metadata": {
+              "guid": "service-guid",
+              "url": "/v2/service_instances/service-guid"
+           },
+           "entity": {
+              "name": "test-service",
+              "credentials": {
+                 "username": "user",
+                 "password": "password"
+              },
+              "type": "managed_service_instance",
+              "route_service_url": "https://something.awesome.com",
+              "space_url": "/v2/spaces/space-1-guid"
+           }
+        }
       }
     }
   ]

--- a/cf/commands/route/routes.go
+++ b/cf/commands/route/routes.go
@@ -57,14 +57,27 @@ func (cmd *ListRoutes) SetDependency(deps command_registry.Dependency, pluginCal
 }
 
 func (cmd *ListRoutes) Execute(c flags.FlagContext) {
-	cmd.ui.Say(T("Getting routes as {{.Username}} ...\n",
-		map[string]interface{}{"Username": terminal.EntityNameColor(cmd.config.Username())}))
+	flag := c.Bool("orglevel")
 
-	table := cmd.ui.Table([]string{T("space"), T("host"), T("domain"), T("apps")})
+	if flag {
+		cmd.ui.Say(T("Getting routes for org {{.OrgName}}  as {{.Username}} ...\n",
+			map[string]interface{}{
+				"Username": terminal.EntityNameColor(cmd.config.Username()),
+				"OrgName":  terminal.EntityNameColor(cmd.config.OrganizationFields().Name),
+			}))
+	} else {
+		cmd.ui.Say(T("Getting routes for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}} ...\n",
+			map[string]interface{}{
+				"Username":  terminal.EntityNameColor(cmd.config.Username()),
+				"OrgName":   terminal.EntityNameColor(cmd.config.OrganizationFields().Name),
+				"SpaceName": terminal.EntityNameColor(cmd.config.SpaceFields().Name),
+			}))
+	}
+
+	table := cmd.ui.Table([]string{T("space"), T("host"), T("domain"), T("apps"), T("service")})
 
 	noRoutes := true
 	var apiErr error
-	flag := c.Bool("orglevel")
 
 	if flag {
 		apiErr = cmd.routeRepo.ListAllRoutes(func(route models.Route) bool {
@@ -74,7 +87,7 @@ func (cmd *ListRoutes) Execute(c flags.FlagContext) {
 				appNames = append(appNames, app.Name)
 			}
 
-			table.Add(route.Space.Name, route.Host, route.Domain.Name, strings.Join(appNames, ","))
+			table.Add(route.Space.Name, route.Host, route.Domain.Name, strings.Join(appNames, ","), route.ServiceInstance.Name)
 			return true
 		})
 
@@ -87,7 +100,7 @@ func (cmd *ListRoutes) Execute(c flags.FlagContext) {
 				appNames = append(appNames, app.Name)
 			}
 
-			table.Add(route.Space.Name, route.Host, route.Domain.Name, strings.Join(appNames, ","))
+			table.Add(route.Space.Name, route.Host, route.Domain.Name, strings.Join(appNames, ","), route.ServiceInstance.Name)
 			return true
 		})
 	}

--- a/cf/commands/route/routes_test.go
+++ b/cf/commands/route/routes_test.go
@@ -78,6 +78,10 @@ var _ = Describe("routes command", func() {
 			route.Host = "hostname-1"
 			route.Domain = domain
 			route.Apps = []models.ApplicationFields{app1}
+			route.ServiceInstance = models.ServiceInstanceFields{
+				Name: "test-service",
+				Guid: "service-guid",
+			}
 
 			route2 := models.Route{}
 			route2.Host = "hostname-2"
@@ -90,9 +94,9 @@ var _ = Describe("routes command", func() {
 			runCommand()
 
 			Expect(ui.Outputs).To(ContainSubstrings(
-				[]string{"Getting routes", "my-user"},
-				[]string{"host", "domain", "apps"},
-				[]string{"hostname-1", "example.com", "dora"},
+				[]string{"Getting routes for org", "/ space", "my-org", "my-space", "my-user"},
+				[]string{"host", "domain", "apps", "service"},
+				[]string{"hostname-1", "example.com", "dora", "test-service"},
 				[]string{"hostname-2", "cookieclicker.co", "dora", "bora"},
 			))
 		})
@@ -114,6 +118,10 @@ var _ = Describe("routes command", func() {
 			route.Domain = domain
 			route.Apps = []models.ApplicationFields{app1}
 			route.Space = space1
+			route.ServiceInstance = models.ServiceInstanceFields{
+				Name: "test-service",
+				Guid: "service-guid",
+			}
 
 			route2 := models.Route{}
 			route2.Host = "hostname-2"
@@ -127,9 +135,9 @@ var _ = Describe("routes command", func() {
 			runCommand("--orglevel")
 
 			Expect(ui.Outputs).To(ContainSubstrings(
-				[]string{"Getting routes", "my-user"},
-				[]string{"space", "host", "domain", "apps"},
-				[]string{"space-1", "hostname-1", "example.com", "dora"},
+				[]string{"Getting routes for org", "my-org", "my-user"},
+				[]string{"space", "host", "domain", "apps", "service"},
+				[]string{"space-1", "hostname-1", "example.com", "dora", "test-service"},
 				[]string{"space-2", "hostname-2", "cookieclicker.co", "dora", "bora"},
 			))
 		})

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -2665,6 +2665,16 @@
       "modified": false
    },
    {
+      "id": "Getting routes for org {{.OrgName}}  as {{.Username}} ...\n",
+      "translation": "Getting routes for org {{.OrgName}}  as {{.Username}} ...\n",
+      "modified": false
+   },
+   {
+      "id": "Getting routes for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}} ...\n",
+      "translation": "Getting routes for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}} ...\n",
+      "modified": false
+   },
+   {
       "id": "Getting rules for the security group  : {{.SecurityGroupName}}...",
       "translation": "Getting rules for the security group  : {{.SecurityGroupName}}...",
       "modified": false

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -2665,6 +2665,16 @@
       "modified": false
    },
    {
+      "id": "Getting routes for org {{.OrgName}}  as {{.Username}} ...\n",
+      "translation": "Getting routes for org {{.OrgName}}  as {{.Username}} ...\n",
+      "modified": false
+   },
+   {
+      "id": "Getting routes for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}} ...\n",
+      "translation": "Getting routes for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}} ...\n",
+      "modified": false
+   },
+   {
       "id": "Getting rules for the security group  : {{.SecurityGroupName}}...",
       "translation": "Getting rules for the security group  : {{.SecurityGroupName}}...",
       "modified": false

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -2665,6 +2665,16 @@
       "modified": false
    },
    {
+      "id": "Getting routes for org {{.OrgName}}  as {{.Username}} ...\n",
+      "translation": "Getting routes for org {{.OrgName}}  as {{.Username}} ...\n",
+      "modified": false
+   },
+   {
+      "id": "Getting routes for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}} ...\n",
+      "translation": "Getting routes for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}} ...\n",
+      "modified": false
+   },
+   {
       "id": "Getting rules for the security group  : {{.SecurityGroupName}}...",
       "translation": "Getting rules for the security group  : {{.SecurityGroupName}}...",
       "modified": false

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -2665,6 +2665,16 @@
       "modified": false
    },
    {
+      "id": "Getting routes for org {{.OrgName}}  as {{.Username}} ...\n",
+      "translation": "Getting routes for org {{.OrgName}}  as {{.Username}} ...\n",
+      "modified": false
+   },
+   {
+      "id": "Getting routes for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}} ...\n",
+      "translation": "Getting routes for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}} ...\n",
+      "modified": false
+   },
+   {
       "id": "Getting rules for the security group  : {{.SecurityGroupName}}...",
       "translation": "Getting rules for the security group  : {{.SecurityGroupName}}...",
       "modified": false

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -2665,6 +2665,16 @@
       "modified": false
    },
    {
+      "id": "Getting routes for org {{.OrgName}}  as {{.Username}} ...\n",
+      "translation": "Getting routes for org {{.OrgName}}  as {{.Username}} ...\n",
+      "modified": false
+   },
+   {
+      "id": "Getting routes for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}} ...\n",
+      "translation": "Getting routes for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}} ...\n",
+      "modified": false
+   },
+   {
       "id": "Getting rules for the security group  : {{.SecurityGroupName}}...",
       "translation": "Getting rules for the security group  : {{.SecurityGroupName}}...",
       "modified": false

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -2665,6 +2665,16 @@
       "modified": false
    },
    {
+      "id": "Getting routes for org {{.OrgName}}  as {{.Username}} ...\n",
+      "translation": "Getting routes for org {{.OrgName}}  as {{.Username}} ...\n",
+      "modified": false
+   },
+   {
+      "id": "Getting routes for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}} ...\n",
+      "translation": "Getting routes for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}} ...\n",
+      "modified": false
+   },
+   {
       "id": "Getting rules for the security group  : {{.SecurityGroupName}}...",
       "translation": "Getting rules for the security group  : {{.SecurityGroupName}}...",
       "modified": false

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -2665,6 +2665,16 @@
       "modified": false
    },
    {
+      "id": "Getting routes for org {{.OrgName}}  as {{.Username}} ...\n",
+      "translation": "Getting routes for org {{.OrgName}}  as {{.Username}} ...\n",
+      "modified": false
+   },
+   {
+      "id": "Getting routes for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}} ...\n",
+      "translation": "Getting routes for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}} ...\n",
+      "modified": false
+   },
+   {
       "id": "Getting rules for the security group  : {{.SecurityGroupName}}...",
       "translation": "Getting rules for the security group  : {{.SecurityGroupName}}...",
       "modified": false

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -2665,6 +2665,16 @@
       "modified": false
    },
    {
+      "id": "Getting routes for org {{.OrgName}}  as {{.Username}} ...\n",
+      "translation": "Getting routes for org {{.OrgName}}  as {{.Username}} ...\n",
+      "modified": false
+   },
+   {
+      "id": "Getting routes for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}} ...\n",
+      "translation": "Getting routes for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}} ...\n",
+      "modified": false
+   },
+   {
       "id": "Getting rules for the security group  : {{.SecurityGroupName}}...",
       "translation": "Getting rules for the security group  : {{.SecurityGroupName}}...",
       "modified": false

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -2665,6 +2665,16 @@
       "modified": false
    },
    {
+      "id": "Getting routes for org {{.OrgName}}  as {{.Username}} ...\n",
+      "translation": "Getting routes for org {{.OrgName}}  as {{.Username}} ...\n",
+      "modified": false
+   },
+   {
+      "id": "Getting routes for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}} ...\n",
+      "translation": "Getting routes for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}} ...\n",
+      "modified": false
+   },
+   {
       "id": "Getting rules for the security group  : {{.SecurityGroupName}}...",
       "translation": "Getting rules for the security group  : {{.SecurityGroupName}}...",
       "modified": false

--- a/cf/models/route.go
+++ b/cf/models/route.go
@@ -7,8 +7,9 @@ type Route struct {
 	Host   string
 	Domain DomainFields
 
-	Space SpaceFields
-	Apps  []ApplicationFields
+	Space           SpaceFields
+	Apps            []ApplicationFields
+	ServiceInstance ServiceInstanceFields
 }
 
 func (route Route) URL() string {


### PR DESCRIPTION
This PR has changes to display route services associated with routes in `cf routes` command.

Pivotal tracker story: https://www.pivotaltracker.com/story/show/100863584

Regards,
@yuzhangcmu and @atulkc 
(CF Routing team)