### PR TITLE
bin/compile is not required in a buildpack

### DIFF
--- a/cf/api/buildpack_bits.go
+++ b/cf/api/buildpack_bits.go
@@ -190,16 +190,18 @@ func normalizeBuildpackArchive(inputFile *os.File, outputFile *os.File) error {
 }
 
 func findBuildpackPath(zipFiles []*zip.File) (parentPath string, foundBuildpack bool) {
-	needle := "bin/compile"
+	needles := []string{"bin/compile", "bin/supply"}
 
 	for _, file := range zipFiles {
-		if strings.HasSuffix(file.Name, needle) {
-			foundBuildpack = true
-			parentPath = path.Join(file.Name, "..", "..")
-			if parentPath == "." {
-				parentPath = ""
+		for _, needle := range needles {
+			if strings.HasSuffix(file.Name, needle) {
+				foundBuildpack = true
+				parentPath = path.Join(file.Name, "..", "..")
+				if parentPath == "." {
+					parentPath = ""
+				}
+				return
 			}
-			return
 		}
 	}
 	return


### PR DESCRIPTION
See https://docs.cloudfoundry.org/buildpacks/understand-buildpacks.html

## What Need Does It Address?

Fixes buildpack validation:
Not only is `bin/compile` is not required, it's deprecated:
https://docs.cloudfoundry.org/buildpacks/understand-buildpacks.html

## Who Is The Functionality For?

Anyone invoking `cf create-buildpack` with a supply/finalize style buildpack.

## How Often Will This Functionality Be Used?

On `cf create-buildpack`

## Possible Drawbacks

NA

## Why Should This Be In Core?

Fixes bug

## Description of the Change

Validate against buildpack containing either `bin/supply` or `bin/finalize`

## How Urgent Is The Change?

Not super urgent, but I know multiple buildpack authors who have spent a lot of cycles trying to figure out why their valid buildpack didn't upload.

