### PR TITLE
Add flag to cf marketplace command to not list plans

### DIFF
--- a/command/v6/marketplace_command.go
+++ b/command/v6/marketplace_command.go
@@ -25,6 +25,7 @@ type ServicesSummariesActor interface {
 
 type MarketplaceCommand struct {
 	ServiceName     string      `short:"s" description:"Show plan details for a particular service offering"`
+	NoPlans         bool        `long:"no-plans" description:"Hide plan information for service offerings"`
 	usage           interface{} `usage:"CF_NAME marketplace [-s SERVICE]"`
 	relatedCommands interface{} `related_commands:"create-service, services"`
 
@@ -146,17 +147,29 @@ func (cmd *MarketplaceCommand) displayServiceSummaries(serviceSummaries []v2acti
 	if len(serviceSummaries) == 0 {
 		cmd.UI.DisplayText("No service offerings found")
 	} else {
-		tableHeaders := []string{"service", "plans", "description", "broker"}
-		table := [][]string{tableHeaders}
-		for _, serviceSummary := range serviceSummaries {
-			table = append(table, []string{
-				serviceSummary.Label,
-				planNames(serviceSummary),
-				serviceSummary.Description,
-				serviceSummary.ServiceBrokerName,
-			})
+		var table = [][]string{}
+		if cmd.NoPlans {
+			tableHeaders := []string{"service", "description", "broker"}
+			table = [][]string{tableHeaders}
+			for _, serviceSummary := range serviceSummaries {
+				table = append(table, []string{
+					serviceSummary.Label,
+					serviceSummary.Description,
+					serviceSummary.ServiceBrokerName,
+				})
+			}
+		} else {
+			tableHeaders := []string{"service", "plans", "description", "broker"}
+			table = [][]string{tableHeaders}
+			for _, serviceSummary := range serviceSummaries {
+				table = append(table, []string{
+					serviceSummary.Label,
+					planNames(serviceSummary),
+					serviceSummary.Description,
+					serviceSummary.ServiceBrokerName,
+				})
+			}
 		}
-
 		cmd.UI.DisplayTableWithHeader("", table, ui.DefaultTableSpacePadding)
 		cmd.UI.DisplayNewline()
 		cmd.UI.DisplayText("TIP: Use 'cf marketplace -s SERVICE' to view descriptions of individual plans of a given service.")

--- a/integration/shared/isolated/marketplace_command_test.go
+++ b/integration/shared/isolated/marketplace_command_test.go
@@ -25,6 +25,7 @@ var _ = Describe("marketplace command", func() {
 				Eventually(session).Should(Say("m"))
 				Eventually(session).Should(Say("OPTIONS:"))
 				Eventually(session).Should(Say("-s\\s+Show plan details for a particular service offering"))
+				Eventually(session).Should(Say("--no-plans\\s+Hide plan information for service offerings"))
 				Eventually(session).Should(Say("create-service, services"))
 				Eventually(session).Should(Exit(0))
 			})
@@ -188,6 +189,19 @@ var _ = Describe("marketplace command", func() {
 							Eventually(session).Should(Say("%s\\s+%s\\s+fake service\\s+%s", getServiceName(broker2), getBrokerPlanNames(broker2), broker2.Name))
 							Eventually(session).Should(Say("TIP: Use 'cf marketplace -s SERVICE' to view descriptions of individual plans of a given service."))
 							Eventually(session).Should(Exit(0))
+						})
+
+						When("--no-plans is passed", func() {
+							It("displays a table with broker name", func() {
+								session := helpers.CF("marketplace", "--no-plans")
+								Eventually(session).Should(Say("Getting services from marketplace in org %s / space %s as %s\\.\\.\\.", org2, space2, user))
+								Eventually(session).Should(Say("OK"))
+								Eventually(session).Should(Say("\n\n"))
+								Eventually(session).Should(Say("service\\s+description\\s+broker"))
+								Eventually(session).Should(Say("%s\\s+fake service\\s+%s", getServiceName(broker2), broker2.Name))
+								Eventually(session).Should(Say("TIP: Use 'cf marketplace -s SERVICE' to view descriptions of individual plans of a given service."))
+								Eventually(session).Should(Exit(0))
+							})
 						})
 					})
 				})


### PR DESCRIPTION
This PR adds a flag to the `cf marketplace` command that enables the user not to print the plans provided by the service.

More context [here](https://www.pivotaltracker.com/n/projects/2105761/stories/164367381)

Best,
Niki
on Behalf of SAPI Team