### PR TITLE
Improves godoc for Table.PrintTo

### DIFF
--- a/cf/terminal/table.go
+++ b/cf/terminal/table.go
@@ -70,7 +70,9 @@ func (t *Table) Add(row ...string) {
 // PrintTo is the core functionality for printing the table, placing
 // the formatted table into the writer given to it as argument. The
 // exported Print() is just a wrapper around this which redirects the
-// result into CF datastructures.
+// result into CF data structures.
+// Once a table has been printed onto a Writer, it cannot be printed
+// again.
 func (t *Table) PrintTo(result io.Writer) error {
 	t.rowHeight = make([]int, len(t.rows)+1)
 
@@ -111,7 +113,6 @@ func (t *Table) PrintTo(result io.Writer) error {
 		rowIndex++
 	}
 
-	// Note, printing a table clears it.
 	t.rows = [][]string{}
 	return nil
 }


### PR DESCRIPTION

## What Need Does It Address?

This PR improves the documentation for the `terminal.Table.PrintTo` method. 

It will benefit developers by saving their time debugging the behavior of `PrintTo` without having to actually inspect the source code to understand its behavior. The behavior being that `PrintTo` clears the rows of the object once it has been written to the `io.Writer`. Perhaps the godoc can be additionally improved by explaining why the `Table`'s rows have to be cleared in the first place.

## Possible Drawbacks

None

## Why Should This Be In Core?

This is a documentation update.

## Description of the Change

1. We are writing a plugin that needs to have a consistent feel and look as compared to the CF CLI.
1.  As part of that requirement we were using the `terminal.Table` to output our data in table format.
1. This required us to test the output format. 
1. This led us to create a [gomega matcher CLITableMatcher](https://github.com/wfernandes/CLITableMatcher) where we use the `Table.PrintTo` method.
1. I spent a decent amount of time trying to understand the behavior of PrintTo. See [this sample](https://github.com/wfernandes/CLITableMatcher/blob/7a4d386a759cdc7f5b0d2a7baa51566f22c96cc4/sample/main.go#L50) for example.

## Alternate Designs

None

## Applicable Issues

None
