### PR TITLE
Add broker name column in `cf marketplace`

### DIFF
--- a/api/cloudcontroller/ccv2/service.go
+++ b/api/cloudcontroller/ccv2/service.go
@@ -19,6 +19,8 @@ type Service struct {
 	// DocumentationURL is a url that points to a documentation page for the
 	// service.
 	DocumentationURL string
+	// ServiceBrokerName is the name of the broker providing this service.
+	ServiceBrokerName string
 	// Extra is a field with extra data pertaining to the service.
 	Extra ServiceExtra
 }
@@ -28,10 +30,11 @@ func (service *Service) UnmarshalJSON(data []byte) error {
 	var ccService struct {
 		Metadata internal.Metadata
 		Entity   struct {
-			Label            string `json:"label"`
-			Description      string `json:"description"`
-			DocumentationURL string `json:"documentation_url"`
-			Extra            string `json:"extra"`
+			Label             string `json:"label"`
+			Description       string `json:"description"`
+			DocumentationURL  string `json:"documentation_url"`
+			ServiceBrokerName string `json:"service_broker_name"`
+			Extra             string `json:"extra"`
 		}
 	}
 
@@ -44,6 +47,7 @@ func (service *Service) UnmarshalJSON(data []byte) error {
 	service.Label = ccService.Entity.Label
 	service.Description = ccService.Entity.Description
 	service.DocumentationURL = ccService.Entity.DocumentationURL
+	service.ServiceBrokerName = ccService.Entity.ServiceBrokerName
 
 	// We explicitly unmarshal the Extra field to type string because CC returns
 	// a stringified JSON object ONLY for the 'extra' key (see test stub JSON

--- a/api/cloudcontroller/ccv2/service_test.go
+++ b/api/cloudcontroller/ccv2/service_test.go
@@ -278,7 +278,8 @@ var _ = Describe("Service", func() {
 								"guid": "some-service-guid-1"
 							},
 							"entity": {
-								"label": "some-service"
+								"label": "some-service",
+								"service_broker_name": "broker-1"
 							}
 						},
 						{
@@ -286,7 +287,8 @@ var _ = Describe("Service", func() {
 								"guid": "some-service-guid-2"
 							},
 							"entity": {
-								"label": "other-service"
+								"label": "other-service",
+								"service_broker_name": "broker-2"
 							}
 						}
 					]
@@ -300,7 +302,8 @@ var _ = Describe("Service", func() {
 								"guid": "some-service-guid-3"
 							},
 							"entity": {
-								"label": "some-service"
+								"label": "some-service",
+								"service_broker_name": "broker-3"
 							}
 						},
 						{
@@ -308,7 +311,8 @@ var _ = Describe("Service", func() {
 								"guid": "some-service-guid-4"
 							},
 							"entity": {
-								"label": "other-service"
+								"label": "other-service",
+								"service_broker_name": "broker-4"
 							}
 						}
 					]
@@ -331,10 +335,10 @@ var _ = Describe("Service", func() {
 			It("returns all the queried services", func() {
 				Expect(executeErr).NotTo(HaveOccurred())
 				Expect(services).To(ConsistOf([]Service{
-					{GUID: "some-service-guid-1", Label: "some-service"},
-					{GUID: "some-service-guid-2", Label: "other-service"},
-					{GUID: "some-service-guid-3", Label: "some-service"},
-					{GUID: "some-service-guid-4", Label: "other-service"},
+					{GUID: "some-service-guid-1", Label: "some-service", ServiceBrokerName: "broker-1"},
+					{GUID: "some-service-guid-2", Label: "other-service", ServiceBrokerName: "broker-2"},
+					{GUID: "some-service-guid-3", Label: "some-service", ServiceBrokerName: "broker-3"},
+					{GUID: "some-service-guid-4", Label: "other-service", ServiceBrokerName: "broker-4"},
 				}))
 				Expect(warnings).To(ConsistOf(Warnings{"this is a warning", "this is another warning"}))
 			})

--- a/api/cloudcontroller/ccversion/minimum_version.go
+++ b/api/cloudcontroller/ccversion/minimum_version.go
@@ -13,6 +13,7 @@ const (
 	MinVersionUserProvidedServiceTagsV2      = "2.104.0"
 	MinVersionZeroAppInstancesV2             = "2.70.0"
 	MinVersionInternalDomainV2               = "2.115.0"
+	MinVersionServiceBrokerNameV2            = "2.125.0"
 
 	MinVersionApplicationFlowV3    = "3.27.0"
 	MinVersionIsolationSegmentV3   = "3.11.0"

--- a/command/v6/marketplace_command.go
+++ b/command/v6/marketplace_command.go
@@ -150,13 +150,14 @@ func (cmd *MarketplaceCommand) displayServiceSummaries(serviceSummaries []v2acti
 	if len(serviceSummaries) == 0 {
 		cmd.UI.DisplayText("No service offerings found")
 	} else {
-		tableHeaders := []string{"service", "plans", "description"}
+		tableHeaders := []string{"service", "plans", "description", "broker"}
 		table := [][]string{tableHeaders}
 		for _, serviceSummary := range serviceSummaries {
 			table = append(table, []string{
 				serviceSummary.Label,
 				planNames(serviceSummary),
 				serviceSummary.Description,
+				serviceSummary.ServiceBrokerName,
 			})
 		}
 

--- a/command/v6/marketplace_command_test.go
+++ b/command/v6/marketplace_command_test.go
@@ -158,8 +158,9 @@ var _ = Describe("marketplace Command", func() {
 					servicesSummaries := []v2action.ServiceSummary{
 						{
 							Service: v2action.Service{
-								Label:       "service-a",
-								Description: "fake service-a",
+								Label:             "service-a",
+								Description:       "fake service-a",
+								ServiceBrokerName: "broker-a",
 							},
 							Plans: []v2action.ServicePlanSummary{
 								{
@@ -172,8 +173,9 @@ var _ = Describe("marketplace Command", func() {
 						},
 						{
 							Service: v2action.Service{
-								Label:       "service-b",
-								Description: "fake service-b",
+								Label:             "service-b",
+								Description:       "fake service-b",
+								ServiceBrokerName: "broker-b",
 							},
 							Plans: []v2action.ServicePlanSummary{
 								{
@@ -195,9 +197,9 @@ var _ = Describe("marketplace Command", func() {
 				})
 
 				It("outputs available services and plans", func() {
-					Expect(testUI.Out).Should(Say("service\\s+plans\\s+description\n" +
-						"service-a\\s+plan-a, plan-b\\s+fake service-a\n" +
-						"service-b\\s+plan-c\\s+fake service-b"))
+					Expect(testUI.Out).Should(Say("service\\s+plans\\s+description\\s+broker\n" +
+						"service-a\\s+plan-a, plan-b\\s+fake service-a\\s+broker-a\n" +
+						"service-b\\s+plan-c\\s+fake service-b\\s+broker-b"))
 				})
 
 				It("outputs a tip to use the -s flag", func() {
@@ -393,8 +395,9 @@ var _ = Describe("marketplace Command", func() {
 						servicesSummaries := []v2action.ServiceSummary{
 							{
 								Service: v2action.Service{
-									Label:       "service-a",
-									Description: "fake service-a",
+									Label:             "service-a",
+									Description:       "fake service-a",
+									ServiceBrokerName: "broker-a",
 								},
 								Plans: []v2action.ServicePlanSummary{
 									{
@@ -407,8 +410,9 @@ var _ = Describe("marketplace Command", func() {
 							},
 							{
 								Service: v2action.Service{
-									Label:       "service-b",
-									Description: "fake service-b",
+									Label:             "service-b",
+									Description:       "fake service-b",
+									ServiceBrokerName: "broker-b",
 								},
 								Plans: []v2action.ServicePlanSummary{
 									{
@@ -434,9 +438,9 @@ var _ = Describe("marketplace Command", func() {
 					})
 
 					It("outputs available services and plans", func() {
-						Expect(testUI.Out).Should(Say("service\\s+plans\\s+description\n" +
-							"service-a\\s+plan-a, plan-b\\s+fake service-a\n" +
-							"service-b\\s+plan-c\\s+fake service-b"))
+						Expect(testUI.Out).Should(Say("service\\s+plans\\s+description\\s+broker\n" +
+							"service-a\\s+plan-a, plan-b\\s+fake service-a\\s+broker-a\n" +
+							"service-b\\s+plan-c\\s+fake service-b\\s+broker-b"))
 					})
 
 					It("outputs a tip to use the -s flag", func() {


### PR DESCRIPTION
The table displayed by `cf marketplace` now has an extra column showing
the name of the broker providing the service.

More information here:
https://www.pivotaltracker.com/story/show/160751597

Best:
@nmaslarski 
on Behalf of SAPI Team