### PR TITLE
Fix flaky marketplace integration test

### DIFF
--- a/integration/shared/global/marketplace_command_test.go
+++ b/integration/shared/global/marketplace_command_test.go
@@ -12,18 +12,15 @@ import (
 var _ = Describe("marketplace command", func() {
 	When("an API endpoint is set", func() {
 		When("not logged in", func() {
-			When("there are no accessible services", func() {
-				BeforeEach(func() {
-					helpers.LogoutCF()
-				})
+			BeforeEach(func() {
+				helpers.LogoutCF()
+			})
 
-				It("displays a message that no services are available", func() {
-					session := helpers.CF("marketplace")
-					Eventually(session).Should(Say("OK"))
-					Eventually(session).Should(Say("\n\n"))
-					Eventually(session).Should(Say("No service offerings found"))
-					Eventually(session).Should(Exit(0))
-				})
+			It("displays an informative message and exits 0", func() {
+				session := helpers.CF("marketplace")
+				Eventually(session).Should(Say("Getting all services from marketplace"))
+				Eventually(session).Should(Say("OK"))
+				Eventually(session).Should(Exit(0))
 			})
 		})
 	})


### PR DESCRIPTION
The issue was happening because of AfterEach() cleanup failing sometimes,
if other tests that deploy a service broker fail during their clean up step.
We have made the test generic to check that the marketplace command succeeds,
when the user is not logged in, whether or not services are empty or not.

More details can be found [here](https://www.pivotaltracker.com/story/show/163624111).