### PR TITLE
Do not hardcode ':' for some languages to be translated correctly

### DIFF
--- a/cf/commandregistry/registry.go
+++ b/cf/commandregistry/registry.go
@@ -135,10 +135,10 @@ func CLICommandUsagePresenter(cmd Command) *usagePresenter {
 func (u *usagePresenter) Usage() string {
 	metadata := u.cmd.MetaData()
 
-	output := T("NAME") + ":" + "\n"
+	output := T("NAME:") + "\n"
 	output += "   " + metadata.Name + " - " + metadata.Description + "\n\n"
 
-	output += T("USAGE") + ":" + "\n"
+	output += T("USAGE:") + "\n"
 	output += "   " + strings.Replace(strings.Join(metadata.Usage, ""), "CF_NAME", cf.Name, -1) + "\n"
 
 	if len(metadata.Examples) > 0 {
@@ -150,12 +150,12 @@ func (u *usagePresenter) Usage() string {
 	}
 
 	if metadata.ShortName != "" {
-		output += "\n" + T("ALIAS") + ":" + "\n"
+		output += "\n" + T("ALIAS:") + "\n"
 		output += "   " + metadata.ShortName + "\n"
 	}
 
 	if metadata.Flags != nil {
-		output += "\n" + T("OPTIONS") + ":" + "\n"
+		output += "\n" + T("OPTIONS:") + "\n"
 		output += flags.NewFlagContext(metadata.Flags).ShowUsage(3)
 	}
 

--- a/cf/commandregistry/registry_test.go
+++ b/cf/commandregistry/registry_test.go
@@ -201,6 +201,46 @@ var _ = Describe("CommandRegistry", func() {
 			))
 		})
 
+		Context("i18n translations", func() {
+			var originalT func(string, ...interface{}) string
+
+			BeforeEach(func() {
+				originalT = T
+			})
+
+			AfterEach(func() {
+				T = originalT
+			})
+
+			It("includes ':' in caption translation strings for language like French to be translated correctly", func() {
+				nameCaption := "NAME:"
+				aliasCaption := "ALIAS:"
+				usageCaption := "USAGE:"
+				optionsCaption := "OPTIONS:"
+				captionCheckCount := 0
+
+				T = func(translationID string, args ...interface{}) string {
+					if strings.HasPrefix(translationID, "NAME") {
+						Expect(translationID).To(Equal(nameCaption))
+						captionCheckCount += 1
+					} else if strings.HasPrefix(translationID, "ALIAS") {
+						Expect(translationID).To(Equal(aliasCaption))
+						captionCheckCount += 1
+					} else if strings.HasPrefix(translationID, "USAGE") {
+						Expect(translationID).To(Equal(usageCaption))
+						captionCheckCount += 1
+					} else if strings.HasPrefix(translationID, "OPTIONS") {
+						Expect(translationID).To(Equal(optionsCaption))
+						captionCheckCount += 1
+					}
+
+					return translationID
+				}
+
+				commandregistry.Commands.CommandUsage("fake-command")
+			})
+		})
+
 		It("prints the flag options", func() {
 			o := commandregistry.Commands.CommandUsage("fake-command")
 			outputs := strings.Split(o, "\n")

--- a/cf/commands/help.go
+++ b/cf/commands/help.go
@@ -57,19 +57,19 @@ func (cmd *Help) Execute(c flags.FlagContext) {
 			for _, meta := range cmd.config.Plugins() {
 				for _, c := range meta.Commands {
 					if c.Name == cmdName || c.Alias == cmdName {
-						output := T("NAME") + ":" + "\n"
+						output := T("NAME:") + "\n"
 						output += "   " + c.Name + " - " + c.HelpText + "\n"
 
 						if c.Alias != "" {
-							output += "\n" + T("ALIAS") + ":" + "\n"
+							output += "\n" + T("ALIAS:") + "\n"
 							output += "   " + c.Alias + "\n"
 						}
 
-						output += "\n" + T("USAGE") + ":" + "\n"
+						output += "\n" + T("USAGE:") + "\n"
 						output += "   " + c.UsageDetails.Usage + "\n"
 
 						if len(c.UsageDetails.Options) > 0 {
-							output += "\n" + T("OPTIONS") + ":" + "\n"
+							output += "\n" + T("OPTIONS:") + "\n"
 
 							//find longest name length
 							l := 0

--- a/cf/i18n/resources/de-de.all.json
+++ b/cf/i18n/resources/de-de.all.json
@@ -164,8 +164,8 @@
     "translation": "ERWEITERT"
   },
   {
-    "id": "ALIAS",
-    "translation": "ALIAS"
+    "id": "ALIAS:",
+    "translation": "ALIAS:"
   },
   {
     "id": "API endpoint",
@@ -3116,8 +3116,8 @@
     "translation": "OK"
   },
   {
-    "id": "OPTIONS",
-    "translation": "OPTIONEN"
+    "id": "OPTIONS:",
+    "translation": "OPTIONEN:"
   },
   {
     "id": "ORG ADMIN",
@@ -4214,10 +4214,6 @@
   {
     "id": "URL to which requests for bound routes will be forwarded. Scheme for this URL must be https",
     "translation": "URL, an die Anforderungen für gebundene Routen weitergeleitet werden. Das Schema für diese URL muss https sein."
-  },
-  {
-    "id": "USAGE",
-    "translation": "VERWENDUNG"
   },
   {
     "id": "USAGE:",

--- a/cf/i18n/resources/en-us.all.json
+++ b/cf/i18n/resources/en-us.all.json
@@ -164,8 +164,8 @@
     "translation": "ADVANCED"
   },
   {
-    "id": "ALIAS",
-    "translation": "ALIAS"
+    "id": "ALIAS:",
+    "translation": "ALIAS:"
   },
   {
     "id": "API endpoint",
@@ -3116,8 +3116,8 @@
     "translation": "OK"
   },
   {
-    "id": "OPTIONS",
-    "translation": "OPTIONS"
+    "id": "OPTIONS:",
+    "translation": "OPTIONS:"
   },
   {
     "id": "ORG ADMIN",
@@ -4214,10 +4214,6 @@
   {
     "id": "URL to which requests for bound routes will be forwarded. Scheme for this URL must be https",
     "translation": "URL to which requests for bound routes will be forwarded. Scheme for this URL must be https"
-  },
-  {
-    "id": "USAGE",
-    "translation": "USAGE"
   },
   {
     "id": "USAGE:",

--- a/cf/i18n/resources/es-es.all.json
+++ b/cf/i18n/resources/es-es.all.json
@@ -164,8 +164,8 @@
     "translation": "AVANZADO"
   },
   {
-    "id": "ALIAS",
-    "translation": "ALIAS"
+    "id": "ALIAS:",
+    "translation": "ALIAS:"
   },
   {
     "id": "API endpoint",
@@ -3116,8 +3116,8 @@
     "translation": "Aceptar"
   },
   {
-    "id": "OPTIONS",
-    "translation": "OPCIONES"
+    "id": "OPTIONS:",
+    "translation": "OPCIONES:"
   },
   {
     "id": "ORG ADMIN",
@@ -4214,10 +4214,6 @@
   {
     "id": "URL to which requests for bound routes will be forwarded. Scheme for this URL must be https",
     "translation": "URL al que se reenviarán las solicitudes para rutas enlazadas. El esquema para este URL debe ser https"
-  },
-  {
-    "id": "USAGE",
-    "translation": "USO"
   },
   {
     "id": "USAGE:",

--- a/cf/i18n/resources/fr-fr.all.json
+++ b/cf/i18n/resources/fr-fr.all.json
@@ -164,8 +164,8 @@
     "translation": "AVANCE"
   },
   {
-    "id": "ALIAS",
-    "translation": "ALIAS"
+    "id": "ALIAS:",
+    "translation": "ALIAS:"
   },
   {
     "id": "API endpoint",
@@ -3116,8 +3116,8 @@
     "translation": "OK"
   },
   {
-    "id": "OPTIONS",
-    "translation": "OPTIONS"
+    "id": "OPTIONS:",
+    "translation": "OPTIONS:"
   },
   {
     "id": "ORG ADMIN",
@@ -4214,10 +4214,6 @@
   {
     "id": "URL to which requests for bound routes will be forwarded. Scheme for this URL must be https",
     "translation": "Adresse URL à laquelle les demandes pour les routes liées doivent être envoyées. Le schéma de cette adresse URL doit être https."
-  },
-  {
-    "id": "USAGE",
-    "translation": "SYNTAXE"
   },
   {
     "id": "USAGE:",

--- a/cf/i18n/resources/it-it.all.json
+++ b/cf/i18n/resources/it-it.all.json
@@ -164,8 +164,8 @@
     "translation": "AVANZATE"
   },
   {
-    "id": "ALIAS",
-    "translation": "ALIAS"
+    "id": "ALIAS:",
+    "translation": "ALIAS:"
   },
   {
     "id": "API endpoint",
@@ -3116,8 +3116,8 @@
     "translation": "OK"
   },
   {
-    "id": "OPTIONS",
-    "translation": "OPZIONI"
+    "id": "OPTIONS:",
+    "translation": "OPZIONI:"
   },
   {
     "id": "ORG ADMIN",
@@ -4214,10 +4214,6 @@
   {
     "id": "URL to which requests for bound routes will be forwarded. Scheme for this URL must be https",
     "translation": "URL a cui verranno inoltrate le richieste per le rotte associate. Lo schema per questo URL deve essere https"
-  },
-  {
-    "id": "USAGE",
-    "translation": "UTILIZZO"
   },
   {
     "id": "USAGE:",

--- a/cf/i18n/resources/ja-jp.all.json
+++ b/cf/i18n/resources/ja-jp.all.json
@@ -164,8 +164,8 @@
     "translation": "詳細"
   },
   {
-    "id": "ALIAS",
-    "translation": "別名"
+    "id": "ALIAS:",
+    "translation": "別名:"
   },
   {
     "id": "API endpoint",
@@ -3116,8 +3116,8 @@
     "translation": "OK"
   },
   {
-    "id": "OPTIONS",
-    "translation": "オプション"
+    "id": "OPTIONS:",
+    "translation": "オプション:"
   },
   {
     "id": "ORG ADMIN",
@@ -4214,10 +4214,6 @@
   {
     "id": "URL to which requests for bound routes will be forwarded. Scheme for this URL must be https",
     "translation": "バインド済み経路の要求の転送先 URL。この URL のスキームは https でなければなりません"
-  },
-  {
-    "id": "USAGE",
-    "translation": "使用法"
   },
   {
     "id": "USAGE:",

--- a/cf/i18n/resources/ko-kr.all.json
+++ b/cf/i18n/resources/ko-kr.all.json
@@ -164,8 +164,8 @@
     "translation": "고급"
   },
   {
-    "id": "ALIAS",
-    "translation": "별명"
+    "id": "ALIAS:",
+    "translation": "별명:"
   },
   {
     "id": "API endpoint",
@@ -3116,8 +3116,8 @@
     "translation": "확인"
   },
   {
-    "id": "OPTIONS",
-    "translation": "옵션"
+    "id": "OPTIONS:",
+    "translation": "옵션:"
   },
   {
     "id": "ORG ADMIN",
@@ -4214,10 +4214,6 @@
   {
     "id": "URL to which requests for bound routes will be forwarded. Scheme for this URL must be https",
     "translation": "바인딩된 라우트에 대한 요청을 전달한 URL입니다. 이 URL에 대한 스킴은 https이어야 합니다. "
-  },
-  {
-    "id": "USAGE",
-    "translation": "사용법"
   },
   {
     "id": "USAGE:",

--- a/cf/i18n/resources/pt-br.all.json
+++ b/cf/i18n/resources/pt-br.all.json
@@ -164,8 +164,8 @@
     "translation": "AVANÇADO"
   },
   {
-    "id": "ALIAS",
-    "translation": "ALIAS"
+    "id": "ALIAS:",
+    "translation": "ALIAS:"
   },
   {
     "id": "API endpoint",
@@ -3116,8 +3116,8 @@
     "translation": "OK"
   },
   {
-    "id": "OPTIONS",
-    "translation": "OPÇÕES"
+    "id": "OPTIONS:",
+    "translation": "OPÇÕES:"
   },
   {
     "id": "ORG ADMIN",
@@ -4214,10 +4214,6 @@
   {
     "id": "URL to which requests for bound routes will be forwarded. Scheme for this URL must be https",
     "translation": "URL para a qual solicitações de rotas de limite serão encaminhadas. O esquema para esta URL deve ser https"
-  },
-  {
-    "id": "USAGE",
-    "translation": "USO"
   },
   {
     "id": "USAGE:",

--- a/cf/i18n/resources/zh-hans.all.json
+++ b/cf/i18n/resources/zh-hans.all.json
@@ -164,8 +164,8 @@
     "translation": "高级"
   },
   {
-    "id": "ALIAS",
-    "translation": "别名"
+    "id": "ALIAS:",
+    "translation": "别名:"
   },
   {
     "id": "API endpoint",
@@ -3116,8 +3116,8 @@
     "translation": "确定"
   },
   {
-    "id": "OPTIONS",
-    "translation": "选项"
+    "id": "OPTIONS:",
+    "translation": "选项:"
   },
   {
     "id": "ORG ADMIN",
@@ -4214,10 +4214,6 @@
   {
     "id": "URL to which requests for bound routes will be forwarded. Scheme for this URL must be https",
     "translation": "将绑定路径的请求转发到的目标 URL。此 URL 的方案必须是 https"
-  },
-  {
-    "id": "USAGE",
-    "translation": "用法"
   },
   {
     "id": "USAGE:",

--- a/cf/i18n/resources/zh-hant.all.json
+++ b/cf/i18n/resources/zh-hant.all.json
@@ -164,8 +164,8 @@
     "translation": "進階"
   },
   {
-    "id": "ALIAS",
-    "translation": "別名"
+    "id": "ALIAS:",
+    "translation": "別名:"
   },
   {
     "id": "API endpoint",
@@ -3116,8 +3116,8 @@
     "translation": "確定"
   },
   {
-    "id": "OPTIONS",
-    "translation": "選項"
+    "id": "OPTIONS:",
+    "translation": "選項:"
   },
   {
     "id": "ORG ADMIN",
@@ -4214,10 +4214,6 @@
   {
     "id": "URL to which requests for bound routes will be forwarded. Scheme for this URL must be https",
     "translation": "將轉遞已連結路徑的要求的 URL。此 URL 的架構必須是 https"
-  },
-  {
-    "id": "USAGE",
-    "translation": "用法"
   },
   {
     "id": "USAGE:",


### PR DESCRIPTION
There should be a space (called 'une espace insecable') before a colon in French, therefore, a colon should not be hardcoded in order for French to be translated correctly.

There are many sources on the internet to confirm the use of 'une espace insecable', here is one of the discussions I have found: [link](http://forum.wordreference.com/threads/fr-space-before-a-colon-semicolon-question-mark-or-exclamation-point.54376/)

I have not included the space in the French translation, it should be properly translated by the next round of translation update.