### PR TITLE
Fix typo in `alligator` used for random route generation

### DIFF
--- a/util/randomword/generator.go
+++ b/util/randomword/generator.go
@@ -84,7 +84,7 @@ wise
 zany`
 
 const nouns = `ardvark
-aligator
+alligator
 antelope
 baboon
 badger


### PR DESCRIPTION
## What Need Does It Address?

There's a typo in the word `alligator` that can be seen when generating random routes.

## Who Is The Functionality For?

Those who are using the `--random-route` flag

## How Often Will This Functionality Be Used?

Infrequently; even for the subset of apps using random routes, there are many animal names that may be randomly selected besides alligator

## Possible Drawbacks

If anyone made their own cache of these animal names, it would be outdated after this fix.

## Why Should This Be In Core?

The functionality is already in core

## Description of the Change

Correcting the typo `aligator` to `alligator`

## Alternate Designs

`crocodile` is already in the list so the alternate is already implemented as well

## Applicable Issues

N/A

## How Urgent Is The Change?

Not urgent at all

## Other Relevant Parties

N/A
