### PR TITLE
trace: Redact all passwords and tokens in JSON

### DIFF
--- a/cf/trace/trace.go
+++ b/cf/trace/trace.go
@@ -16,18 +16,15 @@ func Sanitize(input string) string {
 	re = regexp.MustCompile(`password=[^&]*&`)
 	sanitized = re.ReplaceAllString(sanitized, "password="+PrivateDataPlaceholder()+"&")
 
-	sanitized = sanitizeJSON("access_token", sanitized)
-	sanitized = sanitizeJSON("refresh_token", sanitized)
 	sanitized = sanitizeJSON("token", sanitized)
 	sanitized = sanitizeJSON("password", sanitized)
-	sanitized = sanitizeJSON("oldPassword", sanitized)
 
 	return sanitized
 }
 
-func sanitizeJSON(propertyName string, json string) string {
-	regex := regexp.MustCompile(fmt.Sprintf(`"%s":\s*"[^\,]*"`, propertyName))
-	return regex.ReplaceAllString(json, fmt.Sprintf(`"%s":"%s"`, propertyName, PrivateDataPlaceholder()))
+func sanitizeJSON(propertySubstring string, json string) string {
+	regex := regexp.MustCompile(fmt.Sprintf(`(?i)"([^"]*%s[^"]*)":\s*"[^\,]*"`, propertySubstring))
+	return regex.ReplaceAllString(json, fmt.Sprintf(`"$1":"%s"`, PrivateDataPlaceholder()))
 }
 
 func PrivateDataPlaceholder() string {

--- a/cf/trace/trace_test.go
+++ b/cf/trace/trace_test.go
@@ -147,7 +147,7 @@ Pragma: no-cache
 Pragma: no-cache
 Server: Apache-Coyote/1.1
 
-{"access_token":"[PRIVATE DATA HIDDEN]","token_type":"bearer","refresh_token":"[PRIVATE DATA HIDDEN]","expires_in":43199,"scope":"cloud_controller.read cloud_controller.write openid password.write","jti":"c6a7c136-6497-4faf-8799-4c42e1f3c6f5"}
+{"access_token":"[PRIVATE DATA HIDDEN]","token_type":"[PRIVATE DATA HIDDEN]","refresh_token":"[PRIVATE DATA HIDDEN]","expires_in":43199,"scope":"cloud_controller.read cloud_controller.write openid password.write","jti":"c6a7c136-6497-4faf-8799-4c42e1f3c6f5"}
 `
 
 			Expect(Sanitize(response)).To(Equal(expected))
@@ -189,6 +189,44 @@ Server: Apache-Coyote/1.1
 `
 
 			Expect(Sanitize(response)).To(Equal(expected))
+		})
+
+		Describe("hiding credentials in application environment variables", func() {
+			It("hides the value of any key matching case-insensitive substring 'token'", func() {
+				response := `
+HTTP/1.1 200 OK
+Content-Type: application/json;charset=utf-8
+
+{"guid":"99fefc8e-845e-47f3-a8b1-26e8a00222d9","name":"example","environment_json":{"token":"mytoken","TOKEN":"mytoken","foo_token_bar":"mytoken","FOO_TOKEN_BAR":"mytoken"},"memory":1024,"instances":1}
+`
+
+				expected := `
+HTTP/1.1 200 OK
+Content-Type: application/json;charset=utf-8
+
+{"guid":"99fefc8e-845e-47f3-a8b1-26e8a00222d9","name":"example","environment_json":{"token":"[PRIVATE DATA HIDDEN]","TOKEN":"[PRIVATE DATA HIDDEN]","foo_token_bar":"[PRIVATE DATA HIDDEN]","FOO_TOKEN_BAR":"[PRIVATE DATA HIDDEN]"},"memory":1024,"instances":1}
+`
+
+				Expect(Sanitize(response)).To(Equal(expected))
+			})
+
+			It("hides the value of any key matching case-insensitive substring 'password'", func() {
+				response := `
+HTTP/1.1 200 OK
+Content-Type: application/json;charset=utf-8
+
+{"guid":"99fefc8e-845e-47f3-a8b1-26e8a00222d9","name":"example","environment_json":{"password":"mypass","PASSWORD":"mypass","foo_password_bar":"mypass","FOO_PASSWORD_BAR":"mypass"},"memory":1024,"instances":1}
+`
+
+				expected := `
+HTTP/1.1 200 OK
+Content-Type: application/json;charset=utf-8
+
+{"guid":"99fefc8e-845e-47f3-a8b1-26e8a00222d9","name":"example","environment_json":{"password":"[PRIVATE DATA HIDDEN]","PASSWORD":"[PRIVATE DATA HIDDEN]","foo_password_bar":"[PRIVATE DATA HIDDEN]","FOO_PASSWORD_BAR":"[PRIVATE DATA HIDDEN]"},"memory":1024,"instances":1}
+`
+
+				Expect(Sanitize(response)).To(Equal(expected))
+			})
 		})
 	})
 })


### PR DESCRIPTION
Extend the regex that redacts the values of sensitive keys in JSON responses
to include case-insensitive and substring matches of the key names
"password" and "token".

It's quite common to provide credentials to [12factor][0] applications using
environment variables. These can be unexpectedly leaked in the CLI output if
you run a command such as `CF_TRACE=true cf apps`, because the API endpoints
for space and application summaries always include `environment_json`.

This problem is mitigated by [user-provided services][1], but the docs don't
state that it's a security feature and it would be good to make the default
use case safer.

Some notes about the specific implementation, I have:

- added `(?i)` to the regex to make it a case-insensitive match
- added `[^"]*` around the property name to match substrings
- used the capture group `$1` to preserve the entire matched property name
  in the replacement
- removed the separate function calls for `access_token`, `refresh_token`
  and `oldPassword` because these are now covered by the existing `token`
  and `password` calls with the new regex
- adjusted one of the test assertions to account for the fact that the value
  of `token_type` is now also redacted. This is a side-effect of the
  changes, but I don't think it's a bad thing

[0]: http://12factor.net/config
[1]: https://docs.cloudfoundry.org/devguide/services/user-provided.html