### PR TITLE
Add context path when listing routes

### DIFF
--- a/cf/api/resources/routes.go
+++ b/cf/api/resources/routes.go
@@ -10,6 +10,7 @@ type RouteResource struct {
 type RouteEntity struct {
 	Host            string                  `json:"host"`
 	Domain          DomainResource          `json:"domain"`
+	Path            string                  `json:"path"`
 	Space           SpaceResource           `json:"space"`
 	Apps            []ApplicationResource   `json:"apps"`
 	ServiceInstance ServiceInstanceResource `json:"service_instance"`
@@ -22,6 +23,7 @@ func (resource RouteResource) ToFields() (fields models.Route) {
 }
 func (resource RouteResource) ToModel() (route models.Route) {
 	route.Host = resource.Entity.Host
+	route.Path = resource.Entity.Path
 	route.Guid = resource.Metadata.Guid
 	route.Domain = resource.Entity.Domain.ToFields()
 	route.Space = resource.Entity.Space.ToFields()

--- a/cf/api/routes_test.go
+++ b/cf/api/routes_test.go
@@ -69,7 +69,9 @@ var _ = Describe("route repository", func() {
 			Expect(routes[0].Guid).To(Equal("route-1-guid"))
 			Expect(routes[0].ServiceInstance.Guid).To(Equal("service-guid"))
 			Expect(routes[0].ServiceInstance.Name).To(Equal("test-service"))
+			Expect(routes[0].Path).To(Equal(""))
 			Expect(routes[1].Guid).To(Equal("route-2-guid"))
+			Expect(routes[1].Path).To(Equal("/path-2"))
 			Expect(handler).To(HaveAllRequestsCalled())
 			Expect(apiErr).NotTo(HaveOccurred())
 		})
@@ -106,6 +108,7 @@ var _ = Describe("route repository", func() {
 			Expect(handler).To(HaveAllRequestsCalled())
 			Expect(apiErr).NotTo(HaveOccurred())
 		})
+
 		It("finds a route by host and domain", func() {
 			ts, handler = testnet.NewServer([]testnet.TestRequest{
 				testapi.NewCloudControllerTestRequest(testnet.TestRequest{
@@ -324,6 +327,7 @@ var firstPageRoutesResponse = testnet.TestResponse{Status: http.StatusOK, Body: 
       },
       "entity": {
         "host": "route-1-host",
+        "path": "",
         "domain": {
           "metadata": {
             "guid": "domain-1-guid"
@@ -381,6 +385,7 @@ var secondPageRoutesResponse = testnet.TestResponse{Status: http.StatusOK, Body:
       },
       "entity": {
         "host": "route-2-host",
+        "path": "/path-2",
         "domain": {
           "metadata": {
             "guid": "domain-2-guid"

--- a/cf/commands/route/routes.go
+++ b/cf/commands/route/routes.go
@@ -74,7 +74,7 @@ func (cmd *ListRoutes) Execute(c flags.FlagContext) {
 			}))
 	}
 
-	table := cmd.ui.Table([]string{T("space"), T("host"), T("domain"), T("apps"), T("service")})
+	table := cmd.ui.Table([]string{T("space"), T("host"), T("domain"), T("path"), T("apps"), T("service")})
 
 	noRoutes := true
 	var apiErr error
@@ -87,7 +87,7 @@ func (cmd *ListRoutes) Execute(c flags.FlagContext) {
 				appNames = append(appNames, app.Name)
 			}
 
-			table.Add(route.Space.Name, route.Host, route.Domain.Name, strings.Join(appNames, ","), route.ServiceInstance.Name)
+			table.Add(route.Space.Name, route.Host, route.Domain.Name, route.Path, strings.Join(appNames, ","), route.ServiceInstance.Name)
 			return true
 		})
 
@@ -100,7 +100,7 @@ func (cmd *ListRoutes) Execute(c flags.FlagContext) {
 				appNames = append(appNames, app.Name)
 			}
 
-			table.Add(route.Space.Name, route.Host, route.Domain.Name, strings.Join(appNames, ","), route.ServiceInstance.Name)
+			table.Add(route.Space.Name, route.Host, route.Domain.Name, route.Path, strings.Join(appNames, ","), route.ServiceInstance.Name)
 			return true
 		})
 	}

--- a/cf/commands/route/routes_test.go
+++ b/cf/commands/route/routes_test.go
@@ -85,6 +85,7 @@ var _ = Describe("routes command", func() {
 
 			route2 := models.Route{}
 			route2.Host = "hostname-2"
+			route2.Path = "/foo"
 			route2.Domain = domain2
 			route2.Apps = []models.ApplicationFields{app1, app2}
 			routeRepo.Routes = []models.Route{route, route2}
@@ -97,7 +98,7 @@ var _ = Describe("routes command", func() {
 				[]string{"Getting routes for org", "/ space", "my-org", "my-space", "my-user"},
 				[]string{"host", "domain", "apps", "service"},
 				[]string{"hostname-1", "example.com", "dora", "test-service"},
-				[]string{"hostname-2", "cookieclicker.co", "dora", "bora"},
+				[]string{"hostname-2", "cookieclicker.co", "/foo", "dora", "bora"},
 			))
 		})
 	})
@@ -125,6 +126,7 @@ var _ = Describe("routes command", func() {
 
 			route2 := models.Route{}
 			route2.Host = "hostname-2"
+			route2.Path = "/foo"
 			route2.Domain = domain2
 			route2.Apps = []models.ApplicationFields{app1, app2}
 			route2.Space = space2
@@ -138,7 +140,7 @@ var _ = Describe("routes command", func() {
 				[]string{"Getting routes for org", "my-org", "my-user"},
 				[]string{"space", "host", "domain", "apps", "service"},
 				[]string{"space-1", "hostname-1", "example.com", "dora", "test-service"},
-				[]string{"space-2", "hostname-2", "cookieclicker.co", "dora", "bora"},
+				[]string{"space-2", "hostname-2", "cookieclicker.co", "/foo", "dora", "bora"},
 			))
 		})
 

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -5650,6 +5650,11 @@
       "modified": false
    },
    {
+      "id": "path",
+      "translation": "path",
+      "modified": false
+   },
+   {
       "id": "plan",
       "translation": "plan",
       "modified": false

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -5650,6 +5650,11 @@
       "modified": false
    },
    {
+      "id": "path",
+      "translation": "path",
+      "modified": false
+   },
+   {
       "id": "plan",
       "translation": "plan",
       "modified": false

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -5650,6 +5650,11 @@
       "modified": false
    },
    {
+      "id": "path",
+      "translation": "path",
+      "modified": false
+   },
+   {
       "id": "plan",
       "translation": "plan",
       "modified": false

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -5650,6 +5650,11 @@
       "modified": false
    },
    {
+      "id": "path",
+      "translation": "path",
+      "modified": false
+   },
+   {
       "id": "plan",
       "translation": "plan",
       "modified": false

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -5650,6 +5650,11 @@
       "modified": false
    },
    {
+      "id": "path",
+      "translation": "path",
+      "modified": false
+   },
+   {
       "id": "plan",
       "translation": "plan",
       "modified": false

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -5650,6 +5650,11 @@
       "modified": false
    },
    {
+      "id": "path",
+      "translation": "path",
+      "modified": false
+   },
+   {
       "id": "plan",
       "translation": "plan",
       "modified": false

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -5650,6 +5650,11 @@
       "modified": false
    },
    {
+      "id": "path",
+      "translation": "path",
+      "modified": false
+   },
+   {
       "id": "plan",
       "translation": "plano",
       "modified": false

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -5650,6 +5650,11 @@
       "modified": false
    },
    {
+      "id": "path",
+      "translation": "path",
+      "modified": false
+   },
+   {
       "id": "plan",
       "translation": "服务计划",
       "modified": false

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -5650,6 +5650,11 @@
       "modified": false
    },
    {
+      "id": "path",
+      "translation": "path",
+      "modified": false
+   },
+   {
       "id": "plan",
       "translation": "plan",
       "modified": false

--- a/cf/models/route.go
+++ b/cf/models/route.go
@@ -5,6 +5,7 @@ import "fmt"
 type Route struct {
 	Guid   string
 	Host   string
+	Path   string
 	Domain DomainFields
 
 	Space           SpaceFields


### PR DESCRIPTION
This PR makes changes to list context path in `cf routes` command.

Pivotal tracker story: https://www.pivotaltracker.com/story/show/104020832

Regards,
@atulkc and @shashwathi 
(CF Routing team)