### PR TITLE
Add -b flag to disable-service-access command

### DIFF
--- a/actor/v2action/service.go
+++ b/actor/v2action/service.go
@@ -14,7 +14,7 @@ func (actor Actor) GetService(serviceGUID string) (Service, Warnings, error) {
 	return Service(service), Warnings(warnings), err
 }
 
-// GetServicesByNameAndBrokerName returns services based on the name provided.
+// GetServicesByNameAndBrokerName returns services based on the name and broker provided.
 // If there are no services, a ServiceNotFoundError will be returned.
 func (actor Actor) GetServiceByNameAndBrokerName(serviceName, serviceBrokerName string) (Service, Warnings, error) {
 	filters := []ccv2.Filter{ccv2.Filter{

--- a/actor/v2action/service_access.go
+++ b/actor/v2action/service_access.go
@@ -112,8 +112,8 @@ func (actor Actor) EnablePlanForOrg(serviceName, servicePlanName, orgName, broke
 }
 
 // DisableServiceForAllOrgs disables access for the given service in all orgs.
-func (actor Actor) DisableServiceForAllOrgs(serviceName string) (Warnings, error) {
-	servicePlans, allWarnings, err := actor.GetServicePlansForService(serviceName, "")
+func (actor Actor) DisableServiceForAllOrgs(serviceName, brokerName string) (Warnings, error) {
+	servicePlans, allWarnings, err := actor.GetServicePlansForService(serviceName, brokerName)
 	if err != nil {
 		return allWarnings, err
 	}
@@ -136,9 +136,9 @@ func (actor Actor) DisableServiceForAllOrgs(serviceName string) (Warnings, error
 	return allWarnings, nil
 }
 
-// DisablePlanForAllOrgs disables access to a specific plan of the given service in all orgs.
-func (actor Actor) DisablePlanForAllOrgs(serviceName, servicePlanName string) (Warnings, error) {
-	servicePlans, allWarnings, err := actor.GetServicePlansForService(serviceName, "")
+// DisablePlanForAllOrgs disables access to a specific plan of the given service, from the given broker in all orgs.
+func (actor Actor) DisablePlanForAllOrgs(serviceName, servicePlanName, brokerName string) (Warnings, error) {
+	servicePlans, allWarnings, err := actor.GetServicePlansForService(serviceName, brokerName)
 	if err != nil {
 		return allWarnings, err
 	}
@@ -169,8 +169,8 @@ func (actor Actor) DisablePlanForAllOrgs(serviceName, servicePlanName string) (W
 }
 
 // DisableServiceForOrg disables access for the given service in a specific org.
-func (actor Actor) DisableServiceForOrg(serviceName, orgName string) (Warnings, error) {
-	servicePlans, allWarnings, err := actor.GetServicePlansForService(serviceName, "")
+func (actor Actor) DisableServiceForOrg(serviceName, orgName, brokerName string) (Warnings, error) {
+	servicePlans, allWarnings, err := actor.GetServicePlansForService(serviceName, brokerName)
 	if err != nil {
 		return allWarnings, err
 	}
@@ -191,9 +191,9 @@ func (actor Actor) DisableServiceForOrg(serviceName, orgName string) (Warnings, 
 	return allWarnings, nil
 }
 
-// DisablePlanForOrg disables access to a specific plan of the given service in a specific org.
-func (actor Actor) DisablePlanForOrg(serviceName, servicePlanName, orgName string) (Warnings, error) {
-	servicePlans, allWarnings, err := actor.GetServicePlansForService(serviceName, "")
+// DisablePlanForOrg disables access to a specific plan of the given service from the given broker in a specific org.
+func (actor Actor) DisablePlanForOrg(serviceName, servicePlanName, orgName, brokerName string) (Warnings, error) {
+	servicePlans, allWarnings, err := actor.GetServicePlansForService(serviceName, brokerName)
 	if err != nil {
 		return allWarnings, err
 	}

--- a/actor/v2action/service_access_test.go
+++ b/actor/v2action/service_access_test.go
@@ -842,7 +842,24 @@ var _ = Describe("Service Access", func() {
 		})
 
 		JustBeforeEach(func() {
-			disableServiceWarnings, disableServiceErr = actor.DisableServiceForAllOrgs("service-1")
+			disableServiceWarnings, disableServiceErr = actor.DisableServiceForAllOrgs("service-1", "broker-1")
+		})
+
+		It("should call GetServices with proper filters", func() {
+			filters := fakeCloudControllerClient.GetServicesArgsForCall(0)
+			Expect(len(filters)).To(Equal(2))
+			Expect(filters).To(ConsistOf(
+				ccv2.Filter{
+					Type:     constant.LabelFilter,
+					Operator: constant.EqualOperator,
+					Values:   []string{"service-1"},
+				},
+				ccv2.Filter{
+					Type:     constant.ServiceBrokerGUIDFilter,
+					Operator: constant.EqualOperator,
+					Values:   []string{"broker-guid"},
+				},
+			))
 		})
 
 		It("should update all public plans to non-public", func() {
@@ -881,14 +898,6 @@ var _ = Describe("Service Access", func() {
 			It("returns service not found error", func() {
 				Expect(fakeCloudControllerClient.GetServicesCallCount()).To(Equal(1))
 				Expect(disableServiceErr).To(MatchError(actionerror.ServiceNotFoundError{Name: "service-1"}))
-
-				filters := fakeCloudControllerClient.GetServicesArgsForCall(0)
-				Expect(len(filters)).To(Equal(1))
-				Expect(filters[0]).To(Equal(ccv2.Filter{
-					Type:     constant.LabelFilter,
-					Operator: constant.EqualOperator,
-					Values:   []string{"service-1"},
-				}))
 			})
 		})
 
@@ -1007,7 +1016,24 @@ var _ = Describe("Service Access", func() {
 		})
 
 		JustBeforeEach(func() {
-			disablePlanWarnings, disablePlanErr = actor.DisablePlanForAllOrgs("service-1", "plan-2")
+			disablePlanWarnings, disablePlanErr = actor.DisablePlanForAllOrgs("service-1", "plan-2", "broker-1")
+		})
+
+		It("should call GetServices with proper filters", func() {
+			filters := fakeCloudControllerClient.GetServicesArgsForCall(0)
+			Expect(len(filters)).To(Equal(2))
+			Expect(filters).To(ConsistOf(
+				ccv2.Filter{
+					Type:     constant.LabelFilter,
+					Operator: constant.EqualOperator,
+					Values:   []string{"service-1"},
+				},
+				ccv2.Filter{
+					Type:     constant.ServiceBrokerGUIDFilter,
+					Operator: constant.EqualOperator,
+					Values:   []string{"broker-guid"},
+				},
+			))
 		})
 
 		When("the plan is public", func() {
@@ -1244,7 +1270,7 @@ var _ = Describe("Service Access", func() {
 		var disableServiceForOrgWarnings Warnings
 
 		JustBeforeEach(func() {
-			disableServiceForOrgWarnings, disableServiceForOrgErr = actor.DisableServiceForOrg("service-1", "my-org")
+			disableServiceForOrgWarnings, disableServiceForOrgErr = actor.DisableServiceForOrg("service-1", "my-org", "broker-1")
 		})
 
 		When("the service and org exist", func() {
@@ -1278,6 +1304,14 @@ var _ = Describe("Service Access", func() {
 
 			It("deletes the service plan visibility for all plans for org", func() {
 				Expect(disableServiceForOrgErr).NotTo(HaveOccurred())
+				Expect(fakeCloudControllerClient.GetServiceBrokersCallCount()).To(Equal(1))
+				brokerFilters := fakeCloudControllerClient.GetServiceBrokersArgsForCall(0)
+				Expect(len(brokerFilters)).To(Equal(1))
+				Expect(brokerFilters[0]).To(Equal(ccv2.Filter{
+					Type:     constant.NameFilter,
+					Operator: constant.EqualOperator,
+					Values:   []string{"broker-1"},
+				}))
 				Expect(fakeCloudControllerClient.GetServicesCallCount()).To(Equal(1))
 				Expect(fakeCloudControllerClient.GetServicePlansCallCount()).To(Equal(1))
 				Expect(fakeCloudControllerClient.GetOrganizationsCallCount()).To(Equal(1))
@@ -1341,12 +1375,19 @@ var _ = Describe("Service Access", func() {
 				Expect(disableServiceForOrgErr).To(MatchError(actionerror.ServiceNotFoundError{Name: "service-1"}))
 
 				filters := fakeCloudControllerClient.GetServicesArgsForCall(0)
-				Expect(len(filters)).To(Equal(1))
-				Expect(filters[0]).To(Equal(ccv2.Filter{
-					Type:     constant.LabelFilter,
-					Operator: constant.EqualOperator,
-					Values:   []string{"service-1"},
-				}))
+				Expect(len(filters)).To(Equal(2))
+				Expect(filters).To(ConsistOf(
+					ccv2.Filter{
+						Type:     constant.LabelFilter,
+						Operator: constant.EqualOperator,
+						Values:   []string{"service-1"},
+					},
+					ccv2.Filter{
+						Type:     constant.ServiceBrokerGUIDFilter,
+						Operator: constant.EqualOperator,
+						Values:   []string{"broker-guid"},
+					},
+				))
 			})
 		})
 
@@ -1436,7 +1477,7 @@ var _ = Describe("Service Access", func() {
 		var disablePlanForOrgWarnings Warnings
 
 		JustBeforeEach(func() {
-			disablePlanForOrgWarnings, disablePlanForOrgErr = actor.DisablePlanForOrg("service-1", "service-plan-1", "my-org")
+			disablePlanForOrgWarnings, disablePlanForOrgErr = actor.DisablePlanForOrg("service-1", "service-plan-1", "my-org", "broker-1")
 		})
 
 		When("the service and plan and org exist", func() {
@@ -1465,6 +1506,14 @@ var _ = Describe("Service Access", func() {
 
 			It("deletes the service plan visibility for all plans for org", func() {
 				Expect(disablePlanForOrgErr).NotTo(HaveOccurred())
+				Expect(fakeCloudControllerClient.GetServiceBrokersCallCount()).To(Equal(1))
+				brokerFilters := fakeCloudControllerClient.GetServiceBrokersArgsForCall(0)
+				Expect(len(brokerFilters)).To(Equal(1))
+				Expect(brokerFilters[0]).To(Equal(ccv2.Filter{
+					Type:     constant.NameFilter,
+					Operator: constant.EqualOperator,
+					Values:   []string{"broker-1"},
+				}))
 				Expect(fakeCloudControllerClient.GetServicesCallCount()).To(Equal(1))
 				Expect(fakeCloudControllerClient.GetServicePlansCallCount()).To(Equal(1))
 				Expect(fakeCloudControllerClient.GetOrganizationsCallCount()).To(Equal(1))
@@ -1515,12 +1564,18 @@ var _ = Describe("Service Access", func() {
 				Expect(disablePlanForOrgErr).To(MatchError(actionerror.ServiceNotFoundError{Name: "service-1"}))
 
 				filters := fakeCloudControllerClient.GetServicesArgsForCall(0)
-				Expect(len(filters)).To(Equal(1))
-				Expect(filters[0]).To(Equal(ccv2.Filter{
-					Type:     constant.LabelFilter,
-					Operator: constant.EqualOperator,
-					Values:   []string{"service-1"},
-				}))
+				Expect(len(filters)).To(Equal(2))
+				Expect(filters).To(ConsistOf(
+					ccv2.Filter{
+						Type:     constant.LabelFilter,
+						Operator: constant.EqualOperator,
+						Values:   []string{"service-1"},
+					},
+					ccv2.Filter{
+						Type:     constant.ServiceBrokerGUIDFilter,
+						Operator: constant.EqualOperator,
+						Values:   []string{"broker-guid"},
+					}))
 			})
 		})
 

--- a/command/v6/v6fakes/fake_disable_service_access_actor.go
+++ b/command/v6/v6fakes/fake_disable_service_access_actor.go
@@ -9,11 +9,12 @@ import (
 )
 
 type FakeDisableServiceAccessActor struct {
-	DisablePlanForAllOrgsStub        func(string, string) (v2action.Warnings, error)
+	DisablePlanForAllOrgsStub        func(string, string, string) (v2action.Warnings, error)
 	disablePlanForAllOrgsMutex       sync.RWMutex
 	disablePlanForAllOrgsArgsForCall []struct {
 		arg1 string
 		arg2 string
+		arg3 string
 	}
 	disablePlanForAllOrgsReturns struct {
 		result1 v2action.Warnings
@@ -23,12 +24,13 @@ type FakeDisableServiceAccessActor struct {
 		result1 v2action.Warnings
 		result2 error
 	}
-	DisablePlanForOrgStub        func(string, string, string) (v2action.Warnings, error)
+	DisablePlanForOrgStub        func(string, string, string, string) (v2action.Warnings, error)
 	disablePlanForOrgMutex       sync.RWMutex
 	disablePlanForOrgArgsForCall []struct {
 		arg1 string
 		arg2 string
 		arg3 string
+		arg4 string
 	}
 	disablePlanForOrgReturns struct {
 		result1 v2action.Warnings
@@ -38,10 +40,11 @@ type FakeDisableServiceAccessActor struct {
 		result1 v2action.Warnings
 		result2 error
 	}
-	DisableServiceForAllOrgsStub        func(string) (v2action.Warnings, error)
+	DisableServiceForAllOrgsStub        func(string, string) (v2action.Warnings, error)
 	disableServiceForAllOrgsMutex       sync.RWMutex
 	disableServiceForAllOrgsArgsForCall []struct {
 		arg1 string
+		arg2 string
 	}
 	disableServiceForAllOrgsReturns struct {
 		result1 v2action.Warnings
@@ -51,11 +54,12 @@ type FakeDisableServiceAccessActor struct {
 		result1 v2action.Warnings
 		result2 error
 	}
-	DisableServiceForOrgStub        func(string, string) (v2action.Warnings, error)
+	DisableServiceForOrgStub        func(string, string, string) (v2action.Warnings, error)
 	disableServiceForOrgMutex       sync.RWMutex
 	disableServiceForOrgArgsForCall []struct {
 		arg1 string
 		arg2 string
+		arg3 string
 	}
 	disableServiceForOrgReturns struct {
 		result1 v2action.Warnings
@@ -69,17 +73,18 @@ type FakeDisableServiceAccessActor struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeDisableServiceAccessActor) DisablePlanForAllOrgs(arg1 string, arg2 string) (v2action.Warnings, error) {
+func (fake *FakeDisableServiceAccessActor) DisablePlanForAllOrgs(arg1 string, arg2 string, arg3 string) (v2action.Warnings, error) {
 	fake.disablePlanForAllOrgsMutex.Lock()
 	ret, specificReturn := fake.disablePlanForAllOrgsReturnsOnCall[len(fake.disablePlanForAllOrgsArgsForCall)]
 	fake.disablePlanForAllOrgsArgsForCall = append(fake.disablePlanForAllOrgsArgsForCall, struct {
 		arg1 string
 		arg2 string
-	}{arg1, arg2})
-	fake.recordInvocation("DisablePlanForAllOrgs", []interface{}{arg1, arg2})
+		arg3 string
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("DisablePlanForAllOrgs", []interface{}{arg1, arg2, arg3})
 	fake.disablePlanForAllOrgsMutex.Unlock()
 	if fake.DisablePlanForAllOrgsStub != nil {
-		return fake.DisablePlanForAllOrgsStub(arg1, arg2)
+		return fake.DisablePlanForAllOrgsStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -94,17 +99,17 @@ func (fake *FakeDisableServiceAccessActor) DisablePlanForAllOrgsCallCount() int 
 	return len(fake.disablePlanForAllOrgsArgsForCall)
 }
 
-func (fake *FakeDisableServiceAccessActor) DisablePlanForAllOrgsCalls(stub func(string, string) (v2action.Warnings, error)) {
+func (fake *FakeDisableServiceAccessActor) DisablePlanForAllOrgsCalls(stub func(string, string, string) (v2action.Warnings, error)) {
 	fake.disablePlanForAllOrgsMutex.Lock()
 	defer fake.disablePlanForAllOrgsMutex.Unlock()
 	fake.DisablePlanForAllOrgsStub = stub
 }
 
-func (fake *FakeDisableServiceAccessActor) DisablePlanForAllOrgsArgsForCall(i int) (string, string) {
+func (fake *FakeDisableServiceAccessActor) DisablePlanForAllOrgsArgsForCall(i int) (string, string, string) {
 	fake.disablePlanForAllOrgsMutex.RLock()
 	defer fake.disablePlanForAllOrgsMutex.RUnlock()
 	argsForCall := fake.disablePlanForAllOrgsArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeDisableServiceAccessActor) DisablePlanForAllOrgsReturns(result1 v2action.Warnings, result2 error) {
@@ -133,18 +138,19 @@ func (fake *FakeDisableServiceAccessActor) DisablePlanForAllOrgsReturnsOnCall(i 
 	}{result1, result2}
 }
 
-func (fake *FakeDisableServiceAccessActor) DisablePlanForOrg(arg1 string, arg2 string, arg3 string) (v2action.Warnings, error) {
+func (fake *FakeDisableServiceAccessActor) DisablePlanForOrg(arg1 string, arg2 string, arg3 string, arg4 string) (v2action.Warnings, error) {
 	fake.disablePlanForOrgMutex.Lock()
 	ret, specificReturn := fake.disablePlanForOrgReturnsOnCall[len(fake.disablePlanForOrgArgsForCall)]
 	fake.disablePlanForOrgArgsForCall = append(fake.disablePlanForOrgArgsForCall, struct {
 		arg1 string
 		arg2 string
 		arg3 string
-	}{arg1, arg2, arg3})
-	fake.recordInvocation("DisablePlanForOrg", []interface{}{arg1, arg2, arg3})
+		arg4 string
+	}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("DisablePlanForOrg", []interface{}{arg1, arg2, arg3, arg4})
 	fake.disablePlanForOrgMutex.Unlock()
 	if fake.DisablePlanForOrgStub != nil {
-		return fake.DisablePlanForOrgStub(arg1, arg2, arg3)
+		return fake.DisablePlanForOrgStub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -159,17 +165,17 @@ func (fake *FakeDisableServiceAccessActor) DisablePlanForOrgCallCount() int {
 	return len(fake.disablePlanForOrgArgsForCall)
 }
 
-func (fake *FakeDisableServiceAccessActor) DisablePlanForOrgCalls(stub func(string, string, string) (v2action.Warnings, error)) {
+func (fake *FakeDisableServiceAccessActor) DisablePlanForOrgCalls(stub func(string, string, string, string) (v2action.Warnings, error)) {
 	fake.disablePlanForOrgMutex.Lock()
 	defer fake.disablePlanForOrgMutex.Unlock()
 	fake.DisablePlanForOrgStub = stub
 }
 
-func (fake *FakeDisableServiceAccessActor) DisablePlanForOrgArgsForCall(i int) (string, string, string) {
+func (fake *FakeDisableServiceAccessActor) DisablePlanForOrgArgsForCall(i int) (string, string, string, string) {
 	fake.disablePlanForOrgMutex.RLock()
 	defer fake.disablePlanForOrgMutex.RUnlock()
 	argsForCall := fake.disablePlanForOrgArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeDisableServiceAccessActor) DisablePlanForOrgReturns(result1 v2action.Warnings, result2 error) {
@@ -198,16 +204,17 @@ func (fake *FakeDisableServiceAccessActor) DisablePlanForOrgReturnsOnCall(i int,
 	}{result1, result2}
 }
 
-func (fake *FakeDisableServiceAccessActor) DisableServiceForAllOrgs(arg1 string) (v2action.Warnings, error) {
+func (fake *FakeDisableServiceAccessActor) DisableServiceForAllOrgs(arg1 string, arg2 string) (v2action.Warnings, error) {
 	fake.disableServiceForAllOrgsMutex.Lock()
 	ret, specificReturn := fake.disableServiceForAllOrgsReturnsOnCall[len(fake.disableServiceForAllOrgsArgsForCall)]
 	fake.disableServiceForAllOrgsArgsForCall = append(fake.disableServiceForAllOrgsArgsForCall, struct {
 		arg1 string
-	}{arg1})
-	fake.recordInvocation("DisableServiceForAllOrgs", []interface{}{arg1})
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("DisableServiceForAllOrgs", []interface{}{arg1, arg2})
 	fake.disableServiceForAllOrgsMutex.Unlock()
 	if fake.DisableServiceForAllOrgsStub != nil {
-		return fake.DisableServiceForAllOrgsStub(arg1)
+		return fake.DisableServiceForAllOrgsStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -222,17 +229,17 @@ func (fake *FakeDisableServiceAccessActor) DisableServiceForAllOrgsCallCount() i
 	return len(fake.disableServiceForAllOrgsArgsForCall)
 }
 
-func (fake *FakeDisableServiceAccessActor) DisableServiceForAllOrgsCalls(stub func(string) (v2action.Warnings, error)) {
+func (fake *FakeDisableServiceAccessActor) DisableServiceForAllOrgsCalls(stub func(string, string) (v2action.Warnings, error)) {
 	fake.disableServiceForAllOrgsMutex.Lock()
 	defer fake.disableServiceForAllOrgsMutex.Unlock()
 	fake.DisableServiceForAllOrgsStub = stub
 }
 
-func (fake *FakeDisableServiceAccessActor) DisableServiceForAllOrgsArgsForCall(i int) string {
+func (fake *FakeDisableServiceAccessActor) DisableServiceForAllOrgsArgsForCall(i int) (string, string) {
 	fake.disableServiceForAllOrgsMutex.RLock()
 	defer fake.disableServiceForAllOrgsMutex.RUnlock()
 	argsForCall := fake.disableServiceForAllOrgsArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeDisableServiceAccessActor) DisableServiceForAllOrgsReturns(result1 v2action.Warnings, result2 error) {
@@ -261,17 +268,18 @@ func (fake *FakeDisableServiceAccessActor) DisableServiceForAllOrgsReturnsOnCall
 	}{result1, result2}
 }
 
-func (fake *FakeDisableServiceAccessActor) DisableServiceForOrg(arg1 string, arg2 string) (v2action.Warnings, error) {
+func (fake *FakeDisableServiceAccessActor) DisableServiceForOrg(arg1 string, arg2 string, arg3 string) (v2action.Warnings, error) {
 	fake.disableServiceForOrgMutex.Lock()
 	ret, specificReturn := fake.disableServiceForOrgReturnsOnCall[len(fake.disableServiceForOrgArgsForCall)]
 	fake.disableServiceForOrgArgsForCall = append(fake.disableServiceForOrgArgsForCall, struct {
 		arg1 string
 		arg2 string
-	}{arg1, arg2})
-	fake.recordInvocation("DisableServiceForOrg", []interface{}{arg1, arg2})
+		arg3 string
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("DisableServiceForOrg", []interface{}{arg1, arg2, arg3})
 	fake.disableServiceForOrgMutex.Unlock()
 	if fake.DisableServiceForOrgStub != nil {
-		return fake.DisableServiceForOrgStub(arg1, arg2)
+		return fake.DisableServiceForOrgStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -286,17 +294,17 @@ func (fake *FakeDisableServiceAccessActor) DisableServiceForOrgCallCount() int {
 	return len(fake.disableServiceForOrgArgsForCall)
 }
 
-func (fake *FakeDisableServiceAccessActor) DisableServiceForOrgCalls(stub func(string, string) (v2action.Warnings, error)) {
+func (fake *FakeDisableServiceAccessActor) DisableServiceForOrgCalls(stub func(string, string, string) (v2action.Warnings, error)) {
 	fake.disableServiceForOrgMutex.Lock()
 	defer fake.disableServiceForOrgMutex.Unlock()
 	fake.DisableServiceForOrgStub = stub
 }
 
-func (fake *FakeDisableServiceAccessActor) DisableServiceForOrgArgsForCall(i int) (string, string) {
+func (fake *FakeDisableServiceAccessActor) DisableServiceForOrgArgsForCall(i int) (string, string, string) {
 	fake.disableServiceForOrgMutex.RLock()
 	defer fake.disableServiceForOrgMutex.RUnlock()
 	argsForCall := fake.disableServiceForOrgArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeDisableServiceAccessActor) DisableServiceForOrgReturns(result1 v2action.Warnings, result2 error) {


### PR DESCRIPTION
Add a -b option to cf disable-service-access command to specify the broker.

When two or more services have the same name, the command errors if broker is not specified.

More info can be found in these stories:
https://www.pivotaltracker.com/story/show/160751471
https://www.pivotaltracker.com/story/show/163191490
https://www.pivotaltracker.com/story/show/160751543
https://www.pivotaltracker.com/story/show/163194666
https://www.pivotaltracker.com/story/show/160751348
https://www.pivotaltracker.com/story/show/163452569
