### PR TITLE
limit the -v effect position

### DIFF
--- a/main/main.go
+++ b/main/main.go
@@ -198,7 +198,7 @@ func handleVerbose(args []string) ([]string, bool) {
 		}
 	}
 
-	if idx != -1 && len(args) > 1 {
+	if idx == 1 && len(args) > 1 {
 		verbose = true
 		args = append(args[:idx], args[idx+1:]...)
 	}

--- a/main/main_test.go
+++ b/main/main_test.go
@@ -107,11 +107,11 @@ var _ = Describe("main", func() {
 			Eventually(output.Out.Contents).Should(ContainSubstring("GET /v2/info HTTP/1.1"))
 		})
 
-		It("enables verbose output when -v is provided after a command", func() {
-			output := Cf("curl", "/v2/info", "-v").Wait(5 * time.Second)
-			Eventually(output.Out.Contents).ShouldNot(ContainSubstring("Invalid flag: -v"))
-			Eventually(output.Out.Contents).Should(ContainSubstring("GET /v2/info HTTP/1.1"))
-		})
+		// It("enables verbose output when -v is provided after a command", func() {
+		// 			output := Cf("curl", "/v2/info", "-v").Wait(5 * time.Second)
+		// 			Eventually(output.Out.Contents).ShouldNot(ContainSubstring("Invalid flag: -v"))
+		// 			Eventually(output.Out.Contents).Should(ContainSubstring("GET /v2/info HTTP/1.1"))
+		// 		})
 	})
 
 	Describe("Shows debug information with -b or --build", func() {


### PR DESCRIPTION
As we are talking about this...
In the old days, -v is the cf cli, I believe is short for the version... cf -v = cf --version...
however, a small changes like this will make it clear if user would like to see the cf debug information, or want to see the plugins' verbose result... 
with this change, user can specify `cf -v <plugin command> -v` and the first -v will handled by cf and show the cf debug info, while the second one is totally handled by the plugin itself :) @dkoper  

The same thing is also with `-h`, if the implementation could be done for `-h`, it could be better, since right now, the -h with plugin only shows the upper level help information that plugin registered with the cf in the metadata. However, maybe some plugin itself has the ability to show more detailed help info to the user... Limiting the scale of the global flags will improve that :) 

Thank you ...

Jesse