### PR TITLE
Ignore 404 on instance fetch for cf services cmd

### DIFF
--- a/actor/v2action/service_instance_summary.go
+++ b/actor/v2action/service_instance_summary.go
@@ -208,7 +208,9 @@ func (actor Actor) getSummaryInfoCompositeForInstance(spaceGUID string, serviceI
 		allWarnings = append(allWarnings, bindingsWarnings...)
 		if err != nil {
 			log.WithField("GUID", serviceInstance.GUID).Errorln("looking up service binding:", err)
-			return serviceInstanceSummary, allWarnings, err
+			if _, ok := err.(ccerror.ResourceNotFoundError); !ok {
+				return serviceInstanceSummary, allWarnings, err
+			}
 		}
 	} else {
 		log.Debug("service is user provided")
@@ -218,7 +220,9 @@ func (actor Actor) getSummaryInfoCompositeForInstance(spaceGUID string, serviceI
 		allWarnings = append(allWarnings, bindingsWarnings...)
 		if err != nil {
 			log.WithField("service_instance_guid", serviceInstance.GUID).Errorln("looking up service bindings:", err)
-			return serviceInstanceSummary, allWarnings, err
+			if _, ok := err.(ccerror.ResourceNotFoundError); !ok {
+				return serviceInstanceSummary, allWarnings, err
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR is a bug fix, regarding this issue #1513

## Does this PR modify CLI v6 or v7?

CLI v6

## What Need Does It Address?

Prior to this commit, there was a race condition, that service instances
could be listed, and service bindings for that instance could be listed,
but between the two requests, the service instance could be deleted and
the cf services command would fail.

This commit results in logging the error, but continuing with the rest
of the command.

This commit only applies to both managed and user provided service instances.

Thanks, Sapiteam

Alex + @AartiKriplani 

