### PR TITLE
Include broker name in `cf services` output

### DIFF
--- a/command/v6/services_command.go
+++ b/command/v6/services_command.go
@@ -76,6 +76,7 @@ func (cmd ServicesCommand) Execute(args []string) error {
 		cmd.UI.TranslateText("plan"),
 		cmd.UI.TranslateText("bound apps"),
 		cmd.UI.TranslateText("last operation"),
+		cmd.UI.TranslateText("broker"),
 	}}
 
 	var boundAppNames []string
@@ -96,7 +97,8 @@ func (cmd ServicesCommand) Execute(args []string) error {
 			serviceLabel,
 			summary.ServicePlan.Name,
 			strings.Join(boundAppNames, ", "),
-			fmt.Sprintf("%s %s", summary.LastOperation.Type, summary.LastOperation.State)},
+			fmt.Sprintf("%s %s", summary.LastOperation.Type, summary.LastOperation.State),
+			summary.Service.ServiceBrokerName},
 		)
 	}
 	cmd.UI.DisplayTableWithHeader("", table, 3)

--- a/command/v6/services_command_test.go
+++ b/command/v6/services_command_test.go
@@ -140,7 +140,10 @@ var _ = Describe("services Command", func() {
 									Type: constant.ServiceInstanceTypeManagedService,
 								},
 								ServicePlan: v2action.ServicePlan{Name: "some-plan"},
-								Service:     v2action.Service{Label: "some-service-1"},
+								Service: v2action.Service{
+									Label:             "some-service-1",
+									ServiceBrokerName: "broker-1",
+								},
 								BoundApplications: []v2action.BoundApplication{
 									{AppName: "app-1"},
 									{AppName: "app-2"},
@@ -151,7 +154,10 @@ var _ = Describe("services Command", func() {
 									Name: "instance-2",
 									Type: constant.ServiceInstanceTypeManagedService,
 								},
-								Service: v2action.Service{Label: "some-service-2"},
+								Service: v2action.Service{
+									Label:             "some-service-2",
+									ServiceBrokerName: "broker-2",
+								},
 							},
 							{
 								ServiceInstance: v2action.ServiceInstance{
@@ -169,9 +175,9 @@ var _ = Describe("services Command", func() {
 					Expect(executeErr).ToNot(HaveOccurred())
 					Expect(testUI.Out).To(Say("Getting services in org %s / space %s as %s...", "some-org",
 						"some-space", fakeUser.Name))
-					Expect(testUI.Out).To(Say(`name\s+service\s+plan\s+bound apps\s+last operation`))
-					Expect(testUI.Out).To(Say(`instance-1\s+some-service-1\s+some-plan\s+app-1, app-2\s+some-type some-state`))
-					Expect(testUI.Out).To(Say(`instance-2\s+some-service-2\s+`))
+					Expect(testUI.Out).To(Say(`name\s+service\s+plan\s+bound apps\s+last operation\s+broker`))
+					Expect(testUI.Out).To(Say(`instance-1\s+some-service-1\s+some-plan\s+app-1, app-2\s+some-type some-state\s+broker-1`))
+					Expect(testUI.Out).To(Say(`instance-2\s+some-service-2\s+broker-2`))
 					Expect(testUI.Out).To(Say(`instance-3\s+user-provided\s+`))
 					Expect(testUI.Err).To(Say("get-summary-warnings"))
 				})

--- a/integration/shared/isolated/services_command_test.go
+++ b/integration/shared/isolated/services_command_test.go
@@ -1,6 +1,7 @@
 package isolated
 
 import (
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccversion"
 	"code.cloudfoundry.org/cli/integration/helpers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -120,15 +121,38 @@ var _ = Describe("services command", func() {
 			helpers.QuickDeleteOrg(orgName)
 		})
 
-		It("displays all service information", func() {
-			session := helpers.CF("services")
-			Eventually(session).Should(Say("Getting services in org %s / space %s as %s...", orgName, spaceName, userName))
-			Eventually(session).Should(Say(`name\s+service\s+plan\s+bound apps\s+last operation\s+broker`))
-			Eventually(session).Should(Say(`%s\s+%s\s+%s\s+%s\s+%s\s+%s`, managedService1, service, servicePlan, appName1, "create succeeded", broker.Name))
-			Eventually(session).Should(Say(`%s\s+%s\s+%s\s+%s, %s\s+%s\s+%s`, managedService2, service, servicePlan, appName1, appName2, "create succeeded", broker.Name))
-			Eventually(session).Should(Say(`%s\s+%s\s+%s`, userProvidedService1, "user-provided", appName1))
-			Eventually(session).Should(Say(`%s\s+%s\s+%s, %s`, userProvidedService2, "user-provided", appName1, appName2))
-			Eventually(session).Should(Exit(0))
+		When("CAPI version is < 2.125.0", func() {
+			BeforeEach(func() {
+				helpers.SkipIfVersionAtLeast(ccversion.MinVersionServiceBrokerNameV2)
+			})
+
+			It("displays all service information", func() {
+				session := helpers.CF("services")
+				Eventually(session).Should(Say("Getting services in org %s / space %s as %s...", orgName, spaceName, userName))
+				Eventually(session).Should(Say(`name\s+service\s+plan\s+bound apps\s+last operation\s+broker`))
+				Eventually(session).Should(Say(`%s\s+%s\s+%s\s+%s\s+%s\s`, managedService1, service, servicePlan, appName1, "create succeeded"))
+				Eventually(session).Should(Say(`%s\s+%s\s+%s\s+%s, %s\s+%s\s`, managedService2, service, servicePlan, appName1, appName2, "create succeeded"))
+				Eventually(session).Should(Say(`%s\s+%s\s+%s`, userProvidedService1, "user-provided", appName1))
+				Eventually(session).Should(Say(`%s\s+%s\s+%s, %s`, userProvidedService2, "user-provided", appName1, appName2))
+				Eventually(session).Should(Exit(0))
+			})
+		})
+
+		When("CAPI version is => 2.125.0", func() {
+			BeforeEach(func() {
+				helpers.SkipIfVersionLessThan(ccversion.MinVersionServiceBrokerNameV2)
+			})
+
+			It("displays all service information", func() {
+				session := helpers.CF("services")
+				Eventually(session).Should(Say("Getting services in org %s / space %s as %s...", orgName, spaceName, userName))
+				Eventually(session).Should(Say(`name\s+service\s+plan\s+bound apps\s+last operation\s+broker`))
+				Eventually(session).Should(Say(`%s\s+%s\s+%s\s+%s\s+%s\s+%s`, managedService1, service, servicePlan, appName1, "create succeeded", broker.Name))
+				Eventually(session).Should(Say(`%s\s+%s\s+%s\s+%s, %s\s+%s\s+%s`, managedService2, service, servicePlan, appName1, appName2, "create succeeded", broker.Name))
+				Eventually(session).Should(Say(`%s\s+%s\s+%s`, userProvidedService1, "user-provided", appName1))
+				Eventually(session).Should(Say(`%s\s+%s\s+%s, %s`, userProvidedService2, "user-provided", appName1, appName2))
+				Eventually(session).Should(Exit(0))
+			})
 		})
 	})
 })

--- a/integration/shared/isolated/services_command_test.go
+++ b/integration/shared/isolated/services_command_test.go
@@ -123,9 +123,9 @@ var _ = Describe("services command", func() {
 		It("displays all service information", func() {
 			session := helpers.CF("services")
 			Eventually(session).Should(Say("Getting services in org %s / space %s as %s...", orgName, spaceName, userName))
-			Eventually(session).Should(Say(`name\s+service\s+plan\s+bound apps\s+last operation`))
-			Eventually(session).Should(Say(`%s\s+%s\s+%s\s+%s\s+%s`, managedService1, service, servicePlan, appName1, "create succeeded"))
-			Eventually(session).Should(Say(`%s\s+%s\s+%s\s+%s, %s\s+%s`, managedService2, service, servicePlan, appName1, appName2, "create succeeded"))
+			Eventually(session).Should(Say(`name\s+service\s+plan\s+bound apps\s+last operation\s+broker`))
+			Eventually(session).Should(Say(`%s\s+%s\s+%s\s+%s\s+%s\s+%s`, managedService1, service, servicePlan, appName1, "create succeeded", broker.Name))
+			Eventually(session).Should(Say(`%s\s+%s\s+%s\s+%s, %s\s+%s\s+%s`, managedService2, service, servicePlan, appName1, appName2, "create succeeded", broker.Name))
 			Eventually(session).Should(Say(`%s\s+%s\s+%s`, userProvidedService1, "user-provided", appName1))
 			Eventually(session).Should(Say(`%s\s+%s\s+%s, %s`, userProvidedService2, "user-provided", appName1, appName2))
 			Eventually(session).Should(Exit(0))


### PR DESCRIPTION
When executing `cf services` command you get the list of services in your org/space.
This PR adds a column showing the service broker name of these services.

More information on https://www.pivotaltracker.com/n/projects/2105761/stories/160752090

Best,
Niki
On behalf of SAPI Team
