### PR TITLE
Use concise helper to create a service broker

### DIFF
--- a/integration/shared/isolated/enable_service_access_command_test.go
+++ b/integration/shared/isolated/enable_service_access_command_test.go
@@ -198,10 +198,7 @@ var _ = Describe("enable service access command", func() {
 			When("two services with the same name are registered", func() {
 				BeforeEach(func() {
 					helpers.SkipIfVersionLessThan(ccversion.MinVersionMultiServiceRegistrationV2)
-					secondBroker = helpers.NewServiceBroker(helpers.NewServiceBrokerName(), helpers.NewAssets().ServiceBroker, domain, service, servicePlan)
-					secondBroker.Push()
-					secondBroker.Configure(true)
-					secondBroker.Create()
+					secondBroker = helpers.CreateBroker(domain, service, servicePlan)
 				})
 
 				AfterEach(func() {


### PR DESCRIPTION
Use `CreateBroker` instead of `NewServiceBroker` together with additional commands in enable-service-access integration test.