### PR TITLE
Fix prompting users in locales other than en-US

### DIFF
--- a/cf/i18n/resources/de-de.all.json
+++ b/cf/i18n/resources/de-de.all.json
@@ -6396,6 +6396,10 @@
     "translation": "Version"
   },
   {
+    "id": "y",
+    "translation": "j"
+  },
+  {
     "id": "yes",
     "translation": "Ja"
   },

--- a/cf/i18n/resources/en-us.all.json
+++ b/cf/i18n/resources/en-us.all.json
@@ -6396,6 +6396,10 @@
     "translation": "version"
   },
   {
+    "id": "y",
+    "translation": "y"
+  },
+  {
     "id": "yes",
     "translation": "yes"
   },

--- a/cf/i18n/resources/es-es.all.json
+++ b/cf/i18n/resources/es-es.all.json
@@ -6396,6 +6396,10 @@
     "translation": "versión"
   },
   {
+    "id": "y",
+    "translation": "s"
+  },
+  {
     "id": "yes",
     "translation": "sí"
   },

--- a/cf/i18n/resources/fr-fr.all.json
+++ b/cf/i18n/resources/fr-fr.all.json
@@ -6396,6 +6396,10 @@
     "translation": ""
   },
   {
+    "id": "y",
+    "translation": "o"
+  },
+  {
     "id": "yes",
     "translation": "oui"
   },

--- a/cf/i18n/resources/it-it.all.json
+++ b/cf/i18n/resources/it-it.all.json
@@ -6396,6 +6396,10 @@
     "translation": "versione"
   },
   {
+    "id": "y",
+    "translation": "s"
+  },
+  {
     "id": "yes",
     "translation": "sì"
   },

--- a/cf/i18n/resources/pt-br.all.json
+++ b/cf/i18n/resources/pt-br.all.json
@@ -6396,6 +6396,10 @@
     "translation": "versão"
   },
   {
+    "id": "y",
+    "translation": "s"
+  },
+  {
     "id": "yes",
     "translation": "Sim"
   },

--- a/cf/terminal/ui.go
+++ b/cf/terminal/ui.go
@@ -144,7 +144,7 @@ func (ui *terminalUI) confirmDelete(message string) bool {
 func (ui *terminalUI) Confirm(message string) bool {
 	response := ui.Ask(message)
 	switch strings.ToLower(response) {
-	case "y", "yes", T("yes"):
+	case "y", "yes", T("y"), T("yes"):
 		return true
 	}
 	return false


### PR DESCRIPTION
terminal.UI.Confirm retured true when the user's entry after
transformation to lower case matched either "y", "yes" or the
translation of T("yes").

This did not work for most of the translated prompts.

E.g. "Do you want to install the plugin {{.Plugin}}? (y or n)"
is translated to
"... installieren? (J oder N)"

This only works if "y" is translated and terminal.UI.Confirm also
checks against T("y").