### PR TITLE
Add clarifying notes for integration tests

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -1,7 +1,23 @@
 # CLI Integration Tests
+
+## Introduction
+
 These are high-level tests for the CLI that make assertions about the behavior of the `cf` binary.
 
-These tests require that a `cf` binary built from the latest source is available in your `PATH`.
+On most systems `cf` points to an installed version. To test the latest source (most likely source that you're changing), ensure the dev `cf` binary is in your `PATH`:
+
+```
+[[ `which cf` = *"$GOPATH/src/code.cloudfoundry.org/cli/out"* ]] || 
+    export PATH="$GOPATH/src/code.cloudfoundry.org/cli/out:$PATH"
+```
+
+You'll also need to rebuild `cf` after making any relevant changes to the source:
+
+```
+make build
+```
+
+CLI Integration tests are time-consuming to run. Best to constrain runs to relevant tests until a long break in your workday, when you can run `make integration-tests` and cover everything.
 
 ## Explanation of test suites
 - `global` suite is for tests that affect an entire CF instance. *These tests do not run in parallel.*


### PR DESCRIPTION
Specifically, the docs currently don't point out that the onus is on
the developer to ensure that they are pointing to the correct instance
of cf and have built it before running integration tests.

<!--
## Requirements

* Your contribution will be analyzed for product fit and engineering quality prior to merging.
If your contribution includes a change that is exposed to cf CLI users (e.g. introducing a new command or flag), please submit an issue to discuss it first.
* We're not allowed to accept any PRs without a signed CLA, no matter how small.
If your contribution falls under a company CLA but your membership is not public, expect delays while we confirm.
* All new code requires tests to protect against regressions.
-->

## What Need Does It Address?

Coworkers on CAPI new to CLI dev were tripping up on the lack of documentation when writing/running integration tests.

## Who Is The Functionality For?

The change is for non-CLI-team members trying to ensure they're building correct PRs by running integration tests.

## How Often Will This Functionality Be Used?

Not very often. Only when non-CLI-team members make contributions.

## Possible Drawbacks

None

## Why Should This Be In Core?

It's just documentation.

## Description of the Change

Added a paragraph to the integration-test README

## Alternate Designs

N/A

## Applicable Issues
N/A

## How Urgent Is The Change?

Normal

## Other Relevant Parties

No one
