### PR TITLE
Require a targeted space for delete-service

### DIFF
--- a/cf/commands/service/delete_service.go
+++ b/cf/commands/service/delete_service.go
@@ -47,6 +47,7 @@ func (cmd *DeleteService) Requirements(requirementsFactory requirements.Factory,
 
 	reqs := []requirements.Requirement{
 		requirementsFactory.NewLoginRequirement(),
+		requirementsFactory.NewTargetedSpaceRequirement(),
 	}
 
 	return reqs, nil

--- a/cf/commands/service/delete_service_test.go
+++ b/cf/commands/service/delete_service_test.go
@@ -42,7 +42,6 @@ var _ = Describe("delete-service command", func() {
 		configRepo = testconfig.NewRepositoryWithDefaults()
 		serviceRepo = new(apifakes.FakeServiceRepository)
 		requirementsFactory = new(requirementsfakes.FakeFactory)
-		requirementsFactory.NewLoginRequirementReturns(requirements.Passing{})
 	})
 
 	runCommand := func(args ...string) bool {
@@ -64,102 +63,118 @@ var _ = Describe("delete-service command", func() {
 			requirementsFactory.NewLoginRequirementReturns(requirements.Passing{})
 		})
 
-		It("fails with usage when not provided exactly one arg", func() {
-			runCommand()
-			Expect(ui.Outputs()).To(ContainSubstrings(
-				[]string{"Incorrect Usage", "Requires an argument"},
-			))
-		})
-
-		Context("when the service exists", func() {
-			Context("and the service deletion is asynchronous", func() {
-				BeforeEach(func() {
-					serviceInstance = models.ServiceInstance{}
-					serviceInstance.Name = "my-service"
-					serviceInstance.GUID = "my-service-guid"
-					serviceInstance.LastOperation.Type = "delete"
-					serviceInstance.LastOperation.State = "in progress"
-					serviceInstance.LastOperation.Description = "delete"
-					serviceRepo.FindInstanceByNameReturns(serviceInstance, nil)
-				})
-
-				Context("when the command is confirmed", func() {
-					It("deletes the service", func() {
-						runCommand("my-service")
-
-						Expect(ui.Prompts).To(ContainSubstrings([]string{"Really delete the service my-service"}))
-
-						Expect(ui.Outputs()).To(ContainSubstrings(
-							[]string{"Deleting service", "my-service", "my-org", "my-space", "my-user"},
-							[]string{"OK"},
-							[]string{"Delete in progress. Use 'cf services' or 'cf service my-service' to check operation status."},
-						))
-
-						Expect(serviceRepo.DeleteServiceArgsForCall(0)).To(Equal(serviceInstance))
-					})
-				})
-
-				It("skips confirmation when the -f flag is given", func() {
-					runCommand("-f", "foo.com")
-
-					Expect(ui.Prompts).To(BeEmpty())
-					Expect(ui.Outputs()).To(ContainSubstrings(
-						[]string{"Deleting service", "foo.com"},
-						[]string{"OK"},
-						[]string{"Delete in progress. Use 'cf services' or 'cf service foo.com' to check operation status."},
-					))
-				})
-			})
-
-			Context("and the service deletion is synchronous", func() {
-				BeforeEach(func() {
-					serviceInstance = models.ServiceInstance{}
-					serviceInstance.Name = "my-service"
-					serviceInstance.GUID = "my-service-guid"
-					serviceRepo.FindInstanceByNameReturns(serviceInstance, nil)
-				})
-
-				Context("when the command is confirmed", func() {
-					It("deletes the service", func() {
-						runCommand("my-service")
-
-						Expect(ui.Prompts).To(ContainSubstrings([]string{"Really delete the service my-service"}))
-
-						Expect(ui.Outputs()).To(ContainSubstrings(
-							[]string{"Deleting service", "my-service", "my-org", "my-space", "my-user"},
-							[]string{"OK"},
-						))
-
-						Expect(serviceRepo.DeleteServiceArgsForCall(0)).To(Equal(serviceInstance))
-					})
-				})
-
-				It("skips confirmation when the -f flag is given", func() {
-					runCommand("-f", "foo.com")
-
-					Expect(ui.Prompts).To(BeEmpty())
-					Expect(ui.Outputs()).To(ContainSubstrings(
-						[]string{"Deleting service", "foo.com"},
-						[]string{"OK"},
-					))
-				})
-			})
-		})
-
-		Context("when the service does not exist", func() {
+		When("not targeting an org or space", func() {
 			BeforeEach(func() {
-				serviceRepo.FindInstanceByNameReturns(models.ServiceInstance{}, errors.NewModelNotFoundError("Service instance", "my-service"))
+				requirementsFactory.NewTargetedSpaceRequirementReturns(requirements.Failing{Message: "no space targeted"})
 			})
 
-			It("warns the user the service does not exist", func() {
-				runCommand("-f", "my-service")
+			It("does not pass requirements", func() {
+				Expect(runCommand("vestigial-service")).To(BeFalse())
+			})
+		})
 
+		When("targeting an org and space", func() {
+			BeforeEach(func() {
+				requirementsFactory.NewTargetedSpaceRequirementReturns(requirements.Passing{})
+			})
+
+			It("fails with usage when not provided exactly one arg", func() {
+				runCommand()
 				Expect(ui.Outputs()).To(ContainSubstrings(
-					[]string{"Deleting service", "my-service"},
-					[]string{"OK"},
+					[]string{"Incorrect Usage", "Requires an argument"},
 				))
+			})
 
-				Expect(ui.WarnOutputs).To(ContainSubstrings([]string{"my-service", "does not exist"}))
+			Context("when the service exists", func() {
+				Context("and the service deletion is asynchronous", func() {
+					BeforeEach(func() {
+						serviceInstance = models.ServiceInstance{}
+						serviceInstance.Name = "my-service"
+						serviceInstance.GUID = "my-service-guid"
+						serviceInstance.LastOperation.Type = "delete"
+						serviceInstance.LastOperation.State = "in progress"
+						serviceInstance.LastOperation.Description = "delete"
+						serviceRepo.FindInstanceByNameReturns(serviceInstance, nil)
+					})
+
+					Context("when the command is confirmed", func() {
+						It("deletes the service", func() {
+							runCommand("my-service")
+
+							Expect(ui.Prompts).To(ContainSubstrings([]string{"Really delete the service my-service"}))
+
+							Expect(ui.Outputs()).To(ContainSubstrings(
+								[]string{"Deleting service", "my-service", "my-org", "my-space", "my-user"},
+								[]string{"OK"},
+								[]string{"Delete in progress. Use 'cf services' or 'cf service my-service' to check operation status."},
+							))
+
+							Expect(serviceRepo.DeleteServiceArgsForCall(0)).To(Equal(serviceInstance))
+						})
+					})
+
+					It("skips confirmation when the -f flag is given", func() {
+						runCommand("-f", "foo.com")
+
+						Expect(ui.Prompts).To(BeEmpty())
+						Expect(ui.Outputs()).To(ContainSubstrings(
+							[]string{"Deleting service", "foo.com"},
+							[]string{"OK"},
+							[]string{"Delete in progress. Use 'cf services' or 'cf service foo.com' to check operation status."},
+						))
+					})
+				})
+
+				Context("and the service deletion is synchronous", func() {
+					BeforeEach(func() {
+						serviceInstance = models.ServiceInstance{}
+						serviceInstance.Name = "my-service"
+						serviceInstance.GUID = "my-service-guid"
+						serviceRepo.FindInstanceByNameReturns(serviceInstance, nil)
+					})
+
+					Context("when the command is confirmed", func() {
+						It("deletes the service", func() {
+							runCommand("my-service")
+
+							Expect(ui.Prompts).To(ContainSubstrings([]string{"Really delete the service my-service"}))
+
+							Expect(ui.Outputs()).To(ContainSubstrings(
+								[]string{"Deleting service", "my-service", "my-org", "my-space", "my-user"},
+								[]string{"OK"},
+							))
+
+							Expect(serviceRepo.DeleteServiceArgsForCall(0)).To(Equal(serviceInstance))
+						})
+					})
+
+					It("skips confirmation when the -f flag is given", func() {
+						runCommand("-f", "foo.com")
+
+						Expect(ui.Prompts).To(BeEmpty())
+						Expect(ui.Outputs()).To(ContainSubstrings(
+							[]string{"Deleting service", "foo.com"},
+							[]string{"OK"},
+						))
+					})
+				})
+			})
+
+			Context("when the service does not exist", func() {
+				BeforeEach(func() {
+					serviceRepo.FindInstanceByNameReturns(models.ServiceInstance{}, errors.NewModelNotFoundError("Service instance", "my-service"))
+				})
+
+				It("warns the user the service does not exist", func() {
+					runCommand("-f", "my-service")
+
+					Expect(ui.Outputs()).To(ContainSubstrings(
+						[]string{"Deleting service", "my-service"},
+						[]string{"OK"},
+					))
+
+					Expect(ui.WarnOutputs).To(ContainSubstrings([]string{"my-service", "does not exist"}))
+				})
 			})
 		})
 	})


### PR DESCRIPTION
`cf delete-service` command should require a space to be targeted.
Currently deleting a service without targeting org and space will result in a confusing error.
This PR fixes the behaviour.

More information [here](https://www.pivotaltracker.com/story/show/162635933)

Best,
Niki
On Behalf of SAPI Team
 