### PR TITLE
Reduce superfluous api requests during update-service command

### DIFF
--- a/cf/actors/planbuilder/plan_builder.go
+++ b/cf/actors/planbuilder/plan_builder.go
@@ -145,25 +145,19 @@ func (builder Builder) containsGUID(guidSlice []string, guid string) bool {
 }
 
 func (builder Builder) buildPlanToOrgVisibilityMap(orgName string) (map[string][]string, error) {
-	// Since this map doesn't ever change, we memoize it for performance
-	orgLookup := make(map[string]string)
-
 	org, err := builder.orgRepo.FindByName(orgName)
 	if err != nil {
 		return nil, err
 	}
-	orgLookup[org.GUID] = org.Name
 
-	visibilities, err := builder.servicePlanVisibilityRepo.List()
+	visibilities, err := builder.servicePlanVisibilityRepo.Search(map[string]string{"organization_guid": org.GUID})
 	if err != nil {
 		return nil, err
 	}
 
 	visMap := make(map[string][]string)
 	for _, vis := range visibilities {
-		if _, exists := orgLookup[vis.OrganizationGUID]; exists {
-			visMap[vis.ServicePlanGUID] = append(visMap[vis.ServicePlanGUID], orgLookup[vis.OrganizationGUID])
-		}
+		visMap[vis.ServicePlanGUID] = []string{org.Name}
 	}
 
 	return visMap, nil

--- a/cf/actors/planbuilder/plan_builder_test.go
+++ b/cf/actors/planbuilder/plan_builder_test.go
@@ -60,6 +60,10 @@ var _ = Describe("Plan builder", func() {
 			{ServicePlanGUID: "service-plan1-guid", OrganizationGUID: "org2-guid"},
 			{ServicePlanGUID: "service-plan2-guid", OrganizationGUID: "org1-guid"},
 		}, nil)
+		visibilityRepo.SearchReturns([]models.ServicePlanVisibilityFields{
+			{ServicePlanGUID: "service-plan1-guid", OrganizationGUID: "org1-guid"},
+			{ServicePlanGUID: "service-plan2-guid", OrganizationGUID: "org1-guid"},
+		}, nil)
 		orgRepo.GetManyOrgsByGUIDReturns([]models.Organization{org1, org2}, nil)
 	})
 

--- a/integration/shared/isolated/update_service_command_test.go
+++ b/integration/shared/isolated/update_service_command_test.go
@@ -1,0 +1,73 @@
+package isolated
+
+import (
+	"code.cloudfoundry.org/cli/integration/helpers"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+	. "github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("update-service command", func() {
+	When("an api is targeted, the user is logged in, and an org and space are targeted", func() {
+		var (
+			orgName string
+		)
+
+		BeforeEach(func() {
+			orgName = helpers.NewOrgName()
+			var spaceName = helpers.NewSpaceName()
+			helpers.SetupCF(orgName, spaceName)
+		})
+
+		AfterEach(func() {
+			helpers.QuickDeleteOrg(orgName)
+		})
+
+		When("there is a service instance", func() {
+			var (
+				service             string
+				servicePlan         string
+				broker              helpers.ServiceBroker
+				serviceInstanceName string
+				username	        string
+			)
+
+			BeforeEach(func() {
+				var domain = helpers.DefaultSharedDomain()
+				service = helpers.PrefixedRandomName("SERVICE")
+				servicePlan = helpers.PrefixedRandomName("SERVICE-PLAN")
+				broker = helpers.CreateBroker(domain, service, servicePlan)
+
+				Eventually(helpers.CF("enable-service-access", service)).Should(Exit(0))
+
+				serviceInstanceName = helpers.PrefixedRandomName("SI")
+				Eventually(helpers.CF("create-service", service, servicePlan, serviceInstanceName)).Should(Exit(0))
+
+				username, _ = helpers.GetCredentials()
+			})
+
+			AfterEach(func() {
+				Eventually(helpers.CF("delete-service", serviceInstanceName, "-f")).Should(Exit(0))
+				broker.Destroy()
+			})
+
+			When("updating to a service plan that does not exist", func() {
+				It("displays an informative error message, exits 1", func() {
+					session := helpers.CF("update-service", serviceInstanceName, "-p", "non-existing-service-plan")
+					Eventually(session).Should(Say("Plan does not exist for the %s service", service))
+					Eventually(session).Should(Exit(1))
+				})
+			})
+
+			When("updating to the same service plan (no-op)", func() {
+				It("displays an informative success message, exits 0", func() {
+					session := helpers.CF("update-service", serviceInstanceName, "-p", servicePlan)
+					Eventually(session).Should(Say("Updating service instance %s as %s...", serviceInstanceName, username))
+					Eventually(session).Should(Say("OK"))
+					Eventually(session).Should(Exit(0))
+				})
+			})
+		})
+	})
+})


### PR DESCRIPTION
Instead of getting all service_plan_visibilities, query for a specifc org when possible.

Fixes #1549
