### PR TITLE
Bump NOAA

### DIFF
--- a/vendor/github.com/cloudfoundry/noaa/consumer/consumer.go
+++ b/vendor/github.com/cloudfoundry/noaa/consumer/consumer.go
@@ -44,6 +44,11 @@ func (nullDebugPrinter) Print(title, body string) {
 // Consumer represents the actions that can be performed against trafficcontroller.
 // See sync.go and async.go for trafficcontroller access methods.
 type Consumer struct {
+	// minRetryDelay and maxRetryDelay must be the first words in this struct
+	// in order to be used atomically by 32-bit systems.
+	// https://golang.org/src/sync/atomic/doc.go?#L50
+	minRetryDelay, maxRetryDelay int64
+
 	trafficControllerUrl string
 	idleTimeout          time.Duration
 	callback             func()
@@ -59,8 +64,6 @@ type Consumer struct {
 	refreshTokens  bool
 	refresherMutex sync.RWMutex
 	tokenRefresher TokenRefresher
-
-	minRetryDelay, maxRetryDelay int64
 }
 
 // New creates a new consumer to a trafficcontroller.

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -149,7 +149,7 @@
 			"importpath": "github.com/cloudfoundry/noaa",
 			"repository": "https://github.com/cloudfoundry/noaa",
 			"vcs": "git",
-			"revision": "b427932415f2771cb236f708977d3d64696f06d4",
+			"revision": "1939b6e4d6d76b2ee8541befd6a8fb8aa076933e",
 			"branch": "master",
 			"notests": true
 		},


### PR DESCRIPTION
The noaa updates ensure that 64-bit integers that are accessed using atomics are properly aligned on 32-bit systems.

This should resolve #991.

[#133883341]

Signed-off-by: Jeremy Alvis <jalvis@pivotal.io>