### PR TITLE
Support /spaces and /organizations endpoint without guids param

### DIFF
--- a/api/cloudcontroller/ccversion/minimum_version.go
+++ b/api/cloudcontroller/ccversion/minimum_version.go
@@ -22,4 +22,5 @@ const (
 	MinVersionRoutingV3            = "3.16.0"
 	MinVersionShareServiceV3       = "3.36.0"
 	MinVersionZeroDowntimePushV3   = "3.57.0"
+	MinVersionSpacesGUIDsParamV3   = "3.56.0"
 )


### PR DESCRIPTION
[#163074672]

Signed-off-by: Slawek Ligus <sligus@pivotal.io>

## Does this PR modify CLI v6 or v7?

CLIv6

## What Need Does It Address?

This change enables CC APIs < 3.56.0 (they don't support `guids` filter param) to display organization and space a network policy belongs to

## Who Is The Functionality For?

Users of old CC API releases 

## How Often Will This Functionality Be Used?

Every time `netork-policies` command is issued.

## Possible Drawbacks

On deployments with hundreds of orgs and spaces, the command may take a longer time to run.

## Why Should This Be In Core?

It's an enhancement to an existing feature.

## Description of the Change

* For APIs that support the `guids` param, we narrow down the guids we ask for in the query.
* For APIs that do not support the `guids` param, we narrow down the guids in the client code.

## Alternate Designs

-

@xanderstrike