### PR TITLE
don't order the first page of api returns in "cf orgs"

### DIFF
--- a/cf/api/organizations/organizations.go
+++ b/cf/api/organizations/organizations.go
@@ -40,7 +40,6 @@ func (repo CloudControllerOrganizationRepository) ListOrgs(limit int) ([]models.
 	orgs := []models.Organization{}
 	err := repo.gateway.ListPaginatedResources(
 		repo.config.APIEndpoint(),
-//		"/v2/organizations?order-by=name",
 		"/v2/organizations",
 		resources.OrganizationResource{},
 		func(resource interface{}) bool {

--- a/cf/api/organizations/organizations.go
+++ b/cf/api/organizations/organizations.go
@@ -40,7 +40,8 @@ func (repo CloudControllerOrganizationRepository) ListOrgs(limit int) ([]models.
 	orgs := []models.Organization{}
 	err := repo.gateway.ListPaginatedResources(
 		repo.config.APIEndpoint(),
-		"/v2/organizations?order-by=name",
+//		"/v2/organizations?order-by=name",
+		"/v2/organizations",
 		resources.OrganizationResource{},
 		func(resource interface{}) bool {
 			if orgResource, ok := resource.(resources.OrganizationResource); ok {


### PR DESCRIPTION
If there is more than one page of api results, "cf orgs" seems to order the first page and not order the rest of the pages. This will cause some orgs to be missing in the list and some orgs to be duplicated. Either order all of the results, or don't order the first page. This patch opts for the latter.