### PR TITLE
add missing param route-path to manifest mapper

### DIFF
--- a/cf/manifest/manifest.go
+++ b/cf/manifest/manifest.go
@@ -196,6 +196,7 @@ func mapToAppParams(basePath string, yamlMap generic.Map) (models.AppParams, err
 	appParams.HealthCheckTimeout = intVal(yamlMap, "timeout", &errs)
 	appParams.NoRoute = boolVal(yamlMap, "no-route", &errs)
 	appParams.NoHostname = boolVal(yamlMap, "no-hostname", &errs)
+	appParams.RoutePath = stringVal(yamlMap, "route-path", &errs)
 	appParams.UseRandomHostname = boolVal(yamlMap, "random-route", &errs)
 	appParams.ServicesToBind = sliceOrEmptyVal(yamlMap, "services", &errs)
 	appParams.EnvironmentVars = envVarOrEmptyMap(yamlMap, &errs)


### PR DESCRIPTION
I hope this is correct. It is my first line in go :tada: but untested.