### PR TITLE
Update share/unshare integration tests to check for correct api version

### DIFF
--- a/integration/experimental/v3_share_service_command_test.go
+++ b/integration/experimental/v3_share_service_command_test.go
@@ -104,7 +104,7 @@ var _ = PDescribe("v3-share-service command", func() {
 			It("fails with error message that the minimum version is not met", func() {
 				session := helpers.CF("v3-share-service", serviceInstance, "-s", sharedToSpaceName)
 				Eventually(session).Should(Say("FAILED"))
-				Eventually(session.Err).Should(Say("This command requires CF API version 3\\.34\\.0 or higher\\."))
+				Eventually(session.Err).Should(Say("This command requires CF API version 3\\.36\\.0 or higher\\."))
 				Eventually(session).Should(Exit(1))
 			})
 		})
@@ -123,7 +123,7 @@ var _ = PDescribe("v3-share-service command", func() {
 			It("fails with error message that the minimum version is not met", func() {
 				session := helpers.CF("v3-share-service", serviceInstance, "-s", sharedToSpaceName)
 				Eventually(session).Should(Say("FAILED"))
-				Eventually(session.Err).Should(Say("This command requires CF API version 3\\.34\\.0 or higher\\."))
+				Eventually(session.Err).Should(Say("This command requires CF API version 3\\.36\\.0 or higher\\."))
 				Eventually(session).Should(Exit(1))
 			})
 		})

--- a/integration/experimental/v3_unshare_service_command_test.go
+++ b/integration/experimental/v3_unshare_service_command_test.go
@@ -103,7 +103,7 @@ var _ = PDescribe("v3-unshare-service command", func() {
 			It("fails with error message that the minimum version is not met", func() {
 				session := helpers.CF("v3-unshare-service", serviceInstance, "-s", sharedToSpaceName)
 				Eventually(session).Should(Say("FAILED"))
-				Eventually(session.Err).Should(Say("This command requires CF API version 3\\.34\\.0 or higher\\."))
+				Eventually(session.Err).Should(Say("This command requires CF API version 3\\.36\\.0 or higher\\."))
 				Eventually(session).Should(Exit(1))
 			})
 		})
@@ -122,7 +122,7 @@ var _ = PDescribe("v3-unshare-service command", func() {
 			It("fails with error message that the minimum version is not met", func() {
 				session := helpers.CF("v3-unshare-service", serviceInstance, "-s", sharedToSpaceName)
 				Eventually(session).Should(Say("FAILED"))
-				Eventually(session.Err).Should(Say("This command requires CF API version 3\\.34\\.0 or higher\\."))
+				Eventually(session.Err).Should(Say("This command requires CF API version 3\\.36\\.0 or higher\\."))
 				Eventually(session).Should(Exit(1))
 			})
 		})


### PR DESCRIPTION
It looks as though as part of doing [this](https://github.com/cloudfoundry/cli/pull/1295) PR we forgot to update the integration tests. Sorry about that!

Thanks,
Sam / sapiteam