### PR TITLE
Context path support

### DIFF
--- a/cf/api/fakes/fake_route_repo.go
+++ b/cf/api/fakes/fake_route_repo.go
@@ -21,6 +21,7 @@ type FakeRouteRepository struct {
 	CreatedRoute      models.Route
 
 	CreateInSpaceHost         string
+	CreateInSpacePath         string
 	CreateInSpaceDomainGuid   string
 	CreateInSpaceSpaceGuid    string
 	CreateInSpaceCreatedRoute models.Route
@@ -104,10 +105,11 @@ func (repo *FakeRouteRepository) CheckIfExists(host string, domain models.Domain
 	}
 	return
 }
-func (repo *FakeRouteRepository) CreateInSpace(host, domainGuid, spaceGuid string) (createdRoute models.Route, apiErr error) {
+func (repo *FakeRouteRepository) CreateInSpace(host, path, domainGuid, spaceGuid string) (createdRoute models.Route, apiErr error) {
 	repo.CreateInSpaceHost = host
 	repo.CreateInSpaceDomainGuid = domainGuid
 	repo.CreateInSpaceSpaceGuid = spaceGuid
+	repo.CreateInSpacePath = path
 
 	if repo.CreateInSpaceErr {
 		apiErr = errors.New("Error")

--- a/cf/api/resources/routes.go
+++ b/cf/api/resources/routes.go
@@ -9,6 +9,7 @@ type RouteResource struct {
 
 type RouteEntity struct {
 	Host            string                  `json:"host"`
+	Path            string                  `json:"path"`
 	Domain          DomainResource          `json:"domain"`
 	Space           SpaceResource           `json:"space"`
 	Apps            []ApplicationResource   `json:"apps"`
@@ -20,8 +21,10 @@ func (resource RouteResource) ToFields() (fields models.Route) {
 	fields.Host = resource.Entity.Host
 	return
 }
+
 func (resource RouteResource) ToModel() (route models.Route) {
 	route.Host = resource.Entity.Host
+	route.Path = resource.Entity.Path
 	route.Guid = resource.Metadata.Guid
 	route.Domain = resource.Entity.Domain.ToFields()
 	route.Space = resource.Entity.Space.ToFields()

--- a/cf/api/resources/routes.go
+++ b/cf/api/resources/routes.go
@@ -9,8 +9,8 @@ type RouteResource struct {
 
 type RouteEntity struct {
 	Host            string                  `json:"host"`
-	Path            string                  `json:"path"`
 	Domain          DomainResource          `json:"domain"`
+	Path            string                  `json:"path"`
 	Space           SpaceResource           `json:"space"`
 	Apps            []ApplicationResource   `json:"apps"`
 	ServiceInstance ServiceInstanceResource `json:"service_instance"`

--- a/cf/api/routes.go
+++ b/cf/api/routes.go
@@ -18,7 +18,7 @@ type RouteRepository interface {
 	FindByHostAndDomain(host string, domain models.DomainFields) (route models.Route, apiErr error)
 	Create(host string, domain models.DomainFields) (createdRoute models.Route, apiErr error)
 	CheckIfExists(host string, domain models.DomainFields) (found bool, apiErr error)
-	CreateInSpace(host, domainGuid, spaceGuid string) (createdRoute models.Route, apiErr error)
+	CreateInSpace(host, path, domainGuid, spaceGuid string) (createdRoute models.Route, apiErr error)
 	Bind(routeGuid, appGuid string) (apiErr error)
 	Unbind(routeGuid, appGuid string) (apiErr error)
 	Delete(routeGuid string) (apiErr error)
@@ -74,7 +74,7 @@ func (repo CloudControllerRouteRepository) FindByHostAndDomain(host string, doma
 }
 
 func (repo CloudControllerRouteRepository) Create(host string, domain models.DomainFields) (createdRoute models.Route, apiErr error) {
-	return repo.CreateInSpace(host, domain.Guid, repo.config.SpaceFields().Guid)
+	return repo.CreateInSpace(host, "", domain.Guid, repo.config.SpaceFields().Guid)
 }
 
 func (repo CloudControllerRouteRepository) CheckIfExists(host string, domain models.DomainFields) (found bool, apiErr error) {
@@ -93,8 +93,8 @@ func (repo CloudControllerRouteRepository) CheckIfExists(host string, domain mod
 	return
 }
 
-func (repo CloudControllerRouteRepository) CreateInSpace(host, domainGuid, spaceGuid string) (createdRoute models.Route, apiErr error) {
-	data := fmt.Sprintf(`{"host":"%s","domain_guid":"%s","space_guid":"%s"}`, host, domainGuid, spaceGuid)
+func (repo CloudControllerRouteRepository) CreateInSpace(host, path, domainGuid, spaceGuid string) (createdRoute models.Route, apiErr error) {
+	data := fmt.Sprintf(`{"host":"%s","path":"%s","domain_guid":"%s","space_guid":"%s"}`, host, path, domainGuid, spaceGuid)
 
 	resource := new(resources.RouteResource)
 	apiErr = repo.gateway.CreateResource(repo.config.ApiEndpoint(), "/v2/routes?inline-relations-depth=1", strings.NewReader(data), resource)

--- a/cf/api/routes_test.go
+++ b/cf/api/routes_test.go
@@ -69,7 +69,9 @@ var _ = Describe("route repository", func() {
 			Expect(routes[0].Guid).To(Equal("route-1-guid"))
 			Expect(routes[0].ServiceInstance.Guid).To(Equal("service-guid"))
 			Expect(routes[0].ServiceInstance.Name).To(Equal("test-service"))
+			Expect(routes[0].Path).To(Equal(""))
 			Expect(routes[1].Guid).To(Equal("route-2-guid"))
+			Expect(routes[1].Path).To(Equal("/path-2"))
 			Expect(handler).To(HaveAllRequestsCalled())
 			Expect(apiErr).NotTo(HaveOccurred())
 		})
@@ -106,6 +108,7 @@ var _ = Describe("route repository", func() {
 			Expect(handler).To(HaveAllRequestsCalled())
 			Expect(apiErr).NotTo(HaveOccurred())
 		})
+
 		It("finds a route by host and domain", func() {
 			ts, handler = testnet.NewServer([]testnet.TestRequest{
 				testapi.NewCloudControllerTestRequest(testnet.TestRequest{
@@ -348,6 +351,7 @@ var firstPageRoutesResponse = testnet.TestResponse{Status: http.StatusOK, Body: 
       },
       "entity": {
         "host": "route-1-host",
+        "path": "",
         "domain": {
           "metadata": {
             "guid": "domain-1-guid"
@@ -405,6 +409,7 @@ var secondPageRoutesResponse = testnet.TestResponse{Status: http.StatusOK, Body:
       },
       "entity": {
         "host": "route-2-host",
+        "path": "/path-2",
         "domain": {
           "metadata": {
             "guid": "domain-2-guid"

--- a/cf/api/routes_test.go
+++ b/cf/api/routes_test.go
@@ -155,7 +155,7 @@ var _ = Describe("route repository", func() {
 				testapi.NewCloudControllerTestRequest(testnet.TestRequest{
 					Method:  "POST",
 					Path:    "/v2/routes?inline-relations-depth=1",
-					Matcher: testnet.RequestBodyMatcher(`{"host":"my-cool-app","domain_guid":"my-domain-guid","space_guid":"my-space-guid"}`),
+					Matcher: testnet.RequestBodyMatcher(`{"host":"my-cool-app","path":"","domain_guid":"my-domain-guid","space_guid":"my-space-guid"}`),
 					Response: testnet.TestResponse{Status: http.StatusCreated, Body: `
 						{
 							"metadata": { "guid": "my-route-guid" },
@@ -166,11 +166,35 @@ var _ = Describe("route repository", func() {
 			})
 			configRepo.SetApiEndpoint(ts.URL)
 
-			createdRoute, apiErr := repo.CreateInSpace("my-cool-app", "my-domain-guid", "my-space-guid")
+			createdRoute, apiErr := repo.CreateInSpace("my-cool-app", "", "my-domain-guid", "my-space-guid")
 
 			Expect(handler).To(HaveAllRequestsCalled())
 			Expect(apiErr).NotTo(HaveOccurred())
 			Expect(createdRoute.Guid).To(Equal("my-route-guid"))
+		})
+
+		It("creates routes with a path in a given space", func() {
+			ts, handler = testnet.NewServer([]testnet.TestRequest{
+				testapi.NewCloudControllerTestRequest(testnet.TestRequest{
+					Method:  "POST",
+					Path:    "/v2/routes?inline-relations-depth=1",
+					Matcher: testnet.RequestBodyMatcher(`{"host":"my-cool-app","path":"/this-is-a-path","domain_guid":"my-domain-guid","space_guid":"my-space-guid"}`),
+					Response: testnet.TestResponse{Status: http.StatusCreated, Body: `
+						{
+							"metadata": { "guid": "my-route-guid" },
+							"entity": { "host": "my-cool-app", "path": "/this-is-a-path" }
+						}
+					`},
+				}),
+			})
+			configRepo.SetApiEndpoint(ts.URL)
+
+			createdRoute, apiErr := repo.CreateInSpace("my-cool-app", "/this-is-a-path", "my-domain-guid", "my-space-guid")
+
+			Expect(handler).To(HaveAllRequestsCalled())
+			Expect(apiErr).NotTo(HaveOccurred())
+			Expect(createdRoute.Guid).To(Equal("my-route-guid"))
+			Expect(createdRoute.Path).To(Equal("/this-is-a-path"))
 		})
 
 		It("creates routes", func() {
@@ -178,7 +202,7 @@ var _ = Describe("route repository", func() {
 				testapi.NewCloudControllerTestRequest(testnet.TestRequest{
 					Method:  "POST",
 					Path:    "/v2/routes?inline-relations-depth=1",
-					Matcher: testnet.RequestBodyMatcher(`{"host":"my-cool-app","domain_guid":"my-domain-guid","space_guid":"the-space-guid"}`),
+					Matcher: testnet.RequestBodyMatcher(`{"host":"my-cool-app","path":"","domain_guid":"my-domain-guid","space_guid":"the-space-guid"}`),
 					Response: testnet.TestResponse{Status: http.StatusCreated, Body: `
 						{
 							"metadata": { "guid": "my-route-guid" },

--- a/cf/commands/route/create_route.go
+++ b/cf/commands/route/create_route.go
@@ -31,16 +31,20 @@ func init() {
 }
 
 func (cmd *CreateRoute) MetaData() command_registry.CommandMetadata {
-	contextPathHelp := T(`Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.`)
+	contextPathHelp := T(`Context path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.`)
 	fs := make(map[string]flags.FlagSet)
-	fs["n"] = &cliFlags.StringFlag{Name: "n", Usage: T("Optional hostname")}
+	fs["n"] = &cliFlags.StringFlag{Name: "n", Usage: T("Hostname")}
 	fs["c"] = &cliFlags.StringFlag{Name: "c", Usage: contextPathHelp}
 
 	return command_registry.CommandMetadata{
 		Name:        "create-route",
 		Description: T("Create a url route in a space for later use"),
-		Usage:       T("CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]"),
-		Flags:       fs,
+		Usage: T(`CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]
+
+EXAMPLE:
+   CF_NAME create-route my-space example.com -n myapp -c /foo
+		`),
+		Flags: fs,
 	}
 }
 

--- a/cf/commands/route/create_route.go
+++ b/cf/commands/route/create_route.go
@@ -31,18 +31,18 @@ func init() {
 }
 
 func (cmd *CreateRoute) MetaData() command_registry.CommandMetadata {
-	contextPathHelp := T(`Context path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.`)
+	contextPathHelp := T(`Path starting with a forward slash (e.g. /foo)`)
 	fs := make(map[string]flags.FlagSet)
 	fs["n"] = &cliFlags.StringFlag{Name: "n", Usage: T("Hostname")}
-	fs["c"] = &cliFlags.StringFlag{Name: "c", Usage: contextPathHelp}
+	fs["path"] = &cliFlags.StringFlag{Name: "path", Usage: contextPathHelp}
 
 	return command_registry.CommandMetadata{
 		Name:        "create-route",
 		Description: T("Create a url route in a space for later use"),
-		Usage: T(`CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]
+		Usage: T(`CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [--path PATH]
 
 EXAMPLE:
-   CF_NAME create-route my-space example.com -n myapp -c /foo
+   CF_NAME create-route my-space example.com -n myapp --path /foo
 		`),
 		Flags: fs,
 	}
@@ -78,7 +78,7 @@ func (cmd *CreateRoute) Execute(c flags.FlagContext) {
 	hostName := c.String("n")
 	space := cmd.spaceReq.GetSpace()
 	domain := cmd.domainReq.GetDomain()
-	path := c.String("c")
+	path := c.String("path")
 
 	_, apiErr := cmd.CreateRoute(hostName, path, domain, space.SpaceFields)
 

--- a/cf/commands/route/create_route_test.go
+++ b/cf/commands/route/create_route_test.go
@@ -63,7 +63,7 @@ var _ = Describe("create-route command", func() {
 			runCommand("my-space")
 			Expect(ui.Outputs).To(ContainSubstrings(
 				[]string{"Incorrect Usage", "Requires", "arguments"},
-				[]string{"create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]"},
+				[]string{"create-route SPACE DOMAIN [-n HOSTNAME] [--path PATH]"},
 			))
 		})
 	})
@@ -96,7 +96,7 @@ var _ = Describe("create-route command", func() {
 		})
 
 		It("creates routes with a context path", func() {
-			runCommand("-n", "host", "-c", "/path", "my-space", "example.com")
+			runCommand("-n", "host", "--path", "/path", "my-space", "example.com")
 
 			Expect(ui.Outputs).To(ContainSubstrings(
 				[]string{"Creating route", "host.example.com/path", "my-org", "my-space", "my-user"},

--- a/cf/commands/route/fakes/fake_route_creator.go
+++ b/cf/commands/route/fakes/fake_route_creator.go
@@ -9,13 +9,15 @@ import (
 
 type FakeRouteCreator struct {
 	CreateRouteHostname     string
+	CreateRoutePath         string
 	CreateRouteDomainFields models.DomainFields
 	CreateRouteSpaceFields  models.SpaceFields
 	ReservedRoute           models.Route
 }
 
-func (cmd *FakeRouteCreator) CreateRoute(hostName string, domain models.DomainFields, space models.SpaceFields) (reservedRoute models.Route, apiErr error) {
+func (cmd *FakeRouteCreator) CreateRoute(hostName, path string, domain models.DomainFields, space models.SpaceFields) (reservedRoute models.Route, apiErr error) {
 	cmd.CreateRouteHostname = hostName
+	cmd.CreateRoutePath = path
 	cmd.CreateRouteDomainFields = domain
 	cmd.CreateRouteSpaceFields = space
 	reservedRoute = cmd.ReservedRoute

--- a/cf/commands/route/map_route.go
+++ b/cf/commands/route/map_route.go
@@ -73,7 +73,7 @@ func (cmd *MapRoute) Execute(c flags.FlagContext) {
 	domain := cmd.domainReq.GetDomain()
 	app := cmd.appReq.GetApplication()
 
-	route, apiErr := cmd.routeCreator.CreateRoute(hostName, domain, cmd.config.SpaceFields())
+	route, apiErr := cmd.routeCreator.CreateRoute(hostName, "", domain, cmd.config.SpaceFields())
 	if apiErr != nil {
 		cmd.ui.Failed(T("Error resolving route:\n{{.Err}}", map[string]interface{}{"Err": apiErr.Error()}))
 	}

--- a/cf/commands/route/routes.go
+++ b/cf/commands/route/routes.go
@@ -74,7 +74,7 @@ func (cmd *ListRoutes) Execute(c flags.FlagContext) {
 			}))
 	}
 
-	table := cmd.ui.Table([]string{T("space"), T("host"), T("domain"), T("apps"), T("service")})
+	table := cmd.ui.Table([]string{T("space"), T("host"), T("domain"), T("path"), T("apps"), T("service")})
 
 	noRoutes := true
 	var apiErr error
@@ -87,7 +87,7 @@ func (cmd *ListRoutes) Execute(c flags.FlagContext) {
 				appNames = append(appNames, app.Name)
 			}
 
-			table.Add(route.Space.Name, route.Host, route.Domain.Name, strings.Join(appNames, ","), route.ServiceInstance.Name)
+			table.Add(route.Space.Name, route.Host, route.Domain.Name, route.Path, strings.Join(appNames, ","), route.ServiceInstance.Name)
 			return true
 		})
 
@@ -100,7 +100,7 @@ func (cmd *ListRoutes) Execute(c flags.FlagContext) {
 				appNames = append(appNames, app.Name)
 			}
 
-			table.Add(route.Space.Name, route.Host, route.Domain.Name, strings.Join(appNames, ","), route.ServiceInstance.Name)
+			table.Add(route.Space.Name, route.Host, route.Domain.Name, route.Path, strings.Join(appNames, ","), route.ServiceInstance.Name)
 			return true
 		})
 	}

--- a/cf/commands/route/routes_test.go
+++ b/cf/commands/route/routes_test.go
@@ -85,6 +85,7 @@ var _ = Describe("routes command", func() {
 
 			route2 := models.Route{}
 			route2.Host = "hostname-2"
+			route2.Path = "/foo"
 			route2.Domain = domain2
 			route2.Apps = []models.ApplicationFields{app1, app2}
 			routeRepo.Routes = []models.Route{route, route2}
@@ -97,7 +98,7 @@ var _ = Describe("routes command", func() {
 				[]string{"Getting routes for org", "/ space", "my-org", "my-space", "my-user"},
 				[]string{"host", "domain", "apps", "service"},
 				[]string{"hostname-1", "example.com", "dora", "test-service"},
-				[]string{"hostname-2", "cookieclicker.co", "dora", "bora"},
+				[]string{"hostname-2", "cookieclicker.co", "/foo", "dora", "bora"},
 			))
 		})
 	})
@@ -125,6 +126,7 @@ var _ = Describe("routes command", func() {
 
 			route2 := models.Route{}
 			route2.Host = "hostname-2"
+			route2.Path = "/foo"
 			route2.Domain = domain2
 			route2.Apps = []models.ApplicationFields{app1, app2}
 			route2.Space = space2
@@ -138,7 +140,7 @@ var _ = Describe("routes command", func() {
 				[]string{"Getting routes for org", "my-org", "my-user"},
 				[]string{"space", "host", "domain", "apps", "service"},
 				[]string{"space-1", "hostname-1", "example.com", "dora", "test-service"},
-				[]string{"space-2", "hostname-2", "cookieclicker.co", "dora", "bora"},
+				[]string{"space-2", "hostname-2", "cookieclicker.co", "/foo", "dora", "bora"},
 			))
 		})
 

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -685,7 +685,7 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]\n\nEXAMPLE:\n   CF_NAME create-route my-space example.com -n myapp -c /foo\n\t\t",
       "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
       "modified": true
    },
@@ -1397,6 +1397,11 @@
    {
       "id": "Connected, tailing logs for app {{.AppName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...\n",
       "translation": "Connected, tailing logs for app {{.AppName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...\n",
+      "modified": false
+   },
+   {
+      "id": "Context path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
+      "translation": "Context path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
       "modified": false
    },
    {
@@ -3688,16 +3693,6 @@
       "id": "ORGS",
       "translation": "ORGS",
       "modified": false
-   },
-   {
-      "id": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
-      "translation": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped. Requests received with a trailing slash will match.",
-      "modified": true
-   },
-   {
-      "id": "Optional hostname",
-      "translation": "Optional hostname",
-      "modified": true
    },
    {
       "id": "Org",

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -685,9 +685,9 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]",
       "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
-      "modified": false
+      "modified": true
    },
    {
       "id": "CF_NAME create-security-group SECURITY_GROUP PATH_TO_JSON_RULES_FILE",
@@ -1575,13 +1575,13 @@
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
-      "translation": "Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "id": "Creating route {{.Hostname}}...",
+      "translation": "Creating route {{.Hostname}}...",
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}}...",
-      "translation": "Creating route {{.Hostname}}...",
+      "id": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3688,6 +3688,16 @@
       "id": "ORGS",
       "translation": "ORGS",
       "modified": false
+   },
+   {
+      "id": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
+      "translation": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped. Requests received with a trailing slash will match.",
+      "modified": true
+   },
+   {
+      "id": "Optional hostname",
+      "translation": "Optional hostname",
+      "modified": true
    },
    {
       "id": "Org",

--- a/cf/i18n/resources/de_DE.all.json
+++ b/cf/i18n/resources/de_DE.all.json
@@ -5655,6 +5655,11 @@
       "modified": false
    },
    {
+      "id": "path",
+      "translation": "path",
+      "modified": false
+   },
+   {
       "id": "plan",
       "translation": "plan",
       "modified": false

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -685,8 +685,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]",
-      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]\n\nEXAMPLE:\n   CF_NAME create-route my-space example.com -n myapp -c /foo\n\t\t",
+      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]\n\nEXAMPLE:\n   CF_NAME create-route my-space example.com -n myapp -c /foo\n\t\t",
       "modified": false
    },
    {
@@ -1397,6 +1397,11 @@
    {
       "id": "Connected, tailing logs for app {{.AppName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...\n",
       "translation": "Connected, tailing logs for app {{.AppName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...\n",
+      "modified": false
+   },
+   {
+      "id": "Context path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
+      "translation": "Context path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
       "modified": false
    },
    {
@@ -3687,16 +3692,6 @@
    {
       "id": "ORGS",
       "translation": "ORGS",
-      "modified": false
-   },
-   {
-      "id": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
-      "translation": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
-      "modified": false
-   },
-   {
-      "id": "Optional hostname",
-      "translation": "Optional hostname",
       "modified": false
    },
    {

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -5655,6 +5655,11 @@
       "modified": false
    },
    {
+      "id": "path",
+      "translation": "path",
+      "modified": false
+   },
+   {
       "id": "plan",
       "translation": "plan",
       "modified": false

--- a/cf/i18n/resources/en_US.all.json
+++ b/cf/i18n/resources/en_US.all.json
@@ -685,8 +685,8 @@
       "modified": false
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
-      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]",
+      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]",
       "modified": false
    },
    {
@@ -1575,13 +1575,13 @@
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
-      "translation": "Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "id": "Creating route {{.Hostname}}...",
+      "translation": "Creating route {{.Hostname}}...",
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}}...",
-      "translation": "Creating route {{.Hostname}}...",
+      "id": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3687,6 +3687,16 @@
    {
       "id": "ORGS",
       "translation": "ORGS",
+      "modified": false
+   },
+   {
+      "id": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
+      "translation": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
+      "modified": false
+   },
+   {
+      "id": "Optional hostname",
+      "translation": "Optional hostname",
       "modified": false
    },
    {

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -685,9 +685,9 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]",
       "translation": "CF_NAME create-route SPACE DOMINIO [-n HOSTNAME]",
-      "modified": false
+      "modified": true
    },
    {
       "id": "CF_NAME create-security-group SECURITY_GROUP PATH_TO_JSON_RULES_FILE",
@@ -1575,13 +1575,13 @@
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
-      "translation": "Creando ruta {{.Hostname}} en org {{.OrgName}} / space {{.SpaceName}} como {{.Username}}...",
+      "id": "Creating route {{.Hostname}}...",
+      "translation": "Creando ruta {{.Hostname}}...",
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}}...",
-      "translation": "Creando ruta {{.Hostname}}...",
+      "id": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3688,6 +3688,16 @@
       "id": "ORGS",
       "translation": "ORGS",
       "modified": false
+   },
+   {
+      "id": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
+      "translation": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped. Requests received with a trailing slash will match.",
+      "modified": true
+   },
+   {
+      "id": "Optional hostname",
+      "translation": "Optional hostname",
+      "modified": true
    },
    {
       "id": "Org",

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -5655,6 +5655,11 @@
       "modified": false
    },
    {
+      "id": "path",
+      "translation": "path",
+      "modified": false
+   },
+   {
       "id": "plan",
       "translation": "plan",
       "modified": false

--- a/cf/i18n/resources/es_ES.all.json
+++ b/cf/i18n/resources/es_ES.all.json
@@ -685,7 +685,7 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]\n\nEXAMPLE:\n   CF_NAME create-route my-space example.com -n myapp -c /foo\n\t\t",
       "translation": "CF_NAME create-route SPACE DOMINIO [-n HOSTNAME]",
       "modified": true
    },
@@ -1397,6 +1397,11 @@
    {
       "id": "Connected, tailing logs for app {{.AppName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...\n",
       "translation": "Conectando, tailing logs para la app {{.AppName}} en la org {{.OrgName}} / space {{.SpaceName}} como {{.Username}}...\n",
+      "modified": false
+   },
+   {
+      "id": "Context path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
+      "translation": "Context path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
       "modified": false
    },
    {
@@ -3688,16 +3693,6 @@
       "id": "ORGS",
       "translation": "ORGS",
       "modified": false
-   },
-   {
-      "id": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
-      "translation": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped. Requests received with a trailing slash will match.",
-      "modified": true
-   },
-   {
-      "id": "Optional hostname",
-      "translation": "Optional hostname",
-      "modified": true
    },
    {
       "id": "Org",

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -685,7 +685,7 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]\n\nEXAMPLE:\n   CF_NAME create-route my-space example.com -n myapp -c /foo\n\t\t",
       "translation": "CF_NAME create-route ESPACE DOMAINE [-n HÔTE]",
       "modified": true
    },
@@ -1397,6 +1397,11 @@
    {
       "id": "Connected, tailing logs for app {{.AppName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...\n",
       "translation": "Connecté, suivi des logs pour l'application {{.AppName}} de l'org {{.OrgName}} / espace {{.SpaceName}} en tant que {{.Username}}...\n",
+      "modified": false
+   },
+   {
+      "id": "Context path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
+      "translation": "Context path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
       "modified": false
    },
    {
@@ -3688,16 +3693,6 @@
       "id": "ORGS",
       "translation": "ORGS",
       "modified": false
-   },
-   {
-      "id": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
-      "translation": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped. Requests received with a trailing slash will match.",
-      "modified": true
-   },
-   {
-      "id": "Optional hostname",
-      "translation": "Optional hostname",
-      "modified": true
    },
    {
       "id": "Org",

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -685,9 +685,9 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]",
       "translation": "CF_NAME create-route ESPACE DOMAINE [-n HÔTE]",
-      "modified": false
+      "modified": true
    },
    {
       "id": "CF_NAME create-security-group SECURITY_GROUP PATH_TO_JSON_RULES_FILE",
@@ -1575,13 +1575,13 @@
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
-      "translation": "Création de la route {{.Hostname}} pour l'org {{.OrgName}} / {{.SpaceName}} en tant que {{.Username}}...",
+      "id": "Creating route {{.Hostname}}...",
+      "translation": "Création de la route {{.Hostname}}...",
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}}...",
-      "translation": "Création de la route {{.Hostname}}...",
+      "id": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3688,6 +3688,16 @@
       "id": "ORGS",
       "translation": "ORGS",
       "modified": false
+   },
+   {
+      "id": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
+      "translation": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped. Requests received with a trailing slash will match.",
+      "modified": true
+   },
+   {
+      "id": "Optional hostname",
+      "translation": "Optional hostname",
+      "modified": true
    },
    {
       "id": "Org",

--- a/cf/i18n/resources/fr_FR.all.json
+++ b/cf/i18n/resources/fr_FR.all.json
@@ -5655,6 +5655,11 @@
       "modified": false
    },
    {
+      "id": "path",
+      "translation": "path",
+      "modified": false
+   },
+   {
       "id": "plan",
       "translation": "plan",
       "modified": false

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -685,7 +685,7 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]\n\nEXAMPLE:\n   CF_NAME create-route my-space example.com -n myapp -c /foo\n\t\t",
       "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
       "modified": true
    },
@@ -1397,6 +1397,11 @@
    {
       "id": "Connected, tailing logs for app {{.AppName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...\n",
       "translation": "Connected, tailing logs for app {{.AppName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...\n",
+      "modified": false
+   },
+   {
+      "id": "Context path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
+      "translation": "Context path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
       "modified": false
    },
    {
@@ -3688,16 +3693,6 @@
       "id": "ORGS",
       "translation": "ORGS",
       "modified": false
-   },
-   {
-      "id": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
-      "translation": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped. Requests received with a trailing slash will match.",
-      "modified": true
-   },
-   {
-      "id": "Optional hostname",
-      "translation": "Optional hostname",
-      "modified": true
    },
    {
       "id": "Org",

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -685,9 +685,9 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]",
       "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
-      "modified": false
+      "modified": true
    },
    {
       "id": "CF_NAME create-security-group SECURITY_GROUP PATH_TO_JSON_RULES_FILE",
@@ -1575,13 +1575,13 @@
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
-      "translation": "Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "id": "Creating route {{.Hostname}}...",
+      "translation": "Creating route {{.Hostname}}...",
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}}...",
-      "translation": "Creating route {{.Hostname}}...",
+      "id": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3688,6 +3688,16 @@
       "id": "ORGS",
       "translation": "ORGS",
       "modified": false
+   },
+   {
+      "id": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
+      "translation": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped. Requests received with a trailing slash will match.",
+      "modified": true
+   },
+   {
+      "id": "Optional hostname",
+      "translation": "Optional hostname",
+      "modified": true
    },
    {
       "id": "Org",

--- a/cf/i18n/resources/it_IT.all.json
+++ b/cf/i18n/resources/it_IT.all.json
@@ -5655,6 +5655,11 @@
       "modified": false
    },
    {
+      "id": "path",
+      "translation": "path",
+      "modified": false
+   },
+   {
       "id": "plan",
       "translation": "plan",
       "modified": false

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -685,7 +685,7 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]\n\nEXAMPLE:\n   CF_NAME create-route my-space example.com -n myapp -c /foo\n\t\t",
       "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
       "modified": true
    },
@@ -1397,6 +1397,11 @@
    {
       "id": "Connected, tailing logs for app {{.AppName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...\n",
       "translation": "Connected, tailing logs for app {{.AppName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...\n",
+      "modified": false
+   },
+   {
+      "id": "Context path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
+      "translation": "Context path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
       "modified": false
    },
    {
@@ -3688,16 +3693,6 @@
       "id": "ORGS",
       "translation": "ORGS",
       "modified": false
-   },
-   {
-      "id": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
-      "translation": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped. Requests received with a trailing slash will match.",
-      "modified": true
-   },
-   {
-      "id": "Optional hostname",
-      "translation": "Optional hostname",
-      "modified": true
    },
    {
       "id": "Org",

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -685,9 +685,9 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]",
       "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
-      "modified": false
+      "modified": true
    },
    {
       "id": "CF_NAME create-security-group SECURITY_GROUP PATH_TO_JSON_RULES_FILE",
@@ -1575,13 +1575,13 @@
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
-      "translation": "Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "id": "Creating route {{.Hostname}}...",
+      "translation": "Creating route {{.Hostname}}...",
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}}...",
-      "translation": "Creating route {{.Hostname}}...",
+      "id": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3688,6 +3688,16 @@
       "id": "ORGS",
       "translation": "ORGS",
       "modified": false
+   },
+   {
+      "id": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
+      "translation": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped. Requests received with a trailing slash will match.",
+      "modified": true
+   },
+   {
+      "id": "Optional hostname",
+      "translation": "Optional hostname",
+      "modified": true
    },
    {
       "id": "Org",

--- a/cf/i18n/resources/ja_JA.all.json
+++ b/cf/i18n/resources/ja_JA.all.json
@@ -5655,6 +5655,11 @@
       "modified": false
    },
    {
+      "id": "path",
+      "translation": "path",
+      "modified": false
+   },
+   {
       "id": "plan",
       "translation": "plan",
       "modified": false

--- a/cf/i18n/resources/ko_KR.all.json
+++ b/cf/i18n/resources/ko_KR.all.json
@@ -685,9 +685,9 @@
       "modified": false
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
-      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
-      "modified": false
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]\n\nEXAMPLE:\n   CF_NAME create-route my-space example.com -n myapp -c /foo\n\t\t",
+      "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]",
+      "modified": true
    },
    {
       "id": "CF_NAME create-security-group SECURITY_GROUP PATH_TO_JSON_RULES_FILE",
@@ -1400,6 +1400,11 @@
       "modified": false
    },
    {
+      "id": "Context path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
+      "translation": "Context path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
+      "modified": false
+   },
+   {
       "id": "Copying source from app {{.SourceApp}} to target app {{.TargetApp}} in org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "translation": "Copying source from app {{.SourceApp}} to target app {{.TargetApp}} in org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
@@ -1575,13 +1580,13 @@
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
-      "translation": "Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "id": "Creating route {{.Hostname}}...",
+      "translation": "Creating route {{.Hostname}}...",
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}}...",
-      "translation": "Creating route {{.Hostname}}...",
+      "id": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -685,7 +685,7 @@
       "modified": false
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]\n\nEXAMPLE:\n   CF_NAME create-route my-space example.com -n myapp -c /foo\n\t\t",
       "translation": "CF_NAME create-route ESPAÇO DOMÍNIO [-n HOSTNAME]",
       "modified": true
    },
@@ -1397,6 +1397,11 @@
    {
       "id": "Connected, tailing logs for app {{.AppName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...\n",
       "translation": "Conectado, mostrando logs continuadamente para app {{.AppName}} na org {{.OrgName}} / espaço {{.SpaceName}} como {{.Username}}...\n",
+      "modified": false
+   },
+   {
+      "id": "Context path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
+      "translation": "Context path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
       "modified": false
    },
    {
@@ -3688,16 +3693,6 @@
       "id": "ORGS",
       "translation": "ORGS",
       "modified": false
-   },
-   {
-      "id": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
-      "translation": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped. Requests received with a trailing slash will match.",
-      "modified": true
-   },
-   {
-      "id": "Optional hostname",
-      "translation": "Optional hostname",
-      "modified": true
    },
    {
       "id": "Org",

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -5655,6 +5655,11 @@
       "modified": false
    },
    {
+      "id": "path",
+      "translation": "path",
+      "modified": false
+   },
+   {
       "id": "plan",
       "translation": "plano",
       "modified": false

--- a/cf/i18n/resources/pt_BR.all.json
+++ b/cf/i18n/resources/pt_BR.all.json
@@ -685,9 +685,9 @@
       "modified": false
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]",
       "translation": "CF_NAME create-route ESPAÇO DOMÍNIO [-n HOSTNAME]",
-      "modified": false
+      "modified": true
    },
    {
       "id": "CF_NAME create-security-group SECURITY_GROUP PATH_TO_JSON_RULES_FILE",
@@ -1575,13 +1575,13 @@
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
-      "translation": "Criando rota {{.Hostname}} para org {{.OrgName}} / espaço {{.SpaceName}} como {{.Username}}...",
+      "id": "Creating route {{.Hostname}}...",
+      "translation": "Criando rota {{.Hostname}}...",
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}}...",
-      "translation": "Criando rota {{.Hostname}}...",
+      "id": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3688,6 +3688,16 @@
       "id": "ORGS",
       "translation": "ORGS",
       "modified": false
+   },
+   {
+      "id": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
+      "translation": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped. Requests received with a trailing slash will match.",
+      "modified": true
+   },
+   {
+      "id": "Optional hostname",
+      "translation": "Optional hostname",
+      "modified": true
    },
    {
       "id": "Org",

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -685,9 +685,9 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]",
       "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
-      "modified": false
+      "modified": true
    },
    {
       "id": "CF_NAME create-security-group SECURITY_GROUP PATH_TO_JSON_RULES_FILE",
@@ -1575,13 +1575,13 @@
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
-      "translation": "Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "id": "Creating route {{.Hostname}}...",
+      "translation": "创建路由 {{.Hostname}}...",
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}}...",
-      "translation": "创建路由 {{.Hostname}}...",
+      "id": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3688,6 +3688,16 @@
       "id": "ORGS",
       "translation": "组织",
       "modified": false
+   },
+   {
+      "id": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
+      "translation": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped. Requests received with a trailing slash will match.",
+      "modified": true
+   },
+   {
+      "id": "Optional hostname",
+      "translation": "Optional hostname",
+      "modified": true
    },
    {
       "id": "Org",

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -685,7 +685,7 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]\n\nEXAMPLE:\n   CF_NAME create-route my-space example.com -n myapp -c /foo\n\t\t",
       "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
       "modified": true
    },
@@ -1397,6 +1397,11 @@
    {
       "id": "Connected, tailing logs for app {{.AppName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...\n",
       "translation": "已连接，用户{{.Username}}读取组织 {{.OrgName}} / 空间 {{.SpaceName}}下应用程序{{.AppName}} 的日志...\n",
+      "modified": false
+   },
+   {
+      "id": "Context path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
+      "translation": "Context path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
       "modified": false
    },
    {
@@ -3688,16 +3693,6 @@
       "id": "ORGS",
       "translation": "组织",
       "modified": false
-   },
-   {
-      "id": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
-      "translation": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped. Requests received with a trailing slash will match.",
-      "modified": true
-   },
-   {
-      "id": "Optional hostname",
-      "translation": "Optional hostname",
-      "modified": true
    },
    {
       "id": "Org",

--- a/cf/i18n/resources/zh_Hans.all.json
+++ b/cf/i18n/resources/zh_Hans.all.json
@@ -5655,6 +5655,11 @@
       "modified": false
    },
    {
+      "id": "path",
+      "translation": "path",
+      "modified": false
+   },
+   {
       "id": "plan",
       "translation": "服务计划",
       "modified": false

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -685,7 +685,7 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]\n\nEXAMPLE:\n   CF_NAME create-route my-space example.com -n myapp -c /foo\n\t\t",
       "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
       "modified": true
    },
@@ -1397,6 +1397,11 @@
    {
       "id": "Connected, tailing logs for app {{.AppName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...\n",
       "translation": "Connected, tailing logs for app {{.AppName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...\n",
+      "modified": false
+   },
+   {
+      "id": "Context path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
+      "translation": "Context path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
       "modified": false
    },
    {
@@ -3688,16 +3693,6 @@
       "id": "ORGS",
       "translation": "ORGS",
       "modified": false
-   },
-   {
-      "id": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
-      "translation": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped. Requests received with a trailing slash will match.",
-      "modified": true
-   },
-   {
-      "id": "Optional hostname",
-      "translation": "Optional hostname",
-      "modified": true
    },
    {
       "id": "Org",

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -685,9 +685,9 @@
       "modified": true
    },
    {
-      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
+      "id": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME] [-c PATH]",
       "translation": "CF_NAME create-route SPACE DOMAIN [-n HOSTNAME]",
-      "modified": false
+      "modified": true
    },
    {
       "id": "CF_NAME create-security-group SECURITY_GROUP PATH_TO_JSON_RULES_FILE",
@@ -1575,13 +1575,13 @@
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
-      "translation": "Creating route {{.Hostname}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "id": "Creating route {{.Hostname}}...",
+      "translation": "Creating route {{.Hostname}}...",
       "modified": false
    },
    {
-      "id": "Creating route {{.Hostname}}...",
-      "translation": "Creating route {{.Hostname}}...",
+      "id": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
+      "translation": "Creating route {{.URL}} for org {{.OrgName}} / space {{.SpaceName}} as {{.Username}}...",
       "modified": false
    },
    {
@@ -3688,6 +3688,16 @@
       "id": "ORGS",
       "translation": "ORGS",
       "modified": false
+   },
+   {
+      "id": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped, but requests received with a trailing slash will match.",
+      "translation": "Optional context path. Path must include at least one character following a leading forward slash (/). Trailing slashes will be stripped. Requests received with a trailing slash will match.",
+      "modified": true
+   },
+   {
+      "id": "Optional hostname",
+      "translation": "Optional hostname",
+      "modified": true
    },
    {
       "id": "Org",

--- a/cf/i18n/resources/zh_Hant.all.json
+++ b/cf/i18n/resources/zh_Hant.all.json
@@ -5655,6 +5655,11 @@
       "modified": false
    },
    {
+      "id": "path",
+      "translation": "path",
+      "modified": false
+   },
+   {
       "id": "plan",
       "translation": "plan",
       "modified": false

--- a/cf/models/route.go
+++ b/cf/models/route.go
@@ -3,10 +3,10 @@ package models
 import "fmt"
 
 type Route struct {
-	Guid   string
-	Host   string
-	Domain DomainFields
-
+	Guid            string
+	Host            string
+	Domain          DomainFields
+	Path            string
 	Space           SpaceFields
 	Apps            []ApplicationFields
 	ServiceInstance ServiceInstanceFields
@@ -16,18 +16,19 @@ func (route Route) URL() string {
 	if route.Host == "" {
 		return route.Domain.Name
 	}
-	return fmt.Sprintf("%s.%s", route.Host, route.Domain.Name)
+	return fmt.Sprintf("%s.%s%s", route.Host, route.Domain.Name, route.Path)
 }
 
 type RouteSummary struct {
 	Guid   string
 	Host   string
 	Domain DomainFields
+	Path   string
 }
 
 func (model RouteSummary) URL() string {
 	if model.Host == "" {
 		return model.Domain.Name
 	}
-	return fmt.Sprintf("%s.%s", model.Host, model.Domain.Name)
+	return fmt.Sprintf("%s.%s%s", model.Host, model.Domain.Name, model.Path)
 }

--- a/cf/models/route.go
+++ b/cf/models/route.go
@@ -5,8 +5,8 @@ import "fmt"
 type Route struct {
 	Guid            string
 	Host            string
-	Domain          DomainFields
 	Path            string
+	Domain          DomainFields
 	Space           SpaceFields
 	Apps            []ApplicationFields
 	ServiceInstance ServiceInstanceFields


### PR DESCRIPTION
This PR adds support for specifying context path while creating route. It also consists of changes to list path in `cf routes` command.

Pivotal tracker stories:
https://www.pivotaltracker.com/story/show/104020832
https://www.pivotaltracker.com/story/show/104020104

Regards,
@atulkc and @fordaz
(CF Routing team)