### PR TITLE
Add CreateBroker helper for integration tests

### DIFF
--- a/integration/helpers/service_broker.go
+++ b/integration/helpers/service_broker.go
@@ -189,6 +189,17 @@ func (b ServiceBroker) ToJSON(shareable bool) string {
 	return replacer.Replace(string(bytes))
 }
 
+func CreateBroker(domain, serviceName, planName string) ServiceBroker {
+	service := serviceName
+	servicePlan := planName
+	broker := NewServiceBroker(NewServiceBrokerName(), NewAssets().ServiceBroker, domain, service, servicePlan)
+	broker.Push()
+	broker.Configure(true)
+	broker.Create()
+
+	return broker
+}
+
 type Assets struct {
 	ServiceBroker string
 }

--- a/integration/shared/global/service_command_test.go
+++ b/integration/shared/global/service_command_test.go
@@ -231,10 +231,7 @@ var _ = Describe("service command", func() {
 					service = helpers.PrefixedRandomName("SERVICE")
 					servicePlan = helpers.PrefixedRandomName("SERVICE-PLAN")
 
-					broker = helpers.NewServiceBroker(helpers.NewServiceBrokerName(), helpers.NewAssets().ServiceBroker, domain, service, servicePlan)
-					broker.Push()
-					broker.Configure(true)
-					broker.Create()
+					broker = helpers.CreateBroker(domain, service, servicePlan)
 
 					Eventually(helpers.CF("enable-service-access", service)).Should(Exit(0))
 					Eventually(helpers.CF("create-service", service, servicePlan, serviceInstanceName, "-t", "database, email")).Should(Exit(0))
@@ -419,10 +416,7 @@ var _ = Describe("service command", func() {
 			domain := helpers.DefaultSharedDomain()
 			service = helpers.PrefixedRandomName("SERVICE")
 			servicePlan = helpers.PrefixedRandomName("SERVICE-PLAN")
-			broker = helpers.NewServiceBroker(helpers.NewServiceBrokerName(), helpers.NewAssets().ServiceBroker, domain, service, servicePlan)
-			broker.Push()
-			broker.Configure(true)
-			broker.Create()
+			broker = helpers.CreateBroker(domain, service, servicePlan)
 
 			Eventually(helpers.CF("enable-service-access", service)).Should(Exit(0))
 			Eventually(helpers.CF("create-service", service, servicePlan, serviceInstanceName)).Should(Exit(0))

--- a/integration/shared/global/share_service_command_test.go
+++ b/integration/shared/global/share_service_command_test.go
@@ -126,10 +126,7 @@ var _ = Describe("share-service command", func() {
 			var broker helpers.ServiceBroker
 
 			BeforeEach(func() {
-				broker = helpers.NewServiceBroker(helpers.NewServiceBrokerName(), helpers.NewAssets().ServiceBroker, domain, service, servicePlan)
-				broker.Push()
-				broker.Configure(true)
-				broker.Create()
+				broker = helpers.CreateBroker(domain, service, servicePlan)
 
 				Eventually(helpers.CF("enable-service-access", service)).Should(Exit(0))
 				Eventually(helpers.CF("create-service", service, servicePlan, serviceInstance)).Should(Exit(0))

--- a/integration/shared/global/unshare_service_command_test.go
+++ b/integration/shared/global/unshare_service_command_test.go
@@ -123,10 +123,7 @@ var _ = Describe("unshare-service command", func() {
 			var broker helpers.ServiceBroker
 
 			BeforeEach(func() {
-				broker = helpers.NewServiceBroker(helpers.NewServiceBrokerName(), helpers.NewAssets().ServiceBroker, domain, service, servicePlan)
-				broker.Push()
-				broker.Configure(true)
-				broker.Create()
+				broker = helpers.CreateBroker(domain, service, servicePlan)
 
 				Eventually(helpers.CF("enable-service-access", service)).Should(Exit(0))
 				Eventually(helpers.CF("create-service", service, servicePlan, serviceInstance)).Should(Exit(0))
@@ -332,10 +329,7 @@ var _ = Describe("unshare-service command", func() {
 			var password string
 
 			BeforeEach(func() {
-				broker = helpers.NewServiceBroker(helpers.NewServiceBrokerName(), helpers.NewAssets().ServiceBroker, domain, service, servicePlan)
-				broker.Push()
-				broker.Configure(true)
-				broker.Create()
+				broker = helpers.CreateBroker(domain, service, servicePlan)
 				user = helpers.NewUsername()
 				password = helpers.NewPassword()
 

--- a/integration/shared/isolated/bind_service_command_test.go
+++ b/integration/shared/isolated/bind_service_command_test.go
@@ -316,10 +316,7 @@ var _ = Describe("bind-service command", func() {
 
 				When("the service binding is blocking", func() {
 					BeforeEach(func() {
-						broker = helpers.NewServiceBroker(helpers.NewServiceBrokerName(), helpers.NewAssets().ServiceBroker, domain, service, servicePlan)
-						broker.Push()
-						broker.Configure(true)
-						broker.Create()
+						broker = helpers.CreateBroker(domain, service, servicePlan)
 
 						Eventually(helpers.CF("enable-service-access", service)).Should(Exit(0))
 						Eventually(helpers.CF("create-service", service, servicePlan, serviceInstance)).Should(Exit(0))

--- a/integration/shared/isolated/create_service_key_command_test.go
+++ b/integration/shared/isolated/create_service_key_command_test.go
@@ -123,10 +123,7 @@ var _ = Describe("create-service-key command", func() {
 			BeforeEach(func() {
 				service = helpers.PrefixedRandomName("SERVICE")
 				servicePlan = helpers.PrefixedRandomName("SERVICE-PLAN")
-				broker = helpers.NewServiceBroker(helpers.NewServiceBrokerName(), helpers.NewAssets().ServiceBroker, domain, service, servicePlan)
-				broker.Push()
-				broker.Configure(true)
-				broker.Create()
+				broker = helpers.CreateBroker(domain, service, servicePlan)
 
 				Eventually(helpers.CF("enable-service-access", service)).Should(Exit(0))
 				Eventually(helpers.CF("create-service", service, servicePlan, serviceInstance)).Should(Exit(0))

--- a/integration/shared/isolated/delete_service_command_test.go
+++ b/integration/shared/isolated/delete_service_command_test.go
@@ -42,10 +42,8 @@ var _ = Describe("delete-service command", func() {
 				domain = helpers.DefaultSharedDomain()
 				service = helpers.PrefixedRandomName("SERVICE")
 				servicePlan = helpers.PrefixedRandomName("SERVICE-PLAN")
-				broker = helpers.NewServiceBroker(helpers.NewServiceBrokerName(), helpers.NewAssets().ServiceBroker, domain, service, servicePlan)
-				broker.Push()
-				broker.Configure(true)
-				broker.Create()
+
+				broker = helpers.CreateBroker(domain, service, servicePlan)
 
 				Eventually(helpers.CF("enable-service-access", service)).Should(Exit(0))
 

--- a/integration/shared/isolated/enable_service_access_command_test.go
+++ b/integration/shared/isolated/enable_service_access_command_test.go
@@ -143,10 +143,7 @@ var _ = Describe("enable service access command", func() {
 				service = helpers.PrefixedRandomName("SERVICE")
 				servicePlan = helpers.PrefixedRandomName("SERVICE-PLAN")
 
-				broker = helpers.NewServiceBroker(helpers.NewServiceBrokerName(), helpers.NewAssets().ServiceBroker, domain, service, servicePlan)
-				broker.Push()
-				broker.Configure(true)
-				broker.Create()
+				broker = helpers.CreateBroker(domain, service, servicePlan)
 			})
 
 			AfterEach(func() {

--- a/integration/shared/isolated/marketplace_command_test.go
+++ b/integration/shared/isolated/marketplace_command_test.go
@@ -64,9 +64,9 @@ var _ = Describe("marketplace command", func() {
 
 						domain := helpers.DefaultSharedDomain()
 
-						broker1 = createBroker(domain, "SERVICE-1", "SERVICE-PLAN-1")
+						broker1 = helpers.CreateBroker(domain, helpers.PrefixedRandomName("SERVICE-1"), "SERVICE-PLAN-1")
 						enableServiceAccess(broker1)
-						broker2 = createBroker(domain, "SERVICE-2", "SERVICE-PLAN-2")
+						broker2 = helpers.CreateBroker(domain, helpers.PrefixedRandomName("SERVICE-2"), "SERVICE-PLAN-2")
 						enableServiceAccess(broker2)
 
 						helpers.LogoutCF()
@@ -131,7 +131,7 @@ var _ = Describe("marketplace command", func() {
 
 						domain := helpers.DefaultSharedDomain()
 
-						broker1 = createBroker(domain, "SERVICE-1", "SERVICE-PLAN-1")
+						broker1 = helpers.CreateBroker(domain, helpers.PrefixedRandomName("SERVICE-1"), "SERVICE-PLAN-1")
 						enableServiceAccessForOrg(broker1, org1)
 
 						org2 = helpers.NewOrgName()
@@ -139,7 +139,7 @@ var _ = Describe("marketplace command", func() {
 						helpers.CreateOrgAndSpace(org2, space2)
 						helpers.TargetOrgAndSpace(org2, space2)
 
-						broker2 = createBroker(domain, "SERVICE-2", "SERVICE-PLAN-2")
+						broker2 = helpers.CreateBroker(domain, helpers.PrefixedRandomName("SERVICE-2"), "SERVICE-PLAN-2")
 						enableServiceAccess(broker2)
 					})
 
@@ -213,7 +213,7 @@ var _ = Describe("marketplace command", func() {
 
 							domain := helpers.DefaultSharedDomain()
 
-							broker = createBroker(domain, "SERVICE", "SERVICE-PLAN")
+							broker = helpers.CreateBroker(domain, helpers.PrefixedRandomName("SERVICE"), "SERVICE-PLAN")
 							enableServiceAccess(broker)
 
 							helpers.LogoutCF()
@@ -290,7 +290,7 @@ var _ = Describe("marketplace command", func() {
 
 								domain := helpers.DefaultSharedDomain()
 
-								broker = createBroker(domain, "SERVICE", "SERVICE-PLAN")
+								broker = helpers.CreateBroker(domain, helpers.PrefixedRandomName("SERVICE"), "SERVICE-PLAN")
 								enableServiceAccess(broker)
 							})
 
@@ -326,7 +326,7 @@ var _ = Describe("marketplace command", func() {
 
 								domain := helpers.DefaultSharedDomain()
 
-								broker = createBroker(domain, "SERVICE", "SERVICE-PLAN")
+								broker = helpers.CreateBroker(domain, helpers.PrefixedRandomName("SERVICE"), "SERVICE-PLAN")
 								enableServiceAccessForOrg(broker, org)
 
 								helpers.TargetOrgAndSpace(ReadOnlyOrg, ReadOnlySpace)
@@ -352,17 +352,6 @@ var _ = Describe("marketplace command", func() {
 		})
 	})
 })
-
-func createBroker(domain, serviceName, planName string) helpers.ServiceBroker {
-	service := helpers.PrefixedRandomName(serviceName)
-	servicePlan := helpers.PrefixedRandomName(planName)
-	broker := helpers.NewServiceBroker(helpers.NewServiceBrokerName(), helpers.NewAssets().ServiceBroker, domain, service, servicePlan)
-	broker.Push()
-	broker.Configure(true)
-	broker.Create()
-
-	return broker
-}
 
 func enableServiceAccess(broker helpers.ServiceBroker) {
 	Eventually(helpers.CF("enable-service-access", getServiceName(broker))).Should(Exit(0))

--- a/integration/shared/isolated/service_key_command_test.go
+++ b/integration/shared/isolated/service_key_command_test.go
@@ -41,10 +41,7 @@ var _ = Describe("service-key command", func() {
 
 	When("the service key is not found", func() {
 		BeforeEach(func() {
-			broker = helpers.NewServiceBroker(helpers.NewServiceBrokerName(), helpers.NewAssets().ServiceBroker, domain, service, servicePlan)
-			broker.Push()
-			broker.Configure(true)
-			broker.Create()
+			broker = helpers.CreateBroker(domain, service, servicePlan)
 
 			Eventually(helpers.CF("enable-service-access", service)).Should(Exit(0))
 			Eventually(helpers.CF("create-service", service, servicePlan, serviceInstance)).Should(Exit(0))

--- a/integration/shared/isolated/services_command_test.go
+++ b/integration/shared/isolated/services_command_test.go
@@ -84,10 +84,7 @@ var _ = Describe("services command", func() {
 			domain := helpers.DefaultSharedDomain()
 			service = helpers.PrefixedRandomName("SERVICE")
 			servicePlan = helpers.PrefixedRandomName("SERVICE-PLAN")
-			broker = helpers.NewServiceBroker(helpers.NewServiceBrokerName(), helpers.NewAssets().ServiceBroker, domain, service, servicePlan)
-			broker.Push()
-			broker.Configure(true)
-			broker.Create()
+			broker = helpers.CreateBroker(domain, service, servicePlan)
 			Eventually(helpers.CF("enable-service-access", service)).Should(Exit(0))
 
 			managedService1 = helpers.PrefixedRandomName("MANAGED1")

--- a/integration/shared/isolated/unbind_service_command_test.go
+++ b/integration/shared/isolated/unbind_service_command_test.go
@@ -157,11 +157,7 @@ var _ = Describe("unbind-service command", func() {
 
 			When("the unbinding is blocking", func() {
 				BeforeEach(func() {
-					broker = helpers.NewServiceBroker(helpers.NewServiceBrokerName(), helpers.NewAssets().ServiceBroker, domain, service, servicePlan)
-					broker.Push()
-					broker.Configure(true)
-					broker.Create()
-
+					broker = helpers.CreateBroker(domain, service, servicePlan)
 					Eventually(helpers.CF("enable-service-access", service)).Should(Exit(0))
 				})
 

--- a/integration/shared/plugin/api_test.go
+++ b/integration/shared/plugin/api_test.go
@@ -154,10 +154,8 @@ var _ = Describe("plugin API", func() {
 			servicePlan := helpers.PrefixedRandomName("SERVICE-PLAN")
 			serviceInstance1 = helpers.PrefixedRandomName("SI1")
 			serviceInstance2 = helpers.PrefixedRandomName("SI2")
-			broker = helpers.NewServiceBroker(helpers.NewServiceBrokerName(), helpers.NewAssets().ServiceBroker, domain, service, servicePlan)
-			broker.Push()
-			broker.Configure(true)
-			broker.Create()
+
+			broker = helpers.CreateBroker(domain, service, servicePlan)
 
 			Eventually(helpers.CF("enable-service-access", service)).Should(Exit(0))
 			Eventually(helpers.CF("create-service", service, servicePlan, serviceInstance1)).Should(Exit(0))

--- a/integration/v6/push/bind_to_services_in_manifest_test.go
+++ b/integration/v6/push/bind_to_services_in_manifest_test.go
@@ -54,10 +54,7 @@ var _ = Describe("bind app to provided services from manifest", func() {
 		BeforeEach(func() {
 			domain := helpers.DefaultSharedDomain()
 
-			broker = helpers.NewServiceBroker(helpers.NewServiceBrokerName(), helpers.NewAssets().ServiceBroker, domain, serviceName, servicePlan)
-			broker.Push()
-			broker.Configure(true)
-			broker.Create()
+			broker = helpers.CreateBroker(domain, serviceName, servicePlan)
 
 			Eventually(helpers.CF("enable-service-access", serviceName)).Should(Exit(0))
 


### PR DESCRIPTION
As the [comment](https://github.com/cloudfoundry/cli/pull/1479#discussion_r230159207) of the `cf marketplace` review suggests we could re-use this method in a few places.


More details in [this story](https://www.pivotaltracker.com/story/show/161672768)

Aarti & @ablease ,
On behalf of SAPI-team


