### PR TITLE
ccv3: Add list spaces call

### DIFF
--- a/api/cloudcontroller/ccv3/internal/api_routes.go
+++ b/api/cloudcontroller/ccv3/internal/api_routes.go
@@ -27,6 +27,7 @@ const (
 	GetIsolationSegmentsRequest                           = "GetIsolationSegments"
 	GetOrganizationDefaultIsolationSegmentRequest         = "GetOrganizationDefaultIsolationSegment"
 	GetOrgsRequest                                        = "GetOrgs"
+	GetSpacesRequest                                      = "GetSpaces"
 	GetPackageRequest                                     = "GetPackage"
 	GetPackagesRequest                                    = "GetPackages"
 	GetProcessInstancesRequest                            = "GetProcessInstances"
@@ -65,6 +66,7 @@ var APIRoutes = []Route{
 	{Path: "/", Method: http.MethodGet, Name: GetAppsRequest, Resource: AppsResource},
 	{Path: "/", Method: http.MethodGet, Name: GetIsolationSegmentsRequest, Resource: IsolationSegmentsResource},
 	{Path: "/", Method: http.MethodGet, Name: GetOrgsRequest, Resource: OrgsResource},
+	{Path: "/", Method: http.MethodGet, Name: GetSpacesRequest, Resource: SpacesResource},
 	{Path: "/", Method: http.MethodGet, Name: GetPackagesRequest, Resource: PackagesResource},
 	{Path: "/", Method: http.MethodPost, Name: PostApplicationRequest, Resource: AppsResource},
 	{Path: "/", Method: http.MethodPost, Name: PostBuildRequest, Resource: BuildsResource},

--- a/api/cloudcontroller/ccv3/space.go
+++ b/api/cloudcontroller/ccv3/space.go
@@ -1,0 +1,40 @@
+package ccv3
+
+import (
+	"net/url"
+
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccerror"
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/internal"
+)
+
+// Space represents a Clodu Controller V3 Space.
+type Space struct {
+	Name string `json:"name"`
+	GUID string `json:"guid"`
+}
+
+// GetSpaces lists spaces with optional filters.
+func (client *Client) GetSpaces(query url.Values) ([]Space, Warnings, error) {
+	request, err := client.newHTTPRequest(requestOptions{
+		RequestName: internal.GetSpacesRequest,
+		Query:       query,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var fullSpacesList []Space
+	warnings, err := client.paginate(request, Space{}, func(item interface{}) error {
+		if space, ok := item.(Space); ok {
+			fullSpacesList = append(fullSpacesList, space)
+		} else {
+			return ccerror.UnknownObjectInListError{
+				Expected:   Space{},
+				Unexpected: item,
+			}
+		}
+		return nil
+	})
+
+	return fullSpacesList, warnings, err
+}

--- a/api/cloudcontroller/ccv3/space.go
+++ b/api/cloudcontroller/ccv3/space.go
@@ -7,7 +7,7 @@ import (
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/internal"
 )
 
-// Space represents a Clodu Controller V3 Space.
+// Space represents a Cloud Controller V3 Space.
 type Space struct {
 	Name string `json:"name"`
 	GUID string `json:"guid"`

--- a/api/cloudcontroller/ccv3/space_test.go
+++ b/api/cloudcontroller/ccv3/space_test.go
@@ -1,0 +1,130 @@
+package ccv3_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccerror"
+	. "code.cloudfoundry.org/cli/api/cloudcontroller/ccv3"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/ghttp"
+)
+
+var _ = Describe("Spaces", func() {
+	var client *Client
+
+	BeforeEach(func() {
+		client = NewTestClient()
+	})
+
+	Describe("GetSpaces", func() {
+		Context("when spaces exist", func() {
+			BeforeEach(func() {
+				response1 := fmt.Sprintf(`{
+	"pagination": {
+		"next": {
+			"href": "%s/v3/spaces?names=some-space-name&page=2&per_page=2"
+		}
+	},
+  "resources": [
+    {
+      "name": "space-name-1",
+      "guid": "space-guid-1"
+    },
+    {
+      "name": "space-name-2",
+      "guid": "space-guid-2"
+    }
+  ]
+}`, server.URL())
+				response2 := `{
+	"pagination": {
+		"next": null
+	},
+	"resources": [
+	  {
+      "name": "space-name-3",
+		  "guid": "space-guid-3"
+		}
+	]
+}`
+
+				server.AppendHandlers(
+					CombineHandlers(
+						VerifyRequest(http.MethodGet, "/v3/spaces", "names=some-space-name"),
+						RespondWith(http.StatusOK, response1, http.Header{"X-Cf-Warnings": {"this is a warning"}}),
+					),
+				)
+				server.AppendHandlers(
+					CombineHandlers(
+						VerifyRequest(http.MethodGet, "/v3/spaces", "names=some-space-name&page=2&per_page=2"),
+						RespondWith(http.StatusOK, response2, http.Header{"X-Cf-Warnings": {"this is another warning"}}),
+					),
+				)
+			})
+
+			It("returns the queried spaces and all warnings", func() {
+				spaces, warnings, err := client.GetSpaces(url.Values{
+					NameFilter: []string{"some-space-name"},
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(spaces).To(ConsistOf(
+					Space{Name: "space-name-1", GUID: "space-guid-1"},
+					Space{Name: "space-name-2", GUID: "space-guid-2"},
+					Space{Name: "space-name-3", GUID: "space-guid-3"},
+				))
+				Expect(warnings).To(ConsistOf("this is a warning", "this is another warning"))
+			})
+		})
+
+		Context("when the cloud controller returns errors and warnings", func() {
+			BeforeEach(func() {
+				response := `{
+  "errors": [
+    {
+      "code": 10008,
+      "detail": "The request is semantically invalid: command presence",
+      "title": "CF-UnprocessableEntity"
+    },
+    {
+      "code": 10010,
+      "detail": "Space not found",
+      "title": "CF-SpaceNotFound"
+    }
+  ]
+}`
+				server.AppendHandlers(
+					CombineHandlers(
+						VerifyRequest(http.MethodGet, "/v3/spaces"),
+						RespondWith(http.StatusTeapot, response, http.Header{"X-Cf-Warnings": {"this is a warning"}}),
+					),
+				)
+			})
+
+			It("returns the error and all warnings", func() {
+				_, warnings, err := client.GetSpaces(nil)
+				Expect(err).To(MatchError(ccerror.V3UnexpectedResponseError{
+					ResponseCode: http.StatusTeapot,
+					V3ErrorResponse: ccerror.V3ErrorResponse{
+						Errors: []ccerror.V3Error{
+							{
+								Code:   10008,
+								Detail: "The request is semantically invalid: command presence",
+								Title:  "CF-UnprocessableEntity",
+							},
+							{
+								Code:   10010,
+								Detail: "Space not found",
+								Title:  "CF-SpaceNotFound",
+							},
+						},
+					},
+				}))
+				Expect(warnings).To(ConsistOf("this is a warning"))
+			})
+		})
+	})
+})


### PR DESCRIPTION
## What Need Does It Address?

The ccv3 package exposes a call for _list organizations_, but the corresponding call for listing spaces is missing.  Users of a `ccv3.Client` can list orgs, but if they want to list spaces they have to create a `ccv2.Client`.  With this change both orgs and spaces can be listed with a `ccv3.Client`.

## Possible Drawbacks

None

## Why Should This Be In Core?

It's a missing API call.

## Description of the Change

Add `GetSpaces()` call.  The API is identical to that of `GetOrganizations()`.

## Alternate Designs

None

## Applicable Issues

None
