### PR TITLE
clean up the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,25 +1,31 @@
-High five for submitting a report!  
-If you found an issue with the cf CLI, please visit the [releases page](https://github.com/cloudfoundry/cli/releases/) and confirm it's not fixed already in the latest release.  
-To avoid additional back and forth, please include the following details as relevant:
+<!-- High five for submitting a report! If you found an issue with the cf CLI, please visit the [releases page](https://github.com/cloudfoundry/cli/releases/) and confirm it's not fixed already in the latest release. To avoid additional back and forth, please include the following details as relevant. -->
 
-* Command  
-e.g. `cf push myapp -i 2 --no-route`
+## Command  
 
-* What occurred, incl. error and/or stack trace
+<!-- e.g. `cf push myapp -i 2 --no-route` -->
 
-* What you expected to occur
+## What occurred
 
-* CLI Version  
-e.g. 6.13.0-dfba612 (see `cf -v` output)
+<!-- Include the error and/or stack trace -->
 
-* CC API Endpoint Version  
-see `cf api` output
+## What you expected to occur
 
-* CF Trace, if issue relates to HTTP requests or strange behavior  
-run the command with `-v` and paste or attach the trace output
+## CLI Version  
 
-* Platform & Shell Details  
-e.g. Mac OS X 10.11 iTerm, Windows 8.1 64-bit with PowerShell, Ubuntu 14.04.3 64-bit with gnome-terminal
+<!-- e.g. 6.13.0-dfba612 (see `cf -v` output) -->
 
-* Any other relevant information  
-e.g. details of an environment, cf CLI version, flag or value it does work with, DNS/network configuration, etc.
+## CC API Endpoint Version  
+
+<!-- see `cf api` output -->
+
+## CF Trace
+
+<!-- ...if issue relates to HTTP requests or strange behavior. Run the command with `-v` and paste or attach the trace output. -->
+
+## Platform & Shell Details  
+
+<!-- e.g. Mac OS X 10.11 iTerm, Windows 8.1 64-bit with PowerShell, Ubuntu 14.04.3 64-bit with gnome-terminal -->
+
+## Any other relevant information  
+
+<!-- e.g. details of an environment, cf CLI version, flag or value it does work with, DNS/network configuration, etc. -->


### PR DESCRIPTION
This moves the instructions to the submitter to be comments, so that they don't accidentally get submitted with the issue. Also changed each of the sections to have an actual heading.