### PR TITLE
Provide a default passcode prompt if login server does not provide one (OSS CF/cfdev)

### DIFF
--- a/cf/commands/login.go
+++ b/cf/commands/login.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 
 	"code.cloudfoundry.org/cli/cf/commandregistry"
@@ -175,6 +176,12 @@ func (cmd Login) authenticateSSO(c flags.FlagContext) error {
 
 	credentials := make(map[string]string)
 	passcode := prompts["passcode"]
+	if passcode.DisplayName == "" {
+		passcode = coreconfig.AuthPrompt{
+			Type:        coreconfig.AuthPromptTypePassword,
+			DisplayName: fmt.Sprintf("Temporary Authentication Code ( Get one at %s/passcode )", cmd.config.AuthenticationEndpoint()),
+		}
+	}
 
 	for i := 0; i < maxLoginTries; i++ {
 		if c.IsSet("sso-passcode") && i == 0 {

--- a/cf/commands/login_test.go
+++ b/cf/commands/login_test.go
@@ -394,10 +394,6 @@ var _ = Describe("Login Command", func() {
 						DisplayName: "Username",
 						Type:        coreconfig.AuthPromptTypeText,
 					},
-					"passcode": {
-						DisplayName: "It's a passcode, what you want it to be???",
-						Type:        coreconfig.AuthPromptTypePassword,
-					},
 					"password": {
 						DisplayName: "Your Password",
 						Type:        coreconfig.AuthPromptTypePassword,


### PR DESCRIPTION
```
$ out/cf login -a https://api.v3.pcfdev.io --skip-ssl-validation --sso
API endpoint: https://api.v3.pcfdev.io

Temporary Authentication Code ( Get one at https://login.v3.pcfdev.io/passcode )>
Authenticating...
OK
```


The `cf login --sso` flag is awesome. It feels great to be putting my login details into the UAA (where I have 1password), than to have to copy/paste them into the terminal.

But by default, the cf-deployment + cfdev projects do not include a 'passcode' prompt, even though the UAA does have a /passcode endpoint. So the CLI misbehaves with the `--sso` flag.

This PR ensures that `--sso` works for all Cloud Foundry installations.


This PR is instead of me raising an Issue that `--sso` doesn't work for cfdev.


If the UAA does not include a `passcode` prompt, the CLI will decide on a nice default (the text comes from https://uaa.run.pivotal.io)

```
$ curl -s https://uaa.run.pivotal.io/login -H 'Accept: application/json' | jq .prompts.passcode
[
  "password",
  "Temporary Authentication Code ( Get one at https://login.run.pivotal.io/passcode )"
]
```