### PR TITLE
add stack flag to v3-zdt-push

### DIFF
--- a/actor/v3action/application.go
+++ b/actor/v3action/application.go
@@ -89,6 +89,7 @@ func (actor Actor) CreateApplicationInSpace(app Application, spaceGUID string) (
 		ccv3.Application{
 			LifecycleType:       app.LifecycleType,
 			LifecycleBuildpacks: app.LifecycleBuildpacks,
+			StackName:           app.StackName,
 			Name:                app.Name,
 			Relationships: ccv3.Relationships{
 				constant.RelationshipTypeSpace: ccv3.Relationship{GUID: spaceGUID},

--- a/api/cloudcontroller/ccv3/application.go
+++ b/api/cloudcontroller/ccv3/application.go
@@ -38,9 +38,9 @@ func (a Application) MarshalJSON() ([]byte, error) {
 	if a.LifecycleType == constant.AppLifecycleTypeDocker {
 		ccApp.setDockerLifecycle()
 	} else if a.LifecycleType == constant.AppLifecycleTypeBuildpack {
-		if len(a.LifecycleBuildpacks) > 0 {
+		if len(a.LifecycleBuildpacks) > 0 || a.StackName != "" {
 			if a.hasAutodetectedBuildpack() {
-				ccApp.setAutodetectedBuildpackLifecycle()
+				ccApp.setAutodetectedBuildpackLifecycle(a)
 			} else {
 				ccApp.setBuildpackLifecycle(a)
 			}
@@ -74,6 +74,9 @@ func (a *Application) UnmarshalJSON(data []byte) error {
 }
 
 func (a Application) hasAutodetectedBuildpack() bool {
+	if len(a.LifecycleBuildpacks) == 0 {
+		return false
+	}
 	return a.LifecycleBuildpacks[0] == "default" || a.LifecycleBuildpacks[0] == "null"
 }
 
@@ -93,7 +96,7 @@ type ccApplication struct {
 	State         constant.ApplicationState `json:"state,omitempty"`
 }
 
-func (ccApp *ccApplication) setAutodetectedBuildpackLifecycle() {
+func (ccApp *ccApplication) setAutodetectedBuildpackLifecycle(a Application) {
 	var nullBuildpackLifecycle struct {
 		Type constant.AppLifecycleType `json:"type,omitempty"`
 		Data struct {
@@ -102,6 +105,7 @@ func (ccApp *ccApplication) setAutodetectedBuildpackLifecycle() {
 		} `json:"data"`
 	}
 	nullBuildpackLifecycle.Type = constant.AppLifecycleTypeBuildpack
+	nullBuildpackLifecycle.Data.Stack = a.StackName
 	ccApp.Lifecycle = nullBuildpackLifecycle
 }
 

--- a/api/cloudcontroller/ccv3/application_test.go
+++ b/api/cloudcontroller/ccv3/application_test.go
@@ -68,6 +68,16 @@ var _ = Describe("Application", func() {
 					It("omits the lifecycle from the JSON", func() {
 						Expect(string(appBytes)).To(MatchJSON("{}"))
 					})
+
+					When("but you do specify a stack", func() {
+						BeforeEach(func() {
+							app.StackName = "cflinuxfs9000"
+						})
+
+						It("does, in fact, send the stack in the json", func() {
+							Expect(string(appBytes)).To(MatchJSON(`{"lifecycle":{"data":{"stack":"cflinuxfs9000"},"type":"buildpack"}}`))
+						})
+					})
 				})
 
 				When("default buildpack is provided", func() {

--- a/command/v6/v3_zdt_push_command.go
+++ b/command/v6/v3_zdt_push_command.go
@@ -39,6 +39,7 @@ type V3ZeroDowntimeVersionActor interface {
 type V3ZeroDowntimePushCommand struct {
 	RequiredArgs        flag.AppName                `positional-args:"yes"`
 	Buildpacks          []string                    `short:"b" description:"Custom buildpack by name (e.g. my-buildpack) or Git URL (e.g. 'https://github.com/cloudfoundry/java-buildpack.git') or Git URL with a branch or tag (e.g. 'https://github.com/cloudfoundry/java-buildpack.git#v3.3.0' for 'v3.3.0' tag). To use built-in buildpacks only, specify 'default' or 'null'"`
+	StackName           string                      `short:"s" description:"Stack to use (a stack is a pre-built file system, including an operating system, that can run apps)"`
 	DockerImage         flag.DockerImage            `long:"docker-image" short:"o" description:"Docker image to use (e.g. user/docker-image-name)"`
 	DockerUsername      string                      `long:"docker-username" description:"Repository username; used with password from environment variable CF_DOCKER_PASSWORD"`
 	NoRoute             bool                        `long:"no-route" description:"Do not map a route to this app"`
@@ -265,6 +266,7 @@ func (cmd V3ZeroDowntimePushCommand) createApplication(userName string) (v3actio
 	} else {
 		appToCreate.LifecycleType = constant.AppLifecycleTypeBuildpack
 		appToCreate.LifecycleBuildpacks = cmd.Buildpacks
+		appToCreate.StackName = cmd.StackName
 	}
 
 	app, warnings, err := cmd.ZdtActor.CreateApplicationInSpace(
@@ -316,6 +318,7 @@ func (cmd V3ZeroDowntimePushCommand) updateApplication(userName string, appGUID 
 	} else {
 		appToUpdate.LifecycleType = constant.AppLifecycleTypeBuildpack
 		appToUpdate.LifecycleBuildpacks = cmd.Buildpacks
+		appToUpdate.StackName = cmd.StackName
 	}
 
 	app, warnings, err := cmd.ZdtActor.UpdateApplication(appToUpdate)

--- a/command/v6/v3_zdt_push_command_test.go
+++ b/command/v6/v3_zdt_push_command_test.go
@@ -871,6 +871,21 @@ var _ = Describe("v3-zdt-push Command", func() {
 					})
 				})
 
+				Context("when a stack was provided", func() {
+					BeforeEach(func() {
+						cmd.StackName = "cflinuxfs9000"
+					})
+
+					It("updates the stack", func() {
+						appArg := fakeZdtActor.UpdateApplicationArgsForCall(0)
+						Expect(appArg).To(Equal(v3action.Application{
+							GUID:          "some-app-guid",
+							LifecycleType: constant.AppLifecycleTypeBuildpack,
+							StackName:     "cflinuxfs9000",
+						}))
+					})
+				})
+
 				Context("when multiple buildpacks are provided", func() {
 					BeforeEach(func() {
 						cmd.Buildpacks = []string{"some-buildpack-1", "some-buildpack-2"}


### PR DESCRIPTION
[#161023897](https://www.pivotaltracker.com/story/show/161023897)

Thanks!
Tim and @cwlbraa 

<!--
## Requirements

* Your contribution will be analyzed for product fit and engineering quality prior to merging.
If your contribution includes a change that is exposed to cf CLI users (e.g. introducing a new command or flag), please submit an issue to discuss it first.
* We're not allowed to accept any PRs without a signed CLA, no matter how small.
If your contribution falls under a company CLA but your membership is not public, expect delays while we confirm.
* All new code requires tests to protect against regressions.
-->

## What Need Does It Address?

Upgrading stacks without downtime

## Who Is The Functionality For?

beta zdt users

## How Often Will This Functionality Be Used?

eventually, whenever folks need to update to cflinuxfs4

(and in a summit demo)

## Why Should This Be In Core?

one day zdt-push will be push.

## Description of the Change

We added a stack flag to the zdt-push command. We also needed to fix some json marshalling in the API layer so that an absence of buildpacks wouldn't prevent the stack from being set on the update request.

## How Urgent Is The Change?

planned for use in a summit demo next week, but a custom binary has already been built.

## Other Relevant Parties

@zrob @cwlbraa @dieucao 
