### PR TITLE
Avoid Risky operation of scaling 0 instances

### DIFF
--- a/cf/commands/application/scale.go
+++ b/cf/commands/application/scale.go
@@ -121,6 +121,15 @@ func (cmd *Scale) Execute(c flags.FlagContext) {
 
 	if c.IsSet("i") {
 		instances := c.Int("i")
+		if instances == 0 {
+			response := cmd.ui.Confirm(T("Are you sure you want to scale {{.AppName}} to 0 instances?",
+				map[string]interface{}{
+					"AppName": terminal.EntityNameColor(currentApp.Name),
+				}))
+			if !response {
+				return
+			}
+		}
 		params.InstanceCount = &instances
 	}
 

--- a/cf/i18n/resources/en-us.all.json
+++ b/cf/i18n/resources/en-us.all.json
@@ -3556,6 +3556,11 @@
     "translation": "Scaling app {{.AppName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.CurrentUser}}..."
   },
   {
+    "id": "Are you sure you want to scale {{.AppName}} to 0 instances?",
+    "translation": "Are you sure you want to scale {{.AppName}} to 0 instances?",
+    "modified": false
+  },
+  {
     "id": "Security Groups:",
     "translation": "Security Groups:"
   },


### PR DESCRIPTION
Scaling application to 0 instances is risky , this PR just creates a prompt when scaling to 0 instances.

Output for this check.

```bash
./bin/build && ./out/cf scale hello-java-app -i 0

Generating Binary...

Are you sure you want to scale hello-java-app to 0 instances?>
```