### PR TITLE
The minimum supported CC version of async-bindings is 2.119.0

### DIFF
--- a/api/cloudcontroller/ccversion/minimum_version.go
+++ b/api/cloudcontroller/ccversion/minimum_version.go
@@ -4,7 +4,7 @@ const (
 	MinV2ClientVersion = "2.69.0"
 	MinV3ClientVersion = "3.4.0"
 
-	MinVersionAsyncBindingsV2                = "99.0.0"
+	MinVersionAsyncBindingsV2                = "2.119.0"
 	MinVersionBindingNameV2                  = "2.99.0"
 	MinVersionBuildpackStackAssociationV2    = "2.114.0"
 	MinVersionDockerCredentialsV2            = "2.82.0"


### PR DESCRIPTION
The minimum CC version that has the changes for async bindings is 2.119.0. It is used in the integration test as part of `SkipIfVersionLessThan` helper func.

Thanks,
SAPI Team