### PR TITLE
Add support for route-path via the manifest file

### DIFF
--- a/cf/manifest/manifest.go
+++ b/cf/manifest/manifest.go
@@ -201,6 +201,7 @@ func mapToAppParams(basePath string, yamlMap generic.Map) (models.AppParams, err
 	appParams.EnvironmentVars = envVarOrEmptyMap(yamlMap, &errs)
 	appParams.HealthCheckType = stringVal(yamlMap, "health-check-type", &errs)
 	appParams.AppPorts = intSliceVal(yamlMap, "app-ports", &errs)
+	appParams.RoutePath = stringVal(yamlMap, "route-path", &errs)
 
 	if appParams.Path != nil {
 		path := *appParams.Path

--- a/cf/manifest/manifest_test.go
+++ b/cf/manifest/manifest_test.go
@@ -256,6 +256,7 @@ var _ = Describe("Manifests", func() {
 					"no-route":          true,
 					"no-hostname":       true,
 					"random-route":      true,
+					"route-path":        "my/route/path",
 				},
 			},
 		}))
@@ -277,6 +278,7 @@ var _ = Describe("Manifests", func() {
 		Expect(apps[0].NoRoute).To(BeTrue())
 		Expect(apps[0].NoHostname).To(BeTrue())
 		Expect(apps[0].UseRandomHostname).To(BeTrue())
+		Expect(*apps[0].RoutePath).To(Equal("my/route/path"))
 	})
 
 	It("removes duplicated values in 'hosts' and 'domains'", func() {


### PR DESCRIPTION
Signed-off-by: Alpha Chen <achen@pivotal.io>

This code change will enable us to do blue-green deploys via the concourse autopilot resource. 