### PR TITLE
Fix for CF cli not displaying route service url on "cf service"

### DIFF
--- a/api/cloudcontroller/ccv2/service_instance.go
+++ b/api/cloudcontroller/ccv2/service_instance.go
@@ -37,6 +37,10 @@ type ServiceInstance struct {
 	// features of the service instance.
 	DashboardURL string
 
+	// RouteServiceURL is the URL of the user-provided service to which requests
+	// for bound routes will be forwarded.
+	RouteServiceURL string
+
 	// LastOperation is the status of the last operation requested on the service
 	// instance.
 	LastOperation LastOperation
@@ -59,6 +63,7 @@ func (serviceInstance *ServiceInstance) UnmarshalJSON(data []byte) error {
 			Type            string        `json:"type"`
 			Tags            []string      `json:"tags"`
 			DashboardURL    string        `json:"dashboard_url"`
+			RouteServiceURL string        `json:"route_service_url"`
 			LastOperation   LastOperation `json:"last_operation"`
 		}
 	}
@@ -75,6 +80,7 @@ func (serviceInstance *ServiceInstance) UnmarshalJSON(data []byte) error {
 	serviceInstance.Type = constant.ServiceInstanceType(ccServiceInstance.Entity.Type)
 	serviceInstance.Tags = ccServiceInstance.Entity.Tags
 	serviceInstance.DashboardURL = ccServiceInstance.Entity.DashboardURL
+	serviceInstance.RouteServiceURL = ccServiceInstance.Entity.RouteServiceURL
 	serviceInstance.LastOperation = ccServiceInstance.Entity.LastOperation
 	return nil
 }

--- a/api/cloudcontroller/ccv2/service_instance_test.go
+++ b/api/cloudcontroller/ccv2/service_instance_test.go
@@ -138,6 +138,7 @@ var _ = Describe("Service Instance", func() {
 						"tag-2"
 					],
 					"dashboard_url": "some-dashboard-url",
+					"route_service_url": "some-route-service-url",
 					"last_operation": {
 						"type": "create",
 						"state": "succeeded",
@@ -170,6 +171,7 @@ var _ = Describe("Service Instance", func() {
 					Type:            constant.ServiceInstanceTypeManagedService,
 					Tags:            []string{"tag-1", "tag-2"},
 					DashboardURL:    "some-dashboard-url",
+					RouteServiceURL: "some-route-service-url",
 					LastOperation: LastOperation{
 						Type:        "create",
 						State:       "succeeded",
@@ -195,7 +197,7 @@ var _ = Describe("Service Instance", func() {
 						"entity": {
 							"name": "some-service-name-1",
 							"space_guid": "some-space-guid",
-					"service_guid": "some-service-guid",
+							"service_guid": "some-service-guid",
 							"type": "managed_service_instance"
 						}
 					},
@@ -495,6 +497,7 @@ var _ = Describe("Service Instance", func() {
 						},
 						"entity": {
 							"name": "some-service-name-1",
+							"route_service_url": "some-route-service-url",
 							"space_guid": "some-space-guid",
 							"type": "user_provided_service_instance"
 						}
@@ -505,6 +508,7 @@ var _ = Describe("Service Instance", func() {
 						},
 						"entity": {
 							"name": "some-service-name-2",
+							"route_service_url": "some-route-service-url",
 							"space_guid": "some-space-guid",
 							"type": "user_provided_service_instance"
 						}
@@ -521,6 +525,7 @@ var _ = Describe("Service Instance", func() {
 						},
 						"entity": {
 							"name": "some-service-name-3",
+							"route_service_url": "some-route-service-url",
 							"space_guid": "some-space-guid",
 							"type": "user_provided_service_instance"
 						}
@@ -531,6 +536,7 @@ var _ = Describe("Service Instance", func() {
 						},
 						"entity": {
 							"name": "some-service-name-4",
+							"route_service_url": "some-route-service-url",
 							"space_guid": "some-space-guid",
 							"type": "user_provided_service_instance"
 						}
@@ -558,28 +564,32 @@ var _ = Describe("Service Instance", func() {
 
 				Expect(serviceInstances).To(ConsistOf([]ServiceInstance{
 					{
-						Name:      "some-service-name-1",
-						GUID:      "some-service-guid-1",
-						SpaceGUID: "some-space-guid",
-						Type:      constant.ServiceInstanceTypeUserProvidedService,
+						Name:            "some-service-name-1",
+						GUID:            "some-service-guid-1",
+						SpaceGUID:       "some-space-guid",
+						RouteServiceURL: "some-route-service-url",
+						Type:            constant.ServiceInstanceTypeUserProvidedService,
 					},
 					{
-						Name:      "some-service-name-2",
-						GUID:      "some-service-guid-2",
-						SpaceGUID: "some-space-guid",
-						Type:      constant.ServiceInstanceTypeUserProvidedService,
+						Name:            "some-service-name-2",
+						GUID:            "some-service-guid-2",
+						SpaceGUID:       "some-space-guid",
+						RouteServiceURL: "some-route-service-url",
+						Type:            constant.ServiceInstanceTypeUserProvidedService,
 					},
 					{
-						Name:      "some-service-name-3",
-						GUID:      "some-service-guid-3",
-						SpaceGUID: "some-space-guid",
-						Type:      constant.ServiceInstanceTypeUserProvidedService,
+						Name:            "some-service-name-3",
+						GUID:            "some-service-guid-3",
+						SpaceGUID:       "some-space-guid",
+						RouteServiceURL: "some-route-service-url",
+						Type:            constant.ServiceInstanceTypeUserProvidedService,
 					},
 					{
-						Name:      "some-service-name-4",
-						GUID:      "some-service-guid-4",
-						SpaceGUID: "some-space-guid",
-						Type:      constant.ServiceInstanceTypeUserProvidedService,
+						Name:            "some-service-name-4",
+						GUID:            "some-service-guid-4",
+						SpaceGUID:       "some-space-guid",
+						RouteServiceURL: "some-route-service-url",
+						Type:            constant.ServiceInstanceTypeUserProvidedService,
 					},
 				}))
 

--- a/command/v6/service_command.go
+++ b/command/v6/service_command.go
@@ -183,8 +183,10 @@ func (cmd ServiceCommand) displayUserProvidedServiceInstanceSummary(serviceInsta
 	table := [][]string{
 		{cmd.UI.TranslateText("name:"), serviceInstanceSummary.Name},
 		{cmd.UI.TranslateText("service:"), cmd.UI.TranslateText("user-provided")},
-		{cmd.UI.TranslateText("route service url:"), serviceInstanceSummary.RouteServiceURL},
 		{cmd.UI.TranslateText("tags:"), strings.Join(serviceInstanceSummary.Tags, ", ")},
+	}
+	if serviceInstanceSummary.RouteServiceURL != "" {
+		table = append(table, []string{cmd.UI.TranslateText("route service url:"), serviceInstanceSummary.RouteServiceURL})
 	}
 	cmd.UI.DisplayKeyValueTable("", table, 3)
 }

--- a/command/v6/service_command.go
+++ b/command/v6/service_command.go
@@ -183,6 +183,7 @@ func (cmd ServiceCommand) displayUserProvidedServiceInstanceSummary(serviceInsta
 	table := [][]string{
 		{cmd.UI.TranslateText("name:"), serviceInstanceSummary.Name},
 		{cmd.UI.TranslateText("service:"), cmd.UI.TranslateText("user-provided")},
+		{cmd.UI.TranslateText("route service url:"), serviceInstanceSummary.RouteServiceURL},
 		{cmd.UI.TranslateText("tags:"), strings.Join(serviceInstanceSummary.Tags, ", ")},
 	}
 	cmd.UI.DisplayKeyValueTable("", table, 3)

--- a/command/v6/service_command_test.go
+++ b/command/v6/service_command_test.go
@@ -873,6 +873,28 @@ var _ = Describe("service Command", func() {
 								Expect(testUI.Out).To(Say(`tags:\s+tag-1, tag-2, tag-3`))
 							})
 						})
+
+						When("the service instance has route service url", func() {
+							BeforeEach(func() {
+								fakeActor.GetServiceInstanceSummaryByNameAndSpaceReturns(
+									v2action.ServiceInstanceSummary{
+										ServiceInstance: v2action.ServiceInstance{
+											Name:            "some-service-instance",
+											Type:            constant.ServiceInstanceTypeUserProvidedService,
+											RouteServiceURL: "some-route-service-url",
+										},
+									},
+									v2action.Warnings{"get-service-instance-summary-warning-1", "get-service-instance-summary-warning-2"},
+									nil,
+								)
+							})
+
+							It("displays the route service url", func() {
+								Expect(executeErr).ToNot(HaveOccurred())
+
+								Expect(testUI.Out).To(Say(`route service url:\s+some-route-service-url`))
+							})
+						})
 					})
 				})
 			})


### PR DESCRIPTION
## Does this PR modify CLI v6 or v7?
CLI v6

## What Need Does It Address?
This can be used to debug issues or view the service route URL of a user created service.
Example: "cf cups test_service -r https://<url>". This URL should be shown for that service's detail "cf service test_service"

## Who Is The Functionality For?
This will be to address the bug issued here: https://github.com/cloudfoundry/cli/issues/1506

## How Often Will This Functionality Be Used?
This will be used specifically for "cf service" on user provided services. If routes are not present then the display will show the field, but no results (similar to tags).

## Possible Drawbacks
No potential drawbacks, other than extra clutter to display the URL.

## Why Should This Be In Core?
This should a basic functionality of the service information summary. Otherwise, the end user would be using "cf service <name> -v" to find an essential component of service use.

## Description of the Change
As indicated in the initial Github issue, the Route service URL property was being returned from the cloud controller to the CLI. This commit just exposes the detail for user provided service summaries.

## Alternate Designs
For this addition to the view, due to simplicity, no alternatives were considered.

## Applicable Issues
None.

## How Urgent Is The Change?
Not urgent, as there is a work around to use "cf service <name> -v"

## Other Relevant Parties
None.
