### PR TITLE
Fix create service by broker for spaceDevelopers

### DIFF
--- a/actor/actionerror/service_and_broker_combination_not_found_error.go
+++ b/actor/actionerror/service_and_broker_combination_not_found_error.go
@@ -1,0 +1,12 @@
+package actionerror
+
+import "fmt"
+
+type ServiceAndBrokerCombinationNotFoundError struct {
+	BrokerName  string
+	ServiceName string
+}
+
+func (e ServiceAndBrokerCombinationNotFoundError) Error() string {
+	return fmt.Sprintf("Service '%s' provided by service broker '%s' not found.\n", e.ServiceName, e.BrokerName)
+}

--- a/actor/v2action/service_instance.go
+++ b/actor/v2action/service_instance.go
@@ -12,29 +12,8 @@ type ServiceInstance ccv2.ServiceInstance
 
 // CreateServiceInstance creates a new service instance with the provided attributes.
 func (actor Actor) CreateServiceInstance(spaceGUID, serviceName, servicePlanName, serviceInstanceName, brokerName string, params map[string]interface{}, tags []string) (ServiceInstance, Warnings, error) {
-	var brokerGUID string
 	var allWarnings Warnings
-
-	if brokerName != "" {
-		brokers, warnings, err := actor.CloudControllerClient.GetServiceBrokers(ccv2.Filter{
-			Type:     constant.NameFilter,
-			Operator: constant.EqualOperator,
-			Values:   []string{brokerName},
-		})
-		allWarnings = Warnings(warnings)
-
-		if err != nil {
-			return ServiceInstance{}, allWarnings, err
-		}
-
-		if len(brokers) == 0 {
-			return ServiceInstance{}, allWarnings, actionerror.ServiceBrokerNotFoundError{Name: brokerName}
-		}
-
-		brokerGUID = brokers[0].GUID
-	}
-
-	plan, allWarnings, err := actor.getServicePlanForServiceInSpace(servicePlanName, serviceName, spaceGUID, brokerGUID)
+	plan, allWarnings, err := actor.getServicePlanForServiceInSpace(servicePlanName, serviceName, spaceGUID, brokerName)
 
 	if err != nil {
 		return ServiceInstance{}, allWarnings, err
@@ -46,7 +25,7 @@ func (actor Actor) CreateServiceInstance(spaceGUID, serviceName, servicePlanName
 		return ServiceInstance{}, allWarnings, err
 	}
 
-	return ServiceInstance(instance), allWarnings, err
+	return ServiceInstance(instance), allWarnings, nil
 }
 
 func (actor Actor) GetServiceInstance(guid string) (ServiceInstance, Warnings, error) {


### PR DESCRIPTION
Previously, this command relied on being able to access the list of service brokers, but this is not possible if the user is not an admin.

We've switched to an alternative method that works regardless of admin status.

cc @georgi-lozev 
