### PR TITLE
Fix  enable-service-access command: creating unnecessary plan visibilities 

### DIFF
--- a/actor/v2action/service_access.go
+++ b/actor/v2action/service_access.go
@@ -16,8 +16,14 @@ func (actor Actor) EnableServiceForAllOrgs(serviceName string) (Warnings, error)
 	}
 
 	for _, plan := range servicePlans {
-		warnings, err := actor.CloudControllerClient.UpdateServicePlan(plan.GUID, true)
+		warnings, err := actor.removeOrgLevelServicePlanVisibilities(plan.GUID)
 		allWarnings = append(allWarnings, warnings...)
+		if err != nil {
+			return allWarnings, err
+		}
+
+		ccv2Warnings, err := actor.CloudControllerClient.UpdateServicePlan(plan.GUID, true)
+		allWarnings = append(allWarnings, ccv2Warnings...)
 		if err != nil {
 			return allWarnings, err
 		}
@@ -66,10 +72,12 @@ func (actor Actor) EnableServiceForOrg(serviceName, orgName string) (Warnings, e
 	}
 
 	for _, plan := range servicePlans {
-		_, warnings, err := actor.CloudControllerClient.CreateServicePlanVisibility(plan.GUID, org.GUID)
-		allWarnings = append(allWarnings, warnings...)
-		if err != nil {
-			return allWarnings, err
+		if plan.Public != true {
+			_, warnings, err := actor.CloudControllerClient.CreateServicePlanVisibility(plan.GUID, org.GUID)
+			allWarnings = append(allWarnings, warnings...)
+			if err != nil {
+				return allWarnings, err
+			}
 		}
 	}
 
@@ -91,6 +99,9 @@ func (actor Actor) EnablePlanForOrg(serviceName, servicePlanName, orgName string
 
 	for _, plan := range servicePlans {
 		if plan.Name == servicePlanName {
+			if plan.Public == true {
+				return allWarnings, nil
+			}
 			_, warnings, err := actor.CloudControllerClient.CreateServicePlanVisibility(plan.GUID, org.GUID)
 			allWarnings = append(allWarnings, warnings...)
 			return allWarnings, err

--- a/actor/v2action/service_access_test.go
+++ b/actor/v2action/service_access_test.go
@@ -306,6 +306,24 @@ var _ = Describe("Service Access", func() {
 				Expect(enablePlanErr).NotTo(HaveOccurred())
 			})
 
+			When("the plan is already globally enabled", func() {
+				BeforeEach(func() {
+					fakeCloudControllerClient.GetServicePlansReturns(
+						[]ccv2.ServicePlan{
+							{Name: "plan-2", GUID: "service-plan-guid-2", Public: true},
+						},
+						nil, nil)
+				})
+
+				It("should not create org visibility", func() {
+					Expect(enablePlanErr).ToNot(HaveOccurred())
+					Expect(fakeCloudControllerClient.GetServicesCallCount()).To(Equal(1))
+					Expect(fakeCloudControllerClient.GetServicePlansCallCount()).To(Equal(1))
+
+					Expect(fakeCloudControllerClient.CreateServicePlanVisibilityCallCount()).To(Equal(0))
+				})
+			})
+
 			When("warnings are raised", func() {
 				BeforeEach(func() {
 					fakeCloudControllerClient.CreateServicePlanVisibilityReturns(ccv2.ServicePlanVisibility{}, []string{"foo", "bar"}, nil)
@@ -495,6 +513,29 @@ var _ = Describe("Service Access", func() {
 				Expect(orgGUID2).To(Equal("org-guid-1"))
 				Expect([]string{planGUID1, planGUID2}).To(ConsistOf([]string{"service-plan-guid-1", "service-plan-guid-2"}))
 			})
+
+			When("service is already enabled for all orgs for a plan", func() {
+				BeforeEach(func() {
+					fakeCloudControllerClient.GetServicePlansReturns(
+						[]ccv2.ServicePlan{
+							{Name: "plan-1", GUID: "service-plan-guid-1", Public: true},
+							{Name: "plan-2", GUID: "service-plan-guid-2", Public: false},
+						},
+						nil,
+						nil)
+				})
+
+				It("does not create service plan visibility for the org", func() {
+					Expect(enableServiceForOrgErr).NotTo(HaveOccurred())
+					Expect(fakeCloudControllerClient.GetServicesCallCount()).To(Equal(1))
+					Expect(fakeCloudControllerClient.GetServicePlansCallCount()).To(Equal(1))
+
+					Expect(fakeCloudControllerClient.CreateServicePlanVisibilityCallCount()).To(Equal(1))
+					planGUID1, orgGUID1 := fakeCloudControllerClient.CreateServicePlanVisibilityArgsForCall(0)
+					Expect(orgGUID1).To(Equal("org-guid-1"))
+					Expect(planGUID1).To(Equal("service-plan-guid-2"))
+				})
+			})
 		})
 
 		When("getting services fails", func() {
@@ -623,6 +664,42 @@ var _ = Describe("Service Access", func() {
 			planGuid, public = fakeCloudControllerClient.UpdateServicePlanArgsForCall(1)
 			Expect(planGuid).To(Equal("service-plan-guid-2"))
 			Expect(public).To(BeTrue())
+		})
+
+		When("the service is already enabled for orgs individually", func() {
+			BeforeEach(func() {
+				fakeCloudControllerClient.GetServicePlanVisibilitiesReturns(
+					[]ccv2.ServicePlanVisibility{
+						{GUID: "service-visibility-guid-1"},
+					},
+					nil, nil)
+			})
+
+			It("first disables the plan in both orgs", func() {
+				Expect(fakeCloudControllerClient.GetServicePlanVisibilitiesCallCount()).To(Equal(2))
+
+				filters := fakeCloudControllerClient.GetServicePlanVisibilitiesArgsForCall(0)
+				Expect(filters[0].Type).To(Equal(constant.ServicePlanGUIDFilter))
+				Expect(filters[0].Operator).To(Equal(constant.EqualOperator))
+				Expect(filters[0].Values).To(Equal([]string{"service-plan-guid-1"}))
+
+				Expect(fakeCloudControllerClient.DeleteServicePlanVisibilityCallCount()).To(Equal(2))
+			})
+
+			When("deleting service plan visibilities fails", func() {
+				BeforeEach(func() {
+					fakeCloudControllerClient.DeleteServicePlanVisibilityReturns(
+						[]string{"visibility-warning"}, errors.New("delete-visibility-error"))
+				})
+
+				It("propagates the error", func() {
+					Expect(enableServiceErr).To(MatchError(errors.New("delete-visibility-error")))
+				})
+
+				It("returns the warnings", func() {
+					Expect(enableServiceWarnings).To(Equal(Warnings{"visibility-warning"}))
+				})
+			})
 		})
 
 		When("the service does not exist", func() {


### PR DESCRIPTION
`cf enable-service-acess` command should not create a plan visibility if the plan is already public.

This PR:
1. Delete the service plan visibility, if any, when enabling service for all orgs
2. Do not enable on org level when the plan is already public

For more information [see here](https://www.pivotaltracker.com/story/show/162747373)

Best,
Niki
on Behalf of SAPI Team