### PR TITLE
Follow CLI style guidelines for error messages.

### DIFF
--- a/command/v7/set_label_command.go
+++ b/command/v7/set_label_command.go
@@ -63,7 +63,7 @@ func (cmd SetLabelCommand) Execute(args []string) error {
 	case "org":
 		err = cmd.executeOrg(username, labels)
 	default:
-		err = fmt.Errorf("Unsupported resource type of %s", cmd.RequiredArgs.ResourceType)
+		err = fmt.Errorf("Unsupported resource type of '%s'", cmd.RequiredArgs.ResourceType)
 	}
 
 	if err != nil {

--- a/command/v7/set_label_command_test.go
+++ b/command/v7/set_label_command_test.go
@@ -350,7 +350,7 @@ var _ = Describe("set-label command", func() {
 		})
 
 		It("errors", func() {
-			Expect(executeErr).To(MatchError("Unsupported resource type of unrecognized-resource"))
+			Expect(executeErr).To(MatchError("Unsupported resource type of 'unrecognized-resource'"))
 		})
 	})
 


### PR DESCRIPTION
[Finishes \#165424003](https://www.pivotaltracker.com/story/show/165424003)

### Follow CLI style guidelines for error messages.

Authored-by: Eric Promislow <eric.promislow@suse.com>

## Description of the Change

Wrap unrecognized resource-name in metadata commands with single quotes.
The rest of the story has already been implemented since it was written as part
of story \#164992453

## Why Is This PR Valuable?

It's regular backlog work, but for some reason it's in the CAPI backlog, not the CLI.

## Why Should This Be In Core?

It's regular backlog work, but for some reason it's in the CAPI backlog, not the CLI.

## Applicable Issues

None

## How Urgent Is The Change?

It's regular backlog work, but for some reason it's in the CAPI backlog, not the CLI.
