### PR TITLE
Display service binding operation type

### DIFF
--- a/actor/v2action/service_instance_summary.go
+++ b/actor/v2action/service_instance_summary.go
@@ -5,12 +5,15 @@ import (
 	"sort"
 
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccerror"
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv2"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv2/constant"
 	"code.cloudfoundry.org/cli/util/sorting"
 	log "github.com/sirupsen/logrus"
 )
 
 type ServiceInstanceShareType string
+
+type LastOperation ccv2.LastOperation
 
 const (
 	ServiceInstanceIsSharedFrom ServiceInstanceShareType = "SharedFrom"
@@ -48,8 +51,7 @@ func (s ServiceInstanceSummary) IsSharedTo() bool {
 
 type BoundApplication struct {
 	AppName            string
-	LastOperationState constant.LastOperationState
-	Message            string
+	LastOperation      LastOperation
 	ServiceBindingName string
 }
 
@@ -241,8 +243,7 @@ func (actor Actor) getSummaryInfoCompositeForInstance(spaceGUID string, serviceI
 			BoundApplication{
 				AppName:            app.Name,
 				ServiceBindingName: serviceBinding.Name,
-				LastOperationState: serviceBinding.LastOperation.State,
-				Message:            serviceBinding.LastOperation.Description,
+				LastOperation:      LastOperation(serviceBinding.LastOperation),
 			})
 	}
 

--- a/actor/v2action/service_instance_summary_test.go
+++ b/actor/v2action/service_instance_summary_test.go
@@ -622,13 +622,13 @@ var _ = Describe("Service Instance Summary Actions", func() {
 										GUID:          "some-service-binding-1-guid",
 										Name:          "some-service-binding-1",
 										AppGUID:       "some-app-1-guid",
-										LastOperation: ccv2.LastOperation{State: constant.LastOperationInProgress, Description: "10% complete"},
+										LastOperation: ccv2.LastOperation{Type: "create", State: constant.LastOperationInProgress, Description: "10% complete"},
 									},
 									{
 										GUID:          "some-service-binding-2-guid",
 										Name:          "some-service-binding-2",
 										AppGUID:       "some-app-2-guid",
-										LastOperation: ccv2.LastOperation{State: constant.LastOperationSucceeded, Description: "100% complete"},
+										LastOperation: ccv2.LastOperation{Type: "delete", State: constant.LastOperationSucceeded, Description: "100% complete"},
 									},
 								}
 								fakeCloudControllerClient.GetServiceInstanceServiceBindingsReturns(
@@ -686,14 +686,20 @@ var _ = Describe("Service Instance Summary Actions", func() {
 										{
 											AppName:            "some-app-1",
 											ServiceBindingName: "some-service-binding-1",
-											LastOperationState: constant.LastOperationInProgress,
-											Message:            "10% complete",
+											LastOperation: LastOperation{
+												Type:        "create",
+												State:       constant.LastOperationInProgress,
+												Description: "10% complete",
+											},
 										},
 										{
 											AppName:            "some-app-2",
 											ServiceBindingName: "some-service-binding-2",
-											LastOperationState: constant.LastOperationSucceeded,
-											Message:            "100% complete",
+											LastOperation: LastOperation{
+												Type:        "delete",
+												State:       constant.LastOperationSucceeded,
+												Description: "100% complete",
+											},
 										},
 									}))
 									Expect(summaryWarnings).To(ConsistOf("get-space-service-instance-warning", "get-feature-flags-warning", "get-service-plan-warning", "get-service-warning", "get-service-bindings-warning", "get-application-warning-1", "get-application-warning-2"))

--- a/command/v6/service_command.go
+++ b/command/v6/service_command.go
@@ -208,8 +208,8 @@ func (cmd ServiceCommand) displayBoundApplicationsIfExists(serviceInstanceSummar
 		boundAppsTable = append(boundAppsTable, []string{
 			boundApplication.AppName,
 			boundApplication.ServiceBindingName,
-			string(boundApplication.LastOperationState),
-			boundApplication.Message,
+			fmt.Sprintf("%s %s", boundApplication.LastOperation.Type, boundApplication.LastOperation.State),
+			boundApplication.LastOperation.Description,
 		})
 	}
 

--- a/command/v6/service_command_test.go
+++ b/command/v6/service_command_test.go
@@ -283,14 +283,35 @@ var _ = Describe("service Command", func() {
 									{
 										AppName:            "app-2",
 										ServiceBindingName: "binding-name-2",
-										LastOperationState: constant.LastOperationInProgress,
-										Message:            "10% complete",
+										LastOperation: v2action.LastOperation{
+											Type:        "delete",
+											State:       constant.LastOperationInProgress,
+											Description: "10% complete",
+											UpdatedAt:   "some-updated-at-time",
+											CreatedAt:   "some-created-at-time",
+										},
 									},
 									{
 										AppName:            "app-3",
 										ServiceBindingName: "binding-name-3",
-										LastOperationState: constant.LastOperationFailed,
-										Message:            "Binding failed",
+										LastOperation: v2action.LastOperation{
+											Type:        "create",
+											State:       constant.LastOperationFailed,
+											Description: "Binding failed",
+											UpdatedAt:   "some-updated-at-time",
+											CreatedAt:   "some-created-at-time",
+										},
+									},
+									{
+										AppName:            "app-4",
+										ServiceBindingName: "binding-name-4",
+										LastOperation: v2action.LastOperation{
+											Type:        "create",
+											State:       constant.LastOperationSucceeded,
+											Description: "Binding created",
+											UpdatedAt:   "some-updated-at-time",
+											CreatedAt:   "some-created-at-time",
+										},
 									},
 								}
 								fakeActor.GetServiceInstanceSummaryByNameAndSpaceReturns(
@@ -328,9 +349,10 @@ var _ = Describe("service Command", func() {
 
 								Expect(testUI.Out).To(Say("bound apps:"))
 								Expect(testUI.Out).To(Say("name\\s+binding name\\s+status\\s+message"))
-								Expect(testUI.Out).To(Say("app-1\\s+binding-name-1"))
-								Expect(testUI.Out).To(Say("app-2\\s+binding-name-2\\s+in progress\\s+10\\% complete"))
-								Expect(testUI.Out).To(Say("app-3\\s+binding-name-3\\s+failed\\s+Binding failed"))
+								Expect(testUI.Out).To(Say("app-1\\s+binding-name-1\\s+"))
+								Expect(testUI.Out).To(Say("app-2\\s+binding-name-2\\s+delete in progress\\s+10\\% complete"))
+								Expect(testUI.Out).To(Say("app-3\\s+binding-name-3\\s+create failed\\s+Binding failed"))
+								Expect(testUI.Out).To(Say("app-4\\s+binding-name-4\\s+create succeeded\\s+Binding created"))
 
 								Expect(testUI.Err).To(Say("get-service-instance-summary-warning-1"))
 								Expect(testUI.Err).To(Say("get-service-instance-summary-warning-2"))

--- a/integration/global/service_command_test.go
+++ b/integration/global/service_command_test.go
@@ -387,8 +387,8 @@ var _ = Describe("service command", func() {
 							Eventually(session).Should(Say("name:\\s+%s", serviceInstanceName))
 							Eventually(session).Should(Say("bound apps:"))
 							Eventually(session).Should(Say("name\\s+binding name\\s+status\\s+message"))
-							Eventually(session).Should(Say("%s\\s+%s\\s+succeeded", appName1, bindingName1))
-							Eventually(session).Should(Say("%s\\s+%s\\s+succeeded", appName2, bindingName2))
+							Eventually(session).Should(Say("%s\\s+%s\\s+create succeeded", appName1, bindingName1))
+							Eventually(session).Should(Say("%s\\s+%s\\s+create succeeded", appName2, bindingName2))
 
 							Eventually(session).Should(Exit(0))
 						})


### PR DESCRIPTION
The cf service <service_name> command displays a table of bound
applications and allows users to discover information about bindings.
For asynchronous bindings this includes a state, type and description.
This commit adds the type field.

It is now displayed under the status column by combining the state and
type. E.g. type: 'create' and 'state': 'in progress' becomes the
status string 'create in progress'. This is consistent with displaying
asynchronous service instance information.

Will