### PR TITLE
Add create-org & delete-org to Org management help

### DIFF
--- a/command/common/help_command_test.go
+++ b/command/common/help_command_test.go
@@ -405,7 +405,7 @@ var _ = Describe("help Command", func() {
 			Expect(testUI.Out).To(Say("  spaces\\s+create-space\\s+set-space-role"))
 
 			Expect(testUI.Out).To(Say("Org management:"))
-			Expect(testUI.Out).To(Say("  orgs,o\\s+set-org-role"))
+			Expect(testUI.Out).To(Say("  orgs,o\\s+create-org,co\\s+set-org-role"))
 
 			Expect(testUI.Out).To(Say("CLI plugin management:"))
 			Expect(testUI.Out).To(Say("  install-plugin    list-plugin-repos"))

--- a/command/common/internal/help_common_display.go
+++ b/command/common/internal/help_common_display.go
@@ -55,8 +55,8 @@ var CommonHelpCategoryList = []HelpCategory{
 	{
 		CategoryName: "Org management:",
 		CommandList: [][]string{
-			{"orgs", "set-org-role"},
-			{"org-users", "unset-org-role"},
+			{"orgs", "create-org", "set-org-role"},
+			{"org-users", "delete-org", "unset-org-role"},
 		},
 	},
 

--- a/integration/isolated/help_command_test.go
+++ b/integration/isolated/help_command_test.go
@@ -40,7 +40,7 @@ var _ = Describe("help command", func() {
 			Eventually(session.Out).Should(Say("  spaces\\s+create-space\\s+set-space-role"))
 
 			Eventually(session.Out).Should(Say("Org management:"))
-			Eventually(session.Out).Should(Say("  orgs,o\\s+set-org-role"))
+			Eventually(session.Out).Should(Say("  orgs,o\\s+create-org,co\\s+set-org-role"))
 
 			Eventually(session.Out).Should(Say("CLI plugin management:"))
 			Eventually(session.Out).Should(Say("  install-plugin    list-plugin-repos"))


### PR DESCRIPTION
<!--
## Requirements

* Your contribution will be analyzed for product fit and engineering quality prior to merging.  
If your contribution includes a change that is exposed to cf CLI users (e.g. introducing a new command or flag), please submit an issue to discuss it first.
* We're not allowed to accept any PRs without a signed CLA, no matter how small.  
If your contribution falls under a company CLA but your membership is not public, expect delays while we confirm. 
* All new code requires tests to protect against regressions.
-->

## What Need Does It Address?

As of now when user do `cf help` , `create-space` is visible in default view, but `create-org` is not visible in default view , which sometimes confuses users about basic org management functionality. 

![screen shot 2017-05-19 at 10 29 58 am](https://cloud.githubusercontent.com/assets/2391105/26229683/8bff8fdc-3c7e-11e7-88f8-ee362949bf41.png)


## Possible Drawbacks

Just a change in default view so there shouldn't be any drawbacks.
## Why Should This Be In Core?

Improvement in default options for Org management

## Description of the Change

This PR adds two options `create-org` & `delete-org` to Org management default view , which are now in sync with space management.

![screen shot 2017-05-19 at 10 30 20 am](https://cloud.githubusercontent.com/assets/2391105/26229775/04afe9cc-3c7f-11e7-9021-ab79f0475423.png)

## Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

## Applicable Issues

<!-- List any applicable Issues here -->
