### PR TITLE
Service Instance Sharing is no longer Experimental

### DIFF
--- a/command/common/help_command_test.go
+++ b/command/common/help_command_test.go
@@ -506,6 +506,8 @@ var _ = Describe("help Command", func() {
 				Expect(testUI.Out).To(Say("SERVICES:"))
 				Expect(testUI.Out).To(Say("   marketplace\\s+List available offerings in the marketplace"))
 				Expect(testUI.Out).To(Say("   create-service\\s+Create a service instance"))
+				Expect(testUI.Out).To(Say("   share-service\\s+Share a service instance with another space"))
+				Expect(testUI.Out).To(Say("   unshare-service\\s+Unshare a shared service instance from a space"))
 				Expect(testUI.Out).To(Say(""))
 				Expect(testUI.Out).To(Say("ORGS:"))
 				Expect(testUI.Out).To(Say("   orgs\\s+List all orgs"))
@@ -622,10 +624,6 @@ var _ = Describe("help Command", func() {
 				Expect(testUI.Out).To(Say("   v3-packages\\s+List packages of an app"))
 				Expect(testUI.Out).To(Say("   v3-create-package\\s+Uploads a V3 Package"))
 				Expect(testUI.Out).To(Say("   v3-ssh\\s+SSH to an application container instance"))
-				Expect(testUI.Out).To(Say("SERVICES \\(experimental\\):"))
-				Expect(testUI.Out).To(Say("   share-service\\s+Share a service instance with another space"))
-				Expect(testUI.Out).To(Say("   unshare-service\\s+Unshare a shared service instance from a space"))
-
 			})
 
 			When("there are multiple installed plugins", func() {

--- a/command/common/internal/help_all_display.go
+++ b/command/common/internal/help_all_display.go
@@ -31,6 +31,7 @@ var HelpCategoryList = []HelpCategory{
 			{"bind-service", "unbind-service"},
 			{"bind-route-service", "unbind-route-service"},
 			{"create-user-provided-service", "update-user-provided-service"},
+			{"share-service", "unshare-service"},
 		},
 	},
 	{
@@ -164,12 +165,6 @@ var ExperimentalHelpCategoryList = []HelpCategory{
 			{"v3-get-health-check", "v3-set-health-check"},
 			{"v3-packages", "v3-create-package"},
 			{"v3-ssh"},
-		},
-	},
-	{
-		CategoryName: "SERVICES (experimental):",
-		CommandList: [][]string{
-			{"share-service", "unshare-service"},
 		},
 	},
 }

--- a/command/v3/share_service_command.go
+++ b/command/v3/share_service_command.go
@@ -67,8 +67,6 @@ func (cmd *ShareServiceCommand) Setup(config command.Config, ui command.UI) erro
 }
 
 func (cmd ShareServiceCommand) Execute(args []string) error {
-	cmd.UI.DisplayWarning(command.ExperimentalWarning)
-
 	err := command.MinimumCCAPIVersionCheck(cmd.Actor.CloudControllerV3APIVersion(), ccversion.MinVersionShareServiceV3)
 	if err != nil {
 		return err

--- a/command/v3/unshare_service_command.go
+++ b/command/v3/unshare_service_command.go
@@ -67,8 +67,6 @@ func (cmd *UnshareServiceCommand) Setup(config command.Config, ui command.UI) er
 }
 
 func (cmd UnshareServiceCommand) Execute(args []string) error {
-	cmd.UI.DisplayWarning(command.ExperimentalWarning)
-
 	err := command.MinimumCCAPIVersionCheck(cmd.Actor.CloudControllerV3APIVersion(), ccversion.MinVersionShareServiceV3)
 	if err != nil {
 		return err

--- a/integration/global/unshare_service_command_test.go
+++ b/integration/global/unshare_service_command_test.go
@@ -1,4 +1,4 @@
-package experimental
+package global
 
 import (
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccversion"


### PR DESCRIPTION
This PR:
* Remove experimental warnings
* Move tests from experimental to global

[Story](https://www.pivotaltracker.com/story/show/152478613) on Service API tracker.

Thanks,
Luis & @Samze (Service API Team)