### PR TITLE
Validate -i value for ssh command is an existing app instance

### DIFF
--- a/cf/commands/application/ssh.go
+++ b/cf/commands/application/ssh.go
@@ -67,11 +67,6 @@ func (cmd *SSH) Requirements(requirementsFactory requirements.Factory, fc flags.
 		return nil, fmt.Errorf("Incorrect usage: %d arguments of %d required", len(fc.Args()), 1)
 	}
 
-	if fc.IsSet("i") && fc.Int("i") < 0 {
-		cmd.ui.Failed(fmt.Sprintf(T("Incorrect Usage:")+" %s\n\n%s", T("Value for flag 'app-instance-index' cannot be negative"), commandregistry.Commands.CommandUsage("ssh")))
-		return nil, fmt.Errorf("Incorrect usage: app-instance-index cannot be negative")
-	}
-
 	var err error
 	cmd.opts, err = options.NewSSHOptions(fc)
 
@@ -81,6 +76,17 @@ func (cmd *SSH) Requirements(requirementsFactory requirements.Factory, fc flags.
 	}
 
 	cmd.appReq = requirementsFactory.NewApplicationRequirement(cmd.opts.AppName)
+
+	if fc.IsSet("i") {
+		if fc.Int("i") < 0 {
+			cmd.ui.Failed(fmt.Sprintf(T("Incorrect Usage:")+" %s\n\n%s", T("Value for flag 'app-instance-index' cannot be negative"), commandregistry.Commands.CommandUsage("ssh")))
+			return nil, fmt.Errorf("Incorrect usage: app-instance-index cannot be negative")
+		}
+		if fc.Int("i") >= cmd.appReq.GetApplication().InstanceCount {
+			cmd.ui.Failed(fmt.Sprintf(T("Incorrect Usage:")+" %s\n\n%s", T("The specified application instance does not exist"), commandregistry.Commands.CommandUsage("ssh")))
+			return nil, fmt.Errorf("Incorrect usage: The specified application instance does not exist")
+		}
+	}
 
 	reqs := []requirements.Requirement{
 		requirementsFactory.NewLoginRequirement(),

--- a/cf/commands/application/ssh_test.go
+++ b/cf/commands/application/ssh_test.go
@@ -111,39 +111,18 @@ var _ = Describe("SSH command", func() {
 		})
 
 		Describe("Flag options", func() {
-			var args []string
-
 			BeforeEach(func() {
 				requirementsFactory.NewLoginRequirementReturns(requirements.Passing{})
 				requirementsFactory.NewTargetedSpaceRequirementReturns(requirements.Passing{})
 			})
 
 			Context("when an -i flag is provided", func() {
-				BeforeEach(func() {
-					args = append(args, "app-name")
-				})
-
-				Context("with a negative integer argument", func() {
-					BeforeEach(func() {
-						args = append(args, "-i", "-3")
-					})
-
-					It("returns an error", func() {
-						Expect(runCommand(args...)).To(BeFalse())
-						Expect(ui.Outputs()).To(ContainSubstrings(
-							[]string{"Incorrect Usage", "cannot be negative"},
-						))
-
-					})
-				})
-
 				Context("with a negative integer argument", func() {
 					It("returns an error", func() {
 						Expect(runCommand("my-app", "-i", "-3")).To(BeFalse())
 						Expect(ui.Outputs()).To(ContainSubstrings(
 							[]string{"Incorrect Usage", "cannot be negative"},
 						))
-
 					})
 				})
 

--- a/cf/commands/application/ssh_test.go
+++ b/cf/commands/application/ssh_test.go
@@ -136,6 +136,41 @@ var _ = Describe("SSH command", func() {
 
 					})
 				})
+
+				Context("with a negative integer argument", func() {
+					It("returns an error", func() {
+						Expect(runCommand("my-app", "-i", "-3")).To(BeFalse())
+						Expect(ui.Outputs()).To(ContainSubstrings(
+							[]string{"Incorrect Usage", "cannot be negative"},
+						))
+
+					})
+				})
+
+				Context("with a value greater than the application's highest instance index", func() {
+					BeforeEach(func() {
+						var app models.Application
+
+						app = models.Application{}
+						app.Name = "my-app"
+						app.State = "started"
+						app.GUID = "my-app-guid"
+						app.EnableSSH = true
+						app.Diego = true
+						app.InstanceCount = 3
+
+						applicationReq := new(requirementsfakes.FakeApplicationRequirement)
+						applicationReq.GetApplicationReturns(app)
+						requirementsFactory.NewApplicationRequirementReturns(applicationReq)
+					})
+
+					It("returns an error", func() {
+						Expect(runCommand("my-app", "-i", "3")).To(BeFalse())
+						Expect(ui.Outputs()).To(ContainSubstrings(
+							[]string{"Incorrect Usage", "specified application instance does not exist"},
+						))
+					})
+				})
 			})
 		})
 


### PR DESCRIPTION
## What Need Does It Address?

Without this change, passing a -i value that is equal to or greater than
the total number of instances the application has results in a cryptic
error message about the ssl handshake, which can lead users down a false
trail.

## Possible Drawbacks

To keep the validation checks for the `-i` flag together, I moved the not-negative validation check **after** the creation of `cmd.opts` and `cmd.appReq`. No tests were upset by this, but it could be the case that due to factors I didn't catch--if populating `cmd.appReq` is expensive, for instance--this could result in slower feedback when you enter a negative value for `-i`.

Also, I didn't add any i18n translations for the new message. **Note:** When trying to run `bin/i18n-checkup`, I observed that the schema of the translation `.json` files was completely changed. On Slack, `@anand` indicated that this was probably due to the fact that the team is using a particular version of `i18n4go` that is different than the one I got with `go get`, and that I should not make any changes to the translation files and submit anyway.

## Why Should This Be In Core?

It improves the messaging of a core feature, as opposed to adding new functionality.

## Description of the Change

In addition to checking that the `-i` value is non-negative, fetch the InstanceCount of the specified application and ensure the `-i` value is less than that. If not, fail with a descriptive message.

## Applicable Issues

https://github.com/cloudfoundry/cli/issues/1130
