### PR TITLE
Don't list disabled plans in cf marketplace

### DIFF
--- a/actor/v2action/service_summary.go
+++ b/actor/v2action/service_summary.go
@@ -17,18 +17,18 @@ func (actor Actor) GetServicesSummaries() ([]ServiceSummary, Warnings, error) {
 		return []ServiceSummary{}, Warnings(warnings), err
 	}
 
-	summaries, serviceWarnings, err := actor.createServiceSummaries(services)
+	summaries, serviceWarnings, err := actor.createServiceSummaries(services, "", "")
 	warnings = append(warnings, serviceWarnings...)
 	return summaries, Warnings(warnings), err
 }
 
-func (actor Actor) GetServicesSummariesForSpace(spaceGUID string) ([]ServiceSummary, Warnings, error) {
+func (actor Actor) GetServicesSummariesForSpace(spaceGUID string, organizationGUID string) ([]ServiceSummary, Warnings, error) {
 	services, warnings, err := actor.CloudControllerClient.GetSpaceServices(spaceGUID)
 	if err != nil {
 		return []ServiceSummary{}, Warnings(warnings), err
 	}
 
-	summaries, summaryWarnings, err := actor.createServiceSummaries(services)
+	summaries, summaryWarnings, err := actor.createServiceSummaries(services, organizationGUID, spaceGUID)
 	warnings = append(warnings, summaryWarnings...)
 	return summaries, Warnings(warnings), err
 }
@@ -47,7 +47,13 @@ func (actor Actor) GetServiceSummaryByName(serviceName string) (ServiceSummary, 
 		return ServiceSummary{}, Warnings(warnings), actionerror.ServiceNotFoundError{Name: serviceName}
 	}
 
-	summary, summaryWarnings, err := actor.createServiceSummary(services[0])
+	plans, planWarnings, err := actor.getPlansForOneService(services[0])
+	warnings = append(warnings, planWarnings...)
+	if err != nil {
+		return ServiceSummary{}, Warnings(warnings), err
+	}
+
+	summary, summaryWarnings, err := actor.createServiceSummary(services[0], plans, "", "")
 	warnings = append(warnings, summaryWarnings...)
 	if err != nil {
 		return ServiceSummary{}, Warnings(warnings), err
@@ -56,7 +62,7 @@ func (actor Actor) GetServiceSummaryByName(serviceName string) (ServiceSummary, 
 	return summary, Warnings(warnings), err
 }
 
-func (actor Actor) GetServiceSummaryForSpaceByName(spaceGUID, serviceName string) (ServiceSummary, Warnings, error) {
+func (actor Actor) GetServiceSummaryForSpaceByName(spaceGUID, serviceName, organizationGUID string) (ServiceSummary, Warnings, error) {
 	services, warnings, err := actor.CloudControllerClient.GetSpaceServices(spaceGUID, ccv2.Filter{
 		Type:     constant.LabelFilter,
 		Operator: constant.EqualOperator,
@@ -70,7 +76,13 @@ func (actor Actor) GetServiceSummaryForSpaceByName(spaceGUID, serviceName string
 		return ServiceSummary{}, Warnings(warnings), actionerror.ServiceNotFoundError{Name: serviceName}
 	}
 
-	summary, summaryWarnings, err := actor.createServiceSummary(services[0])
+	plans, planWarnings, err := actor.getPlansForOneService(services[0])
+	warnings = append(warnings, planWarnings...)
+	if err != nil {
+		return ServiceSummary{}, Warnings(warnings), err
+	}
+
+	summary, summaryWarnings, err := actor.createServiceSummary(services[0], plans, organizationGUID, spaceGUID)
 	warnings = append(warnings, summaryWarnings...)
 	if err != nil {
 		return ServiceSummary{}, Warnings(warnings), err
@@ -79,25 +91,56 @@ func (actor Actor) GetServiceSummaryForSpaceByName(spaceGUID, serviceName string
 	return summary, Warnings(warnings), err
 }
 
-func (actor Actor) createServiceSummaries(services []ccv2.Service) ([]ServiceSummary, ccv2.Warnings, error) {
+func (actor Actor) createServiceSummaries(services []ccv2.Service, organizationGUID, spaceGUID string) ([]ServiceSummary, ccv2.Warnings, error) {
 	var serviceSummaries []ServiceSummary
 	var warnings ccv2.Warnings
 
+	plans, planWarnings, err := actor.getPlansForManyServices(services)
+	warnings = append(warnings, planWarnings...)
+	if err != nil {
+		return []ServiceSummary{}, warnings, err
+	}
+
 	for _, service := range services {
-		summary, summaryWarnings, err := actor.createServiceSummary(service)
+		plansForThatService := actor.getPlansForService(service, plans)
+
+		summary, summaryWarnings, err := actor.createServiceSummary(service, plansForThatService, organizationGUID, spaceGUID)
 		warnings = append(warnings, summaryWarnings...)
 		if err != nil {
 			return []ServiceSummary{}, warnings, err
 		}
 
-		serviceSummaries = append(serviceSummaries, summary)
+		if len(summary.Plans) > 0 {
+			serviceSummaries = append(serviceSummaries, summary)
+		}
 	}
 
 	return serviceSummaries, warnings, nil
 }
 
-func (actor Actor) createServiceSummary(service ccv2.Service) (ServiceSummary, ccv2.Warnings, error) {
-	planSummaries, warnings, err := actor.getPlanSummariesForService(service)
+func (actor Actor) getPlansForOneService(service ccv2.Service) ([]ccv2.ServicePlan, ccv2.Warnings, error) {
+	return actor.CloudControllerClient.GetServicePlans(ccv2.Filter{
+		Type:     constant.ServiceGUIDFilter,
+		Operator: constant.EqualOperator,
+		Values:   []string{service.GUID},
+	})
+}
+
+func (actor Actor) getPlansForManyServices(services []ccv2.Service) ([]ccv2.ServicePlan, ccv2.Warnings, error) {
+	serviceGUIDs := []string{}
+	for _, service := range services {
+		serviceGUIDs = append(serviceGUIDs, service.GUID)
+	}
+
+	return actor.CloudControllerClient.GetServicePlans(ccv2.Filter{
+		Type:     constant.ServiceGUIDFilter,
+		Operator: constant.InOperator,
+		Values:   serviceGUIDs,
+	})
+}
+
+func (actor Actor) createServiceSummary(service ccv2.Service, plans []ccv2.ServicePlan, organizationGUID, spaceGUID string) (ServiceSummary, ccv2.Warnings, error) {
+	planSummaries, warnings, err := actor.getPlanSummariesForService(service, plans, organizationGUID, spaceGUID)
 	if err != nil {
 		return ServiceSummary{}, warnings, err
 	}
@@ -105,20 +148,88 @@ func (actor Actor) createServiceSummary(service ccv2.Service) (ServiceSummary, c
 	return ServiceSummary{Service: Service(service), Plans: planSummaries}, warnings, nil
 }
 
-func (actor Actor) getPlanSummariesForService(service ccv2.Service) ([]ServicePlanSummary, ccv2.Warnings, error) {
-	plans, warnings, err := actor.CloudControllerClient.GetServicePlans(ccv2.Filter{
-		Type:     constant.ServiceGUIDFilter,
-		Operator: constant.EqualOperator,
-		Values:   []string{service.GUID},
-	})
-	if err != nil {
-		return []ServicePlanSummary{}, warnings, err
+func (actor Actor) getPlanSummariesForService(service ccv2.Service, plans []ccv2.ServicePlan, organizationGUID, spaceGUID string) ([]ServicePlanSummary, ccv2.Warnings, error) {
+	var err error
+	var warnings ccv2.Warnings
+
+	nonPublicPlans := []string{}
+	for _, plan := range plans {
+		if !plan.Public {
+			nonPublicPlans = append(nonPublicPlans, plan.GUID)
+		}
 	}
 
-	var planSummaries []ServicePlanSummary
-	for _, plan := range plans {
-		planSummaries = append(planSummaries, ServicePlanSummary{ServicePlan: ServicePlan(plan)})
+	var broker ServiceBroker
+	if spaceGUID != "" && len(nonPublicPlans) > 0 {
+		var brokerWarnings Warnings
+		broker, brokerWarnings, err = actor.GetServiceBrokerByName(service.ServiceBrokerName)
+		warnings = append(warnings, brokerWarnings...)
+		if err != nil {
+			return []ServicePlanSummary{}, warnings, err
+		}
 	}
+
+	var visibilities []ccv2.ServicePlanVisibility
+
+	if len(nonPublicPlans) > 0 {
+		var visibilityWarnings ccv2.Warnings
+
+		visibilities, visibilityWarnings, err = actor.getPlanVisibilitiesForOrg(nonPublicPlans, organizationGUID)
+		warnings = append(warnings, visibilityWarnings...)
+		if err != nil {
+			return []ServicePlanSummary{}, warnings, err
+		}
+	}
+
+	planSummaries := actor.getSummariesForVisiblePlans(plans, broker, visibilities, spaceGUID)
 
 	return planSummaries, warnings, nil
+}
+
+func (actor Actor) getSummariesForVisiblePlans(plans []ccv2.ServicePlan, broker ServiceBroker, visibilities []ccv2.ServicePlanVisibility, spaceGUID string) []ServicePlanSummary {
+	var planSummaries []ServicePlanSummary
+	for _, plan := range plans {
+		if plan.Public || (spaceGUID != "" && broker.SpaceGUID == spaceGUID) {
+			planSummaries = append(planSummaries, ServicePlanSummary{ServicePlan: ServicePlan(plan)})
+		} else {
+			visibleInOrg := false
+			for _, visibility := range visibilities {
+				if visibility.ServicePlanGUID == plan.GUID {
+					visibleInOrg = true
+					break
+				}
+			}
+
+			if visibleInOrg {
+				planSummaries = append(planSummaries, ServicePlanSummary{ServicePlan: ServicePlan(plan)})
+			}
+		}
+	}
+
+	return planSummaries
+}
+
+func (actor Actor) getPlanVisibilitiesForOrg(plans []string, organizationGUID string) ([]ccv2.ServicePlanVisibility, ccv2.Warnings, error) {
+	return actor.CloudControllerClient.GetServicePlanVisibilities(
+		ccv2.Filter{
+			Type:     constant.ServicePlanGUIDFilter,
+			Operator: constant.InOperator,
+			Values:   plans,
+		},
+		ccv2.Filter{
+			Type:     constant.OrganizationGUIDFilter,
+			Operator: constant.EqualOperator,
+			Values:   []string{organizationGUID},
+		},
+	)
+}
+
+func (actor Actor) getPlansForService(service ccv2.Service, plans []ccv2.ServicePlan) []ccv2.ServicePlan {
+	plansForThatService := []ccv2.ServicePlan{}
+	for _, plan := range plans {
+		if plan.ServiceGUID == service.GUID {
+			plansForThatService = append(plansForThatService, plan)
+		}
+	}
+	return plansForThatService
 }

--- a/actor/v2action/service_summary_test.go
+++ b/actor/v2action/service_summary_test.go
@@ -62,18 +62,22 @@ var _ = Describe("Service Summary Actions", func() {
 			BeforeEach(func() {
 				services := []ccv2.Service{
 					{
+						GUID:        "service-a-guid",
 						Label:       "service-a",
 						Description: "service-a-description",
 					},
 					{
+						GUID:        "service-b-guid",
 						Label:       "service-b",
 						Description: "service-b-description",
 					},
 				}
 
 				plans := []ccv2.ServicePlan{
-					{Name: "plan-a"},
-					{Name: "plan-b"},
+					{Name: "plan-a", ServiceGUID: "service-a-guid", Public: true},
+					{Name: "plan-b", ServiceGUID: "service-b-guid", Public: true},
+					{Name: "plan-c", ServiceGUID: "service-b-guid", Public: true},
+					{Name: "plan-d", ServiceGUID: "service-a-guid", Public: true},
 				}
 
 				fakeCloudControllerClient.GetServicesReturns(services, ccv2.Warnings{"get-services-warning"}, nil)
@@ -85,42 +89,53 @@ var _ = Describe("Service Summary Actions", func() {
 				Expect(servicesSummaries).To(ConsistOf(
 					ServiceSummary{
 						Service: Service{
+							GUID:        "service-a-guid",
 							Label:       "service-a",
 							Description: "service-a-description",
 						},
 						Plans: []ServicePlanSummary{
 							ServicePlanSummary{
 								ServicePlan: ServicePlan{
-									Name: "plan-a",
+									ServiceGUID: "service-a-guid",
+									Name:        "plan-a",
+									Public:      true,
 								},
 							},
 							ServicePlanSummary{
 								ServicePlan: ServicePlan{
-									Name: "plan-b",
+									ServiceGUID: "service-a-guid",
+									Name:        "plan-d",
+									Public:      true,
 								},
 							},
 						},
 					},
 					ServiceSummary{
 						Service: Service{
+							GUID:        "service-b-guid",
 							Label:       "service-b",
 							Description: "service-b-description",
 						},
 						Plans: []ServicePlanSummary{
 							ServicePlanSummary{
 								ServicePlan: ServicePlan{
-									Name: "plan-a",
+									ServiceGUID: "service-b-guid",
+									Name:        "plan-b",
+									Public:      true,
 								},
 							},
 							ServicePlanSummary{
 								ServicePlan: ServicePlan{
-									Name: "plan-b",
+									ServiceGUID: "service-b-guid",
+									Name:        "plan-c",
+									Public:      true,
 								},
 							},
 						},
 					},
 				))
-				Expect(warnings).To(ConsistOf("get-services-warning", "get-plans-warning", "get-plans-warning"))
+
+				Expect(warnings).To(ConsistOf("get-services-warning", "get-plans-warning"))
 			})
 
 			Context("and fetching plans returns an error", func() {
@@ -134,6 +149,10 @@ var _ = Describe("Service Summary Actions", func() {
 				})
 			})
 		})
+
+		AfterEach(func() {
+			Expect(fakeCloudControllerClient.GetServiceBrokersCallCount()).To(Equal(0))
+		})
 	})
 
 	Describe("GetServicesSummariesForSpace", func() {
@@ -142,10 +161,11 @@ var _ = Describe("Service Summary Actions", func() {
 			warnings          Warnings
 			err               error
 			spaceGUID         = "space-123"
+			organizationGUID  = "org-guid-123"
 		)
 
 		JustBeforeEach(func() {
-			servicesSummaries, warnings, err = actor.GetServicesSummariesForSpace(spaceGUID)
+			servicesSummaries, warnings, err = actor.GetServicesSummariesForSpace(spaceGUID, organizationGUID)
 		})
 
 		When("there are no services", func() {
@@ -171,22 +191,50 @@ var _ = Describe("Service Summary Actions", func() {
 			})
 		})
 
-		When("there are services with plans", func() {
+		It("retrieves the services for the correct space", func() {
+			requestedSpaceGUID, _ := fakeCloudControllerClient.GetSpaceServicesArgsForCall(0)
+			Expect(requestedSpaceGUID).To(Equal(spaceGUID))
+		})
+
+		Context("and fetching plans returns an error", func() {
 			BeforeEach(func() {
 				services := []ccv2.Service{
 					{
 						Label:       "service-a",
 						Description: "service-a-description",
 					},
+				}
+
+				fakeCloudControllerClient.GetSpaceServicesReturns(services, ccv2.Warnings{"get-services-warning"}, nil)
+				fakeCloudControllerClient.GetServicePlansReturns([]ccv2.ServicePlan{}, ccv2.Warnings{"get-plans-warning"}, errors.New("plan-oops"))
+			})
+
+			It("returns the error and all warnings", func() {
+				Expect(err).To(MatchError("plan-oops"))
+				Expect(warnings).To(ConsistOf("get-services-warning", "get-plans-warning"))
+			})
+		})
+
+		When("there are services with public plans", func() {
+			BeforeEach(func() {
+				services := []ccv2.Service{
 					{
+						GUID:        "service-a-guid",
+						Label:       "service-a",
+						Description: "service-a-description",
+					},
+					{
+						GUID:        "service-b-guid",
 						Label:       "service-b",
 						Description: "service-b-description",
 					},
 				}
 
 				plans := []ccv2.ServicePlan{
-					{Name: "plan-a"},
-					{Name: "plan-b"},
+					{Name: "plan-a", ServiceGUID: "service-b-guid", Public: true},
+					{Name: "plan-b", ServiceGUID: "service-a-guid", Public: true},
+					{Name: "plan-c", ServiceGUID: "service-a-guid", Public: true},
+					{Name: "plan-d", ServiceGUID: "service-b-guid", Public: true},
 				}
 
 				fakeCloudControllerClient.GetSpaceServicesReturns(services, ccv2.Warnings{"get-services-warning"}, nil)
@@ -198,60 +246,415 @@ var _ = Describe("Service Summary Actions", func() {
 				Expect(servicesSummaries).To(ConsistOf(
 					ServiceSummary{
 						Service: Service{
+							GUID:        "service-a-guid",
 							Label:       "service-a",
 							Description: "service-a-description",
 						},
 						Plans: []ServicePlanSummary{
 							ServicePlanSummary{
 								ServicePlan: ServicePlan{
-									Name: "plan-a",
+									ServiceGUID: "service-a-guid",
+									Name:        "plan-b",
+									Public:      true,
 								},
 							},
 							ServicePlanSummary{
 								ServicePlan: ServicePlan{
-									Name: "plan-b",
+									ServiceGUID: "service-a-guid",
+									Name:        "plan-c",
+									Public:      true,
 								},
 							},
 						},
 					},
 					ServiceSummary{
 						Service: Service{
+							GUID:        "service-b-guid",
 							Label:       "service-b",
 							Description: "service-b-description",
 						},
 						Plans: []ServicePlanSummary{
 							ServicePlanSummary{
 								ServicePlan: ServicePlan{
-									Name: "plan-a",
+									ServiceGUID: "service-b-guid",
+									Name:        "plan-a",
+									Public:      true,
 								},
 							},
 							ServicePlanSummary{
 								ServicePlan: ServicePlan{
-									Name: "plan-b",
+									ServiceGUID: "service-b-guid",
+									Name:        "plan-d",
+									Public:      true,
 								},
 							},
 						},
 					},
 				))
-				Expect(warnings).To(ConsistOf("get-services-warning", "get-plans-warning", "get-plans-warning"))
+
+				Expect(warnings).To(ConsistOf("get-services-warning", "get-plans-warning"))
 			})
 
-			It("retrieves the services for the correct space", func() {
-				requestedSpaceGUID, _ := fakeCloudControllerClient.GetSpaceServicesArgsForCall(0)
-				Expect(requestedSpaceGUID).To(Equal(spaceGUID))
+			It("uses the IN filter to get all the plans for all services and then match them up", func() {
+				Expect(fakeCloudControllerClient.GetServicePlansCallCount()).To(Equal(1))
+
+				Expect(fakeCloudControllerClient.GetServicePlansArgsForCall(0)).To(ConsistOf(
+					ccv2.Filter{
+						Type:     constant.ServiceGUIDFilter,
+						Operator: constant.InOperator,
+						Values:   []string{"service-a-guid", "service-b-guid"},
+					},
+				))
 			})
 
-			Context("and fetching plans returns an error", func() {
+			It("does not request service plan visibilities", func() {
+				Expect(fakeCloudControllerClient.GetServicePlanVisibilitiesCallCount()).To(Equal(0))
+			})
+		})
+
+		When("there are services with one non-public plan", func() {
+			BeforeEach(func() {
+				services := []ccv2.Service{
+					{
+						GUID:        "service-a-guid",
+						Label:       "service-a",
+						Description: "service-a-description",
+					},
+					{
+						GUID:        "service-b-guid",
+						Label:       "service-b",
+						Description: "service-b-description",
+					},
+				}
+
+				plans := []ccv2.ServicePlan{
+					{Name: "plan-a", ServiceGUID: "service-a-guid", Public: true},
+					{Name: "plan-b", ServiceGUID: "service-a-guid", Public: false},
+					{Name: "plan-c", ServiceGUID: "service-b-guid", Public: true},
+					{Name: "plan-d", ServiceGUID: "service-b-guid", Public: false},
+				}
+
+				brokers := []ccv2.ServiceBroker{
+					{Name: "normal-broker"},
+				}
+
+				fakeCloudControllerClient.GetSpaceServicesReturns(services, ccv2.Warnings{"get-services-warning"}, nil)
+				fakeCloudControllerClient.GetServicePlansReturns(plans, ccv2.Warnings{"get-plans-warning"}, nil)
+				fakeCloudControllerClient.GetServiceBrokersReturns(brokers, ccv2.Warnings{"get-brokers-warning"}, nil)
+			})
+
+			It("returns summaries excluding non public plans and all warnings", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(servicesSummaries).To(ConsistOf(
+					ServiceSummary{
+						Service: Service{
+							GUID:        "service-a-guid",
+							Label:       "service-a",
+							Description: "service-a-description",
+						},
+						Plans: []ServicePlanSummary{
+							ServicePlanSummary{
+								ServicePlan: ServicePlan{
+									ServiceGUID: "service-a-guid",
+									Name:        "plan-a",
+									Public:      true,
+								},
+							},
+						},
+					},
+					ServiceSummary{
+						Service: Service{
+							GUID:        "service-b-guid",
+							Label:       "service-b",
+							Description: "service-b-description",
+						},
+						Plans: []ServicePlanSummary{
+							ServicePlanSummary{
+								ServicePlan: ServicePlan{
+									ServiceGUID: "service-b-guid",
+									Name:        "plan-c",
+									Public:      true,
+								},
+							},
+						},
+					},
+				))
+
+				Expect(warnings).To(ConsistOf("get-services-warning", "get-plans-warning", "get-brokers-warning", "get-brokers-warning"))
+			})
+		})
+
+		When("there are services with non-public plan but visible to the org", func() {
+			BeforeEach(func() {
+				services := []ccv2.Service{
+					{
+						GUID:        "service-a-guid",
+						Label:       "service-a",
+						Description: "service-a-description",
+					},
+					{
+						GUID:        "service-b-guid",
+						Label:       "service-b",
+						Description: "service-b-description",
+					},
+				}
+
+				plans := []ccv2.ServicePlan{
+					{GUID: "plan-a-guid", ServiceGUID: "service-a-guid", Name: "plan-a", Public: false},
+					{GUID: "plan-b-guid", ServiceGUID: "service-a-guid", Name: "plan-b", Public: false},
+					{GUID: "plan-c-guid", ServiceGUID: "service-b-guid", Name: "plan-c", Public: false},
+					{GUID: "plan-d-guid", ServiceGUID: "service-b-guid", Name: "plan-d", Public: false},
+				}
+
+				visibilities1 := []ccv2.ServicePlanVisibility{
+					{OrganizationGUID: "org-guid-1", ServicePlanGUID: "plan-a-guid"},
+					{OrganizationGUID: "org-guid-1", ServicePlanGUID: "plan-b-guid"},
+				}
+
+				visibilities2 := []ccv2.ServicePlanVisibility{
+					{OrganizationGUID: "org-guid-1", ServicePlanGUID: "plan-c-guid"},
+				}
+
+				brokers := []ccv2.ServiceBroker{
+					{Name: "normal-broker"},
+				}
+
+				fakeCloudControllerClient.GetSpaceServicesReturns(services, ccv2.Warnings{"get-services-warning"}, nil)
+				fakeCloudControllerClient.GetServicePlansReturns(plans, ccv2.Warnings{"get-plans-warning"}, nil)
+				fakeCloudControllerClient.GetServiceBrokersReturns(brokers, ccv2.Warnings{"get-brokers-warning"}, nil)
+				fakeCloudControllerClient.GetServicePlanVisibilitiesReturnsOnCall(0, visibilities1, ccv2.Warnings{"get-visibilities-a-warning"}, nil)
+				fakeCloudControllerClient.GetServicePlanVisibilitiesReturnsOnCall(1, visibilities2, ccv2.Warnings{"get-visibilities-b-warning"}, nil)
+			})
+
+			It("returns summaries with plans visible for the org", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(servicesSummaries).To(ConsistOf(
+					ServiceSummary{
+						Service: Service{
+							GUID:        "service-a-guid",
+							Label:       "service-a",
+							Description: "service-a-description",
+						},
+						Plans: []ServicePlanSummary{
+							ServicePlanSummary{
+								ServicePlan: ServicePlan{
+									GUID:        "plan-a-guid",
+									ServiceGUID: "service-a-guid",
+									Name:        "plan-a",
+									Public:      false,
+								},
+							},
+							ServicePlanSummary{
+								ServicePlan: ServicePlan{
+									ServiceGUID: "service-a-guid",
+									GUID:        "plan-b-guid",
+									Name:        "plan-b",
+									Public:      false,
+								},
+							},
+						},
+					},
+					ServiceSummary{
+						Service: Service{
+							GUID:        "service-b-guid",
+							Label:       "service-b",
+							Description: "service-b-description",
+						},
+						Plans: []ServicePlanSummary{
+							ServicePlanSummary{
+								ServicePlan: ServicePlan{
+									ServiceGUID: "service-b-guid",
+									GUID:        "plan-c-guid",
+									Name:        "plan-c",
+									Public:      false,
+								},
+							},
+						},
+					},
+				))
+			})
+
+			It("returns all warnings", func() {
+				Expect(warnings).To(ConsistOf(
+					"get-services-warning",
+					"get-plans-warning",
+					"get-brokers-warning",
+					"get-visibilities-a-warning",
+					"get-brokers-warning",
+					"get-visibilities-b-warning",
+				))
+			})
+
+			It("gets service plans using IN filter for all services at once", func() {
+				Expect(fakeCloudControllerClient.GetServicePlansCallCount()).To(Equal(1))
+
+				Expect(fakeCloudControllerClient.GetServicePlansArgsForCall(0)).To(ConsistOf(
+					ccv2.Filter{
+						Type:     constant.ServiceGUIDFilter,
+						Operator: constant.InOperator,
+						Values:   []string{"service-a-guid", "service-b-guid"},
+					},
+				))
+			})
+
+			It("gets plan visibilities for the non-public plan for the org", func() {
+				Expect(fakeCloudControllerClient.GetServicePlanVisibilitiesCallCount()).To(Equal(2))
+
+				Expect(fakeCloudControllerClient.GetServicePlanVisibilitiesArgsForCall(0)).To(ConsistOf(
+					ccv2.Filter{
+						Type:     constant.ServicePlanGUIDFilter,
+						Operator: constant.InOperator,
+						Values:   []string{"plan-a-guid", "plan-b-guid"},
+					},
+					ccv2.Filter{
+						Type:     constant.OrganizationGUIDFilter,
+						Operator: constant.EqualOperator,
+						Values:   []string{organizationGUID},
+					},
+				))
+
+				Expect(fakeCloudControllerClient.GetServicePlanVisibilitiesArgsForCall(1)).To(ConsistOf(
+					ccv2.Filter{
+						Type:     constant.ServicePlanGUIDFilter,
+						Operator: constant.InOperator,
+						Values:   []string{"plan-c-guid", "plan-d-guid"},
+					},
+					ccv2.Filter{
+						Type:     constant.OrganizationGUIDFilter,
+						Operator: constant.EqualOperator,
+						Values:   []string{organizationGUID},
+					},
+				))
+			})
+
+			When("getting visibilities fails", func() {
 				BeforeEach(func() {
-					fakeCloudControllerClient.GetServicePlansReturns([]ccv2.ServicePlan{}, ccv2.Warnings{"get-plans-warning"}, errors.New("plan-oops"))
+					fakeCloudControllerClient.GetServicePlanVisibilitiesReturnsOnCall(0, []ccv2.ServicePlanVisibility{}, ccv2.Warnings{"get-visibilities-warning"}, errors.New("oopsie"))
 				})
 
-				It("returns the error and all warnings", func() {
-					Expect(err).To(MatchError("plan-oops"))
-					Expect(warnings).To(ConsistOf("get-services-warning", "get-plans-warning"))
+				It("returns errors and warnings", func() {
+					Expect(err).To(MatchError(errors.New("oopsie")))
+					Expect(warnings).To(ConsistOf("get-services-warning", "get-plans-warning", "get-brokers-warning", "get-visibilities-warning"))
 				})
 			})
 		})
+
+		When("when there are space scoped services", func() {
+			BeforeEach(func() {
+				services := []ccv2.Service{
+					{
+						GUID:              "service-a-guid",
+						Label:             "service-a",
+						Description:       "service-a-description",
+						ServiceBrokerName: "broker-a",
+					},
+					{
+						GUID:              "service-b-guid",
+						Label:             "service-b",
+						Description:       "service-b-description",
+						ServiceBrokerName: "broker-b",
+					},
+				}
+
+				plans := []ccv2.ServicePlan{
+					{GUID: "plan-a-guid", ServiceGUID: "service-a-guid", Name: "plan-a", Public: false},
+					{GUID: "plan-b-guid", ServiceGUID: "service-a-guid", Name: "plan-b", Public: false},
+					{GUID: "plan-c-guid", ServiceGUID: "service-b-guid", Name: "plan-c", Public: false},
+					{GUID: "plan-d-guid", ServiceGUID: "service-b-guid", Name: "plan-d", Public: false},
+				}
+
+				brokersA := []ccv2.ServiceBroker{
+					{GUID: "broker-a-guid", Name: "broker-a", SpaceGUID: spaceGUID},
+				}
+
+				brokersB := []ccv2.ServiceBroker{
+					{GUID: "broker-b-guid", Name: "broker-b", SpaceGUID: "different-space-guid"},
+				}
+
+				fakeCloudControllerClient.GetSpaceServicesReturns(services, ccv2.Warnings{"get-services-warning"}, nil)
+				fakeCloudControllerClient.GetServicePlansReturns(plans, ccv2.Warnings{"get-plans-warning"}, nil)
+				fakeCloudControllerClient.GetServiceBrokersReturnsOnCall(0, brokersA, ccv2.Warnings{"get-brokers-a-warning"}, nil)
+				fakeCloudControllerClient.GetServiceBrokersReturnsOnCall(1, brokersB, ccv2.Warnings{"get-brokers-b-warning"}, nil)
+			})
+
+			It("returns summaries including plans only for brokers scoped to the current space", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(servicesSummaries).To(ConsistOf(
+					ServiceSummary{
+						Service: Service{
+							GUID:              "service-a-guid",
+							Label:             "service-a",
+							Description:       "service-a-description",
+							ServiceBrokerName: "broker-a",
+						},
+						Plans: []ServicePlanSummary{
+							ServicePlanSummary{
+								ServicePlan: ServicePlan{
+									GUID:        "plan-a-guid",
+									ServiceGUID: "service-a-guid",
+									Name:        "plan-a",
+									Public:      false,
+								},
+							},
+							ServicePlanSummary{
+								ServicePlan: ServicePlan{
+									GUID:        "plan-b-guid",
+									ServiceGUID: "service-a-guid",
+									Name:        "plan-b",
+									Public:      false,
+								},
+							},
+						},
+					},
+				))
+			})
+
+			It("gets all plans at once using IN operator for service GUIDs", func() {
+				Expect(fakeCloudControllerClient.GetServicePlansCallCount()).To(Equal(1))
+
+				Expect(fakeCloudControllerClient.GetServicePlansArgsForCall(0)).To(ConsistOf(
+					ccv2.Filter{
+						Type:     constant.ServiceGUIDFilter,
+						Operator: constant.InOperator,
+						Values:   []string{"service-a-guid", "service-b-guid"},
+					},
+				))
+			})
+
+			It("applies filter by broker name when fetching list of brokers", func() {
+				Expect(fakeCloudControllerClient.GetServiceBrokersArgsForCall(0)).To(ConsistOf(
+					ccv2.Filter{
+						Type:     constant.NameFilter,
+						Operator: constant.EqualOperator,
+						Values:   []string{"broker-a"},
+					},
+				))
+
+				Expect(fakeCloudControllerClient.GetServiceBrokersArgsForCall(1)).To(ConsistOf(
+					ccv2.Filter{
+						Type:     constant.NameFilter,
+						Operator: constant.EqualOperator,
+						Values:   []string{"broker-b"},
+					},
+				))
+			})
+
+			It("returns warnings", func() {
+				Expect(warnings).To(ConsistOf("get-services-warning", "get-plans-warning", "get-brokers-a-warning", "get-brokers-b-warning"))
+			})
+
+			When("getting broker fails with an error", func() {
+				BeforeEach(func() {
+					fakeCloudControllerClient.GetServiceBrokersReturnsOnCall(0, []ccv2.ServiceBroker{}, ccv2.Warnings{"get-brokers-warning"}, errors.New("oopsie"))
+				})
+
+				It("returns error and warnings", func() {
+					Expect(err).To(MatchError(errors.New("oopsie")))
+					Expect(warnings).To(ConsistOf("get-services-warning", "get-plans-warning", "get-brokers-warning"))
+				})
+			})
+		})
+
 	})
 
 	Describe("GetServiceSummaryByName", func() {
@@ -298,13 +701,14 @@ var _ = Describe("Service Summary Actions", func() {
 			BeforeEach(func() {
 				services = []ccv2.Service{
 					{
+						GUID:        "service-a-guid",
 						Label:       "service",
 						Description: "service-description",
 					},
 				}
 				plans := []ccv2.ServicePlan{
-					{Name: "plan-a"},
-					{Name: "plan-b"},
+					{Name: "plan-a", ServiceGUID: "service-a-guid", Public: true},
+					{Name: "plan-b", ServiceGUID: "service-a-guid", Public: true},
 				}
 
 				fakeCloudControllerClient.GetServicesStub = func(filters ...ccv2.Filter) ([]ccv2.Service, ccv2.Warnings, error) {
@@ -329,22 +733,28 @@ var _ = Describe("Service Summary Actions", func() {
 				Expect(serviceSummary).To(Equal(
 					ServiceSummary{
 						Service: Service{
+							GUID:        "service-a-guid",
 							Label:       "service",
 							Description: "service-description",
 						},
 						Plans: []ServicePlanSummary{
 							ServicePlanSummary{
 								ServicePlan: ServicePlan{
-									Name: "plan-a",
+									ServiceGUID: "service-a-guid",
+									Name:        "plan-a",
+									Public:      true,
 								},
 							},
 							ServicePlanSummary{
 								ServicePlan: ServicePlan{
-									Name: "plan-b",
+									ServiceGUID: "service-a-guid",
+									Name:        "plan-b",
+									Public:      true,
 								},
 							},
 						},
 					}))
+
 				Expect(warnings).To(ConsistOf("get-services-warning", "get-plans-warning"))
 			})
 
@@ -360,24 +770,24 @@ var _ = Describe("Service Summary Actions", func() {
 				})
 			})
 		})
+
+		AfterEach(func() {
+			Expect(fakeCloudControllerClient.GetServiceBrokersCallCount()).To(Equal(0))
+		})
 	})
 
 	Describe("GetServiceSummaryForSpaceByName", func() {
 		var (
-			serviceName    string
-			spaceGUID      string
-			serviceSummary ServiceSummary
-			warnings       Warnings
-			err            error
+			serviceName      = "service"
+			spaceGUID        = "space-123"
+			organizationGUID = "org-guid-123"
+			serviceSummary   ServiceSummary
+			warnings         Warnings
+			err              error
 		)
 
-		BeforeEach(func() {
-			serviceName = "service"
-			spaceGUID = "space-123"
-		})
-
 		JustBeforeEach(func() {
-			serviceSummary, warnings, err = actor.GetServiceSummaryForSpaceByName(spaceGUID, serviceName)
+			serviceSummary, warnings, err = actor.GetServiceSummaryForSpaceByName(spaceGUID, serviceName, organizationGUID)
 		})
 
 		When("there is no service matching the provided name", func() {
@@ -402,7 +812,7 @@ var _ = Describe("Service Summary Actions", func() {
 			})
 		})
 
-		When("the service exists", func() {
+		When("the service exists with all plans public", func() {
 			var services []ccv2.Service
 
 			BeforeEach(func() {
@@ -413,8 +823,8 @@ var _ = Describe("Service Summary Actions", func() {
 					},
 				}
 				plans := []ccv2.ServicePlan{
-					{Name: "plan-a"},
-					{Name: "plan-b"},
+					{Name: "plan-a", Public: true},
+					{Name: "plan-b", Public: true},
 				}
 
 				fakeCloudControllerClient.GetSpaceServicesStub = func(guid string, filters ...ccv2.Filter) ([]ccv2.Service, ccv2.Warnings, error) {
@@ -445,12 +855,14 @@ var _ = Describe("Service Summary Actions", func() {
 						Plans: []ServicePlanSummary{
 							ServicePlanSummary{
 								ServicePlan: ServicePlan{
-									Name: "plan-a",
+									Name:   "plan-a",
+									Public: true,
 								},
 							},
 							ServicePlanSummary{
 								ServicePlan: ServicePlan{
-									Name: "plan-b",
+									Name:   "plan-b",
+									Public: true,
 								},
 							},
 						},
@@ -467,6 +879,176 @@ var _ = Describe("Service Summary Actions", func() {
 				It("returns the error and all warnings", func() {
 					Expect(err).To(MatchError("plan-oops"))
 					Expect(warnings).To(ConsistOf("get-services-warning", "get-plans-warning"))
+				})
+			})
+		})
+
+		When("the service exists with one non-public plan", func() {
+			var services []ccv2.Service
+
+			BeforeEach(func() {
+				services = []ccv2.Service{
+					{
+						Label:       "service",
+						Description: "service-description",
+					},
+				}
+				plans := []ccv2.ServicePlan{
+					{GUID: "plan-a-guid", Name: "plan-a", Public: true},
+					{GUID: "plan-b-guid", Name: "plan-b", Public: false},
+				}
+
+				brokers := []ccv2.ServiceBroker{
+					{Name: "normal-broker"},
+				}
+
+				fakeCloudControllerClient.GetSpaceServicesStub = func(guid string, filters ...ccv2.Filter) ([]ccv2.Service, ccv2.Warnings, error) {
+					filterToMatch := ccv2.Filter{
+						Type:     constant.LabelFilter,
+						Operator: constant.EqualOperator,
+						Values:   []string{"service"},
+					}
+
+					if len(filters) == 1 && reflect.DeepEqual(filters[0], filterToMatch) && spaceGUID == guid {
+						return services, ccv2.Warnings{"get-services-warning"}, nil
+					}
+
+					return []ccv2.Service{}, nil, nil
+				}
+
+				fakeCloudControllerClient.GetServicePlansReturns(plans, ccv2.Warnings{"get-plans-warning"}, nil)
+				fakeCloudControllerClient.GetServiceBrokersReturns(brokers, ccv2.Warnings{"get-brokers-warning"}, nil)
+			})
+
+			It("returns service summary excluding non public plans and all warnings", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(serviceSummary).To(Equal(
+					ServiceSummary{
+						Service: Service{
+							Label:       "service",
+							Description: "service-description",
+						},
+						Plans: []ServicePlanSummary{
+							ServicePlanSummary{
+								ServicePlan: ServicePlan{
+									GUID:   "plan-a-guid",
+									Name:   "plan-a",
+									Public: true,
+								},
+							},
+						},
+					}))
+				Expect(warnings).To(ConsistOf("get-services-warning", "get-plans-warning", "get-brokers-warning"))
+			})
+
+			When("the service broker is space-scoped", func() {
+				BeforeEach(func() {
+					services[0].ServiceBrokerName = "broker-a"
+
+					brokers := []ccv2.ServiceBroker{
+						{GUID: "broker-a-guid", Name: "broker-a", SpaceGUID: spaceGUID},
+					}
+
+					fakeCloudControllerClient.GetServiceBrokersReturns(brokers, ccv2.Warnings{"get-brokers-warning"}, nil)
+				})
+
+				It("returns summaries with all plans related to this space-scoped broker", func() {
+					Expect(err).NotTo(HaveOccurred())
+					Expect(serviceSummary).To(Equal(
+						ServiceSummary{
+							Service: Service{
+								Label:             "service",
+								Description:       "service-description",
+								ServiceBrokerName: "broker-a",
+							},
+							Plans: []ServicePlanSummary{
+								ServicePlanSummary{
+									ServicePlan: ServicePlan{
+										GUID:   "plan-a-guid",
+										Name:   "plan-a",
+										Public: true,
+									},
+								},
+								ServicePlanSummary{
+									ServicePlan: ServicePlan{
+										GUID:   "plan-b-guid",
+										Name:   "plan-b",
+										Public: false,
+									},
+								},
+							},
+						}))
+				})
+
+				It("returns all warnings", func() {
+					Expect(warnings).To(ConsistOf(
+						"get-services-warning",
+						"get-plans-warning",
+						"get-brokers-warning",
+					))
+				})
+			})
+
+			When("the non-public plan is visible to the org", func() {
+				BeforeEach(func() {
+					visibilities := []ccv2.ServicePlanVisibility{
+						{OrganizationGUID: "org-guid-1", ServicePlanGUID: "plan-b-guid"},
+					}
+
+					fakeCloudControllerClient.GetServicePlanVisibilitiesReturns(visibilities, ccv2.Warnings{"get-visibilities-warning"}, nil)
+				})
+
+				It("returns summaries with plans visible for the org", func() {
+					Expect(err).NotTo(HaveOccurred())
+					Expect(serviceSummary).To(Equal(
+						ServiceSummary{
+							Service: Service{
+								Label:       "service",
+								Description: "service-description",
+							},
+							Plans: []ServicePlanSummary{
+								ServicePlanSummary{
+									ServicePlan: ServicePlan{
+										GUID:   "plan-a-guid",
+										Name:   "plan-a",
+										Public: true,
+									},
+								},
+								ServicePlanSummary{
+									ServicePlan: ServicePlan{
+										GUID:   "plan-b-guid",
+										Name:   "plan-b",
+										Public: false,
+									},
+								},
+							},
+						}))
+				})
+
+				It("returns all warnings", func() {
+					Expect(warnings).To(ConsistOf(
+						"get-services-warning",
+						"get-plans-warning",
+						"get-brokers-warning",
+						"get-visibilities-warning",
+					))
+				})
+
+				It("gets plan visibilities for the non-public plan for the org", func() {
+					Expect(fakeCloudControllerClient.GetServicePlanVisibilitiesCallCount()).To(Equal(1))
+
+					Expect(fakeCloudControllerClient.GetServicePlanVisibilitiesArgsForCall(0)).To(ConsistOf(
+						ccv2.Filter{
+							Type:     constant.ServicePlanGUIDFilter,
+							Operator: constant.InOperator,
+							Values:   []string{"plan-b-guid"},
+						},
+						ccv2.Filter{
+							Type:     constant.OrganizationGUIDFilter,
+							Operator: constant.EqualOperator,
+							Values:   []string{organizationGUID},
+						},
+					))
 				})
 			})
 		})

--- a/command/v6/marketplace_command.go
+++ b/command/v6/marketplace_command.go
@@ -17,10 +17,10 @@ import (
 
 type ServicesSummariesActor interface {
 	GetServicesSummaries() ([]v2action.ServiceSummary, v2action.Warnings, error)
-	GetServicesSummariesForSpace(spaceGUID string) ([]v2action.ServiceSummary, v2action.Warnings, error)
+	GetServicesSummariesForSpace(spaceGUID string, organizationGUID string) ([]v2action.ServiceSummary, v2action.Warnings, error)
 
 	GetServiceSummaryByName(serviceName string) (v2action.ServiceSummary, v2action.Warnings, error)
-	GetServiceSummaryForSpaceByName(spaceGUID, serviceName string) (v2action.ServiceSummary, v2action.Warnings, error)
+	GetServiceSummaryForSpaceByName(spaceGUID, serviceName string, organizationGUID string) (v2action.ServiceSummary, v2action.Warnings, error)
 }
 
 type MarketplaceCommand struct {
@@ -80,7 +80,10 @@ func (cmd *MarketplaceCommand) marketplace() error {
 			"SpaceName": cmd.Config.TargetedSpace().Name,
 			"Username":  user.Name,
 		})
-		serviceSummaries, warnings, err := cmd.Actor.GetServicesSummariesForSpace(cmd.Config.TargetedSpace().GUID)
+		serviceSummaries, warnings, err := cmd.Actor.GetServicesSummariesForSpace(
+			cmd.Config.TargetedSpace().GUID,
+			cmd.Config.TargetedOrganization().GUID,
+		)
 		cmd.UI.DisplayWarnings(warnings)
 		if err != nil {
 			return err
@@ -99,7 +102,7 @@ func (cmd *MarketplaceCommand) marketplace() error {
 				"Username":    user.Name,
 			})
 
-		serviceSummary, warnings, err := cmd.Actor.GetServiceSummaryForSpaceByName(cmd.Config.TargetedSpace().GUID, cmd.ServiceName)
+		serviceSummary, warnings, err := cmd.Actor.GetServiceSummaryForSpaceByName(cmd.Config.TargetedSpace().GUID, cmd.ServiceName, cmd.Config.TargetedOrganization().GUID)
 		cmd.UI.DisplayWarnings(warnings)
 		if err != nil {
 			return err

--- a/command/v6/marketplace_command_test.go
+++ b/command/v6/marketplace_command_test.go
@@ -431,7 +431,7 @@ var _ = Describe("marketplace Command", func() {
 			fakeSharedActor.IsOrgTargetedReturns(true)
 			fakeSharedActor.IsSpaceTargetedReturns(true)
 
-			fakeConfig.TargetedOrganizationReturns(configv3.Organization{Name: "org-a"})
+			fakeConfig.TargetedOrganizationReturns(configv3.Organization{GUID: "org-guid", Name: "org-a"})
 			fakeConfig.TargetedSpaceReturns(configv3.Space{Name: "space-a", GUID: "space-guid"})
 		})
 
@@ -500,6 +500,13 @@ var _ = Describe("marketplace Command", func() {
 
 					It("outputs any warnings", func() {
 						Expect(testUI.Err).To(Say("warning"))
+					})
+
+					It("gets services for the correct space", func() {
+						spaceGUID, serviceName, orgGUID := fakeActor.GetServiceSummaryForSpaceByNameArgsForCall(0)
+						Expect(spaceGUID).To(Equal("space-guid"))
+						Expect(serviceName).To(Equal("service-a"))
+						Expect(orgGUID).To(Equal("org-guid"))
 					})
 				})
 
@@ -676,7 +683,9 @@ var _ = Describe("marketplace Command", func() {
 					})
 
 					It("gets services for the correct space", func() {
-						Expect(fakeActor.GetServicesSummariesForSpaceArgsForCall(0)).To(Equal("space-guid"))
+						spaceGUID, orgGUID := fakeActor.GetServicesSummariesForSpaceArgsForCall(0)
+						Expect(spaceGUID).To(Equal("space-guid"))
+						Expect(orgGUID).To(Equal("org-guid"))
 					})
 
 					It("outputs a header", func() {
@@ -728,7 +737,9 @@ var _ = Describe("marketplace Command", func() {
 					})
 
 					It("gets services for the correct space", func() {
-						Expect(fakeActor.GetServicesSummariesForSpaceArgsForCall(0)).To(Equal("space-guid"))
+						spaceGUID, orgGUID := fakeActor.GetServicesSummariesForSpaceArgsForCall(0)
+						Expect(spaceGUID).To(Equal("space-guid"))
+						Expect(orgGUID).To(Equal("org-guid"))
 					})
 
 					It("outputs a header", func() {

--- a/command/v6/v6fakes/fake_services_summaries_actor.go
+++ b/command/v6/v6fakes/fake_services_summaries_actor.go
@@ -24,11 +24,12 @@ type FakeServicesSummariesActor struct {
 		result2 v2action.Warnings
 		result3 error
 	}
-	GetServiceSummaryForSpaceByNameStub        func(string, string) (v2action.ServiceSummary, v2action.Warnings, error)
+	GetServiceSummaryForSpaceByNameStub        func(string, string, string) (v2action.ServiceSummary, v2action.Warnings, error)
 	getServiceSummaryForSpaceByNameMutex       sync.RWMutex
 	getServiceSummaryForSpaceByNameArgsForCall []struct {
 		arg1 string
 		arg2 string
+		arg3 string
 	}
 	getServiceSummaryForSpaceByNameReturns struct {
 		result1 v2action.ServiceSummary
@@ -54,10 +55,11 @@ type FakeServicesSummariesActor struct {
 		result2 v2action.Warnings
 		result3 error
 	}
-	GetServicesSummariesForSpaceStub        func(string) ([]v2action.ServiceSummary, v2action.Warnings, error)
+	GetServicesSummariesForSpaceStub        func(string, string) ([]v2action.ServiceSummary, v2action.Warnings, error)
 	getServicesSummariesForSpaceMutex       sync.RWMutex
 	getServicesSummariesForSpaceArgsForCall []struct {
 		arg1 string
+		arg2 string
 	}
 	getServicesSummariesForSpaceReturns struct {
 		result1 []v2action.ServiceSummary
@@ -139,17 +141,18 @@ func (fake *FakeServicesSummariesActor) GetServiceSummaryByNameReturnsOnCall(i i
 	}{result1, result2, result3}
 }
 
-func (fake *FakeServicesSummariesActor) GetServiceSummaryForSpaceByName(arg1 string, arg2 string) (v2action.ServiceSummary, v2action.Warnings, error) {
+func (fake *FakeServicesSummariesActor) GetServiceSummaryForSpaceByName(arg1 string, arg2 string, arg3 string) (v2action.ServiceSummary, v2action.Warnings, error) {
 	fake.getServiceSummaryForSpaceByNameMutex.Lock()
 	ret, specificReturn := fake.getServiceSummaryForSpaceByNameReturnsOnCall[len(fake.getServiceSummaryForSpaceByNameArgsForCall)]
 	fake.getServiceSummaryForSpaceByNameArgsForCall = append(fake.getServiceSummaryForSpaceByNameArgsForCall, struct {
 		arg1 string
 		arg2 string
-	}{arg1, arg2})
-	fake.recordInvocation("GetServiceSummaryForSpaceByName", []interface{}{arg1, arg2})
+		arg3 string
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("GetServiceSummaryForSpaceByName", []interface{}{arg1, arg2, arg3})
 	fake.getServiceSummaryForSpaceByNameMutex.Unlock()
 	if fake.GetServiceSummaryForSpaceByNameStub != nil {
-		return fake.GetServiceSummaryForSpaceByNameStub(arg1, arg2)
+		return fake.GetServiceSummaryForSpaceByNameStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
@@ -164,17 +167,17 @@ func (fake *FakeServicesSummariesActor) GetServiceSummaryForSpaceByNameCallCount
 	return len(fake.getServiceSummaryForSpaceByNameArgsForCall)
 }
 
-func (fake *FakeServicesSummariesActor) GetServiceSummaryForSpaceByNameCalls(stub func(string, string) (v2action.ServiceSummary, v2action.Warnings, error)) {
+func (fake *FakeServicesSummariesActor) GetServiceSummaryForSpaceByNameCalls(stub func(string, string, string) (v2action.ServiceSummary, v2action.Warnings, error)) {
 	fake.getServiceSummaryForSpaceByNameMutex.Lock()
 	defer fake.getServiceSummaryForSpaceByNameMutex.Unlock()
 	fake.GetServiceSummaryForSpaceByNameStub = stub
 }
 
-func (fake *FakeServicesSummariesActor) GetServiceSummaryForSpaceByNameArgsForCall(i int) (string, string) {
+func (fake *FakeServicesSummariesActor) GetServiceSummaryForSpaceByNameArgsForCall(i int) (string, string, string) {
 	fake.getServiceSummaryForSpaceByNameMutex.RLock()
 	defer fake.getServiceSummaryForSpaceByNameMutex.RUnlock()
 	argsForCall := fake.getServiceSummaryForSpaceByNameArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeServicesSummariesActor) GetServiceSummaryForSpaceByNameReturns(result1 v2action.ServiceSummary, result2 v2action.Warnings, result3 error) {
@@ -264,16 +267,17 @@ func (fake *FakeServicesSummariesActor) GetServicesSummariesReturnsOnCall(i int,
 	}{result1, result2, result3}
 }
 
-func (fake *FakeServicesSummariesActor) GetServicesSummariesForSpace(arg1 string) ([]v2action.ServiceSummary, v2action.Warnings, error) {
+func (fake *FakeServicesSummariesActor) GetServicesSummariesForSpace(arg1 string, arg2 string) ([]v2action.ServiceSummary, v2action.Warnings, error) {
 	fake.getServicesSummariesForSpaceMutex.Lock()
 	ret, specificReturn := fake.getServicesSummariesForSpaceReturnsOnCall[len(fake.getServicesSummariesForSpaceArgsForCall)]
 	fake.getServicesSummariesForSpaceArgsForCall = append(fake.getServicesSummariesForSpaceArgsForCall, struct {
 		arg1 string
-	}{arg1})
-	fake.recordInvocation("GetServicesSummariesForSpace", []interface{}{arg1})
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("GetServicesSummariesForSpace", []interface{}{arg1, arg2})
 	fake.getServicesSummariesForSpaceMutex.Unlock()
 	if fake.GetServicesSummariesForSpaceStub != nil {
-		return fake.GetServicesSummariesForSpaceStub(arg1)
+		return fake.GetServicesSummariesForSpaceStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
@@ -288,17 +292,17 @@ func (fake *FakeServicesSummariesActor) GetServicesSummariesForSpaceCallCount() 
 	return len(fake.getServicesSummariesForSpaceArgsForCall)
 }
 
-func (fake *FakeServicesSummariesActor) GetServicesSummariesForSpaceCalls(stub func(string) ([]v2action.ServiceSummary, v2action.Warnings, error)) {
+func (fake *FakeServicesSummariesActor) GetServicesSummariesForSpaceCalls(stub func(string, string) ([]v2action.ServiceSummary, v2action.Warnings, error)) {
 	fake.getServicesSummariesForSpaceMutex.Lock()
 	defer fake.getServicesSummariesForSpaceMutex.Unlock()
 	fake.GetServicesSummariesForSpaceStub = stub
 }
 
-func (fake *FakeServicesSummariesActor) GetServicesSummariesForSpaceArgsForCall(i int) string {
+func (fake *FakeServicesSummariesActor) GetServicesSummariesForSpaceArgsForCall(i int) (string, string) {
 	fake.getServicesSummariesForSpaceMutex.RLock()
 	defer fake.getServicesSummariesForSpaceMutex.RUnlock()
 	argsForCall := fake.getServicesSummariesForSpaceArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeServicesSummariesActor) GetServicesSummariesForSpaceReturns(result1 []v2action.ServiceSummary, result2 v2action.Warnings, result3 error) {

--- a/integration/helpers/service_broker.go
+++ b/integration/helpers/service_broker.go
@@ -144,6 +144,12 @@ func (b ServiceBroker) Create() {
 	Eventually(CF("service-brokers")).Should(And(Exit(0), Say(b.Name)))
 }
 
+func (b ServiceBroker) CreateSpaceScoped() {
+	appURI := fmt.Sprintf("http://%s.%s", b.Name, b.AppsDomain)
+	Eventually(CF("create-service-broker", b.Name, "username", "password", appURI, "--space-scoped")).Should(Exit(0))
+	Eventually(CF("service-brokers")).Should(And(Exit(0), Say(b.Name)))
+}
+
 func (b ServiceBroker) Update() {
 	appURI := fmt.Sprintf("http://%s.%s", b.Name, b.AppsDomain)
 	Eventually(CF("update-service-broker", b.Name, "username", "password", appURI)).Should(Exit(0))
@@ -200,6 +206,17 @@ func CreateBroker(domain, serviceName, planName string) ServiceBroker {
 	broker.Push()
 	broker.Configure(true)
 	broker.Create()
+
+	return broker
+}
+
+func CreateSpaceScopedBroker(domain, serviceName, planName string) ServiceBroker {
+	service := serviceName
+	servicePlan := planName
+	broker := NewServiceBroker(NewServiceBrokerName(), NewAssets().ServiceBroker, domain, service, servicePlan)
+	broker.Push()
+	broker.Configure(true)
+	broker.CreateSpaceScoped()
 
 	return broker
 }

--- a/integration/shared/isolated/marketplace_command_test.go
+++ b/integration/shared/isolated/marketplace_command_test.go
@@ -85,8 +85,8 @@ var _ = Describe("marketplace command", func() {
 						Eventually(session).Should(Say("OK"))
 						Eventually(session).Should(Say("\n\n"))
 						Eventually(session).Should(Say("service\\s+plans\\s+description"))
-						Eventually(session).Should(Say("%s\\s+%s\\s+fake service", getServiceName(broker1), getBrokerPlanNames(broker1)))
-						Eventually(session).Should(Say("%s\\s+%s\\s+fake service", getServiceName(broker2), getBrokerPlanNames(broker2)))
+						Eventually(session).Should(Say("%s\\s+%s\\s+fake service", getServiceName(broker1), getBrokerPlanNamesAsString(broker1)))
+						Eventually(session).Should(Say("%s\\s+%s\\s+fake service", getServiceName(broker2), getBrokerPlanNamesAsString(broker2)))
 						Eventually(session).Should(Say("TIP: Use 'cf marketplace -s SERVICE' to view descriptions of individual plans of a given service."))
 						Eventually(session).Should(Exit(0))
 					})
@@ -121,6 +121,8 @@ var _ = Describe("marketplace command", func() {
 
 						broker2      helpers.ServiceBroker
 						org2, space2 string
+
+						domain string
 					)
 
 					BeforeEach(func() {
@@ -129,7 +131,7 @@ var _ = Describe("marketplace command", func() {
 						helpers.SetupCF(org1, space1)
 						helpers.TargetOrgAndSpace(org1, space1)
 
-						domain := helpers.DefaultSharedDomain()
+						domain = helpers.DefaultSharedDomain()
 
 						broker1 = helpers.CreateBroker(domain, helpers.PrefixedRandomName("SERVICE-1"), "SERVICE-PLAN-1")
 						enableServiceAccessForOrg(broker1, org1)
@@ -165,8 +167,8 @@ var _ = Describe("marketplace command", func() {
 							Eventually(session).Should(Say("\n\n"))
 							Eventually(session).Should(Say("service\\s+plans\\s+description\\s+broker"))
 							Consistently(session).ShouldNot(Say(getServiceName(broker1)))
-							Consistently(session).ShouldNot(Say(getBrokerPlanNames(broker1)))
-							Eventually(session).Should(Say("%s\\s+%s\\s+fake service\\s*", getServiceName(broker2), getBrokerPlanNames(broker2)))
+							Consistently(session).ShouldNot(Say(getBrokerPlanNamesAsString(broker1)))
+							Eventually(session).Should(Say("%s\\s+%s\\s+fake service\\s*", getServiceName(broker2), getBrokerPlanNamesAsString(broker2)))
 							Eventually(session).Should(Say("TIP: Use 'cf marketplace -s SERVICE' to view descriptions of individual plans of a given service."))
 							Eventually(session).Should(Exit(0))
 						})
@@ -184,9 +186,9 @@ var _ = Describe("marketplace command", func() {
 							Eventually(session).Should(Say("\n\n"))
 							Eventually(session).Should(Say("service\\s+plans\\s+description\\s+broker"))
 							Consistently(session).ShouldNot(Say(getServiceName(broker1)))
-							Consistently(session).ShouldNot(Say(getBrokerPlanNames(broker1)))
+							Consistently(session).ShouldNot(Say(getBrokerPlanNamesAsString(broker1)))
 							Consistently(session).ShouldNot(Say(broker1.Name))
-							Eventually(session).Should(Say("%s\\s+%s\\s+fake service\\s+%s", getServiceName(broker2), getBrokerPlanNames(broker2), broker2.Name))
+							Eventually(session).Should(Say("%s\\s+%s\\s+fake service\\s+%s", getServiceName(broker2), getBrokerPlanNamesAsString(broker2), broker2.Name))
 							Eventually(session).Should(Say("TIP: Use 'cf marketplace -s SERVICE' to view descriptions of individual plans of a given service."))
 							Eventually(session).Should(Exit(0))
 						})
@@ -199,6 +201,68 @@ var _ = Describe("marketplace command", func() {
 								Eventually(session).Should(Say("\n\n"))
 								Eventually(session).Should(Say("service\\s+description\\s+broker"))
 								Eventually(session).Should(Say("%s\\s+fake service\\s+%s", getServiceName(broker2), broker2.Name))
+								Eventually(session).Should(Say("TIP: Use 'cf marketplace -s SERVICE' to view descriptions of individual plans of a given service."))
+								Eventually(session).Should(Exit(0))
+							})
+						})
+
+						When("one of the plans for the service is not enabled for any org", func() {
+							BeforeEach(func() {
+								Eventually(helpers.CF("disable-service-access", getServiceName(broker2), "-p", getBrokerPlanNames(broker2)[0])).Should(Exit(0))
+							})
+
+							It("does not include the plan in the table", func() {
+								session := helpers.CF("marketplace")
+								Eventually(session).Should(Say("Getting services from marketplace in org %s / space %s as %s\\.\\.\\.", org2, space2, user))
+								Eventually(session).Should(Say("OK"))
+								Eventually(session).Should(Say("\n\n"))
+								Eventually(session).Should(Say("service\\s+plans\\s+description\\s+broker"))
+								Eventually(session).Should(Say(getServiceName(broker2)))
+								Consistently(session).ShouldNot(Say(getBrokerPlanNames(broker2)[0]))
+								Eventually(session).Should(Say(getBrokerPlanNames(broker2)[1]))
+								Eventually(session).Should(Say("TIP: Use 'cf marketplace -s SERVICE' to view descriptions of individual plans of a given service."))
+								Eventually(session).Should(Exit(0))
+							})
+						})
+
+						When("one of the plans for the service is enabled for current org", func() {
+							BeforeEach(func() {
+								Eventually(helpers.CF("disable-service-access", getServiceName(broker2))).Should(Exit(0))
+								Eventually(helpers.CF("enable-service-access", getServiceName(broker2), "-p", getBrokerPlanNames(broker2)[0], "-o", org2)).Should(Exit(0))
+							})
+
+							It("includes only that plan in the table", func() {
+								session := helpers.CF("marketplace")
+								Eventually(session).Should(Say("Getting services from marketplace in org %s / space %s as %s\\.\\.\\.", org2, space2, user))
+								Eventually(session).Should(Say("OK"))
+								Eventually(session).Should(Say("\n\n"))
+								Eventually(session).Should(Say("service\\s+plans\\s+description\\s+broker"))
+								Eventually(session).Should(Say(getServiceName(broker2)))
+								Eventually(session).Should(Say(getBrokerPlanNames(broker2)[0]))
+								Consistently(session).ShouldNot(Say(getBrokerPlanNames(broker2)[1]))
+								Eventually(session).Should(Say("TIP: Use 'cf marketplace -s SERVICE' to view descriptions of individual plans of a given service."))
+								Eventually(session).Should(Exit(0))
+							})
+						})
+
+						When("one of the plans for the service is from a space-scoped broker", func() {
+							var broker3 helpers.ServiceBroker
+
+							BeforeEach(func() {
+								Eventually(helpers.CF("disable-service-access", getServiceName(broker2))).Should(Exit(0))
+								broker3 = helpers.CreateSpaceScopedBroker(domain, helpers.PrefixedRandomName("SERVICE-3"), "SERVICE-PLAN-3")
+							})
+
+							It("includes that plan in the table", func() {
+								session := helpers.CF("marketplace")
+								Eventually(session).Should(Say("Getting services from marketplace in org %s / space %s as %s\\.\\.\\.", org2, space2, user))
+								Eventually(session).Should(Say("OK"))
+								Eventually(session).Should(Say("\n\n"))
+								Eventually(session).Should(Say("service\\s+plans\\s+description\\s+broker"))
+								Consistently(session).ShouldNot(Say(getServiceName(broker2)))
+								Eventually(session).Should(Say(getServiceName(broker3)))
+								Eventually(session).Should(Say(getBrokerPlanNames(broker3)[0]))
+								Eventually(session).Should(Say(getBrokerPlanNames(broker3)[1]))
 								Eventually(session).Should(Say("TIP: Use 'cf marketplace -s SERVICE' to view descriptions of individual plans of a given service."))
 								Eventually(session).Should(Exit(0))
 							})
@@ -409,8 +473,12 @@ func getPlanName(broker helpers.ServiceBroker) string {
 	return broker.SyncPlans[0].Name
 }
 
-func getBrokerPlanNames(broker helpers.ServiceBroker) string {
-	return strings.Join(plansToNames(append(broker.SyncPlans, broker.AsyncPlans...)), ", ")
+func getBrokerPlanNamesAsString(broker helpers.ServiceBroker) string {
+	return strings.Join(getBrokerPlanNames(broker), ", ")
+}
+
+func getBrokerPlanNames(broker helpers.ServiceBroker) []string {
+	return plansToNames(append(broker.SyncPlans, broker.AsyncPlans...))
 }
 
 func plansToNames(plans []helpers.Plan) []string {


### PR DESCRIPTION
Currently executing the `cf marketplace` command will give you
a list of services and related to them plans. If you have the admin role
it will list the disabled plans as well.

This commit fixes this issue and `cf marketplace` will be showing
only the plans that are available in the current space.

[fixes #967]

Co-authored-by: Aarti Kriplani <akriplani@pivotal.io>
Signed-off-by: Aarti Kriplani <akriplani@pivotal.io>