### PR TITLE
Add -b flag to enable-service-access command

### DIFF
--- a/actor/actionerror/duplicate_service_error.go
+++ b/actor/actionerror/duplicate_service_error.go
@@ -1,0 +1,11 @@
+package actionerror
+
+import "fmt"
+
+type DuplicateServiceError struct {
+	Name string
+}
+
+func (e DuplicateServiceError) Error() string {
+	return fmt.Sprintf("Service '%s' is provided by multiple service brokers.", e.Name)
+}

--- a/actor/actionerror/service_broker_not_found_error.go
+++ b/actor/actionerror/service_broker_not_found_error.go
@@ -1,0 +1,11 @@
+package actionerror
+
+import "fmt"
+
+type ServiceBrokerNotFoundError struct {
+	Name string
+}
+
+func (e ServiceBrokerNotFoundError) Error() string {
+	return fmt.Sprintf("Service broker '%s' not found.\nTIP: Use 'cf service-brokers' to see a list of available brokers.", e.Name)
+}

--- a/actor/v2action/service_access.go
+++ b/actor/v2action/service_access.go
@@ -9,8 +9,8 @@ import (
 )
 
 // EnableServiceForAllOrgs enables access for the given service in all orgs.
-func (actor Actor) EnableServiceForAllOrgs(serviceName string) (Warnings, error) {
-	servicePlans, allWarnings, err := actor.GetServicePlansForService(serviceName)
+func (actor Actor) EnableServiceForAllOrgs(serviceName, brokerName string) (Warnings, error) {
+	servicePlans, allWarnings, err := actor.GetServicePlansForService(serviceName, brokerName)
 	if err != nil {
 		return allWarnings, err
 	}
@@ -27,8 +27,8 @@ func (actor Actor) EnableServiceForAllOrgs(serviceName string) (Warnings, error)
 }
 
 // EnablePlanForAllOrgs enables access to a specific plan of the given service in all orgs.
-func (actor Actor) EnablePlanForAllOrgs(serviceName, servicePlanName string) (Warnings, error) {
-	servicePlans, allWarnings, err := actor.GetServicePlansForService(serviceName)
+func (actor Actor) EnablePlanForAllOrgs(serviceName, servicePlanName, brokerName string) (Warnings, error) {
+	servicePlans, allWarnings, err := actor.GetServicePlansForService(serviceName, brokerName)
 	if err != nil {
 		return allWarnings, err
 	}
@@ -53,8 +53,8 @@ func (actor Actor) EnablePlanForAllOrgs(serviceName, servicePlanName string) (Wa
 }
 
 // EnableServiceForOrg enables access for the given service in a specific org.
-func (actor Actor) EnableServiceForOrg(serviceName, orgName string) (Warnings, error) {
-	servicePlans, allWarnings, err := actor.GetServicePlansForService(serviceName)
+func (actor Actor) EnableServiceForOrg(serviceName, orgName, brokerName string) (Warnings, error) {
+	servicePlans, allWarnings, err := actor.GetServicePlansForService(serviceName, brokerName)
 	if err != nil {
 		return allWarnings, err
 	}
@@ -77,8 +77,8 @@ func (actor Actor) EnableServiceForOrg(serviceName, orgName string) (Warnings, e
 }
 
 // EnablePlanForOrg enables access to a specific plan of the given service in a specific org.
-func (actor Actor) EnablePlanForOrg(serviceName, servicePlanName, orgName string) (Warnings, error) {
-	servicePlans, allWarnings, err := actor.GetServicePlansForService(serviceName)
+func (actor Actor) EnablePlanForOrg(serviceName, servicePlanName, orgName, brokerName string) (Warnings, error) {
+	servicePlans, allWarnings, err := actor.GetServicePlansForService(serviceName, brokerName)
 	if err != nil {
 		return allWarnings, err
 	}
@@ -102,7 +102,7 @@ func (actor Actor) EnablePlanForOrg(serviceName, servicePlanName, orgName string
 
 // DisableServiceForAllOrgs disables access for the given service in all orgs.
 func (actor Actor) DisableServiceForAllOrgs(serviceName string) (Warnings, error) {
-	servicePlans, allWarnings, err := actor.GetServicePlansForService(serviceName)
+	servicePlans, allWarnings, err := actor.GetServicePlansForService(serviceName, "")
 	if err != nil {
 		return allWarnings, err
 	}
@@ -127,7 +127,7 @@ func (actor Actor) DisableServiceForAllOrgs(serviceName string) (Warnings, error
 
 // DisablePlanForAllOrgs disables access to a specific plan of the given service in all orgs.
 func (actor Actor) DisablePlanForAllOrgs(serviceName, servicePlanName string) (Warnings, error) {
-	servicePlans, allWarnings, err := actor.GetServicePlansForService(serviceName)
+	servicePlans, allWarnings, err := actor.GetServicePlansForService(serviceName, "")
 	if err != nil {
 		return allWarnings, err
 	}
@@ -159,7 +159,7 @@ func (actor Actor) DisablePlanForAllOrgs(serviceName, servicePlanName string) (W
 
 // DisableServiceForOrg disables access for the given service in a specific org.
 func (actor Actor) DisableServiceForOrg(serviceName, orgName string) (Warnings, error) {
-	servicePlans, allWarnings, err := actor.GetServicePlansForService(serviceName)
+	servicePlans, allWarnings, err := actor.GetServicePlansForService(serviceName, "")
 	if err != nil {
 		return allWarnings, err
 	}
@@ -182,7 +182,7 @@ func (actor Actor) DisableServiceForOrg(serviceName, orgName string) (Warnings, 
 
 // DisablePlanForOrg disables access to a specific plan of the given service in a specific org.
 func (actor Actor) DisablePlanForOrg(serviceName, servicePlanName, orgName string) (Warnings, error) {
-	servicePlans, allWarnings, err := actor.GetServicePlansForService(serviceName)
+	servicePlans, allWarnings, err := actor.GetServicePlansForService(serviceName, "")
 	if err != nil {
 		return allWarnings, err
 	}

--- a/actor/v2action/service_access_test.go
+++ b/actor/v2action/service_access_test.go
@@ -22,6 +22,8 @@ var _ = Describe("Service Access", func() {
 	BeforeEach(func() {
 		fakeCloudControllerClient = new(v2actionfakes.FakeCloudControllerClient)
 		actor = NewActor(fakeCloudControllerClient, nil, nil)
+
+		fakeCloudControllerClient.GetServiceBrokersReturns([]ccv2.ServiceBroker{{GUID: "broker-guid"}}, nil, nil)
 	})
 
 	Describe("EnablePlanForAllOrgs", func() {
@@ -46,7 +48,7 @@ var _ = Describe("Service Access", func() {
 		})
 
 		JustBeforeEach(func() {
-			enablePlanWarnings, enablePlanErr = actor.EnablePlanForAllOrgs("service-1", "plan-2")
+			enablePlanWarnings, enablePlanErr = actor.EnablePlanForAllOrgs("service-1", "plan-2", "some-broker")
 		})
 
 		It("updates the service plan visibility", func() {
@@ -259,7 +261,7 @@ var _ = Describe("Service Access", func() {
 		})
 
 		JustBeforeEach(func() {
-			enablePlanWarnings, enablePlanErr = actor.EnablePlanForOrg("service-1", "plan-2", "my-org")
+			enablePlanWarnings, enablePlanErr = actor.EnablePlanForOrg("service-1", "plan-2", "my-org", "broker")
 		})
 
 		When("the specified service does not exist", func() {
@@ -273,12 +275,19 @@ var _ = Describe("Service Access", func() {
 				Expect(fakeCloudControllerClient.GetServicesCallCount()).To(Equal(1))
 				Expect(enablePlanErr).To(MatchError(actionerror.ServiceNotFoundError{Name: "service-1"}))
 				filters := fakeCloudControllerClient.GetServicesArgsForCall(0)
-				Expect(len(filters)).To(Equal(1))
-				Expect(filters[0]).To(Equal(ccv2.Filter{
-					Type:     constant.LabelFilter,
-					Operator: constant.EqualOperator,
-					Values:   []string{"service-1"},
-				}))
+				Expect(len(filters)).To(Equal(2))
+				Expect(filters).To(ConsistOf(
+					ccv2.Filter{
+						Type:     constant.LabelFilter,
+						Operator: constant.EqualOperator,
+						Values:   []string{"service-1"},
+					},
+					ccv2.Filter{
+						Type:     constant.ServiceBrokerGUIDFilter,
+						Operator: constant.EqualOperator,
+						Values:   []string{"broker-guid"},
+					},
+				))
 			})
 		})
 
@@ -419,7 +428,7 @@ var _ = Describe("Service Access", func() {
 		var enableServiceForOrgWarnings Warnings
 
 		JustBeforeEach(func() {
-			enableServiceForOrgWarnings, enableServiceForOrgErr = actor.EnableServiceForOrg("service-1", "my-org")
+			enableServiceForOrgWarnings, enableServiceForOrgErr = actor.EnableServiceForOrg("service-1", "my-org", "some-broker")
 		})
 
 		When("the service does not exist", func() {
@@ -434,12 +443,19 @@ var _ = Describe("Service Access", func() {
 				Expect(enableServiceForOrgErr).To(MatchError(actionerror.ServiceNotFoundError{Name: "service-1"}))
 
 				filters := fakeCloudControllerClient.GetServicesArgsForCall(0)
-				Expect(len(filters)).To(Equal(1))
-				Expect(filters[0]).To(Equal(ccv2.Filter{
-					Type:     constant.LabelFilter,
-					Operator: constant.EqualOperator,
-					Values:   []string{"service-1"},
-				}))
+				Expect(len(filters)).To(Equal(2))
+				Expect(filters).To(ConsistOf(
+					ccv2.Filter{
+						Type:     constant.LabelFilter,
+						Operator: constant.EqualOperator,
+						Values:   []string{"service-1"},
+					},
+					ccv2.Filter{
+						Type:     constant.ServiceBrokerGUIDFilter,
+						Operator: constant.EqualOperator,
+						Values:   []string{"broker-guid"},
+					},
+				))
 			})
 		})
 
@@ -608,7 +624,7 @@ var _ = Describe("Service Access", func() {
 		})
 
 		JustBeforeEach(func() {
-			enableServiceWarnings, enableServiceErr = actor.EnableServiceForAllOrgs("service-1")
+			enableServiceWarnings, enableServiceErr = actor.EnableServiceForAllOrgs("service-1", "some-broker")
 		})
 
 		It("should update all plans to public", func() {
@@ -636,12 +652,19 @@ var _ = Describe("Service Access", func() {
 				Expect(enableServiceErr).To(MatchError(actionerror.ServiceNotFoundError{Name: "service-1"}))
 
 				filters := fakeCloudControllerClient.GetServicesArgsForCall(0)
-				Expect(len(filters)).To(Equal(1))
-				Expect(filters[0]).To(Equal(ccv2.Filter{
-					Type:     constant.LabelFilter,
-					Operator: constant.EqualOperator,
-					Values:   []string{"service-1"},
-				}))
+				Expect(len(filters)).To(Equal(2))
+				Expect(filters).To(ConsistOf(
+					ccv2.Filter{
+						Type:     constant.LabelFilter,
+						Operator: constant.EqualOperator,
+						Values:   []string{"service-1"},
+					},
+					ccv2.Filter{
+						Type:     constant.ServiceBrokerGUIDFilter,
+						Operator: constant.EqualOperator,
+						Values:   []string{"broker-guid"},
+					},
+				))
 			})
 		})
 

--- a/actor/v2action/service_broker.go
+++ b/actor/v2action/service_broker.go
@@ -1,12 +1,14 @@
 package v2action
 
 import (
+	"code.cloudfoundry.org/cli/actor/actionerror"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv2"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv2/constant"
 )
 
 type ServiceBroker ccv2.ServiceBroker
 
+// CreateServiceBroker returns a ServiceBroker and any warnings or errors
 func (actor Actor) CreateServiceBroker(serviceBrokerName, username, password, brokerURI, spaceGUID string) (ServiceBroker, Warnings, error) {
 	serviceBroker, warnings, err := actor.CloudControllerClient.CreateServiceBroker(serviceBrokerName, username, password, brokerURI, spaceGUID)
 	return ServiceBroker(serviceBroker), Warnings(warnings), err
@@ -26,15 +28,21 @@ func (actor Actor) GetServiceBrokers() ([]ServiceBroker, Warnings, error) {
 	return brokersToReturn, Warnings(warnings), nil
 }
 
+// GetServiceBrokerByName returns a ServiceBroker and any warnings or errors
 func (actor Actor) GetServiceBrokerByName(brokerName string) (ServiceBroker, Warnings, error) {
 	serviceBrokers, warnings, err := actor.CloudControllerClient.GetServiceBrokers(ccv2.Filter{
 		Type:     constant.NameFilter,
 		Operator: constant.EqualOperator,
 		Values:   []string{brokerName},
 	})
+
 	if err != nil {
 		return ServiceBroker{}, Warnings(warnings), err
 	}
 
-	return ServiceBroker(serviceBrokers[0]), Warnings(warnings), nil
+	if len(serviceBrokers) == 0 {
+		return ServiceBroker{}, Warnings(warnings), actionerror.ServiceBrokerNotFoundError{Name: brokerName}
+	}
+
+	return ServiceBroker(serviceBrokers[0]), Warnings(warnings), err
 }

--- a/actor/v2action/service_plan.go
+++ b/actor/v2action/service_plan.go
@@ -13,9 +13,9 @@ func (actor Actor) GetServicePlan(servicePlanGUID string) (ServicePlan, Warnings
 	return ServicePlan(servicePlan), Warnings(warnings), err
 }
 
-// GetServicePlansForService returns a list of plans associated with the service.
-func (actor Actor) GetServicePlansForService(serviceName string) ([]ServicePlan, Warnings, error) {
-	service, allWarnings, err := actor.GetServiceByName(serviceName)
+// GetServicePlansForService returns a list of plans associated with the service and the broker if provided
+func (actor Actor) GetServicePlansForService(serviceName, brokerName string) ([]ServicePlan, Warnings, error) {
+	service, allWarnings, err := actor.GetServiceByNameAndBrokerName(serviceName, brokerName)
 	if err != nil {
 		return []ServicePlan{}, allWarnings, err
 	}

--- a/api/cloudcontroller/ccv2/service.go
+++ b/api/cloudcontroller/ccv2/service.go
@@ -19,7 +19,7 @@ type Service struct {
 	// DocumentationURL is a url that points to a documentation page for the
 	// service.
 	DocumentationURL string
-	// ServiceBrokerName is the name of the broker providing this service.
+	// ServiceBrokerName is name of the service broker associated with the service
 	ServiceBrokerName string
 	// Extra is a field with extra data pertaining to the service.
 	Extra ServiceExtra

--- a/api/cloudcontroller/ccv2/service_test.go
+++ b/api/cloudcontroller/ccv2/service_test.go
@@ -29,6 +29,7 @@ var _ = Describe("Service", func() {
 						"entity": {
 							"label": "some-service",
 							"description": "some-description",
+							"service_broker_name": "service-broker",
 							"extra": "{\"provider\":{\"name\":\"The name\"},\"listing\":{\"imageUrl\":\"http://catgifpage.com/cat.gif\",\"blurb\":\"fake broker that is fake\",\"longDescription\":\"A long time ago, in a galaxy far far away...\"},\"displayName\":\"The Fake Broker\",\"shareable\":true}"
 						}
 					}`
@@ -45,9 +46,10 @@ var _ = Describe("Service", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(service).To(Equal(Service{
-						GUID:        "some-service-guid",
-						Label:       "some-service",
-						Description: "some-description",
+						GUID:              "some-service-guid",
+						Label:             "some-service",
+						Description:       "some-description",
+						ServiceBrokerName: "service-broker",
 						Extra: ServiceExtra{
 							Shareable: true,
 						},

--- a/api/cloudcontroller/ccversion/minimum_version.go
+++ b/api/cloudcontroller/ccversion/minimum_version.go
@@ -13,7 +13,7 @@ const (
 	MinVersionUserProvidedServiceTagsV2      = "2.104.0"
 	MinVersionZeroAppInstancesV2             = "2.70.0"
 	MinVersionInternalDomainV2               = "2.115.0"
-	MinVersionServiceBrokerNameV2            = "2.125.0"
+	MinVersionMultiServiceRegistrationV2     = "2.125.0"
 
 	MinVersionApplicationFlowV3    = "3.27.0"
 	MinVersionIsolationSegmentV3   = "3.11.0"

--- a/command/v6/v6fakes/fake_enable_service_access_actor.go
+++ b/command/v6/v6fakes/fake_enable_service_access_actor.go
@@ -9,11 +9,12 @@ import (
 )
 
 type FakeEnableServiceAccessActor struct {
-	EnablePlanForAllOrgsStub        func(string, string) (v2action.Warnings, error)
+	EnablePlanForAllOrgsStub        func(string, string, string) (v2action.Warnings, error)
 	enablePlanForAllOrgsMutex       sync.RWMutex
 	enablePlanForAllOrgsArgsForCall []struct {
 		arg1 string
 		arg2 string
+		arg3 string
 	}
 	enablePlanForAllOrgsReturns struct {
 		result1 v2action.Warnings
@@ -23,12 +24,13 @@ type FakeEnableServiceAccessActor struct {
 		result1 v2action.Warnings
 		result2 error
 	}
-	EnablePlanForOrgStub        func(string, string, string) (v2action.Warnings, error)
+	EnablePlanForOrgStub        func(string, string, string, string) (v2action.Warnings, error)
 	enablePlanForOrgMutex       sync.RWMutex
 	enablePlanForOrgArgsForCall []struct {
 		arg1 string
 		arg2 string
 		arg3 string
+		arg4 string
 	}
 	enablePlanForOrgReturns struct {
 		result1 v2action.Warnings
@@ -38,10 +40,11 @@ type FakeEnableServiceAccessActor struct {
 		result1 v2action.Warnings
 		result2 error
 	}
-	EnableServiceForAllOrgsStub        func(string) (v2action.Warnings, error)
+	EnableServiceForAllOrgsStub        func(string, string) (v2action.Warnings, error)
 	enableServiceForAllOrgsMutex       sync.RWMutex
 	enableServiceForAllOrgsArgsForCall []struct {
 		arg1 string
+		arg2 string
 	}
 	enableServiceForAllOrgsReturns struct {
 		result1 v2action.Warnings
@@ -51,11 +54,12 @@ type FakeEnableServiceAccessActor struct {
 		result1 v2action.Warnings
 		result2 error
 	}
-	EnableServiceForOrgStub        func(string, string) (v2action.Warnings, error)
+	EnableServiceForOrgStub        func(string, string, string) (v2action.Warnings, error)
 	enableServiceForOrgMutex       sync.RWMutex
 	enableServiceForOrgArgsForCall []struct {
 		arg1 string
 		arg2 string
+		arg3 string
 	}
 	enableServiceForOrgReturns struct {
 		result1 v2action.Warnings
@@ -69,17 +73,18 @@ type FakeEnableServiceAccessActor struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeEnableServiceAccessActor) EnablePlanForAllOrgs(arg1 string, arg2 string) (v2action.Warnings, error) {
+func (fake *FakeEnableServiceAccessActor) EnablePlanForAllOrgs(arg1 string, arg2 string, arg3 string) (v2action.Warnings, error) {
 	fake.enablePlanForAllOrgsMutex.Lock()
 	ret, specificReturn := fake.enablePlanForAllOrgsReturnsOnCall[len(fake.enablePlanForAllOrgsArgsForCall)]
 	fake.enablePlanForAllOrgsArgsForCall = append(fake.enablePlanForAllOrgsArgsForCall, struct {
 		arg1 string
 		arg2 string
-	}{arg1, arg2})
-	fake.recordInvocation("EnablePlanForAllOrgs", []interface{}{arg1, arg2})
+		arg3 string
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("EnablePlanForAllOrgs", []interface{}{arg1, arg2, arg3})
 	fake.enablePlanForAllOrgsMutex.Unlock()
 	if fake.EnablePlanForAllOrgsStub != nil {
-		return fake.EnablePlanForAllOrgsStub(arg1, arg2)
+		return fake.EnablePlanForAllOrgsStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -94,17 +99,17 @@ func (fake *FakeEnableServiceAccessActor) EnablePlanForAllOrgsCallCount() int {
 	return len(fake.enablePlanForAllOrgsArgsForCall)
 }
 
-func (fake *FakeEnableServiceAccessActor) EnablePlanForAllOrgsCalls(stub func(string, string) (v2action.Warnings, error)) {
+func (fake *FakeEnableServiceAccessActor) EnablePlanForAllOrgsCalls(stub func(string, string, string) (v2action.Warnings, error)) {
 	fake.enablePlanForAllOrgsMutex.Lock()
 	defer fake.enablePlanForAllOrgsMutex.Unlock()
 	fake.EnablePlanForAllOrgsStub = stub
 }
 
-func (fake *FakeEnableServiceAccessActor) EnablePlanForAllOrgsArgsForCall(i int) (string, string) {
+func (fake *FakeEnableServiceAccessActor) EnablePlanForAllOrgsArgsForCall(i int) (string, string, string) {
 	fake.enablePlanForAllOrgsMutex.RLock()
 	defer fake.enablePlanForAllOrgsMutex.RUnlock()
 	argsForCall := fake.enablePlanForAllOrgsArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeEnableServiceAccessActor) EnablePlanForAllOrgsReturns(result1 v2action.Warnings, result2 error) {
@@ -133,18 +138,19 @@ func (fake *FakeEnableServiceAccessActor) EnablePlanForAllOrgsReturnsOnCall(i in
 	}{result1, result2}
 }
 
-func (fake *FakeEnableServiceAccessActor) EnablePlanForOrg(arg1 string, arg2 string, arg3 string) (v2action.Warnings, error) {
+func (fake *FakeEnableServiceAccessActor) EnablePlanForOrg(arg1 string, arg2 string, arg3 string, arg4 string) (v2action.Warnings, error) {
 	fake.enablePlanForOrgMutex.Lock()
 	ret, specificReturn := fake.enablePlanForOrgReturnsOnCall[len(fake.enablePlanForOrgArgsForCall)]
 	fake.enablePlanForOrgArgsForCall = append(fake.enablePlanForOrgArgsForCall, struct {
 		arg1 string
 		arg2 string
 		arg3 string
-	}{arg1, arg2, arg3})
-	fake.recordInvocation("EnablePlanForOrg", []interface{}{arg1, arg2, arg3})
+		arg4 string
+	}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("EnablePlanForOrg", []interface{}{arg1, arg2, arg3, arg4})
 	fake.enablePlanForOrgMutex.Unlock()
 	if fake.EnablePlanForOrgStub != nil {
-		return fake.EnablePlanForOrgStub(arg1, arg2, arg3)
+		return fake.EnablePlanForOrgStub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -159,17 +165,17 @@ func (fake *FakeEnableServiceAccessActor) EnablePlanForOrgCallCount() int {
 	return len(fake.enablePlanForOrgArgsForCall)
 }
 
-func (fake *FakeEnableServiceAccessActor) EnablePlanForOrgCalls(stub func(string, string, string) (v2action.Warnings, error)) {
+func (fake *FakeEnableServiceAccessActor) EnablePlanForOrgCalls(stub func(string, string, string, string) (v2action.Warnings, error)) {
 	fake.enablePlanForOrgMutex.Lock()
 	defer fake.enablePlanForOrgMutex.Unlock()
 	fake.EnablePlanForOrgStub = stub
 }
 
-func (fake *FakeEnableServiceAccessActor) EnablePlanForOrgArgsForCall(i int) (string, string, string) {
+func (fake *FakeEnableServiceAccessActor) EnablePlanForOrgArgsForCall(i int) (string, string, string, string) {
 	fake.enablePlanForOrgMutex.RLock()
 	defer fake.enablePlanForOrgMutex.RUnlock()
 	argsForCall := fake.enablePlanForOrgArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeEnableServiceAccessActor) EnablePlanForOrgReturns(result1 v2action.Warnings, result2 error) {
@@ -198,16 +204,17 @@ func (fake *FakeEnableServiceAccessActor) EnablePlanForOrgReturnsOnCall(i int, r
 	}{result1, result2}
 }
 
-func (fake *FakeEnableServiceAccessActor) EnableServiceForAllOrgs(arg1 string) (v2action.Warnings, error) {
+func (fake *FakeEnableServiceAccessActor) EnableServiceForAllOrgs(arg1 string, arg2 string) (v2action.Warnings, error) {
 	fake.enableServiceForAllOrgsMutex.Lock()
 	ret, specificReturn := fake.enableServiceForAllOrgsReturnsOnCall[len(fake.enableServiceForAllOrgsArgsForCall)]
 	fake.enableServiceForAllOrgsArgsForCall = append(fake.enableServiceForAllOrgsArgsForCall, struct {
 		arg1 string
-	}{arg1})
-	fake.recordInvocation("EnableServiceForAllOrgs", []interface{}{arg1})
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("EnableServiceForAllOrgs", []interface{}{arg1, arg2})
 	fake.enableServiceForAllOrgsMutex.Unlock()
 	if fake.EnableServiceForAllOrgsStub != nil {
-		return fake.EnableServiceForAllOrgsStub(arg1)
+		return fake.EnableServiceForAllOrgsStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -222,17 +229,17 @@ func (fake *FakeEnableServiceAccessActor) EnableServiceForAllOrgsCallCount() int
 	return len(fake.enableServiceForAllOrgsArgsForCall)
 }
 
-func (fake *FakeEnableServiceAccessActor) EnableServiceForAllOrgsCalls(stub func(string) (v2action.Warnings, error)) {
+func (fake *FakeEnableServiceAccessActor) EnableServiceForAllOrgsCalls(stub func(string, string) (v2action.Warnings, error)) {
 	fake.enableServiceForAllOrgsMutex.Lock()
 	defer fake.enableServiceForAllOrgsMutex.Unlock()
 	fake.EnableServiceForAllOrgsStub = stub
 }
 
-func (fake *FakeEnableServiceAccessActor) EnableServiceForAllOrgsArgsForCall(i int) string {
+func (fake *FakeEnableServiceAccessActor) EnableServiceForAllOrgsArgsForCall(i int) (string, string) {
 	fake.enableServiceForAllOrgsMutex.RLock()
 	defer fake.enableServiceForAllOrgsMutex.RUnlock()
 	argsForCall := fake.enableServiceForAllOrgsArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeEnableServiceAccessActor) EnableServiceForAllOrgsReturns(result1 v2action.Warnings, result2 error) {
@@ -261,17 +268,18 @@ func (fake *FakeEnableServiceAccessActor) EnableServiceForAllOrgsReturnsOnCall(i
 	}{result1, result2}
 }
 
-func (fake *FakeEnableServiceAccessActor) EnableServiceForOrg(arg1 string, arg2 string) (v2action.Warnings, error) {
+func (fake *FakeEnableServiceAccessActor) EnableServiceForOrg(arg1 string, arg2 string, arg3 string) (v2action.Warnings, error) {
 	fake.enableServiceForOrgMutex.Lock()
 	ret, specificReturn := fake.enableServiceForOrgReturnsOnCall[len(fake.enableServiceForOrgArgsForCall)]
 	fake.enableServiceForOrgArgsForCall = append(fake.enableServiceForOrgArgsForCall, struct {
 		arg1 string
 		arg2 string
-	}{arg1, arg2})
-	fake.recordInvocation("EnableServiceForOrg", []interface{}{arg1, arg2})
+		arg3 string
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("EnableServiceForOrg", []interface{}{arg1, arg2, arg3})
 	fake.enableServiceForOrgMutex.Unlock()
 	if fake.EnableServiceForOrgStub != nil {
-		return fake.EnableServiceForOrgStub(arg1, arg2)
+		return fake.EnableServiceForOrgStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -286,17 +294,17 @@ func (fake *FakeEnableServiceAccessActor) EnableServiceForOrgCallCount() int {
 	return len(fake.enableServiceForOrgArgsForCall)
 }
 
-func (fake *FakeEnableServiceAccessActor) EnableServiceForOrgCalls(stub func(string, string) (v2action.Warnings, error)) {
+func (fake *FakeEnableServiceAccessActor) EnableServiceForOrgCalls(stub func(string, string, string) (v2action.Warnings, error)) {
 	fake.enableServiceForOrgMutex.Lock()
 	defer fake.enableServiceForOrgMutex.Unlock()
 	fake.EnableServiceForOrgStub = stub
 }
 
-func (fake *FakeEnableServiceAccessActor) EnableServiceForOrgArgsForCall(i int) (string, string) {
+func (fake *FakeEnableServiceAccessActor) EnableServiceForOrgArgsForCall(i int) (string, string, string) {
 	fake.enableServiceForOrgMutex.RLock()
 	defer fake.enableServiceForOrgMutex.RUnlock()
 	argsForCall := fake.enableServiceForOrgArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeEnableServiceAccessActor) EnableServiceForOrgReturns(result1 v2action.Warnings, result2 error) {

--- a/integration/shared/isolated/marketplace_command_test.go
+++ b/integration/shared/isolated/marketplace_command_test.go
@@ -152,9 +152,9 @@ var _ = Describe("marketplace command", func() {
 						helpers.QuickDeleteOrg(org1)
 					})
 
-					When("cc api version < 2.125.0", func() {
+					When("CC API does not return broker names in response", func() {
 						BeforeEach(func() {
-							helpers.SkipIfVersionAtLeast(ccversion.MinVersionServiceBrokerNameV2)
+							helpers.SkipIfVersionAtLeast(ccversion.MinVersionMultiServiceRegistrationV2)
 						})
 
 						It("displays a table and tip that does not include that service", func() {
@@ -171,9 +171,9 @@ var _ = Describe("marketplace command", func() {
 						})
 					})
 
-					When("cc api version >= 2.125.0", func() {
+					When("CC API returns broker names in response", func() {
 						BeforeEach(func() {
-							helpers.SkipIfVersionLessThan(ccversion.MinVersionServiceBrokerNameV2)
+							helpers.SkipIfVersionLessThan(ccversion.MinVersionMultiServiceRegistrationV2)
 						})
 
 						It("displays a table with broker name", func() {


### PR DESCRIPTION
Since the CC has recently changed to allow the same broker to be
registered multiple times, it is possible to there to be naming
collisions on service offerings.

The -b flag allows the CLI to search for a service by name within the
context of a particular broker, allowing for disambiguation.

More context here: https://www.pivotaltracker.com/story/show/162726522 and in the linked stories.

Best,
@nmaslarski 
on Behalf of SAPI team