### PR TITLE
added 3 min timeout for requests with 10 times retry

### DIFF
--- a/cf/net/gateway.go
+++ b/cf/net/gateway.go
@@ -426,9 +426,10 @@ func (gateway Gateway) doRequest(request *http.Request) (response *http.Response
 
 	httpClient.DumpRequest(request)
 
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 10; i++ {
 		response, err = httpClient.Do(request)
 		if response == nil && err != nil {
+			fmt.Printf("request timeout, retry %d\n", i)
 			continue
 		} else {
 			break

--- a/cf/net/gateway_test.go
+++ b/cf/net/gateway_test.go
@@ -88,14 +88,14 @@ var _ = Describe("Gateway", func() {
 			Expect(apiErr).To(HaveOccurred())
 		})
 
-		It("Retries 3 times if we cannot contact the server", func() {
+		It("Retries 10 times if we cannot contact the server", func() {
 			client.DoReturns(nil, errors.New("Connection refused"))
 			request, apiErr := ccGateway.NewRequest("GET", "https://example.com/v2/apps", "BEARER my-access-token", nil)
 			Expect(apiErr).ToNot(HaveOccurred())
 
 			_, apiErr = ccGateway.PerformRequest(request)
 			Expect(apiErr).To(HaveOccurred())
-			Expect(client.DoCallCount()).To(Equal(3))
+			Expect(client.DoCallCount()).To(Equal(10))
 		})
 	})
 

--- a/cf/net/http_client.go
+++ b/cf/net/http_client.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/cloudfoundry/cli/cf/errors"
 	. "github.com/cloudfoundry/cli/cf/i18n"
@@ -28,9 +29,11 @@ type client struct {
 }
 
 var NewHttpClient = func(tr *http.Transport, dumper RequestDumper) HttpClientInterface {
+	timeout := time.Duration(180 * time.Second)
 	c := client{
 		&http.Client{
 			Transport: tr,
+			Timeout: timeout,
 		},
 		dumper,
 	}


### PR DESCRIPTION
We struggle with the issue, that the cloud doesn't responds to requests, and the cf tool just hangs. I added a timeout of 3 minutes to the requests, and increased the retry count to 10, and added command line logging.