### PR TITLE
Make enable-service-access command idempotent

### DIFF
--- a/actor/v2action/service_access.go
+++ b/actor/v2action/service_access.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"code.cloudfoundry.org/cli/actor/actionerror"
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccerror"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv2"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv2/constant"
 )
@@ -75,6 +76,9 @@ func (actor Actor) EnableServiceForOrg(serviceName, orgName, brokerName string) 
 		if plan.Public != true {
 			_, warnings, err := actor.CloudControllerClient.CreateServicePlanVisibility(plan.GUID, org.GUID)
 			allWarnings = append(allWarnings, warnings...)
+			if _, alreadyExistsError := err.(ccerror.ServicePlanVisibilityExistsError); alreadyExistsError {
+				return allWarnings, nil
+			}
 			if err != nil {
 				return allWarnings, err
 			}
@@ -104,6 +108,9 @@ func (actor Actor) EnablePlanForOrg(serviceName, servicePlanName, orgName, broke
 			}
 			_, warnings, err := actor.CloudControllerClient.CreateServicePlanVisibility(plan.GUID, org.GUID)
 			allWarnings = append(allWarnings, warnings...)
+			if _, alreadyExistsError := err.(ccerror.ServicePlanVisibilityExistsError); alreadyExistsError {
+				return allWarnings, nil
+			}
 			return allWarnings, err
 		}
 	}

--- a/actor/v2action/service_access_test.go
+++ b/actor/v2action/service_access_test.go
@@ -9,6 +9,7 @@ import (
 	"code.cloudfoundry.org/cli/actor/actionerror"
 	. "code.cloudfoundry.org/cli/actor/v2action"
 	"code.cloudfoundry.org/cli/actor/v2action/v2actionfakes"
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccerror"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv2"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv2/constant"
 )
@@ -422,6 +423,23 @@ var _ = Describe("Service Access", func() {
 				It("returns the error", func() {
 					Expect(enablePlanErr).To(MatchError(errors.New("some error")))
 				})
+
+				Context("because the service plan visibility already exists", func() {
+					BeforeEach(func() {
+						fakeCloudControllerClient.CreateServicePlanVisibilityReturns(
+							ccv2.ServicePlanVisibility{},
+							ccv2.Warnings{"qux"},
+							ccerror.ServicePlanVisibilityExistsError{Message: "sorry"})
+					})
+
+					It("does not return the error", func() {
+						Expect(enablePlanErr).NotTo(HaveOccurred())
+					})
+
+					It("returns all warnings", func() {
+						Expect(enablePlanWarnings).To(ConsistOf("foo", "bar", "qux"))
+					})
+				})
 			})
 		})
 
@@ -644,6 +662,23 @@ var _ = Describe("Service Access", func() {
 
 			It("returns all warnings", func() {
 				Expect(enableServiceForOrgWarnings).To(ConsistOf("foo", "bar", "baz", "qux"))
+			})
+
+			Context("because the service plan visibility already exists", func() {
+				BeforeEach(func() {
+					fakeCloudControllerClient.CreateServicePlanVisibilityReturns(
+						ccv2.ServicePlanVisibility{},
+						ccv2.Warnings{"qux"},
+						ccerror.ServicePlanVisibilityExistsError{Message: "sorry"})
+				})
+
+				It("does not return the error", func() {
+					Expect(enableServiceForOrgErr).NotTo(HaveOccurred())
+				})
+
+				It("returns all warnings", func() {
+					Expect(enableServiceForOrgWarnings).To(ConsistOf("foo", "bar", "baz", "qux"))
+				})
 			})
 		})
 	})

--- a/api/cloudcontroller/ccerror/service_plan_visibility_exists_error.go
+++ b/api/cloudcontroller/ccerror/service_plan_visibility_exists_error.go
@@ -1,0 +1,11 @@
+package ccerror
+
+// ServicePlanVisibilityExistsError is returned when creating a
+// service plan visibility that already exists
+type ServicePlanVisibilityExistsError struct {
+	Message string
+}
+
+func (e ServicePlanVisibilityExistsError) Error() string {
+	return e.Message
+}

--- a/api/cloudcontroller/ccv2/errors.go
+++ b/api/cloudcontroller/ccv2/errors.go
@@ -118,6 +118,8 @@ func handleBadRequest(errorResponse ccerror.V2ErrorResponse) error {
 		return ccerror.SpaceNameTakenError{Message: errorResponse.Description}
 	case "CF-ServiceInstanceNameTaken":
 		return ccerror.ServiceInstanceNameTakenError{Message: errorResponse.Description}
+	case "CF-ServicePlanVisibilityAlreadyExists":
+		return ccerror.ServicePlanVisibilityExistsError{Message: errorResponse.Description}
 	default:
 		return ccerror.BadRequestError{Message: errorResponse.Description}
 	}

--- a/api/cloudcontroller/ccv2/errors_test.go
+++ b/api/cloudcontroller/ccv2/errors_test.go
@@ -242,6 +242,22 @@ var _ = Describe("Error Wrapper", func() {
 							}))
 						})
 					})
+
+					When("creating a service plan visibility fails because it already exists", func() {
+						BeforeEach(func() {
+							serverResponse = `{
+								"code": 40002,
+								"description": "Service plan visibility already exists",
+								"error_code": "CF-ServicePlanVisibilityAlreadyExists"
+							  }`
+						})
+
+						It("returns a ServicePlanVisibilityExistsError", func() {
+							Expect(executeErr).To(MatchError(ccerror.ServicePlanVisibilityExistsError{
+								Message: "Service plan visibility already exists",
+							}))
+						})
+					})
 				})
 
 				Context("(401) Unauthorized", func() {

--- a/integration/shared/isolated/enable_service_access_command_test.go
+++ b/integration/shared/isolated/enable_service_access_command_test.go
@@ -360,12 +360,11 @@ var _ = Describe("enable service access command", func() {
 					Eventually(session).Should(Say("OK"))
 				})
 
-				It("displays FAILED, an informative error message and exits 1", func() {
+				It("displays OK, and exits 0", func() {
 					session := helpers.CF("enable-service-access", service, "-o", orgName)
 					Eventually(session).Should(Say("Enabling access to all plans of service %s for the org %s as admin...", service, orgName))
-					Eventually(session).Should(Say("FAILED"))
-					Eventually(session.Err).Should(Say("^This combination of ServicePlan and Organization is already taken: organization_id and service_plan_id unique"))
-					Eventually(session).Should(Exit(1))
+					Eventually(session).Should(Say("OK"))
+					Eventually(session).Should(Exit(0))
 				})
 			})
 


### PR DESCRIPTION
Fixes this issue https://github.com/cloudfoundry/cli/issues/939.

When re-enabling a plan for org, if the service plan visibility exists, CC throws a ServicePlanVisibilityExistsError which we just ignore and do not fail to make `enable-service-access` command idempotent.

Aarti
On behalf of SAPI team.