### PR TITLE
Always add authorization header when requesting new tokens

### DIFF
--- a/api/uaa/auth.go
+++ b/api/uaa/auth.go
@@ -29,11 +29,11 @@ func (client Client) Authenticate(username string, password string) (string, str
 			"Content-Type": {"application/x-www-form-urlencoded"},
 		},
 		Body: strings.NewReader(requestBody.Encode()),
+		AddClientAuthorization: true,
 	})
 	if err != nil {
 		return "", "", err
 	}
-	request.SetBasicAuth(client.id, client.secret)
 
 	responseBody := AuthResponse{}
 	response := Response{

--- a/api/uaa/request.go
+++ b/api/uaa/request.go
@@ -24,6 +24,9 @@ type requestOptions struct {
 
 	// Body is the request body
 	Body io.Reader
+
+	// AddClientAuthorization adds client ID / secret basic auth header if set
+	AddClientAuthorization bool
 }
 
 // newRequest returns a constructed http.Request with some defaults. The
@@ -49,6 +52,10 @@ func (client *Client) newRequest(passedRequest requestOptions) (*http.Request, e
 	request.Header.Set("Accept", "application/json")
 	request.Header.Set("Connection", "close")
 	request.Header.Set("User-Agent", client.userAgent)
+
+	if passedRequest.AddClientAuthorization {
+		client.addClientAuthorizationToRequest(request)
+	}
 
 	return request, nil
 }


### PR DESCRIPTION
Appears to be required for older versions of API server. Fixes issue 1175.

## What Need Does It Address?

Fixes https://github.com/cloudfoundry/cli/issues/1175
