### PR TITLE
Add cell_id to description of app crashed events

### DIFF
--- a/cf/api/resources/events.go
+++ b/cf/api/resources/events.go
@@ -69,6 +69,7 @@ func (resource EventResourceOldV2) ToFields() models.EventFields {
 var knownMetadataKeys = []string{
 	"index",
 	"reason",
+	"cell_id",
 	"exit_description",
 	"exit_status",
 	"recursive",

--- a/cf/api/resources/events.go
+++ b/cf/api/resources/events.go
@@ -70,6 +70,7 @@ var knownMetadataKeys = []string{
 	"index",
 	"reason",
 	"cell_id",
+	"instance",
 	"exit_description",
 	"exit_status",
 	"recursive",

--- a/cf/api/resources/events_test.go
+++ b/cf/api/resources/events_test.go
@@ -30,6 +30,7 @@ var _ = Describe("Event resources", func() {
 				"metadata": {
 				  "instance": "50dd66d3f8874b35988d23a25d19bfa0",
 				  "index": 3,
+					"cell_id": "some-cell",
 				  "exit_status": -1,
 				  "exit_description": "unknown",
 				  "reason": "CRASHED"
@@ -45,7 +46,7 @@ var _ = Describe("Event resources", func() {
 			Expect(eventFields.GUID).To(Equal("event-1-guid"))
 			Expect(eventFields.Name).To(Equal("app.crash"))
 			Expect(eventFields.Timestamp).To(Equal(timestamp))
-			Expect(eventFields.Description).To(Equal(`index: 3, reason: CRASHED, exit_description: unknown, exit_status: -1`))
+			Expect(eventFields.Description).To(Equal(`index: 3, reason: CRASHED, cell_id: some-cell, exit_description: unknown, exit_status: -1`))
 		})
 
 		It("unmarshals app update events", func() {

--- a/cf/api/resources/events_test.go
+++ b/cf/api/resources/events_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Event resources", func() {
 			Expect(eventFields.GUID).To(Equal("event-1-guid"))
 			Expect(eventFields.Name).To(Equal("app.crash"))
 			Expect(eventFields.Timestamp).To(Equal(timestamp))
-			Expect(eventFields.Description).To(Equal(`index: 3, reason: CRASHED, cell_id: some-cell, exit_description: unknown, exit_status: -1`))
+			Expect(eventFields.Description).To(Equal(`index: 3, reason: CRASHED, cell_id: some-cell, instance: 50dd66d3f8874b35988d23a25d19bfa0, exit_description: unknown, exit_status: -1`))
 		})
 
 		It("unmarshals app update events", func() {


### PR DESCRIPTION
- This field is populated by a new field added to the metadata of
app crash events from Cloud Controller

[#155871993]

Signed-off-by: Nima Kaviani <nkavian@us.ibm.com>

<!--
## Requirements

* Your contribution will be analyzed for product fit and engineering quality prior to merging.
If your contribution includes a change that is exposed to cf CLI users (e.g. introducing a new command or flag), please submit an issue to discuss it first.
* We're not allowed to accept any PRs without a signed CLA, no matter how small.
If your contribution falls under a company CLA but your membership is not public, expect delays while we confirm.
* All new code requires tests to protect against regressions.
-->

## What Need Does It Address?

As a CF app developer, I expect to see the Diego cell ID in the app crash event metadata so that I can more easily report the cell on which an app instance crashed


<!-- What benefits will be realized by the code change? Explain its value to users. What is their current solution to the problem, and why is it insufficient? -->

## Who Is The Functionality For?

see the story in Diego's backlog: https://www.pivotaltracker.com/story/show/155871993

## How Often Will This Functionality Be Used?

whenever app developers call `cf events APP`

## Description of the Change

We added an extra field to the list of keyboards extracted from the events received from CC for the event information to also include cell id when the app crashes.

## Other Relevant Parties

Diego and CAPI are other parties involved. Please check [this story](https://www.pivotaltracker.com/story/show/155871993) for the details and also other PRs we submitted to CAPI.
