### PR TITLE
Add support for SHA256 SSH fingerprints

### DIFF
--- a/cf/ssh/ssh.go
+++ b/cf/ssh/ssh.go
@@ -1,6 +1,7 @@
 package sshCmd
 
 import (
+        "encoding/base64"
 	"crypto/md5"
 	"crypto/sha1"
 	"crypto/sha256"
@@ -27,8 +28,10 @@ import (
 
 const (
 	md5FingerprintLength  = 47 // inclusive of space between bytes
-	sha1FingerprintLength = 59 // inclusive of space between bytes
-	sha2FingerprintLength = 95 // inclusive of space between bytes
+	hexSha1FingerprintLength = 59 // inclusive of space between bytes
+	hexSha256FingerprintLength = 95 // inclusive of space between bytes
+	base64Sha1FingerprintLength = 27
+	base64Sha256FingerprintLength = 43
 )
 
 //go:generate counterfeiter . SecureShell
@@ -338,14 +341,24 @@ func md5Fingerprint(key ssh.PublicKey) string {
 	return strings.Replace(fmt.Sprintf("% x", sum), " ", ":", -1)
 }
 
-func sha1Fingerprint(key ssh.PublicKey) string {
+func hexSha1Fingerprint(key ssh.PublicKey) string {
 	sum := sha1.Sum(key.Marshal())
 	return strings.Replace(fmt.Sprintf("% x", sum), " ", ":", -1)
 }
 
-func sha2Fingerprint(key ssh.PublicKey) string {
+func hexSha256Fingerprint(key ssh.PublicKey) string {
 	sum := sha256.Sum256(key.Marshal())
 	return strings.Replace(fmt.Sprintf("% x", sum), " ", ":", -1)
+}
+
+func base64Sha1Fingerprint(key ssh.PublicKey) string {
+	sum := sha1.Sum(key.Marshal())
+	return base64.RawStdEncoding.EncodeToString(sum[:])
+}
+
+func base64Sha256Fingerprint(key ssh.PublicKey) string {
+	sum := sha256.Sum256(key.Marshal())
+	return base64.RawStdEncoding.EncodeToString(sum[:])
 }
 
 type hostKeyCallback func(hostname string, remote net.Addr, key ssh.PublicKey) error
@@ -356,27 +369,28 @@ func fingerprintCallback(opts *options.SSHOptions, expectedFingerprint string) h
 	}
 
 	return func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+		var fingerprint string
+
 		switch len(expectedFingerprint) {
-		case sha2FingerprintLength:
-			fingerprint := sha2Fingerprint(key)
-			if fingerprint != expectedFingerprint {
-				return fmt.Errorf("Host key verification failed.\n\nThe fingerprint of the received key was %q.", fingerprint)
-			}
-		case sha1FingerprintLength:
-			fingerprint := sha1Fingerprint(key)
-			if fingerprint != expectedFingerprint {
-				return fmt.Errorf("Host key verification failed.\n\nThe fingerprint of the received key was %q.", fingerprint)
-			}
+		case hexSha256FingerprintLength:
+			fingerprint = hexSha256Fingerprint(key)
+		case base64Sha256FingerprintLength:
+			fingerprint = base64Sha256Fingerprint(key)
+		case hexSha1FingerprintLength:
+			fingerprint = hexSha1Fingerprint(key)
+		case base64Sha1FingerprintLength:
+			fingerprint = base64Sha1Fingerprint(key)
 		case md5FingerprintLength:
-			fingerprint := md5Fingerprint(key)
-			if fingerprint != expectedFingerprint {
-				return fmt.Errorf("Host key verification failed.\n\nThe fingerprint of the received key was %q.", fingerprint)
-			}
+			fingerprint = md5Fingerprint(key)
 		case 0:
-			fingerprint := md5Fingerprint(key)
+			fingerprint = md5Fingerprint(key)
 			return fmt.Errorf("Unable to verify identity of host.\n\nThe fingerprint of the received key was %q.", fingerprint)
 		default:
 			return errors.New("Unsupported host key fingerprint format")
+		}
+
+		if fingerprint != expectedFingerprint {
+			return fmt.Errorf("Host key verification failed.\n\nThe fingerprint of the received key was %q.", fingerprint)
 		}
 		return nil
 	}

--- a/cf/ssh/ssh_test.go
+++ b/cf/ssh/ssh_test.go
@@ -228,7 +228,19 @@ var _ = Describe("SSH", func() {
 				listener.Close()
 			})
 
-			Context("when the SHA256 fingerprint does not match", func() {
+			Context("when the base64 SHA256 fingerprint does not match", func() {
+				BeforeEach(func() {
+					sshEndpointFingerprint = "0000000000000000000000000000000000000000000"
+				})
+
+				It("returns an error'", func() {
+					err := callback("", addr, TestHostKey.PublicKey())
+					Expect(err).To(MatchError(MatchRegexp("Host key verification failed\\.")))
+					Expect(err).To(MatchError(MatchRegexp("The fingerprint of the received key was \".*\"")))
+				})
+			})
+
+			Context("when the hex SHA256 fingerprint does not match", func() {
 				BeforeEach(func() {
 					sshEndpointFingerprint = "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00"
 				})
@@ -240,7 +252,19 @@ var _ = Describe("SSH", func() {
 				})
 			})
 
-			Context("when the SHA1 fingerprint does not match", func() {
+			Context("when the base64 SHA1 fingerprint does not match", func() {
+				BeforeEach(func() {
+					sshEndpointFingerprint = "000000000000000000000000000"
+				})
+
+				It("returns an error'", func() {
+					err := callback("", addr, TestHostKey.PublicKey())
+					Expect(err).To(MatchError(MatchRegexp("Host key verification failed\\.")))
+					Expect(err).To(MatchError(MatchRegexp("The fingerprint of the received key was \".*\"")))
+				})
+			})
+
+			Context("when the hex SHA1 fingerprint does not match", func() {
 				BeforeEach(func() {
 					sshEndpointFingerprint = "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00"
 				})

--- a/cf/ssh/ssh_test.go
+++ b/cf/ssh/ssh_test.go
@@ -228,6 +228,18 @@ var _ = Describe("SSH", func() {
 				listener.Close()
 			})
 
+			Context("when the SHA256 fingerprint does not match", func() {
+				BeforeEach(func() {
+					sshEndpointFingerprint = "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00"
+				})
+
+				It("returns an error'", func() {
+					err := callback("", addr, TestHostKey.PublicKey())
+					Expect(err).To(MatchError(MatchRegexp("Host key verification failed\\.")))
+					Expect(err).To(MatchError(MatchRegexp("The fingerprint of the received key was \".*\"")))
+				})
+			})
+
 			Context("when the SHA1 fingerprint does not match", func() {
 				BeforeEach(func() {
 					sshEndpointFingerprint = "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00"


### PR DESCRIPTION
This pull request adds support for verifying SHA256 hashes of the Diego SSH proxy public key. 

Existing functionality supports MD5 and SHA1 hashes, however, these hashes are widely deprecated for applications that require collision resistance. Further - [NIST Guidance][1], [General sentiment][2]

[1]:http://csrc.nist.gov/groups/ST/hash/policy.html
[2]:https://www.google.com/#q=sha1+support

