### PR TITLE
Handle scenarios of extra org level visibility objects for `enable-service-access` cmd

### DIFF
--- a/integration/shared/isolated/enable_service_access_command_test.go
+++ b/integration/shared/isolated/enable_service_access_command_test.go
@@ -170,7 +170,7 @@ var _ = Describe("enable service access command", func() {
 					))
 				})
 
-				When("service is already enabled for an org", func() {
+				When("service is already enabled for an org for a plan", func() {
 					BeforeEach(func() {
 						session := helpers.CF("enable-service-access", service, "-p", servicePlan, "-o", orgName)
 						Eventually(session).Should(Say("OK"))
@@ -191,6 +191,23 @@ var _ = Describe("enable service access command", func() {
 							servicePlan,
 						))
 
+					})
+
+					When("enabling access globally", func() {
+						It("should disbale org level access first", func() {
+							session := helpers.CF("enable-service-access", service)
+							Eventually(session).Should(Say("OK"))
+							Eventually(session).Should(Exit(0))
+
+							session = helpers.CF("service-access", "-e", service)
+							Eventually(session).Should(Exit(0))
+							Eventually(session).Should(Say("broker:\\s+%s", broker.Name))
+							Eventually(session).Should(Say("%s\\s+%s\\s+all",
+								service,
+								servicePlan,
+							))
+							Consistently(session).ShouldNot(Say(orgName))
+						})
 					})
 				})
 			})
@@ -357,7 +374,42 @@ var _ = Describe("enable service access command", func() {
 
 			Context("when access is already globally enabled", func() {
 				BeforeEach(func() {
-					helpers.CF("enable-service-access", service)
+					Eventually(helpers.CF("enable-service-access", service)).Should(Exit(0))
+				})
+
+				When("when we try to enable access for an org", func() {
+					It("should still be enabled only globally", func() {
+						session := helpers.CF("enable-service-access", service, "-o", orgName)
+						Eventually(session).Should(Say("OK"))
+						Eventually(session).Should(Exit(0))
+
+						session = helpers.CF("service-access", "-e", service)
+						Eventually(session).Should(Exit(0))
+						Eventually(session).Should(Say("broker:\\s+%s", broker.Name))
+						Eventually(session).Should(Say("%s\\s+%s\\s+all",
+							service,
+							servicePlan,
+						))
+						Consistently(session).ShouldNot(Say(orgName))
+
+					})
+				})
+
+				When("when we try to enable access for an org for a plan", func() {
+					It("should still be enabled only globally", func() {
+						session := helpers.CF("enable-service-access", service, "-o", orgName, "-p", servicePlan)
+						Eventually(session).Should(Say("OK"))
+						Eventually(session).Should(Exit(0))
+
+						session = helpers.CF("service-access", "-e", service)
+						Eventually(session).Should(Exit(0))
+						Eventually(session).Should(Say("broker:\\s+%s", broker.Name))
+						Eventually(session).Should(Say("%s\\s+%s\\s+all",
+							service,
+							servicePlan,
+						))
+						Consistently(session).ShouldNot(Say(orgName))
+					})
 				})
 
 				When("the service already has access globally enabled", func() {


### PR DESCRIPTION
1. Disable on org level first (i.e. delete the service plan visibility, if any), when enabling service for all orgs
2. Do not enable on org level ((i.e. no new service plan visibility), when the plan is already public

[finishes #162747373]

More details can be found [here].(https://www.pivotaltracker.com/n/projects/2105761/stories/162747373)

-Aarti
On behalf of SAPI team

