### PR TITLE
if cf misconfigured, still allow user to 'cf login --sso'

### DIFF
--- a/cf/commands/login.go
+++ b/cf/commands/login.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccversion"
@@ -175,6 +176,13 @@ func (cmd Login) authenticateSSO(c flags.FlagContext) error {
 
 	credentials := make(map[string]string)
 	passcode := prompts["passcode"]
+
+	if passcode.DisplayName == "" {
+		passcode = coreconfig.AuthPrompt{
+			Type:        coreconfig.AuthPromptTypePassword,
+			DisplayName: fmt.Sprintf("Temporary Authentication Code ( Get one at %s/passcode )", cmd.config.AuthenticationEndpoint()),
+		}
+	}
 
 	for i := 0; i < maxLoginTries; i++ {
 		if c.IsSet("sso-passcode") && i == 0 {


### PR DESCRIPTION
If a target CF has not been configured correctly, this PR still allows a user to `cf login --sso`. This is a "good thing". We should encourage authentication via browsers and password vaults.

## Why Is This PR Valuable?
​
We should encourage all users to move away from providing passwords via CLIs in terminals. An oauth sequence into the browser allows the user to use their 1password integration.

Currently some users cannot use `cf login --sso` because their platform operator misconfigured their UAA prompts. This PR fixes this issue for those users.

## What benefits will be realized by the code change? What users would want this change? What user need is this change addressing? 

I am doing a video on `cf login` tips & tricks. I'll be promoting `cf login --sso` as my preferred method for ppl to login. Currently it's broken for some users. 

## Explain why this functionality should be in the cf CLI, as opposed to a plugin.

Its a fix to `cf login`.
​
## Applicable Issues

Initial PR does not have i18n. I'll do this in a follow up PR.

## How Urgent Is The Change?

I'd like to have this feature fixed for my video.​

## Other Relevant Parties

UAA