### PR TITLE
Update delete-orphaned-routes description to clarify deletion scope

### DIFF
--- a/cf/commands/route/delete_orphaned_routes.go
+++ b/cf/commands/route/delete_orphaned_routes.go
@@ -29,7 +29,7 @@ func (cmd *DeleteOrphanedRoutes) MetaData() commandregistry.CommandMetadata {
 
 	return commandregistry.CommandMetadata{
 		Name:        "delete-orphaned-routes",
-		Description: T("Delete all orphaned routes (i.e. those that are not mapped to an app)"),
+		Description: T("Delete all orphaned routes in the currently targeted space (i.e. those that are not mapped to an app)"),
 		Usage: []string{
 			T("CF_NAME delete-orphaned-routes [-f]"),
 		},

--- a/command/common/command_list_v6.go
+++ b/command/common/command_list_v6.go
@@ -80,7 +80,7 @@ type commandList struct {
 	DeleteDomain                       v6.DeleteDomainCommand                       `command:"delete-domain" description:"Delete a domain"`
 	DeleteIsolationSegment             v6.DeleteIsolationSegmentCommand             `command:"delete-isolation-segment" description:"Delete an isolation segment"`
 	DeleteOrg                          v6.DeleteOrgCommand                          `command:"delete-org" description:"Delete an org"`
-	DeleteOrphanedRoutes               v6.DeleteOrphanedRoutesCommand               `command:"delete-orphaned-routes" description:"Delete all orphaned routes (i.e. those that are not mapped to an app)"`
+	DeleteOrphanedRoutes               v6.DeleteOrphanedRoutesCommand               `command:"delete-orphaned-routes" description:"Delete all orphaned routes in the currently targeted space (i.e. those that are not mapped to an app)"`
 	DeleteQuota                        v6.DeleteQuotaCommand                        `command:"delete-quota" description:"Delete a quota"`
 	DeleteRoute                        v6.DeleteRouteCommand                        `command:"delete-route" description:"Delete a route"`
 	DeleteSecurityGroup                v6.DeleteSecurityGroupCommand                `command:"delete-security-group" description:"Deletes a security group"`


### PR DESCRIPTION
It's unclear from the help text description how wide a `cf delete-orphaned-routes` command will
look to find orphaned routes, e.g. as when run as an admin or as a SpaceDeveloper who
has access to multiple spaces.

This cosmetic update makes it clear that it's only routes which exist in the current space,
not mapped to an app, which will be deleted.

## How Urgent Is The Change?

It is not.