### PR TITLE
Order logs by timestamp

### DIFF
--- a/actor/v2action/logging.go
+++ b/actor/v2action/logging.go
@@ -1,6 +1,7 @@
 package v2action
 
 import (
+	"sort"
 	"time"
 
 	"github.com/cloudfoundry/noaa"
@@ -9,6 +10,8 @@ import (
 )
 
 const StagingLog = "STG"
+
+var flushInterval = 300 * time.Millisecond
 
 type LogMessage struct {
 	message        string
@@ -55,6 +58,18 @@ func NewLogMessage(message string, messageType int, timestamp time.Time, sourceT
 	}
 }
 
+type LogMessages []*LogMessage
+
+func (lm LogMessages) Len() int { return len(lm) }
+
+func (lm LogMessages) Less(i, j int) bool {
+	return lm[i].timestamp.Before(lm[j].timestamp)
+}
+
+func (lm LogMessages) Swap(i, j int) {
+	lm[i], lm[j] = lm[j], lm[i]
+}
+
 func (Actor) GetStreamingLogs(appGUID string, client NOAAClient, config Config) (<-chan *LogMessage, <-chan error) {
 	// Do not pass in token because client should have a TokenRefresher set
 	eventStream, errStream := client.TailingLogs(appGUID, "")
@@ -66,6 +81,11 @@ func (Actor) GetStreamingLogs(appGUID string, client NOAAClient, config Config) 
 		defer close(messages)
 		defer close(errs)
 
+		ticker := time.NewTicker(flushInterval)
+		defer ticker.Stop()
+
+		var logs LogMessages
+
 	dance:
 		for {
 			select {
@@ -74,13 +94,13 @@ func (Actor) GetStreamingLogs(appGUID string, client NOAAClient, config Config) 
 					break dance
 				}
 
-				messages <- &LogMessage{
+				logs = append(logs, &LogMessage{
 					message:        string(event.GetMessage()),
 					messageType:    event.GetMessageType(),
 					timestamp:      time.Unix(0, event.GetTimestamp()),
 					sourceInstance: event.GetSourceInstance(),
 					sourceType:     event.GetSourceType(),
-				}
+				})
 			case err, ok := <-errStream:
 				if !ok {
 					break dance
@@ -93,6 +113,13 @@ func (Actor) GetStreamingLogs(appGUID string, client NOAAClient, config Config) 
 				if err != nil {
 					errs <- err
 				}
+			case <-ticker.C:
+				sort.Stable(logs)
+				for _, l := range logs {
+					messages <- l
+				}
+
+				logs = logs[0:0]
 			}
 		}
 	}()

--- a/actor/v2action/logging_test.go
+++ b/actor/v2action/logging_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Logging Actions", func() {
 		BeforeEach(func() {
 			expectedAppGUID = "some-app-guid"
 
-			eventStream = make(chan *events.LogMessage)
+			eventStream = make(chan *events.LogMessage, 100)
 			errStream = make(chan error)
 		})
 
@@ -84,31 +84,29 @@ var _ = Describe("Logging Actions", func() {
 					Expect(appGUID).To(Equal(expectedAppGUID))
 					Expect(authToken).To(BeEmpty())
 
-					go func() {
-						outMessage := events.LogMessage_OUT
-						ts1 := int64(10)
-						sourceType := "some-source-type"
-						sourceInstance := "some-source-instance"
+					outMessage := events.LogMessage_OUT
+					ts1 := int64(10)
+					sourceType := "some-source-type"
+					sourceInstance := "some-source-instance"
 
-						eventStream <- &events.LogMessage{
-							Message:        []byte("message-1"),
-							MessageType:    &outMessage,
-							Timestamp:      &ts1,
-							SourceType:     &sourceType,
-							SourceInstance: &sourceInstance,
-						}
+					eventStream <- &events.LogMessage{
+						Message:        []byte("message-1"),
+						MessageType:    &outMessage,
+						Timestamp:      &ts1,
+						SourceType:     &sourceType,
+						SourceInstance: &sourceInstance,
+					}
 
-						errMessage := events.LogMessage_ERR
-						ts2 := int64(20)
+					errMessage := events.LogMessage_ERR
+					ts2 := int64(20)
 
-						eventStream <- &events.LogMessage{
-							Message:        []byte("message-2"),
-							MessageType:    &errMessage,
-							Timestamp:      &ts2,
-							SourceType:     &sourceType,
-							SourceInstance: &sourceInstance,
-						}
-					}()
+					eventStream <- &events.LogMessage{
+						Message:        []byte("message-2"),
+						MessageType:    &errMessage,
+						Timestamp:      &ts2,
+						SourceType:     &sourceType,
+						SourceInstance: &sourceInstance,
+					}
 
 					return eventStream, errStream
 				}
@@ -128,6 +126,43 @@ var _ = Describe("Logging Actions", func() {
 				Expect(message.Timestamp()).To(Equal(time.Unix(0, 20)))
 				Expect(message.SourceType()).To(Equal("some-source-type"))
 				Expect(message.SourceInstance()).To(Equal("some-source-instance"))
+			})
+
+			It("sorts the logs by timestamp", func() {
+				outMessage := events.LogMessage_OUT
+				sourceType := "some-source-type"
+				sourceInstance := "some-source-instance"
+
+				ts3 := int64(0)
+				eventStream <- &events.LogMessage{
+					Message:        []byte("message-3"),
+					MessageType:    &outMessage,
+					Timestamp:      &ts3,
+					SourceType:     &sourceType,
+					SourceInstance: &sourceInstance,
+				}
+
+				errMessage := events.LogMessage_ERR
+				ts4 := int64(15)
+				eventStream <- &events.LogMessage{
+					Message:        []byte("message-4"),
+					MessageType:    &errMessage,
+					Timestamp:      &ts4,
+					SourceType:     &sourceType,
+					SourceInstance: &sourceInstance,
+				}
+
+				message := <-messages
+				Expect(message.Timestamp()).To(Equal(time.Unix(0, 0)))
+
+				message = <-messages
+				Expect(message.Timestamp()).To(Equal(time.Unix(0, 10)))
+
+				message = <-messages
+				Expect(message.Timestamp()).To(Equal(time.Unix(0, 15)))
+
+				message = <-messages
+				Expect(message.Timestamp()).To(Equal(time.Unix(0, 20)))
 			})
 		})
 


### PR DESCRIPTION
## What Need Does It Address?

When a user invokes `cf logs <app-name>`, streaming logs will be ordered.

## Possible Drawbacks

There will be a slight (300ms) delay when streaming logs.

## Why Should This Be In Core?

A user would be surprised if their application log stream did not appear in chronological order.

## Description of the Change

Rather than write a log message into a channel immediately, the code here adds a 300ms delay and orders those logs before passing them onto the channel.
