### PR TITLE
Fix query parameter regex in trace.Sanitize()

### DIFF
--- a/cf/trace/trace.go
+++ b/cf/trace/trace.go
@@ -13,8 +13,10 @@ func Sanitize(input string) string {
 	re := regexp.MustCompile(`(?m)^Authorization: .*`)
 	sanitized := re.ReplaceAllString(input, "Authorization: "+PrivateDataPlaceholder())
 
-	re = regexp.MustCompile(`password=[^&]*&`)
-	sanitized = re.ReplaceAllString(sanitized, "password="+PrivateDataPlaceholder()+"&")
+	// allow query parameter to contain all characters of the "query" character class, except for &
+	// https://tools.ietf.org/html/rfc3986#appendix-A
+	re = regexp.MustCompile(`([&?]password)=[A-Za-z0-9\-._~!$'()*+,;=:@/?]*`)
+	sanitized = re.ReplaceAllString(sanitized, "$1="+PrivateDataPlaceholder())
 
 	sanitized = sanitizeJSON("token", sanitized)
 	sanitized = sanitizeJSON("password", sanitized)

--- a/cf/trace/trace_test.go
+++ b/cf/trace/trace_test.go
@@ -54,6 +54,56 @@ grant_type=password&password=[PRIVATE DATA HIDDEN]&scope=&username=mgehard%2Bcli
 				Expect(Sanitize(request)).To(Equal(expected))
 			})
 
+			It("hides passwords in the first and last query parameters", func() {
+				response := `
+HTTP/1.1 200 BORK
+
+{
+  "resources": [
+    {
+      "entity": {
+        "credentials": {
+          "jdbcUrl": "jdbc:mysql://hostname/db-name?user=username&password=very-secret-password"
+        }
+      }
+    },
+	{
+      "entity": {
+        "credentials": {
+          "jdbcUrl": "jdbc:mysql://hostname/db-name?password=very-secret-password&user=username"
+        }
+      }
+    }
+  ]
+}
+`
+
+				expected := `
+HTTP/1.1 200 BORK
+
+{
+  "resources": [
+    {
+      "entity": {
+        "credentials": {
+          "jdbcUrl": "jdbc:mysql://hostname/db-name?user=username&password=[PRIVATE DATA HIDDEN]"
+        }
+      }
+    },
+	{
+      "entity": {
+        "credentials": {
+          "jdbcUrl": "jdbc:mysql://hostname/db-name?password=[PRIVATE DATA HIDDEN]&user=username"
+        }
+      }
+    }
+  ]
+}
+`
+
+				Expect(Sanitize(response)).To(Equal(expected))
+			})
+
 			It("hides passwords in the JSON-formatted request body", func() {
 				request := `
 REQUEST: [2014-03-07T10:53:36-08:00]


### PR DESCRIPTION
## Description of the Change

The previous regular expression, `&password=[^&}*&`, did not match password parameters at the end of the query string. In that case it also ate the rest of the input, until the next & character.

I replaced it with an expression that is, sadly, rather complicated, but should match all characters that can be part of a query parameter value as per the RFC.

This change does not address passwords in the userinfo URI component.

## Alternate Designs

`trace.Sanitize()` could find URIs in the input string and parse them, then cleanly replace the userinfo component and parameter values

## Applicable Issues

#1375 