### PR TITLE
On an exit signal, wait for plugins to exit

### DIFF
--- a/integration/assets/test_plugin/test_plugin.go
+++ b/integration/assets/test_plugin/test_plugin.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"time"
 
 	"code.cloudfoundry.org/cli/plugin"
 )
@@ -13,6 +15,13 @@ type Test1 struct {
 
 func (c *Test1) Run(cliConnection plugin.CliConnection, args []string) {
 	switch args[0] {
+	case "Sleep":
+		sleepDurationInMs, err := strconv.ParseInt(args[1], 10, 64)
+		if err != nil {
+			panic(err)
+		}
+		time.Sleep(time.Duration(sleepDurationInMs) * time.Millisecond)
+		fmt.Println("Slept for", sleepDurationInMs, "ms")
 	case "CliCommandWithoutTerminalOutput":
 		result, _ := cliConnection.CliCommandWithoutTerminalOutput("target")
 		fmt.Println("Done CliCommandWithoutTerminalOutput:", result)
@@ -119,6 +128,7 @@ func (c *Test1) GetMetadata() plugin.PluginMetadata {
 			Build: 0,
 		},
 		Commands: []plugin.Command{
+			{Name: "Sleep"},
 			{Name: "CliCommandWithoutTerminalOutput"},
 			{Name: "CliCommand"},
 			{Name: "GetCurrentSpace"},


### PR DESCRIPTION
## What Need Does It Address?

In #1373 we reported the CF CLI exits immediately when it receives a `SIGINT` (e.g., when a user runs `CTRL+C` in their shell.) This is problematic because it means that plugins can't use the CF CLI's RPC server to perform cleanup tasks.

## Possible Drawbacks

If a `SIGINT` is directed at the CF CLI process alone, rather than the process tree, the CF CLI will no longer exit. This could be worked around by only intercepting the first `SIGINT`, or relaying signals to the plugin's child process.

## Why Should This Be In Core?

The RPC server is in Core and it keeps it alive for cleanup.

## Description of the Change

See commit message.

## Alternate Designs

This was a first pass at the problem, which ignores all signals until the plugin exits. If you review we're happy to adopt a different design, such as the first signal triggering a controlled shutdown and the second force-killing.

## Applicable Issues

https://github.com/cloudfoundry/cli/issues/1373