### PR TITLE
Fixing integration cleanup command

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -144,7 +144,7 @@ If the number of parallel nodes for the non-global test suites would like to be
 adjusted, set the `NODES` environment variable:
 
 ```bash
-NODES=10 make integration-tests
+NODES=10 make integration-cleanup
 ```
 
 # Modifying the CLI codebase


### PR DESCRIPTION
The Makefile command is `integration-cleanup` not, `integration-tests`