### PR TITLE
Prevent test failing under zsh

### DIFF
--- a/command/flag/environment_variable_test.go
+++ b/command/flag/environment_variable_test.go
@@ -94,7 +94,7 @@ var _ = Describe("EnvironmentVariable", func() {
 
 				Context("when there are no matching environment variables", func() {
 					It("returns no matches", func() {
-						Expect(envVar.Complete("$Z")).To(BeEmpty())
+						Expect(envVar.Complete("$ZZZZ")).To(BeEmpty())
 					})
 				})
 			})


### PR DESCRIPTION
Many zsh users export $ZSH and this caused a test to fail.
