### PR TITLE
experimental: NTLM proxy authentication using NTLM_PROXY environment variable

### DIFF
--- a/cf/api/buildpack_bits.go
+++ b/cf/api/buildpack_bits.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"mime/multipart"
 	gonet "net"
+	netdialer "net"
 	"net/http"
 	"os"
 	"path"
@@ -22,6 +23,7 @@ import (
 	. "code.cloudfoundry.org/cli/cf/i18n"
 	"code.cloudfoundry.org/cli/cf/models"
 	"code.cloudfoundry.org/cli/cf/net"
+	"code.cloudfoundry.org/cli/cf/net/dialcontext"
 	"code.cloudfoundry.org/gofileutils/fileutils"
 )
 
@@ -223,11 +225,17 @@ func (repo CloudControllerBuildpackBitsRepository) downloadBuildpack(url string,
 			}
 		}
 
+		dialContext := dialcontext.FromEnvironment((&netdialer.Dialer{
+			KeepAlive: 30 * time.Second,
+			Timeout:   30 * time.Second,
+		}).DialContext)
+
 		client := &http.Client{
 			Transport: &http.Transport{
 				Dial:            (&gonet.Dialer{Timeout: 5 * time.Second}).Dial,
 				TLSClientConfig: &tls.Config{RootCAs: certPool},
 				Proxy:           http.ProxyFromEnvironment,
+				DialContext:     dialContext,
 			},
 		}
 

--- a/cf/net/dialcontext/dialcontext.go
+++ b/cf/net/dialcontext/dialcontext.go
@@ -1,0 +1,81 @@
+package dialcontext
+
+import (
+	"context"
+	"net"
+	"os"
+	"sync"
+
+	"github.com/anynines/go-proxy-setup-ntlm/proxysetup/ntlm"
+)
+
+// Go does not support NTLM proxy authentication by default.
+//
+// An attempt https://github.com/golang/go/issues/22288 to add NTLM proxy
+// authentication to Go's code base has not been accepted.
+//
+// But there is a workaround/hack overwriting http.Transport.DialContext to do
+// NTLM proxy authentication.
+
+// Returns the passed DialContext by default.
+//
+// Experimental:
+// Returns NTLM proxy authentication handler if NTLM_PROXY is set.
+// The environment variable NTLM_PROXY contains the proxy to be used. Works on
+// Windows only.
+func FromEnvironment(dialContext func(ctx context.Context, network, addr string) (net.Conn, error)) func(ctx context.Context, network, addr string) (net.Conn, error) {
+	if len(ntlmProxyAddr.Get()) > 0 {
+		return func(ctx context.Context, network, address string) (net.Conn, error) {
+			conn, err := dialContext(ctx, network, ntlmProxyAddr.Get())
+			if err != nil {
+				return conn, err
+			}
+			err = ntlm.ProxySetup(conn, address)
+			if err != nil {
+				return conn, err
+			}
+			return conn, err
+		}
+	}
+
+	return dialContext
+}
+
+//
+// Private implementation past this point.
+//
+
+var (
+	ntlmProxyAddr = &envOnce{
+		names: []string{"NTLM_PROXY", "ntlm_proxy"},
+	}
+)
+
+// envOnce looks up an environment variable (optionally by multiple
+// names) once. It mitigates expensive lookups on some platforms
+// (e.g. Windows).
+type envOnce struct {
+	names []string
+	once  sync.Once
+	val   string
+}
+
+func (e *envOnce) Get() string {
+	e.once.Do(e.init)
+	return e.val
+}
+
+func (e *envOnce) init() {
+	for _, n := range e.names {
+		e.val = os.Getenv(n)
+		if e.val != "" {
+			return
+		}
+	}
+}
+
+// reset is used by tests
+func (e *envOnce) reset() {
+	e.once = sync.Once{}
+	e.val = ""
+}

--- a/cf/net/gateway.go
+++ b/cf/net/gateway.go
@@ -19,6 +19,7 @@ import (
 	"code.cloudfoundry.org/cli/cf/configuration/coreconfig"
 	"code.cloudfoundry.org/cli/cf/errors"
 	. "code.cloudfoundry.org/cli/cf/i18n"
+	"code.cloudfoundry.org/cli/cf/net/dialcontext"
 	"code.cloudfoundry.org/cli/cf/terminal"
 	"code.cloudfoundry.org/cli/cf/trace"
 	"code.cloudfoundry.org/cli/version"
@@ -446,6 +447,11 @@ func (gateway Gateway) doRequest(request *http.Request) (*http.Response, error) 
 }
 
 func makeHTTPTransport(gateway *Gateway) {
+	dialContext := dialcontext.FromEnvironment((&net.Dialer{
+		KeepAlive: 30 * time.Second,
+		Timeout:   30 * time.Second,
+	}).DialContext)
+
 	gateway.transport = &http.Transport{
 		Dial: (&net.Dialer{
 			KeepAlive: 30 * time.Second,
@@ -453,6 +459,7 @@ func makeHTTPTransport(gateway *Gateway) {
 		}).Dial,
 		TLSClientConfig: NewTLSConfig(gateway.trustedCerts, gateway.config.IsSSLDisabled()),
 		Proxy:           http.ProxyFromEnvironment,
+		DialContext:     dialContext,
 	}
 }
 

--- a/vendor/github.com/anynines/go-proxy-setup-ntlm/proxysetup/ntlm/ntlm.go
+++ b/vendor/github.com/anynines/go-proxy-setup-ntlm/proxysetup/ntlm/ntlm.go
@@ -1,0 +1,93 @@
+// +build windows
+
+package ntlm
+
+import (
+	"bufio"
+	"encoding/base64"
+	"errors"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+
+	ntlmauth "github.com/anynines/go-ntlm-auth/ntlm"
+)
+
+func ProxySetup(conn net.Conn, targetAddr string) error {
+	auth, authOk := ntlmauth.GetDefaultCredentialsAuth()
+	if !authOk {
+		return errors.New("Failed to get NTLM default credentials auth")
+	}
+
+	negotiateMessageBytes, err := auth.GetNegotiateBytes()
+	if err != nil {
+		return errors.New("Failed to get NTLM negotiaten bytes")
+	}
+	defer auth.ReleaseContext()
+
+	negotiateMsg := base64.StdEncoding.EncodeToString(negotiateMessageBytes)
+
+	hdr := make(http.Header)
+	hdr.Set("Proxy-Connection", "Keep-Alive")
+	hdr.Set("Proxy-Authorization", "NTLM "+negotiateMsg)
+	connectReq := &http.Request{
+		Method: "CONNECT",
+		URL:    &url.URL{Opaque: targetAddr},
+		Host:   targetAddr,
+		Header: hdr,
+	}
+
+	connectReq.Write(conn)
+
+	// Read response.
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, connectReq)
+	if err != nil {
+		return err
+	}
+	_, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != 407 {
+		f := strings.SplitN(resp.Status, " ", 2)
+		return errors.New(f[1])
+	}
+
+	// decode challenge
+	challengeMessage, err := ntlmauth.ParseChallengeResponse(resp.Header.Get("Proxy-Authenticate"))
+	if err != nil {
+		return err
+	}
+
+	challengeBytes, err := auth.GetResponseBytes(challengeMessage)
+	if err != nil {
+		return err
+	}
+
+	authMsg := base64.StdEncoding.EncodeToString(challengeBytes)
+	hdr.Set("Proxy-Authorization", "NTLM "+authMsg)
+	connectReq = &http.Request{
+		Method: "CONNECT",
+		URL:    &url.URL{Opaque: targetAddr},
+		Host:   targetAddr,
+		Header: hdr,
+	}
+	connectReq.Write(conn)
+
+	// Read response.
+	resp, err = http.ReadResponse(br, connectReq)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != 200 {
+		f := strings.SplitN(resp.Status, " ", 2)
+		return errors.New(f[1])
+	}
+
+	return nil
+}

--- a/vendor/github.com/anynines/go-proxy-setup-ntlm/proxysetup/ntlm/ntlm_other.go
+++ b/vendor/github.com/anynines/go-proxy-setup-ntlm/proxysetup/ntlm/ntlm_other.go
@@ -1,0 +1,12 @@
+// +build !windows
+
+package ntlm
+
+import (
+	"errors"
+	"net"
+)
+
+func ProxySetup(conn net.Conn, targetAddr string) error {
+	return errors.New("NTLM currently only supported on Windows")
+}


### PR DESCRIPTION
Go does not support NTLM proxy authentication by default.

An attempt https://github.com/golang/go/issues/22288 to add NTLM
proxy authentication to Go's code base has not been accepted.

But there is a workaround/hack overwriting http.Transport.DialContext
to do NTLM proxy authentication (also mentioned in https://github.com/golang/go/issues/22288).

Unfortunately, there was no follow-up discussion in https://github.com/cloudfoundry/cli/issues/577
Therefore I'm just posting the current WIP here to discuss how NTLM proxy authentication might be possible.
