### PR TITLE
add QuoteMeta to allow any timezone to be checked

### DIFF
--- a/util/ui/request_logger_terminal_display_test.go
+++ b/util/ui/request_logger_terminal_display_test.go
@@ -2,6 +2,7 @@ package ui_test
 
 import (
 	"errors"
+	"regexp"
 	"time"
 
 	. "code.cloudfoundry.org/cli/util/ui"
@@ -186,7 +187,7 @@ Origin: wss://doppler.bosh-lite.com:443`
 			err = display.Stop()
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(testUI.Out).To(Say("banana: \\[%s\\]", passedTime.Format(time.RFC3339)))
+			Expect(testUI.Out).To(Say("banana: \\[%s\\]", regexp.QuoteMeta(passedTime.Format(time.RFC3339))))
 		})
 	})
 


### PR DESCRIPTION
Fixed this test that fails due to the `+` in the GMT timezone:
```
• Failure [0.000 seconds]
Request Logger Terminal Display
/Users/pivotal/go/src/code.cloudfoundry.org/cli/util/ui/request_logger_terminal_display_test.go:14
  DisplayType
  /Users/pivotal/go/src/code.cloudfoundry.org/cli/util/ui/request_logger_terminal_display_test.go:180
    displays the passed type and time in localized ISO 8601 [It]
    /Users/pivotal/go/src/code.cloudfoundry.org/cli/util/ui/request_logger_terminal_display_test.go:181

    Got stuck at:
        banana: [2018-06-25T10:55:26+01:00]


    Waiting for:
        banana: \[2018-06-25T10:55:26+01:00\]

    /Users/pivotal/go/src/code.cloudfoundry.org/cli/util/ui/request_logger_terminal_display_test.go:189
```

Anand approved!