### PR TITLE
Compile linux binaries statically

### DIFF
--- a/ci/tasks/build-binaries.yml
+++ b/ci/tasks/build-binaries.yml
@@ -24,13 +24,13 @@ run:
       bin/replace-sha
 
       echo "Building 32-bit Linux"
-      GOARCH=386 GOOS=linux go build -o out/cf-cli_linux_i686 ./main
+      CGO_ENABLED=0 GOARCH=386 GOOS=linux go build -o out/cf-cli_linux_i686 ./main
 
       echo "Building 32-bit Windows"
       GOARCH=386 GOOS=windows go build -o out/cf-cli_win32.exe ./main
 
       echo "Building 64-bit Linux"
-      GOARCH=amd64 GOOS=linux go build -o out/cf-cli_linux_x86-64 ./main
+      CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -o out/cf-cli_linux_x86-64 ./main
 
       echo "Building 64-bit Windows"
       GOARCH=amd64 GOOS=windows go build -o out/cf-cli_winx64.exe ./main


### PR DESCRIPTION
In order to be able to use the linux binaries in different distributions
with different libc implementation (e.g. Linux Alpine), we must
compile it statically by setting CGO_ENABLED=0.

More info in https://golang.org/cmd/cgo/

Fixes #807

Refers to pivotal stories:
 * [#116760875](https://www.pivotaltracker.com/story/show/116760875)
 * [#115376361](https://www.pivotaltracker.com/story/show/115376361)