### PR TITLE
plugin: Friendly error when run without arguments

### DIFF
--- a/plugin/plugin_shim.go
+++ b/plugin/plugin_shim.go
@@ -13,8 +13,12 @@ import (
 		* SendMetadata - used to fetch the plugin metadata
 **/
 func Start(cmd Plugin) {
-	cliConnection := NewCliConnection(os.Args[1])
+	if len(os.Args) < 2 {
+		fmt.Printf("This cf CLI plugin is not intended to be run on its own\n\n")
+		os.Exit(1)
+	}
 
+	cliConnection := NewCliConnection(os.Args[1])
 	cliConnection.pingCLI()
 	if isMetadataRequest(os.Args) {
 		cliConnection.sendPluginMetadataToCliServer(cmd.GetMetadata())

--- a/plugin/plugin_shim_test.go
+++ b/plugin/plugin_shim_test.go
@@ -19,6 +19,14 @@ var _ = Describe("Command", func() {
 	)
 
 	Describe(".Start", func() {
+		It("Exits with status 1 and error message if no arguments are passed", func() {
+			args := []string{}
+			session, err := Start(exec.Command(validPluginPath, args...), GinkgoWriter, GinkgoWriter)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(session, 2).Should(Exit(1))
+			Expect(session).To(gbytes.Say("This cf CLI plugin is not intended to be run on its own"))
+		})
+
 		It("Exits with status 1 if it cannot ping the host port passed as an argument", func() {
 			args := []string{"0", "0"}
 			session, err := Start(exec.Command(validPluginPath, args...), GinkgoWriter, GinkgoWriter)


### PR DESCRIPTION
## What Need Does It Address?

Users of plugins who attempt to run the plugin binary directly will get a friendly error message instead of panic and backtrace. I noticed this while repeatedly testing whether a dynamically linked plugin would work on Alpine Linux.

Before:

    ➜  cf-blue-green-deploy git:(master) ✗ ./cf-blue-green-deploy
    panic: runtime error: index out of range

    goroutine 1 [running]:
    code.cloudfoundry.org/cli/plugin.Start(0x1594860, 0xc42011b560)
            /Users/dcarley/projects/gocode/src/code.cloudfoundry.org/cli/plugin/plugin_shim.go:16 +0x3bd
    main.main()
            /Users/dcarley/projects/gocode/src/github.com/bluemixgaragelondon/cf-blue-green-deploy/main.go:198 +0xe9

After:

    ➜  cf-blue-green-deploy git:(master) ✗ ./cf-blue-green-deploy
    This cf CLI plugin is not intended to be run on its own

## Possible Drawbacks

None that I'm aware of.

## Why Should This Be In Core?

This is core functionality used by all plugins.

## Description of the Change

Returns an error message and non-zero exit code if a plugin is run with less than one argument. 

## Alternate Designs

I considered printing a usage message describing the required and optional arguments. I don't think this is useful for the majority of plugin users though, because they needn't know about the RPC internals of plugins and cf-cli. I think the message is appropriate, because the only time a plugin is likely to be called without any arguments is by someone running it directly from the command line.

## Applicable Issues

- bluemixgaragelondon/cf-blue-green-deploy#24