### PR TITLE
Update Gomega to latest sha

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -400,7 +400,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:9f7277d03f6ef663bef62532e3aa4aa81b027d5bcf104c05f1fe2a6885c99bbd"
+  digest = "1:c0e0ad5d6ef541568042ee873801372dd02042fe5a7701c8b62d9812deacadea"
   name = "github.com/onsi/gomega"
   packages = [
     ".",
@@ -422,7 +422,7 @@
     "types",
   ]
   pruneopts = "NUT"
-  revision = "cc102abc031d83b2c8294f7a0532a459abd63b1a"
+  revision = "9078de543588a442b7e49ae2e887db64812d77ce"
 
 [[projects]]
   digest = "1:e0cc8395ea893c898ff5eb0850f4d9851c1f57c78c232304a026379a47a552d0"

--- a/vendor/github.com/onsi/gomega/gbytes/say_matcher.go
+++ b/vendor/github.com/onsi/gomega/gbytes/say_matcher.go
@@ -36,12 +36,11 @@ In such cases, Say simply operates on the *gbytes.Buffer returned by Buffer()
 If the buffer is closed, the Say matcher will tell Eventually to abort.
 */
 func Say(expected string, args ...interface{}) *sayMatcher {
-	formattedRegexp := expected
 	if len(args) > 0 {
-		formattedRegexp = fmt.Sprintf(expected, args...)
+		expected = fmt.Sprintf(expected, args...)
 	}
 	return &sayMatcher{
-		re: regexp.MustCompile(formattedRegexp),
+		re: regexp.MustCompile(expected),
 	}
 }
 

--- a/vendor/github.com/onsi/gomega/ghttp/handlers.go
+++ b/vendor/github.com/onsi/gomega/ghttp/handlers.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"strings"
 
 	"github.com/golang/protobuf/proto"
 	. "github.com/onsi/gomega"
@@ -52,6 +53,14 @@ func VerifyRequest(method string, path interface{}, rawQuery ...string) http.Han
 func VerifyContentType(contentType string) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		Expect(req.Header.Get("Content-Type")).Should(Equal(contentType))
+	}
+}
+
+//VerifyMimeType returns a handler that verifies that a request has a specified mime type set
+//in Content-Type header
+func VerifyMimeType(mimeType string) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		Expect(strings.Split(req.Header.Get("Content-Type"), ";")[0]).Should(Equal(mimeType))
 	}
 }
 
@@ -109,7 +118,7 @@ func VerifyBody(expectedBody []byte) http.HandlerFunc {
 //VerifyJSON also verifies that the request's content type is application/json
 func VerifyJSON(expectedJSON string) http.HandlerFunc {
 	return CombineHandlers(
-		VerifyContentType("application/json"),
+		VerifyMimeType("application/json"),
 		func(w http.ResponseWriter, req *http.Request) {
 			body, err := ioutil.ReadAll(req.Body)
 			req.Body.Close()

--- a/vendor/github.com/onsi/gomega/ghttp/test_server.go
+++ b/vendor/github.com/onsi/gomega/ghttp/test_server.go
@@ -124,7 +124,7 @@ func new() *Server {
 	return &Server{
 		AllowUnhandledRequests:     false,
 		UnhandledRequestStatusCode: http.StatusInternalServerError,
-		writeLock:                  &sync.Mutex{},
+		rwMutex:                    &sync.RWMutex{},
 	}
 }
 
@@ -179,8 +179,8 @@ type Server struct {
 	requestHandlers  []http.HandlerFunc
 	routedHandlers   []routedHandler
 
-	writeLock *sync.Mutex
-	calls     int
+	rwMutex *sync.RWMutex
+	calls   int
 }
 
 //Start() starts an unstarted ghttp server.  It is a catastrophic error to call Start more than once (thanks, httptest).
@@ -190,20 +190,24 @@ func (s *Server) Start() {
 
 //URL() returns a url that will hit the server
 func (s *Server) URL() string {
+	s.rwMutex.RLock()
+	defer s.rwMutex.RUnlock()
 	return s.HTTPTestServer.URL
 }
 
 //Addr() returns the address on which the server is listening.
 func (s *Server) Addr() string {
+	s.rwMutex.RLock()
+	defer s.rwMutex.RUnlock()
 	return s.HTTPTestServer.Listener.Addr().String()
 }
 
 //Close() should be called at the end of each test.  It spins down and cleans up the test server.
 func (s *Server) Close() {
-	s.writeLock.Lock()
+	s.rwMutex.Lock()
 	server := s.HTTPTestServer
 	s.HTTPTestServer = nil
-	s.writeLock.Unlock()
+	s.rwMutex.Unlock()
 
 	if server != nil {
 		server.Close()
@@ -219,7 +223,7 @@ func (s *Server) Close() {
 //   a) If AllowUnhandledRequests is set to true, the request will be handled with response code of UnhandledRequestStatusCode
 //   b) If AllowUnhandledRequests is false, the request will not be handled and the current test will be marked as failed.
 func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	s.writeLock.Lock()
+	s.rwMutex.Lock()
 	defer func() {
 		e := recover()
 		if e != nil {
@@ -252,15 +256,15 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	s.receivedRequests = append(s.receivedRequests, req)
 	if routedHandler, ok := s.handlerForRoute(req.Method, req.URL.Path); ok {
-		s.writeLock.Unlock()
+		s.rwMutex.Unlock()
 		routedHandler(w, req)
 	} else if s.calls < len(s.requestHandlers) {
 		h := s.requestHandlers[s.calls]
 		s.calls++
-		s.writeLock.Unlock()
+		s.rwMutex.Unlock()
 		h(w, req)
 	} else {
-		s.writeLock.Unlock()
+		s.rwMutex.Unlock()
 		if s.GetAllowUnhandledRequests() {
 			ioutil.ReadAll(req.Body)
 			req.Body.Close()
@@ -275,8 +279,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 //ReceivedRequests is an array containing all requests received by the server (both handled and unhandled requests)
 func (s *Server) ReceivedRequests() []*http.Request {
-	s.writeLock.Lock()
-	defer s.writeLock.Unlock()
+	s.rwMutex.RLock()
+	defer s.rwMutex.RUnlock()
 
 	return s.receivedRequests
 }
@@ -286,8 +290,8 @@ func (s *Server) ReceivedRequests() []*http.Request {
 //
 //The path may be either a string object or a *regexp.Regexp.
 func (s *Server) RouteToHandler(method string, path interface{}, handler http.HandlerFunc) {
-	s.writeLock.Lock()
-	defer s.writeLock.Unlock()
+	s.rwMutex.Lock()
+	defer s.rwMutex.Unlock()
 
 	rh := routedHandler{
 		method:  method,
@@ -332,8 +336,8 @@ func (s *Server) handlerForRoute(method string, path string) (http.HandlerFunc, 
 
 //AppendHandlers will appends http.HandlerFuncs to the server's list of registered handlers.  The first incoming request is handled by the first handler, the second by the second, etc...
 func (s *Server) AppendHandlers(handlers ...http.HandlerFunc) {
-	s.writeLock.Lock()
-	defer s.writeLock.Unlock()
+	s.rwMutex.Lock()
+	defer s.rwMutex.Unlock()
 
 	s.requestHandlers = append(s.requestHandlers, handlers...)
 }
@@ -342,23 +346,23 @@ func (s *Server) AppendHandlers(handlers ...http.HandlerFunc) {
 //This is useful, for example, when a server has been set up in a shared context, but must be tweaked
 //for a particular test.
 func (s *Server) SetHandler(index int, handler http.HandlerFunc) {
-	s.writeLock.Lock()
-	defer s.writeLock.Unlock()
+	s.rwMutex.Lock()
+	defer s.rwMutex.Unlock()
 
 	s.requestHandlers[index] = handler
 }
 
 //GetHandler returns the handler registered at the passed in index.
 func (s *Server) GetHandler(index int) http.HandlerFunc {
-	s.writeLock.Lock()
-	defer s.writeLock.Unlock()
+	s.rwMutex.RLock()
+	defer s.rwMutex.RUnlock()
 
 	return s.requestHandlers[index]
 }
 
 func (s *Server) Reset() {
-	s.writeLock.Lock()
-	defer s.writeLock.Unlock()
+	s.rwMutex.Lock()
+	defer s.rwMutex.Unlock()
 
 	s.HTTPTestServer.CloseClientConnections()
 	s.calls = 0
@@ -379,40 +383,40 @@ func (s *Server) WrapHandler(index int, handler http.HandlerFunc) {
 }
 
 func (s *Server) CloseClientConnections() {
-	s.writeLock.Lock()
-	defer s.writeLock.Unlock()
+	s.rwMutex.Lock()
+	defer s.rwMutex.Unlock()
 
 	s.HTTPTestServer.CloseClientConnections()
 }
 
 //SetAllowUnhandledRequests enables the server to accept unhandled requests.
 func (s *Server) SetAllowUnhandledRequests(allowUnhandledRequests bool) {
-	s.writeLock.Lock()
-	defer s.writeLock.Unlock()
+	s.rwMutex.Lock()
+	defer s.rwMutex.Unlock()
 
 	s.AllowUnhandledRequests = allowUnhandledRequests
 }
 
 //GetAllowUnhandledRequests returns true if the server accepts unhandled requests.
 func (s *Server) GetAllowUnhandledRequests() bool {
-	s.writeLock.Lock()
-	defer s.writeLock.Unlock()
+	s.rwMutex.RLock()
+	defer s.rwMutex.RUnlock()
 
 	return s.AllowUnhandledRequests
 }
 
 //SetUnhandledRequestStatusCode status code to be returned when the server receives unhandled requests
 func (s *Server) SetUnhandledRequestStatusCode(statusCode int) {
-	s.writeLock.Lock()
-	defer s.writeLock.Unlock()
+	s.rwMutex.Lock()
+	defer s.rwMutex.Unlock()
 
 	s.UnhandledRequestStatusCode = statusCode
 }
 
 //GetUnhandledRequestStatusCode returns the current status code being returned for unhandled requests
 func (s *Server) GetUnhandledRequestStatusCode() int {
-	s.writeLock.Lock()
-	defer s.writeLock.Unlock()
+	s.rwMutex.RLock()
+	defer s.rwMutex.RUnlock()
 
 	return s.UnhandledRequestStatusCode
 }

--- a/vendor/github.com/onsi/gomega/gomega_dsl.go
+++ b/vendor/github.com/onsi/gomega/gomega_dsl.go
@@ -24,7 +24,7 @@ import (
 	"github.com/onsi/gomega/types"
 )
 
-const GOMEGA_VERSION = "1.4.0"
+const GOMEGA_VERSION = "1.4.2"
 
 const nilFailHandlerPanic = `You are trying to make an assertion, but Gomega's fail handler is nil.
 If you're using Ginkgo then you probably forgot to put your assertion in an It().
@@ -32,7 +32,7 @@ Alternatively, you may have forgotten to register a fail handler with RegisterFa
 Depending on your vendoring solution you may be inadvertently importing gomega and subpackages (e.g. ghhtp, gexec,...) from different locations.
 `
 
-var globalFailHandler types.GomegaFailHandler
+var globalFailWrapper *types.GomegaFailWrapper
 
 var defaultEventuallyTimeout = time.Second
 var defaultEventuallyPollingInterval = 10 * time.Millisecond
@@ -42,7 +42,14 @@ var defaultConsistentlyPollingInterval = 10 * time.Millisecond
 //RegisterFailHandler connects Ginkgo to Gomega.  When a matcher fails
 //the fail handler passed into RegisterFailHandler is called.
 func RegisterFailHandler(handler types.GomegaFailHandler) {
-	globalFailHandler = handler
+	if handler == nil {
+		globalFailWrapper = nil
+		return
+	}
+	globalFailWrapper = &types.GomegaFailWrapper{
+		Fail:        handler,
+		TWithHelper: testingtsupport.EmptyTWithHelper{},
+	}
 }
 
 //RegisterTestingT connects Gomega to Golang's XUnit style
@@ -52,12 +59,12 @@ func RegisterFailHandler(handler types.GomegaFailHandler) {
 //
 //You'll need to call this at the top of each XUnit style test:
 //
-// func TestFarmHasCow(t *testing.T) {
-//     RegisterTestingT(t)
+//    func TestFarmHasCow(t *testing.T) {
+//        RegisterTestingT(t)
 //
-//	   f := farm.New([]string{"Cow", "Horse"})
-//     Expect(f.HasCow()).To(BeTrue(), "Farm should have cow")
-// }
+//        f := farm.New([]string{"Cow", "Horse"})
+//        Expect(f.HasCow()).To(BeTrue(), "Farm should have cow")
+//    }
 //
 // Note that this *testing.T is registered *globally* by Gomega (this is why you don't have to
 // pass `t` down to the matcher itself).  This means that you cannot run the XUnit style tests
@@ -67,7 +74,7 @@ func RegisterFailHandler(handler types.GomegaFailHandler) {
 //
 // (As an aside: Ginkgo gets around this limitation by running parallel tests in different *processes*).
 func RegisterTestingT(t types.GomegaTestingT) {
-	RegisterFailHandler(testingtsupport.BuildTestingTGomegaFailHandler(t))
+	RegisterFailHandler(testingtsupport.BuildTestingTGomegaFailWrapper(t).Fail)
 }
 
 //InterceptGomegaHandlers runs a given callback and returns an array of
@@ -80,7 +87,7 @@ func RegisterTestingT(t types.GomegaTestingT) {
 //This is most useful when testing custom matchers, but can also be used to check
 //on a value using a Gomega assertion without causing a test failure.
 func InterceptGomegaFailures(f func()) []string {
-	originalHandler := globalFailHandler
+	originalHandler := globalFailWrapper.Fail
 	failures := []string{}
 	RegisterFailHandler(func(message string, callerSkip ...int) {
 		failures = append(failures, message)
@@ -91,7 +98,7 @@ func InterceptGomegaFailures(f func()) []string {
 }
 
 //Ω wraps an actual value allowing assertions to be made on it:
-//	Ω("foo").Should(Equal("foo"))
+//    Ω("foo").Should(Equal("foo"))
 //
 //If Ω is passed more than one argument it will pass the *first* argument to the matcher.
 //All subsequent arguments will be required to be nil/zero.
@@ -112,7 +119,7 @@ func Ω(actual interface{}, extra ...interface{}) GomegaAssertion {
 }
 
 //Expect wraps an actual value allowing assertions to be made on it:
-//	Expect("foo").To(Equal("foo"))
+//    Expect("foo").To(Equal("foo"))
 //
 //If Expect is passed more than one argument it will pass the *first* argument to the matcher.
 //All subsequent arguments will be required to be nil/zero.
@@ -142,10 +149,10 @@ func Expect(actual interface{}, extra ...interface{}) GomegaAssertion {
 //error message to refer to the calling line in the test (as opposed to the line in the helper function)
 //set the first argument of `ExpectWithOffset` appropriately.
 func ExpectWithOffset(offset int, actual interface{}, extra ...interface{}) GomegaAssertion {
-	if globalFailHandler == nil {
+	if globalFailWrapper == nil {
 		panic(nilFailHandlerPanic)
 	}
-	return assertion.New(actual, globalFailHandler, offset, extra...)
+	return assertion.New(actual, globalFailWrapper, offset, extra...)
 }
 
 //Eventually wraps an actual value allowing assertions to be made on it.
@@ -192,7 +199,7 @@ func Eventually(actual interface{}, intervals ...interface{}) GomegaAsyncAsserti
 //initial argument to indicate an offset in the call stack.  This is useful when building helper
 //functions that contain matchers.  To learn more, read about `ExpectWithOffset`.
 func EventuallyWithOffset(offset int, actual interface{}, intervals ...interface{}) GomegaAsyncAssertion {
-	if globalFailHandler == nil {
+	if globalFailWrapper == nil {
 		panic(nilFailHandlerPanic)
 	}
 	timeoutInterval := defaultEventuallyTimeout
@@ -203,7 +210,7 @@ func EventuallyWithOffset(offset int, actual interface{}, intervals ...interface
 	if len(intervals) > 1 {
 		pollingInterval = toDuration(intervals[1])
 	}
-	return asyncassertion.New(asyncassertion.AsyncAssertionTypeEventually, actual, globalFailHandler, timeoutInterval, pollingInterval, offset)
+	return asyncassertion.New(asyncassertion.AsyncAssertionTypeEventually, actual, globalFailWrapper, timeoutInterval, pollingInterval, offset)
 }
 
 //Consistently wraps an actual value allowing assertions to be made on it.
@@ -237,7 +244,7 @@ func Consistently(actual interface{}, intervals ...interface{}) GomegaAsyncAsser
 //initial argument to indicate an offset in the call stack.  This is useful when building helper
 //functions that contain matchers.  To learn more, read about `ExpectWithOffset`.
 func ConsistentlyWithOffset(offset int, actual interface{}, intervals ...interface{}) GomegaAsyncAssertion {
-	if globalFailHandler == nil {
+	if globalFailWrapper == nil {
 		panic(nilFailHandlerPanic)
 	}
 	timeoutInterval := defaultConsistentlyDuration
@@ -248,7 +255,7 @@ func ConsistentlyWithOffset(offset int, actual interface{}, intervals ...interfa
 	if len(intervals) > 1 {
 		pollingInterval = toDuration(intervals[1])
 	}
-	return asyncassertion.New(asyncassertion.AsyncAssertionTypeConsistently, actual, globalFailHandler, timeoutInterval, pollingInterval, offset)
+	return asyncassertion.New(asyncassertion.AsyncAssertionTypeConsistently, actual, globalFailWrapper, timeoutInterval, pollingInterval, offset)
 }
 
 //Set the default timeout duration for Eventually.  Eventually will repeatedly poll your condition until it succeeds, or until this timeout elapses.
@@ -326,12 +333,12 @@ type GomegaWithT struct {
 //NewGomegaWithT takes a *testing.T and returngs a `GomegaWithT` allowing you to use `Expect`, `Eventually`, and `Consistently` along with
 //Gomega's rich ecosystem of matchers in standard `testing` test suits.
 //
-// func TestFarmHasCow(t *testing.T) {
-//     g := GomegaWithT(t)
+//    func TestFarmHasCow(t *testing.T) {
+//        g := GomegaWithT(t)
 //
-//	   f := farm.New([]string{"Cow", "Horse"})
-//     g.Expect(f.HasCow()).To(BeTrue(), "Farm should have cow")
-// }
+//        f := farm.New([]string{"Cow", "Horse"})
+//        g.Expect(f.HasCow()).To(BeTrue(), "Farm should have cow")
+//     }
 func NewGomegaWithT(t types.GomegaTestingT) *GomegaWithT {
 	return &GomegaWithT{
 		t: t,
@@ -340,7 +347,7 @@ func NewGomegaWithT(t types.GomegaTestingT) *GomegaWithT {
 
 //See documentation for Expect
 func (g *GomegaWithT) Expect(actual interface{}, extra ...interface{}) GomegaAssertion {
-	return assertion.New(actual, testingtsupport.BuildTestingTGomegaFailHandler(g.t), 0, extra...)
+	return assertion.New(actual, testingtsupport.BuildTestingTGomegaFailWrapper(g.t), 0, extra...)
 }
 
 //See documentation for Eventually
@@ -353,7 +360,7 @@ func (g *GomegaWithT) Eventually(actual interface{}, intervals ...interface{}) G
 	if len(intervals) > 1 {
 		pollingInterval = toDuration(intervals[1])
 	}
-	return asyncassertion.New(asyncassertion.AsyncAssertionTypeEventually, actual, testingtsupport.BuildTestingTGomegaFailHandler(g.t), timeoutInterval, pollingInterval, 0)
+	return asyncassertion.New(asyncassertion.AsyncAssertionTypeEventually, actual, testingtsupport.BuildTestingTGomegaFailWrapper(g.t), timeoutInterval, pollingInterval, 0)
 }
 
 //See documentation for Consistently
@@ -366,7 +373,7 @@ func (g *GomegaWithT) Consistently(actual interface{}, intervals ...interface{})
 	if len(intervals) > 1 {
 		pollingInterval = toDuration(intervals[1])
 	}
-	return asyncassertion.New(asyncassertion.AsyncAssertionTypeConsistently, actual, testingtsupport.BuildTestingTGomegaFailHandler(g.t), timeoutInterval, pollingInterval, 0)
+	return asyncassertion.New(asyncassertion.AsyncAssertionTypeConsistently, actual, testingtsupport.BuildTestingTGomegaFailWrapper(g.t), timeoutInterval, pollingInterval, 0)
 }
 
 func toDuration(input interface{}) time.Duration {

--- a/vendor/github.com/onsi/gomega/gstruct/elements.go
+++ b/vendor/github.com/onsi/gomega/gstruct/elements.go
@@ -13,10 +13,14 @@ import (
 
 //MatchAllElements succeeds if every element of a slice matches the element matcher it maps to
 //through the id function, and every element matcher is matched.
-//  Expect([]string{"a", "b"}).To(MatchAllElements(idFn, matchers.Elements{
-//      "a": BeEqual("a"),
-//      "b": BeEqual("b"),
-//  })
+//    idFn := func(element interface{}) string {
+//        return fmt.Sprintf("%v", element)
+//    }
+//
+//    Expect([]string{"a", "b"}).To(MatchAllElements(idFn, Elements{
+//        "a": Equal("a"),
+//        "b": Equal("b"),
+//    }))
 func MatchAllElements(identifier Identifier, elements Elements) types.GomegaMatcher {
 	return &ElementsMatcher{
 		Identifier: identifier,
@@ -26,10 +30,20 @@ func MatchAllElements(identifier Identifier, elements Elements) types.GomegaMatc
 
 //MatchElements succeeds if each element of a slice matches the element matcher it maps to
 //through the id function. It can ignore extra elements and/or missing elements.
-//  Expect([]string{"a", "c"}).To(MatchElements(idFn, IgnoreMissing|IgnoreExtra, matchers.Elements{
-//      "a": BeEqual("a")
-//      "b": BeEqual("b"),
-//  })
+//    idFn := func(element interface{}) string {
+//        return fmt.Sprintf("%v", element)
+//    }
+//
+//    Expect([]string{"a", "b", "c"}).To(MatchElements(idFn, IgnoreExtras, Elements{
+//        "a": Equal("a"),
+//        "b": Equal("b"),
+//    }))
+//    Expect([]string{"a", "c"}).To(MatchElements(idFn, IgnoreMissing, Elements{
+//        "a": Equal("a"),
+//        "b": Equal("b"),
+//        "c": Equal("c"),
+//        "d": Equal("d"),
+//    }))
 func MatchElements(identifier Identifier, options Options, elements Elements) types.GomegaMatcher {
 	return &ElementsMatcher{
 		Identifier:      identifier,

--- a/vendor/github.com/onsi/gomega/gstruct/fields.go
+++ b/vendor/github.com/onsi/gomega/gstruct/fields.go
@@ -14,10 +14,21 @@ import (
 
 //MatchAllFields succeeds if every field of a struct matches the field matcher associated with
 //it, and every element matcher is matched.
-//  Expect([]string{"a", "b"}).To(MatchAllFields(gstruct.Fields{
-//      "a": BeEqual("a"),
-//      "b": BeEqual("b"),
-//  })
+//    actual := struct{
+//      A int
+//      B []bool
+//      C string
+//    }{
+//      A: 5,
+//      B: []bool{true, false},
+//      C: "foo",
+//    }
+//
+//    Expect(actual).To(MatchAllFields(Fields{
+//      "A": Equal(5),
+//      "B": ConsistOf(true, false),
+//      "C": Equal("foo"),
+//    }))
 func MatchAllFields(fields Fields) types.GomegaMatcher {
 	return &FieldsMatcher{
 		Fields: fields,
@@ -26,10 +37,26 @@ func MatchAllFields(fields Fields) types.GomegaMatcher {
 
 //MatchFields succeeds if each element of a struct matches the field matcher associated with
 //it. It can ignore extra fields and/or missing fields.
-//  Expect([]string{"a", "c"}).To(MatchFields(IgnoreMissing|IgnoreExtra, gstruct.Fields{
-//      "a": BeEqual("a")
-//      "b": BeEqual("b"),
-//  })
+//    actual := struct{
+//      A int
+//      B []bool
+//      C string
+//    }{
+//      A: 5,
+//      B: []bool{true, false},
+//      C: "foo",
+//    }
+//
+//    Expect(actual).To(MatchFields(IgnoreExtras, Fields{
+//      "A": Equal(5),
+//      "B": ConsistOf(true, false),
+//    }))
+//    Expect(actual).To(MatchFields(IgnoreMissing, Fields{
+//      "A": Equal(5),
+//      "B": ConsistOf(true, false),
+//      "C": Equal("foo"),
+//      "D": Equal("extra"),
+//    }))
 func MatchFields(options Options, fields Fields) types.GomegaMatcher {
 	return &FieldsMatcher{
 		Fields:        fields,

--- a/vendor/github.com/onsi/gomega/internal/asyncassertion/async_assertion.go
+++ b/vendor/github.com/onsi/gomega/internal/asyncassertion/async_assertion.go
@@ -22,11 +22,11 @@ type AsyncAssertion struct {
 	actualInput     interface{}
 	timeoutInterval time.Duration
 	pollingInterval time.Duration
-	fail            types.GomegaFailHandler
+	failWrapper     *types.GomegaFailWrapper
 	offset          int
 }
 
-func New(asyncType AsyncAssertionType, actualInput interface{}, fail types.GomegaFailHandler, timeoutInterval time.Duration, pollingInterval time.Duration, offset int) *AsyncAssertion {
+func New(asyncType AsyncAssertionType, actualInput interface{}, failWrapper *types.GomegaFailWrapper, timeoutInterval time.Duration, pollingInterval time.Duration, offset int) *AsyncAssertion {
 	actualType := reflect.TypeOf(actualInput)
 	if actualType.Kind() == reflect.Func {
 		if actualType.NumIn() != 0 || actualType.NumOut() == 0 {
@@ -37,7 +37,7 @@ func New(asyncType AsyncAssertionType, actualInput interface{}, fail types.Gomeg
 	return &AsyncAssertion{
 		asyncType:       asyncType,
 		actualInput:     actualInput,
-		fail:            fail,
+		failWrapper:     failWrapper,
 		timeoutInterval: timeoutInterval,
 		pollingInterval: pollingInterval,
 		offset:          offset,
@@ -45,10 +45,12 @@ func New(asyncType AsyncAssertionType, actualInput interface{}, fail types.Gomeg
 }
 
 func (assertion *AsyncAssertion) Should(matcher types.GomegaMatcher, optionalDescription ...interface{}) bool {
+	assertion.failWrapper.TWithHelper.Helper()
 	return assertion.match(matcher, true, optionalDescription...)
 }
 
 func (assertion *AsyncAssertion) ShouldNot(matcher types.GomegaMatcher, optionalDescription ...interface{}) bool {
+	assertion.failWrapper.TWithHelper.Helper()
 	return assertion.match(matcher, false, optionalDescription...)
 }
 
@@ -110,6 +112,8 @@ func (assertion *AsyncAssertion) match(matcher types.GomegaMatcher, desiredMatch
 		matches, err = matcher.Match(value)
 	}
 
+	assertion.failWrapper.TWithHelper.Helper()
+
 	fail := func(preamble string) {
 		errMsg := ""
 		message := ""
@@ -122,7 +126,8 @@ func (assertion *AsyncAssertion) match(matcher types.GomegaMatcher, desiredMatch
 				message = matcher.NegatedFailureMessage(value)
 			}
 		}
-		assertion.fail(fmt.Sprintf("%s after %.3fs.\n%s%s%s", preamble, time.Since(timer).Seconds(), description, message, errMsg), 3+assertion.offset)
+		assertion.failWrapper.TWithHelper.Helper()
+		assertion.failWrapper.Fail(fmt.Sprintf("%s after %.3fs.\n%s%s%s", preamble, time.Since(timer).Seconds(), description, message, errMsg), 3+assertion.offset)
 	}
 
 	if assertion.asyncType == AsyncAssertionTypeEventually {

--- a/vendor/github.com/onsi/gomega/internal/testingtsupport/testing_t_support.go
+++ b/vendor/github.com/onsi/gomega/internal/testingtsupport/testing_t_support.go
@@ -8,30 +8,50 @@ import (
 	"github.com/onsi/gomega/types"
 )
 
+var StackTracePruneRE = regexp.MustCompile(`\/gomega\/|\/ginkgo\/|\/pkg\/testing\/|\/pkg\/runtime\/`)
+
+type EmptyTWithHelper struct{}
+
+func (e EmptyTWithHelper) Helper() {}
+
 type gomegaTestingT interface {
 	Fatalf(format string, args ...interface{})
 }
 
-func BuildTestingTGomegaFailHandler(t gomegaTestingT) types.GomegaFailHandler {
-	return func(message string, callerSkip ...int) {
-		skip := 1
-		if len(callerSkip) > 0 {
-			skip = callerSkip[0]
+func BuildTestingTGomegaFailWrapper(t gomegaTestingT) *types.GomegaFailWrapper {
+	tWithHelper, hasHelper := t.(types.TWithHelper)
+	if !hasHelper {
+		tWithHelper = EmptyTWithHelper{}
+	}
+
+	fail := func(message string, callerSkip ...int) {
+		if hasHelper {
+			tWithHelper.Helper()
+			t.Fatalf("\n%s", message)
+		} else {
+			skip := 2
+			if len(callerSkip) > 0 {
+				skip += callerSkip[0]
+			}
+			stackTrace := pruneStack(string(debug.Stack()), skip)
+			t.Fatalf("\n%s\n%s\n", stackTrace, message)
 		}
-		stackTrace := pruneStack(string(debug.Stack()), skip)
-		t.Fatalf("\n%s\n%s", stackTrace, message)
+	}
+
+	return &types.GomegaFailWrapper{
+		Fail:        fail,
+		TWithHelper: tWithHelper,
 	}
 }
 
 func pruneStack(fullStackTrace string, skip int) string {
-	stack := strings.Split(fullStackTrace, "\n")
-	if len(stack) > 2*(skip+1) {
-		stack = stack[2*(skip+1):]
+	stack := strings.Split(fullStackTrace, "\n")[1:]
+	if len(stack) > 2*skip {
+		stack = stack[2*skip:]
 	}
 	prunedStack := []string{}
-	re := regexp.MustCompile(`\/ginkgo\/|\/pkg\/testing\/|\/pkg\/runtime\/`)
 	for i := 0; i < len(stack)/2; i++ {
-		if !re.Match([]byte(stack[i*2])) {
+		if !StackTracePruneRE.Match([]byte(stack[i*2])) {
 			prunedStack = append(prunedStack, stack[i*2])
 			prunedStack = append(prunedStack, stack[i*2+1])
 		}

--- a/vendor/github.com/onsi/gomega/matchers.go
+++ b/vendor/github.com/onsi/gomega/matchers.go
@@ -344,9 +344,9 @@ func BeTemporally(comparator string, compareTo time.Time, threshold ...time.Dura
 
 //BeAssignableToTypeOf succeeds if actual is assignable to the type of expected.
 //It will return an error when one of the values is nil.
-//	  Expect(0).Should(BeAssignableToTypeOf(0))         // Same values
-//	  Expect(5).Should(BeAssignableToTypeOf(-1))        // different values same type
-//	  Expect("foo").Should(BeAssignableToTypeOf("bar")) // different values same type
+//    Expect(0).Should(BeAssignableToTypeOf(0))         // Same values
+//    Expect(5).Should(BeAssignableToTypeOf(-1))        // different values same type
+//    Expect("foo").Should(BeAssignableToTypeOf("bar")) // different values same type
 //    Expect(struct{ Foo string }{}).Should(BeAssignableToTypeOf(struct{ Foo string }{}))
 func BeAssignableToTypeOf(expected interface{}) types.GomegaMatcher {
 	return &matchers.AssignableToTypeOfMatcher{

--- a/vendor/github.com/onsi/gomega/matchers/be_closed_matcher.go
+++ b/vendor/github.com/onsi/gomega/matchers/be_closed_matcher.go
@@ -23,8 +23,8 @@ func (matcher *BeClosedMatcher) Match(actual interface{}) (success bool, err err
 	}
 
 	winnerIndex, _, open := reflect.Select([]reflect.SelectCase{
-		reflect.SelectCase{Dir: reflect.SelectRecv, Chan: channelValue},
-		reflect.SelectCase{Dir: reflect.SelectDefault},
+		{Dir: reflect.SelectRecv, Chan: channelValue},
+		{Dir: reflect.SelectDefault},
 	})
 
 	var closed bool

--- a/vendor/github.com/onsi/gomega/matchers/be_numerically_matcher.go
+++ b/vendor/github.com/onsi/gomega/matchers/be_numerically_matcher.go
@@ -13,11 +13,23 @@ type BeNumericallyMatcher struct {
 }
 
 func (matcher *BeNumericallyMatcher) FailureMessage(actual interface{}) (message string) {
-	return format.Message(actual, fmt.Sprintf("to be %s", matcher.Comparator), matcher.CompareTo[0])
+	return matcher.FormatFailureMessage(actual, false)
 }
 
 func (matcher *BeNumericallyMatcher) NegatedFailureMessage(actual interface{}) (message string) {
-	return format.Message(actual, fmt.Sprintf("not to be %s", matcher.Comparator), matcher.CompareTo[0])
+	return matcher.FormatFailureMessage(actual, true)
+}
+
+func (matcher *BeNumericallyMatcher) FormatFailureMessage(actual interface{}, negated bool) (message string) {
+	if len(matcher.CompareTo) == 1 {
+		message = fmt.Sprintf("to be %s", matcher.Comparator)
+	} else {
+		message = fmt.Sprintf("to be within %v of %s", matcher.CompareTo[1], matcher.Comparator)
+	}
+	if negated {
+		message = "not " + message
+	}
+	return format.Message(actual, message, matcher.CompareTo[0])
 }
 
 func (matcher *BeNumericallyMatcher) Match(actual interface{}) (success bool, err error) {

--- a/vendor/github.com/onsi/gomega/matchers/be_sent_matcher.go
+++ b/vendor/github.com/onsi/gomega/matchers/be_sent_matcher.go
@@ -42,8 +42,8 @@ func (matcher *BeSentMatcher) Match(actual interface{}) (success bool, err error
 	}()
 
 	winnerIndex, _, _ := reflect.Select([]reflect.SelectCase{
-		reflect.SelectCase{Dir: reflect.SelectSend, Chan: channelValue, Send: argValue},
-		reflect.SelectCase{Dir: reflect.SelectDefault},
+		{Dir: reflect.SelectSend, Chan: channelValue, Send: argValue},
+		{Dir: reflect.SelectDefault},
 	})
 
 	var didSend bool

--- a/vendor/github.com/onsi/gomega/matchers/match_json_matcher.go
+++ b/vendor/github.com/onsi/gomega/matchers/match_json_matcher.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"reflect"
-	"strings"
 
 	"github.com/onsi/gomega/format"
 )
@@ -42,32 +40,6 @@ func (matcher *MatchJSONMatcher) NegatedFailureMessage(actual interface{}) (mess
 	return formattedMessage(format.Message(actualString, "not to match JSON of", expectedString), matcher.firstFailurePath)
 }
 
-func formattedMessage(comparisonMessage string, failurePath []interface{}) string {
-	var diffMessage string
-	if len(failurePath) == 0 {
-		diffMessage = ""
-	} else {
-		diffMessage = fmt.Sprintf("\n\nfirst mismatched key: %s", formattedFailurePath(failurePath))
-	}
-	return fmt.Sprintf("%s%s", comparisonMessage, diffMessage)
-}
-
-func formattedFailurePath(failurePath []interface{}) string {
-	formattedPaths := []string{}
-	for i := len(failurePath) - 1; i >= 0; i-- {
-		switch p := failurePath[i].(type) {
-		case int:
-			formattedPaths = append(formattedPaths, fmt.Sprintf(`[%d]`, p))
-		default:
-			if i != len(failurePath)-1 {
-				formattedPaths = append(formattedPaths, ".")
-			}
-			formattedPaths = append(formattedPaths, fmt.Sprintf(`"%s"`, p))
-		}
-	}
-	return strings.Join(formattedPaths, "")
-}
-
 func (matcher *MatchJSONMatcher) prettyPrint(actual interface{}) (actualFormatted, expectedFormatted string, err error) {
 	actualString, ok := toString(actual)
 	if !ok {
@@ -90,46 +62,4 @@ func (matcher *MatchJSONMatcher) prettyPrint(actual interface{}) (actualFormatte
 	}
 
 	return abuf.String(), ebuf.String(), nil
-}
-
-func deepEqual(a interface{}, b interface{}) (bool, []interface{}) {
-	var errorPath []interface{}
-	if reflect.TypeOf(a) != reflect.TypeOf(b) {
-		return false, errorPath
-	}
-
-	switch a.(type) {
-	case []interface{}:
-		if len(a.([]interface{})) != len(b.([]interface{})) {
-			return false, errorPath
-		}
-
-		for i, v := range a.([]interface{}) {
-			elementEqual, keyPath := deepEqual(v, b.([]interface{})[i])
-			if !elementEqual {
-				return false, append(keyPath, i)
-			}
-		}
-		return true, errorPath
-
-	case map[string]interface{}:
-		if len(a.(map[string]interface{})) != len(b.(map[string]interface{})) {
-			return false, errorPath
-		}
-
-		for k, v1 := range a.(map[string]interface{}) {
-			v2, ok := b.(map[string]interface{})[k]
-			if !ok {
-				return false, errorPath
-			}
-			elementEqual, keyPath := deepEqual(v1, v2)
-			if !elementEqual {
-				return false, append(keyPath, k)
-			}
-		}
-		return true, errorPath
-
-	default:
-		return a == b, errorPath
-	}
 }

--- a/vendor/github.com/onsi/gomega/matchers/match_yaml_matcher.go
+++ b/vendor/github.com/onsi/gomega/matchers/match_yaml_matcher.go
@@ -2,7 +2,6 @@ package matchers
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 
 	"github.com/onsi/gomega/format"
@@ -10,7 +9,8 @@ import (
 )
 
 type MatchYAMLMatcher struct {
-	YAMLToMatch interface{}
+	YAMLToMatch      interface{}
+	firstFailurePath []interface{}
 }
 
 func (matcher *MatchYAMLMatcher) Match(actual interface{}) (success bool, err error) {
@@ -29,17 +29,19 @@ func (matcher *MatchYAMLMatcher) Match(actual interface{}) (success bool, err er
 		return false, fmt.Errorf("Expected '%s' should be valid YAML, but it is not.\nUnderlying error:%s", expectedString, err)
 	}
 
-	return reflect.DeepEqual(aval, eval), nil
+	var equal bool
+	equal, matcher.firstFailurePath = deepEqual(aval, eval)
+	return equal, nil
 }
 
 func (matcher *MatchYAMLMatcher) FailureMessage(actual interface{}) (message string) {
 	actualString, expectedString, _ := matcher.toNormalisedStrings(actual)
-	return format.Message(actualString, "to match YAML of", expectedString)
+	return formattedMessage(format.Message(actualString, "to match YAML of", expectedString), matcher.firstFailurePath)
 }
 
 func (matcher *MatchYAMLMatcher) NegatedFailureMessage(actual interface{}) (message string) {
 	actualString, expectedString, _ := matcher.toNormalisedStrings(actual)
-	return format.Message(actualString, "not to match YAML of", expectedString)
+	return formattedMessage(format.Message(actualString, "not to match YAML of", expectedString), matcher.firstFailurePath)
 }
 
 func (matcher *MatchYAMLMatcher) toNormalisedStrings(actual interface{}) (actualFormatted, expectedFormatted string, err error) {

--- a/vendor/github.com/onsi/gomega/matchers/receive_matcher.go
+++ b/vendor/github.com/onsi/gomega/matchers/receive_matcher.go
@@ -35,17 +35,12 @@ func (matcher *ReceiveMatcher) Match(actual interface{}) (success bool, err erro
 			if argType.Kind() != reflect.Ptr {
 				return false, fmt.Errorf("Cannot assign a value from the channel:\n%s\nTo:\n%s\nYou need to pass a pointer!", format.Object(actual, 1), format.Object(matcher.Arg, 1))
 			}
-
-			assignable := channelType.Elem().AssignableTo(argType.Elem())
-			if !assignable {
-				return false, fmt.Errorf("Cannot assign a value from the channel:\n%s\nTo:\n%s", format.Object(actual, 1), format.Object(matcher.Arg, 1))
-			}
 		}
 	}
 
 	winnerIndex, value, open := reflect.Select([]reflect.SelectCase{
-		reflect.SelectCase{Dir: reflect.SelectRecv, Chan: channelValue},
-		reflect.SelectCase{Dir: reflect.SelectDefault},
+		{Dir: reflect.SelectRecv, Chan: channelValue},
+		{Dir: reflect.SelectDefault},
 	})
 
 	var closed bool
@@ -71,7 +66,18 @@ func (matcher *ReceiveMatcher) Match(actual interface{}) (success bool, err erro
 	if didReceive {
 		if matcher.Arg != nil {
 			outValue := reflect.ValueOf(matcher.Arg)
-			reflect.Indirect(outValue).Set(value)
+
+			if value.Type().AssignableTo(outValue.Elem().Type()) {
+				outValue.Elem().Set(value)
+				return true, nil
+			}
+			if value.Type().Kind() == reflect.Interface && value.Elem().Type().AssignableTo(outValue.Elem().Type()) {
+				outValue.Elem().Set(value.Elem())
+				return true, nil
+			} else {
+				return false, fmt.Errorf("Cannot assign a value from the channel:\n%s\nType:\n%s\nTo:\n%s", format.Object(actual, 1), format.Object(value.Interface(), 1), format.Object(matcher.Arg, 1))
+			}
+
 		}
 
 		return true, nil

--- a/vendor/github.com/onsi/gomega/matchers/semi_structured_data_support.go
+++ b/vendor/github.com/onsi/gomega/matchers/semi_structured_data_support.go
@@ -1,0 +1,92 @@
+package matchers
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+func formattedMessage(comparisonMessage string, failurePath []interface{}) string {
+	var diffMessage string
+	if len(failurePath) == 0 {
+		diffMessage = ""
+	} else {
+		diffMessage = fmt.Sprintf("\n\nfirst mismatched key: %s", formattedFailurePath(failurePath))
+	}
+	return fmt.Sprintf("%s%s", comparisonMessage, diffMessage)
+}
+
+func formattedFailurePath(failurePath []interface{}) string {
+	formattedPaths := []string{}
+	for i := len(failurePath) - 1; i >= 0; i-- {
+		switch p := failurePath[i].(type) {
+		case int:
+			formattedPaths = append(formattedPaths, fmt.Sprintf(`[%d]`, p))
+		default:
+			if i != len(failurePath)-1 {
+				formattedPaths = append(formattedPaths, ".")
+			}
+			formattedPaths = append(formattedPaths, fmt.Sprintf(`"%s"`, p))
+		}
+	}
+	return strings.Join(formattedPaths, "")
+}
+
+func deepEqual(a interface{}, b interface{}) (bool, []interface{}) {
+	var errorPath []interface{}
+	if reflect.TypeOf(a) != reflect.TypeOf(b) {
+		return false, errorPath
+	}
+
+	switch a.(type) {
+	case []interface{}:
+		if len(a.([]interface{})) != len(b.([]interface{})) {
+			return false, errorPath
+		}
+
+		for i, v := range a.([]interface{}) {
+			elementEqual, keyPath := deepEqual(v, b.([]interface{})[i])
+			if !elementEqual {
+				return false, append(keyPath, i)
+			}
+		}
+		return true, errorPath
+
+	case map[interface{}]interface{}:
+		if len(a.(map[interface{}]interface{})) != len(b.(map[interface{}]interface{})) {
+			return false, errorPath
+		}
+
+		for k, v1 := range a.(map[interface{}]interface{}) {
+			v2, ok := b.(map[interface{}]interface{})[k]
+			if !ok {
+				return false, errorPath
+			}
+			elementEqual, keyPath := deepEqual(v1, v2)
+			if !elementEqual {
+				return false, append(keyPath, k)
+			}
+		}
+		return true, errorPath
+
+	case map[string]interface{}:
+		if len(a.(map[string]interface{})) != len(b.(map[string]interface{})) {
+			return false, errorPath
+		}
+
+		for k, v1 := range a.(map[string]interface{}) {
+			v2, ok := b.(map[string]interface{})[k]
+			if !ok {
+				return false, errorPath
+			}
+			elementEqual, keyPath := deepEqual(v1, v2)
+			if !elementEqual {
+				return false, append(keyPath, k)
+			}
+		}
+		return true, errorPath
+
+	default:
+		return a == b, errorPath
+	}
+}

--- a/vendor/github.com/onsi/gomega/matchers/support/goraph/bipartitegraph/bipartitegraph.go
+++ b/vendor/github.com/onsi/gomega/matchers/support/goraph/bipartitegraph/bipartitegraph.go
@@ -14,12 +14,12 @@ type BipartiteGraph struct {
 
 func NewBipartiteGraph(leftValues, rightValues []interface{}, neighbours func(interface{}, interface{}) (bool, error)) (*BipartiteGraph, error) {
 	left := NodeOrderedSet{}
-	for i, _ := range leftValues {
+	for i := range leftValues {
 		left = append(left, Node{Id: i})
 	}
 
 	right := NodeOrderedSet{}
-	for j, _ := range rightValues {
+	for j := range rightValues {
 		right = append(right, Node{Id: j + len(left)})
 	}
 

--- a/vendor/github.com/onsi/gomega/matchers/type_support.go
+++ b/vendor/github.com/onsi/gomega/matchers/type_support.go
@@ -9,6 +9,7 @@ http://onsi.github.io/gomega/
 package matchers
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 )
@@ -131,6 +132,11 @@ func toString(a interface{}) (string, bool) {
 	aStringer, isStringer := a.(fmt.Stringer)
 	if isStringer {
 		return aStringer.String(), true
+	}
+
+	aJSONRawMessage, isJSONRawMessage := a.(json.RawMessage)
+	if isJSONRawMessage {
+		return string(aJSONRawMessage), true
 	}
 
 	return "", false

--- a/vendor/github.com/onsi/gomega/types/types.go
+++ b/vendor/github.com/onsi/gomega/types/types.go
@@ -1,6 +1,15 @@
 package types
 
+type TWithHelper interface {
+	Helper()
+}
+
 type GomegaFailHandler func(message string, callerSkip ...int)
+
+type GomegaFailWrapper struct {
+	Fail        GomegaFailHandler
+	TWithHelper TWithHelper
+}
 
 //A simple *testing.T interface wrapper
 type GomegaTestingT interface {


### PR DESCRIPTION
In recent Go releases, go test is internally calling go vet and the
version of Gomega currently used in the CLI fails vetting on gbytes.Say
matchers that contain `%` characters.

This is the PR that fixes it in Gomega: https://github.com/onsi/gomega/pull/300

Signed-off-by: William Martin <wmartin@pivotal.io>
Co-authored-by: William Martin <wmartin@pivotal.io>
