### PR TITLE
Handle ServiceBrokerCatalogInvalid errors in CLI

### DIFF
--- a/api/cloudcontroller/ccerror/service_broker_catalog_invalid_error.go
+++ b/api/cloudcontroller/ccerror/service_broker_catalog_invalid_error.go
@@ -1,0 +1,9 @@
+package ccerror
+
+type ServiceBrokerCatalogInvalidError struct {
+	Message string
+}
+
+func (e ServiceBrokerCatalogInvalidError) Error() string {
+	return e.Message
+}


### PR DESCRIPTION
Handle invalid service broker catalog 502 errors and present them as known CLI errors. (For all other HTTP 502 errors, we continue to present a V2UnexpectedError.)

This change improves error presentation when CC returns a 502 due to an invalid service broker catalog. Without this change, in the refactored code we would be returning a V2UnexpectedError, which prints to the screen as a whole lot of JSON - instead, we want to display a better-formatted error. For more context, please see @mattmcneeney's comment [here](https://www.pivotaltracker.com/story/show/160751304/comments/196480234).

https://www.pivotaltracker.com/story/show/160751304

cc @georgi-lozev @ablease 