### PR TITLE
Bump CC API version to 3.36.0

### DIFF
--- a/api/cloudcontroller/ccversion/minimum_version.go
+++ b/api/cloudcontroller/ccversion/minimum_version.go
@@ -12,5 +12,5 @@ const (
 	MinVersionV3                 = "3.27.0"
 	MinVersionRunTaskV3          = "3.0.0"
 	MinVersionIsolationSegmentV3 = "3.11.0"
-	MinVersionShareServiceV3     = "3.34.0"
+	MinVersionShareServiceV3     = "3.36.0"
 )


### PR DESCRIPTION
Bump minimum version requirement of CC API to [latest](https://github.com/cloudfoundry/capi-release/releases/tag/1.46.0) required for service instance sharing functionality.