### PR TITLE
Add -b flag to create-service command

### DIFF
--- a/actor/v2action/service.go
+++ b/actor/v2action/service.go
@@ -52,18 +52,34 @@ func (actor Actor) GetServiceByNameAndBrokerName(serviceName, serviceBrokerName 
 	return Service(services[0]), Warnings(warnings), nil
 }
 
-func (actor Actor) getServiceByNameForSpace(serviceName, spaceGUID string) (Service, Warnings, error) {
-	services, warnings, err := actor.CloudControllerClient.GetSpaceServices(spaceGUID, ccv2.Filter{
+func (actor Actor) getServiceByNameForSpace(serviceName, spaceGUID, brokerGUID string) (Service, Warnings, error) {
+	var filters []ccv2.Filter
+
+	filters = append(filters, ccv2.Filter{
 		Type:     constant.LabelFilter,
 		Operator: constant.EqualOperator,
 		Values:   []string{serviceName},
 	})
+
+	if brokerGUID != "" {
+		filters = append(filters, ccv2.Filter{
+			Type:     constant.ServiceBrokerGUIDFilter,
+			Operator: constant.EqualOperator,
+			Values:   []string{brokerGUID},
+		})
+	}
+
+	services, warnings, err := actor.CloudControllerClient.GetSpaceServices(spaceGUID, filters...)
 	if err != nil {
 		return Service{}, Warnings(warnings), err
 	}
 
 	if len(services) == 0 {
 		return Service{}, Warnings(warnings), actionerror.ServiceNotFoundError{Name: serviceName}
+	}
+
+	if len(services) > 1 {
+		return Service{}, Warnings(warnings), actionerror.DuplicateServiceError{Name: serviceName}
 	}
 
 	return Service(services[0]), Warnings(warnings), nil

--- a/actor/v2action/service_plan.go
+++ b/actor/v2action/service_plan.go
@@ -38,8 +38,8 @@ func (actor Actor) GetServicePlansForService(serviceName, brokerName string) ([]
 	return plansToReturn, allWarnings, nil
 }
 
-func (actor Actor) getServicePlanForServiceInSpace(servicePlanName, serviceName, spaceGUID string) (ServicePlan, Warnings, error) {
-	service, allWarnings, err := actor.getServiceByNameForSpace(serviceName, spaceGUID)
+func (actor Actor) getServicePlanForServiceInSpace(servicePlanName, serviceName, spaceGUID, brokerGUID string) (ServicePlan, Warnings, error) {
+	service, allWarnings, err := actor.getServiceByNameForSpace(serviceName, spaceGUID, brokerGUID)
 	if err != nil {
 		return ServicePlan{}, allWarnings, err
 	}

--- a/command/v6/create_service_command.go
+++ b/command/v6/create_service_command.go
@@ -14,11 +14,12 @@ import (
 //go:generate counterfeiter . CreateServiceActor
 
 type CreateServiceActor interface {
-	CreateServiceInstance(spaceGUID, serviceName, servicePlanName, serviceInstanceName string, params map[string]interface{}, tags []string) (v2action.ServiceInstance, v2action.Warnings, error)
+	CreateServiceInstance(spaceGUID, serviceName, servicePlanName, serviceInstanceName, brokerName string, params map[string]interface{}, tags []string) (v2action.ServiceInstance, v2action.Warnings, error)
 }
 
 type CreateServiceCommand struct {
 	RequiredArgs     flag.CreateServiceArgs        `positional-args:"yes"`
+	ServiceBroker    string                        `short:"b" hidden:"true" description:"[Experimental] Enable access to a service from a specific service broker"`
 	ParametersAsJSON flag.JSONOrFileWithValidation `short:"c" description:"Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering."`
 	Tags             flag.Tags                     `short:"t" description:"User provided tags"`
 	usage            interface{}                   `usage:"CF_NAME create-service SERVICE PLAN SERVICE_INSTANCE [-c PARAMETERS_AS_JSON] [-t TAGS]\n\n   Optionally provide service-specific configuration parameters in a valid JSON object in-line:\n\n   CF_NAME create-service SERVICE PLAN SERVICE_INSTANCE -c '{\"name\":\"value\",\"name\":\"value\"}'\n\n   Optionally provide a file containing service-specific configuration parameters in a valid JSON object.\n   The path to the parameters file can be an absolute or relative path to a file:\n\n   CF_NAME create-service SERVICE PLAN SERVICE_INSTANCE -c PATH_TO_FILE\n\n   Example of valid JSON object:\n   {\n      \"cluster_nodes\": {\n         \"count\": 5,\n         \"memory_mb\": 1024\n      }\n   }\n\nTIP:\n   Use 'CF_NAME create-user-provided-service' to make user-provided services available to CF apps\n\nEXAMPLES:\n   Linux/Mac:\n      CF_NAME create-service db-service silver mydb -c '{\"ram_gb\":4}'\n\n   Windows Command Line:\n      CF_NAME create-service db-service silver mydb -c \"{\\\"ram_gb\\\":4}\"\n\n   Windows PowerShell:\n      CF_NAME create-service db-service silver mydb -c '{\\\"ram_gb\\\":4}'\n\n   CF_NAME create-service db-service silver mydb -c ~/workspace/tmp/instance_config.json\n\n   CF_NAME create-service db-service silver mydb -t \"list, of, tags\""`
@@ -75,6 +76,7 @@ func (cmd CreateServiceCommand) Execute(args []string) error {
 		cmd.RequiredArgs.Service,
 		cmd.RequiredArgs.ServicePlan,
 		cmd.RequiredArgs.ServiceInstance,
+		cmd.ServiceBroker,
 		cmd.ParametersAsJSON,
 		cmd.Tags,
 	)

--- a/command/v6/create_service_command_test.go
+++ b/command/v6/create_service_command_test.go
@@ -103,7 +103,7 @@ var _ = Describe("create-service Command", func() {
 			It("passes the correct args when creating the service instance", func() {
 				Expect(executeErr).NotTo(HaveOccurred())
 				Expect(fakeActor.CreateServiceInstanceCallCount()).To(Equal(1))
-				spaceGUID, service, servicePlan, serviceInstance, _, _ := fakeActor.CreateServiceInstanceArgsForCall(0)
+				spaceGUID, service, servicePlan, serviceInstance, _, _, _ := fakeActor.CreateServiceInstanceArgsForCall(0)
 				Expect(spaceGUID).To(Equal("some-space-guid"))
 				Expect(service).To(Equal("cool-broker"))
 				Expect(servicePlan).To(Equal("cool-plan"))
@@ -123,7 +123,7 @@ var _ = Describe("create-service Command", func() {
 				It("passes the tags as args when creating the service instance", func() {
 					Expect(executeErr).NotTo(HaveOccurred())
 					Expect(fakeActor.CreateServiceInstanceCallCount()).To(Equal(1))
-					_, _, _, _, _, tags := fakeActor.CreateServiceInstanceArgsForCall(0)
+					_, _, _, _, _, _, tags := fakeActor.CreateServiceInstanceArgsForCall(0)
 					Expect(tags).To(Equal([]string{"tag-1", "tag-2"}))
 				})
 			})
@@ -138,8 +138,21 @@ var _ = Describe("create-service Command", func() {
 				It("passes the parameters as args when creating the service instance", func() {
 					Expect(executeErr).NotTo(HaveOccurred())
 					Expect(fakeActor.CreateServiceInstanceCallCount()).To(Equal(1))
-					_, _, _, _, params, _ := fakeActor.CreateServiceInstanceArgsForCall(0)
+					_, _, _, _, _, params, _ := fakeActor.CreateServiceInstanceArgsForCall(0)
 					Expect(params).To(Equal(map[string]interface{}{"some-key": "some-value"}))
+				})
+			})
+
+			Context("the user passes in broker name", func() {
+				BeforeEach(func() {
+					cmd.ServiceBroker = "some-broker"
+				})
+
+				It("passes the broker name as arg when creating the service instance", func() {
+					Expect(executeErr).NotTo(HaveOccurred())
+					Expect(fakeActor.CreateServiceInstanceCallCount()).To(Equal(1))
+					_, _, _, _, brokerName, _, _ := fakeActor.CreateServiceInstanceArgsForCall(0)
+					Expect(brokerName).To(Equal("some-broker"))
 				})
 			})
 

--- a/command/v6/v6fakes/fake_create_service_actor.go
+++ b/command/v6/v6fakes/fake_create_service_actor.go
@@ -9,15 +9,16 @@ import (
 )
 
 type FakeCreateServiceActor struct {
-	CreateServiceInstanceStub        func(string, string, string, string, map[string]interface{}, []string) (v2action.ServiceInstance, v2action.Warnings, error)
+	CreateServiceInstanceStub        func(string, string, string, string, string, map[string]interface{}, []string) (v2action.ServiceInstance, v2action.Warnings, error)
 	createServiceInstanceMutex       sync.RWMutex
 	createServiceInstanceArgsForCall []struct {
 		arg1 string
 		arg2 string
 		arg3 string
 		arg4 string
-		arg5 map[string]interface{}
-		arg6 []string
+		arg5 string
+		arg6 map[string]interface{}
+		arg7 []string
 	}
 	createServiceInstanceReturns struct {
 		result1 v2action.ServiceInstance
@@ -33,11 +34,11 @@ type FakeCreateServiceActor struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeCreateServiceActor) CreateServiceInstance(arg1 string, arg2 string, arg3 string, arg4 string, arg5 map[string]interface{}, arg6 []string) (v2action.ServiceInstance, v2action.Warnings, error) {
-	var arg6Copy []string
-	if arg6 != nil {
-		arg6Copy = make([]string, len(arg6))
-		copy(arg6Copy, arg6)
+func (fake *FakeCreateServiceActor) CreateServiceInstance(arg1 string, arg2 string, arg3 string, arg4 string, arg5 string, arg6 map[string]interface{}, arg7 []string) (v2action.ServiceInstance, v2action.Warnings, error) {
+	var arg7Copy []string
+	if arg7 != nil {
+		arg7Copy = make([]string, len(arg7))
+		copy(arg7Copy, arg7)
 	}
 	fake.createServiceInstanceMutex.Lock()
 	ret, specificReturn := fake.createServiceInstanceReturnsOnCall[len(fake.createServiceInstanceArgsForCall)]
@@ -46,13 +47,14 @@ func (fake *FakeCreateServiceActor) CreateServiceInstance(arg1 string, arg2 stri
 		arg2 string
 		arg3 string
 		arg4 string
-		arg5 map[string]interface{}
-		arg6 []string
-	}{arg1, arg2, arg3, arg4, arg5, arg6Copy})
-	fake.recordInvocation("CreateServiceInstance", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6Copy})
+		arg5 string
+		arg6 map[string]interface{}
+		arg7 []string
+	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7Copy})
+	fake.recordInvocation("CreateServiceInstance", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7Copy})
 	fake.createServiceInstanceMutex.Unlock()
 	if fake.CreateServiceInstanceStub != nil {
-		return fake.CreateServiceInstanceStub(arg1, arg2, arg3, arg4, arg5, arg6)
+		return fake.CreateServiceInstanceStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
@@ -67,17 +69,17 @@ func (fake *FakeCreateServiceActor) CreateServiceInstanceCallCount() int {
 	return len(fake.createServiceInstanceArgsForCall)
 }
 
-func (fake *FakeCreateServiceActor) CreateServiceInstanceCalls(stub func(string, string, string, string, map[string]interface{}, []string) (v2action.ServiceInstance, v2action.Warnings, error)) {
+func (fake *FakeCreateServiceActor) CreateServiceInstanceCalls(stub func(string, string, string, string, string, map[string]interface{}, []string) (v2action.ServiceInstance, v2action.Warnings, error)) {
 	fake.createServiceInstanceMutex.Lock()
 	defer fake.createServiceInstanceMutex.Unlock()
 	fake.CreateServiceInstanceStub = stub
 }
 
-func (fake *FakeCreateServiceActor) CreateServiceInstanceArgsForCall(i int) (string, string, string, string, map[string]interface{}, []string) {
+func (fake *FakeCreateServiceActor) CreateServiceInstanceArgsForCall(i int) (string, string, string, string, string, map[string]interface{}, []string) {
 	fake.createServiceInstanceMutex.RLock()
 	defer fake.createServiceInstanceMutex.RUnlock()
 	argsForCall := fake.createServiceInstanceArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7
 }
 
 func (fake *FakeCreateServiceActor) CreateServiceInstanceReturns(result1 v2action.ServiceInstance, result2 v2action.Warnings, result3 error) {


### PR DESCRIPTION
Add a `-b` option to `cf create-service` command to specify the broker. 

When two or more services have the same name, the command errors on create if broker is not specified.

More info can be found in these stories:
https://www.pivotaltracker.com/story/show/160751849
https://www.pivotaltracker.com/story/show/163452070
https://www.pivotaltracker.com/story/show/163452612

