### PR TITLE
Dont list disabled plans in cf marketplace

### DIFF
--- a/actor/actionerror/service_broker_not_found_error.go
+++ b/actor/actionerror/service_broker_not_found_error.go
@@ -2,10 +2,18 @@ package actionerror
 
 import "fmt"
 
+type ServiceBrokerNotFoundKey string
+
+const (
+	KeyName ServiceBrokerNotFoundKey = "name"
+	KeyGUID ServiceBrokerNotFoundKey = "GUID"
+)
+
 type ServiceBrokerNotFoundError struct {
-	Name string
+	Key   ServiceBrokerNotFoundKey
+	Value string
 }
 
 func (e ServiceBrokerNotFoundError) Error() string {
-	return fmt.Sprintf("Service broker '%s' not found.\nTIP: Use 'cf service-brokers' to see a list of available brokers.", e.Name)
+	return fmt.Sprintf("Service broker with %s '%s' not found.\nTIP: Use 'cf service-brokers' to see a list of available brokers.", e.Key, e.Value)
 }

--- a/actor/v2action/cloud_controller_client.go
+++ b/actor/v2action/cloud_controller_client.go
@@ -54,6 +54,7 @@ type CloudControllerClient interface {
 	GetSecurityGroups(filters ...ccv2.Filter) ([]ccv2.SecurityGroup, ccv2.Warnings, error)
 	GetService(serviceGUID string) (ccv2.Service, ccv2.Warnings, error)
 	GetServiceBindings(filters ...ccv2.Filter) ([]ccv2.ServiceBinding, ccv2.Warnings, error)
+	GetServiceBroker(serviceBrokerGUID string) (ccv2.ServiceBroker, ccv2.Warnings, error)
 	GetServiceBrokers(filters ...ccv2.Filter) ([]ccv2.ServiceBroker, ccv2.Warnings, error)
 	GetServiceInstance(serviceInstanceGUID string) (ccv2.ServiceInstance, ccv2.Warnings, error)
 	GetServiceInstanceServiceBindings(serviceInstanceGUID string) ([]ccv2.ServiceBinding, ccv2.Warnings, error)

--- a/actor/v2action/service_broker_test.go
+++ b/actor/v2action/service_broker_test.go
@@ -9,6 +9,7 @@ import (
 	"code.cloudfoundry.org/cli/actor/actionerror"
 	. "code.cloudfoundry.org/cli/actor/v2action"
 	"code.cloudfoundry.org/cli/actor/v2action/v2actionfakes"
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccerror"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv2"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv2/constant"
 )
@@ -155,7 +156,65 @@ var _ = Describe("Service Broker", func() {
 					Expect(filter).To(Equal([]ccv2.Filter{{Type: constant.NameFilter, Operator: constant.EqualOperator, Values: []string{"broker-name"}}}))
 
 					Expect(warnings).To(Equal(Warnings{"a-warning", "another-warning"}))
-					Expect(executeErr).To(MatchError(actionerror.ServiceBrokerNotFoundError{Name: "broker-name"}))
+					Expect(executeErr).To(MatchError(actionerror.ServiceBrokerNotFoundError{Key: actionerror.KeyName, Value: "broker-name"}))
+				})
+			})
+		})
+	})
+
+	Describe("GetServiceBroker", func() {
+		var (
+			executeErr    error
+			warnings      Warnings
+			serviceBroker ServiceBroker
+		)
+
+		JustBeforeEach(func() {
+			serviceBroker, warnings, executeErr = actor.GetServiceBroker("broker-guid")
+		})
+
+		When("there are no errors", func() {
+			When("a service broker exists", func() {
+				BeforeEach(func() {
+					fakeCloudControllerClient.GetServiceBrokerReturns(ccv2.ServiceBroker{GUID: "broker-guid"}, []string{"a-warning", "another-warning"}, nil)
+				})
+
+				It("gets the service broker", func() {
+					Expect(fakeCloudControllerClient.GetServiceBrokerCallCount()).To(Equal(1))
+					brokerGUID := fakeCloudControllerClient.GetServiceBrokerArgsForCall(0)
+					Expect(brokerGUID).To(Equal("broker-guid"))
+
+					Expect(warnings).To(Equal(Warnings{"a-warning", "another-warning"}))
+					Expect(executeErr).NotTo(HaveOccurred())
+					Expect(serviceBroker.GUID).To(Equal("broker-guid"))
+				})
+			})
+		})
+
+		When("there is an error", func() {
+			When("calling the client", func() {
+				BeforeEach(func() {
+					fakeCloudControllerClient.GetServiceBrokerReturns(ccv2.ServiceBroker{GUID: "broker-guid"}, []string{"one-warning", "two-warnings"}, errors.New("error fetching broker"))
+				})
+
+				It("returns the errors and warnings", func() {
+					Expect(warnings).To(Equal(Warnings{"one-warning", "two-warnings"}))
+					Expect(executeErr).To(MatchError("error fetching broker"))
+				})
+			})
+
+			When("a service broker does not exist", func() {
+				BeforeEach(func() {
+					fakeCloudControllerClient.GetServiceBrokerReturns(ccv2.ServiceBroker{}, []string{"a-warning", "another-warning"}, ccerror.ResourceNotFoundError{})
+				})
+
+				It("raises a service broker not found error", func() {
+					Expect(fakeCloudControllerClient.GetServiceBrokerCallCount()).To(Equal(1))
+					brokerGUID := fakeCloudControllerClient.GetServiceBrokerArgsForCall(0)
+					Expect(brokerGUID).To(Equal("broker-guid"))
+
+					Expect(warnings).To(Equal(Warnings{"a-warning", "another-warning"}))
+					Expect(executeErr).To(MatchError(actionerror.ServiceBrokerNotFoundError{Key: actionerror.KeyGUID, Value: "broker-guid"}))
 				})
 			})
 		})

--- a/actor/v2action/service_summary.go
+++ b/actor/v2action/service_summary.go
@@ -17,18 +17,18 @@ func (actor Actor) GetServicesSummaries() ([]ServiceSummary, Warnings, error) {
 		return []ServiceSummary{}, Warnings(warnings), err
 	}
 
-	summaries, serviceWarnings, err := actor.createServiceSummaries(services)
+	summaries, serviceWarnings, err := actor.createServiceSummaries(services, "", "")
 	warnings = append(warnings, serviceWarnings...)
 	return summaries, Warnings(warnings), err
 }
 
-func (actor Actor) GetServicesSummariesForSpace(spaceGUID string) ([]ServiceSummary, Warnings, error) {
+func (actor Actor) GetServicesSummariesForSpace(spaceGUID string, organizationGUID string) ([]ServiceSummary, Warnings, error) {
 	services, warnings, err := actor.CloudControllerClient.GetSpaceServices(spaceGUID)
 	if err != nil {
 		return []ServiceSummary{}, Warnings(warnings), err
 	}
 
-	summaries, summaryWarnings, err := actor.createServiceSummaries(services)
+	summaries, summaryWarnings, err := actor.createServiceSummaries(services, organizationGUID, spaceGUID)
 	warnings = append(warnings, summaryWarnings...)
 	return summaries, Warnings(warnings), err
 }
@@ -47,7 +47,13 @@ func (actor Actor) GetServiceSummaryByName(serviceName string) (ServiceSummary, 
 		return ServiceSummary{}, Warnings(warnings), actionerror.ServiceNotFoundError{Name: serviceName}
 	}
 
-	summary, summaryWarnings, err := actor.createServiceSummary(services[0])
+	plans, planWarnings, err := actor.getPlansForOneService(services[0])
+	warnings = append(warnings, planWarnings...)
+	if err != nil {
+		return ServiceSummary{}, Warnings(warnings), err
+	}
+
+	summary, summaryWarnings, err := actor.createServiceSummary(services[0], plans, "", "")
 	warnings = append(warnings, summaryWarnings...)
 	if err != nil {
 		return ServiceSummary{}, Warnings(warnings), err
@@ -56,7 +62,7 @@ func (actor Actor) GetServiceSummaryByName(serviceName string) (ServiceSummary, 
 	return summary, Warnings(warnings), err
 }
 
-func (actor Actor) GetServiceSummaryForSpaceByName(spaceGUID, serviceName string) (ServiceSummary, Warnings, error) {
+func (actor Actor) GetServiceSummaryForSpaceByName(spaceGUID, serviceName, organizationGUID string) (ServiceSummary, Warnings, error) {
 	services, warnings, err := actor.CloudControllerClient.GetSpaceServices(spaceGUID, ccv2.Filter{
 		Type:     constant.LabelFilter,
 		Operator: constant.EqualOperator,
@@ -70,7 +76,13 @@ func (actor Actor) GetServiceSummaryForSpaceByName(spaceGUID, serviceName string
 		return ServiceSummary{}, Warnings(warnings), actionerror.ServiceNotFoundError{Name: serviceName}
 	}
 
-	summary, summaryWarnings, err := actor.createServiceSummary(services[0])
+	plans, planWarnings, err := actor.getPlansForOneService(services[0])
+	warnings = append(warnings, planWarnings...)
+	if err != nil {
+		return ServiceSummary{}, Warnings(warnings), err
+	}
+
+	summary, summaryWarnings, err := actor.createServiceSummary(services[0], plans, organizationGUID, spaceGUID)
 	warnings = append(warnings, summaryWarnings...)
 	if err != nil {
 		return ServiceSummary{}, Warnings(warnings), err
@@ -79,25 +91,56 @@ func (actor Actor) GetServiceSummaryForSpaceByName(spaceGUID, serviceName string
 	return summary, Warnings(warnings), err
 }
 
-func (actor Actor) createServiceSummaries(services []ccv2.Service) ([]ServiceSummary, ccv2.Warnings, error) {
+func (actor Actor) createServiceSummaries(services []ccv2.Service, organizationGUID, spaceGUID string) ([]ServiceSummary, ccv2.Warnings, error) {
 	var serviceSummaries []ServiceSummary
 	var warnings ccv2.Warnings
 
+	plans, planWarnings, err := actor.getPlansForManyServices(services)
+	warnings = append(warnings, planWarnings...)
+	if err != nil {
+		return []ServiceSummary{}, warnings, err
+	}
+
 	for _, service := range services {
-		summary, summaryWarnings, err := actor.createServiceSummary(service)
+		plansForThatService := actor.getPlansForService(service, plans)
+
+		summary, summaryWarnings, err := actor.createServiceSummary(service, plansForThatService, organizationGUID, spaceGUID)
 		warnings = append(warnings, summaryWarnings...)
 		if err != nil {
 			return []ServiceSummary{}, warnings, err
 		}
 
-		serviceSummaries = append(serviceSummaries, summary)
+		if len(summary.Plans) > 0 {
+			serviceSummaries = append(serviceSummaries, summary)
+		}
 	}
 
 	return serviceSummaries, warnings, nil
 }
 
-func (actor Actor) createServiceSummary(service ccv2.Service) (ServiceSummary, ccv2.Warnings, error) {
-	planSummaries, warnings, err := actor.getPlanSummariesForService(service)
+func (actor Actor) getPlansForOneService(service ccv2.Service) ([]ccv2.ServicePlan, ccv2.Warnings, error) {
+	return actor.CloudControllerClient.GetServicePlans(ccv2.Filter{
+		Type:     constant.ServiceGUIDFilter,
+		Operator: constant.EqualOperator,
+		Values:   []string{service.GUID},
+	})
+}
+
+func (actor Actor) getPlansForManyServices(services []ccv2.Service) ([]ccv2.ServicePlan, ccv2.Warnings, error) {
+	serviceGUIDs := []string{}
+	for _, service := range services {
+		serviceGUIDs = append(serviceGUIDs, service.GUID)
+	}
+
+	return actor.CloudControllerClient.GetServicePlans(ccv2.Filter{
+		Type:     constant.ServiceGUIDFilter,
+		Operator: constant.InOperator,
+		Values:   serviceGUIDs,
+	})
+}
+
+func (actor Actor) createServiceSummary(service ccv2.Service, plans []ccv2.ServicePlan, organizationGUID, spaceGUID string) (ServiceSummary, ccv2.Warnings, error) {
+	planSummaries, warnings, err := actor.getPlanSummariesForService(service, plans, organizationGUID, spaceGUID)
 	if err != nil {
 		return ServiceSummary{}, warnings, err
 	}
@@ -105,20 +148,88 @@ func (actor Actor) createServiceSummary(service ccv2.Service) (ServiceSummary, c
 	return ServiceSummary{Service: Service(service), Plans: planSummaries}, warnings, nil
 }
 
-func (actor Actor) getPlanSummariesForService(service ccv2.Service) ([]ServicePlanSummary, ccv2.Warnings, error) {
-	plans, warnings, err := actor.CloudControllerClient.GetServicePlans(ccv2.Filter{
-		Type:     constant.ServiceGUIDFilter,
-		Operator: constant.EqualOperator,
-		Values:   []string{service.GUID},
-	})
-	if err != nil {
-		return []ServicePlanSummary{}, warnings, err
+func (actor Actor) getPlanSummariesForService(service ccv2.Service, plans []ccv2.ServicePlan, organizationGUID, spaceGUID string) ([]ServicePlanSummary, ccv2.Warnings, error) {
+	var err error
+	var warnings ccv2.Warnings
+
+	nonPublicPlans := []string{}
+	for _, plan := range plans {
+		if !plan.Public {
+			nonPublicPlans = append(nonPublicPlans, plan.GUID)
+		}
 	}
 
-	var planSummaries []ServicePlanSummary
-	for _, plan := range plans {
-		planSummaries = append(planSummaries, ServicePlanSummary{ServicePlan: ServicePlan(plan)})
+	var broker ServiceBroker
+	if spaceGUID != "" && len(nonPublicPlans) > 0 {
+		var brokerWarnings Warnings
+		broker, brokerWarnings, err = actor.GetServiceBroker(service.ServiceBrokerGUID)
+		warnings = append(warnings, brokerWarnings...)
+		if err != nil {
+			return []ServicePlanSummary{}, warnings, err
+		}
 	}
+
+	var visibilities []ccv2.ServicePlanVisibility
+
+	if len(nonPublicPlans) > 0 {
+		var visibilityWarnings ccv2.Warnings
+
+		visibilities, visibilityWarnings, err = actor.getPlanVisibilitiesForOrg(nonPublicPlans, organizationGUID)
+		warnings = append(warnings, visibilityWarnings...)
+		if err != nil {
+			return []ServicePlanSummary{}, warnings, err
+		}
+	}
+
+	planSummaries := actor.getSummariesForVisiblePlans(plans, broker, visibilities, spaceGUID)
 
 	return planSummaries, warnings, nil
+}
+
+func (actor Actor) getSummariesForVisiblePlans(plans []ccv2.ServicePlan, broker ServiceBroker, visibilities []ccv2.ServicePlanVisibility, spaceGUID string) []ServicePlanSummary {
+	var planSummaries []ServicePlanSummary
+	for _, plan := range plans {
+		if plan.Public || (spaceGUID != "" && broker.SpaceGUID == spaceGUID) {
+			planSummaries = append(planSummaries, ServicePlanSummary{ServicePlan: ServicePlan(plan)})
+		} else {
+			visibleInOrg := false
+			for _, visibility := range visibilities {
+				if visibility.ServicePlanGUID == plan.GUID {
+					visibleInOrg = true
+					break
+				}
+			}
+
+			if visibleInOrg {
+				planSummaries = append(planSummaries, ServicePlanSummary{ServicePlan: ServicePlan(plan)})
+			}
+		}
+	}
+
+	return planSummaries
+}
+
+func (actor Actor) getPlanVisibilitiesForOrg(plans []string, organizationGUID string) ([]ccv2.ServicePlanVisibility, ccv2.Warnings, error) {
+	return actor.CloudControllerClient.GetServicePlanVisibilities(
+		ccv2.Filter{
+			Type:     constant.ServicePlanGUIDFilter,
+			Operator: constant.InOperator,
+			Values:   plans,
+		},
+		ccv2.Filter{
+			Type:     constant.OrganizationGUIDFilter,
+			Operator: constant.EqualOperator,
+			Values:   []string{organizationGUID},
+		},
+	)
+}
+
+func (actor Actor) getPlansForService(service ccv2.Service, plans []ccv2.ServicePlan) []ccv2.ServicePlan {
+	plansForThatService := []ccv2.ServicePlan{}
+	for _, plan := range plans {
+		if plan.ServiceGUID == service.GUID {
+			plansForThatService = append(plansForThatService, plan)
+		}
+	}
+	return plansForThatService
 }

--- a/actor/v2action/service_summary_test.go
+++ b/actor/v2action/service_summary_test.go
@@ -62,18 +62,22 @@ var _ = Describe("Service Summary Actions", func() {
 			BeforeEach(func() {
 				services := []ccv2.Service{
 					{
+						GUID:        "service-a-guid",
 						Label:       "service-a",
 						Description: "service-a-description",
 					},
 					{
+						GUID:        "service-b-guid",
 						Label:       "service-b",
 						Description: "service-b-description",
 					},
 				}
 
 				plans := []ccv2.ServicePlan{
-					{Name: "plan-a"},
-					{Name: "plan-b"},
+					{Name: "plan-a", ServiceGUID: "service-a-guid", Public: true},
+					{Name: "plan-b", ServiceGUID: "service-b-guid", Public: true},
+					{Name: "plan-c", ServiceGUID: "service-b-guid", Public: true},
+					{Name: "plan-d", ServiceGUID: "service-a-guid", Public: true},
 				}
 
 				fakeCloudControllerClient.GetServicesReturns(services, ccv2.Warnings{"get-services-warning"}, nil)
@@ -85,42 +89,53 @@ var _ = Describe("Service Summary Actions", func() {
 				Expect(servicesSummaries).To(ConsistOf(
 					ServiceSummary{
 						Service: Service{
+							GUID:        "service-a-guid",
 							Label:       "service-a",
 							Description: "service-a-description",
 						},
 						Plans: []ServicePlanSummary{
 							ServicePlanSummary{
 								ServicePlan: ServicePlan{
-									Name: "plan-a",
+									ServiceGUID: "service-a-guid",
+									Name:        "plan-a",
+									Public:      true,
 								},
 							},
 							ServicePlanSummary{
 								ServicePlan: ServicePlan{
-									Name: "plan-b",
+									ServiceGUID: "service-a-guid",
+									Name:        "plan-d",
+									Public:      true,
 								},
 							},
 						},
 					},
 					ServiceSummary{
 						Service: Service{
+							GUID:        "service-b-guid",
 							Label:       "service-b",
 							Description: "service-b-description",
 						},
 						Plans: []ServicePlanSummary{
 							ServicePlanSummary{
 								ServicePlan: ServicePlan{
-									Name: "plan-a",
+									ServiceGUID: "service-b-guid",
+									Name:        "plan-b",
+									Public:      true,
 								},
 							},
 							ServicePlanSummary{
 								ServicePlan: ServicePlan{
-									Name: "plan-b",
+									ServiceGUID: "service-b-guid",
+									Name:        "plan-c",
+									Public:      true,
 								},
 							},
 						},
 					},
 				))
-				Expect(warnings).To(ConsistOf("get-services-warning", "get-plans-warning", "get-plans-warning"))
+
+				Expect(warnings).To(ConsistOf("get-services-warning", "get-plans-warning"))
 			})
 
 			Context("and fetching plans returns an error", func() {
@@ -134,6 +149,10 @@ var _ = Describe("Service Summary Actions", func() {
 				})
 			})
 		})
+
+		AfterEach(func() {
+			Expect(fakeCloudControllerClient.GetServiceBrokerCallCount()).To(Equal(0))
+		})
 	})
 
 	Describe("GetServicesSummariesForSpace", func() {
@@ -142,10 +161,11 @@ var _ = Describe("Service Summary Actions", func() {
 			warnings          Warnings
 			err               error
 			spaceGUID         = "space-123"
+			organizationGUID  = "org-guid-123"
 		)
 
 		JustBeforeEach(func() {
-			servicesSummaries, warnings, err = actor.GetServicesSummariesForSpace(spaceGUID)
+			servicesSummaries, warnings, err = actor.GetServicesSummariesForSpace(spaceGUID, organizationGUID)
 		})
 
 		When("there are no services", func() {
@@ -171,22 +191,50 @@ var _ = Describe("Service Summary Actions", func() {
 			})
 		})
 
-		When("there are services with plans", func() {
+		It("retrieves the services for the correct space", func() {
+			requestedSpaceGUID, _ := fakeCloudControllerClient.GetSpaceServicesArgsForCall(0)
+			Expect(requestedSpaceGUID).To(Equal(spaceGUID))
+		})
+
+		Context("and fetching plans returns an error", func() {
 			BeforeEach(func() {
 				services := []ccv2.Service{
 					{
 						Label:       "service-a",
 						Description: "service-a-description",
 					},
+				}
+
+				fakeCloudControllerClient.GetSpaceServicesReturns(services, ccv2.Warnings{"get-services-warning"}, nil)
+				fakeCloudControllerClient.GetServicePlansReturns([]ccv2.ServicePlan{}, ccv2.Warnings{"get-plans-warning"}, errors.New("plan-oops"))
+			})
+
+			It("returns the error and all warnings", func() {
+				Expect(err).To(MatchError("plan-oops"))
+				Expect(warnings).To(ConsistOf("get-services-warning", "get-plans-warning"))
+			})
+		})
+
+		When("there are services with public plans", func() {
+			BeforeEach(func() {
+				services := []ccv2.Service{
 					{
+						GUID:        "service-a-guid",
+						Label:       "service-a",
+						Description: "service-a-description",
+					},
+					{
+						GUID:        "service-b-guid",
 						Label:       "service-b",
 						Description: "service-b-description",
 					},
 				}
 
 				plans := []ccv2.ServicePlan{
-					{Name: "plan-a"},
-					{Name: "plan-b"},
+					{Name: "plan-a", ServiceGUID: "service-b-guid", Public: true},
+					{Name: "plan-b", ServiceGUID: "service-a-guid", Public: true},
+					{Name: "plan-c", ServiceGUID: "service-a-guid", Public: true},
+					{Name: "plan-d", ServiceGUID: "service-b-guid", Public: true},
 				}
 
 				fakeCloudControllerClient.GetSpaceServicesReturns(services, ccv2.Warnings{"get-services-warning"}, nil)
@@ -198,60 +246,406 @@ var _ = Describe("Service Summary Actions", func() {
 				Expect(servicesSummaries).To(ConsistOf(
 					ServiceSummary{
 						Service: Service{
+							GUID:        "service-a-guid",
 							Label:       "service-a",
 							Description: "service-a-description",
 						},
 						Plans: []ServicePlanSummary{
 							ServicePlanSummary{
 								ServicePlan: ServicePlan{
-									Name: "plan-a",
+									ServiceGUID: "service-a-guid",
+									Name:        "plan-b",
+									Public:      true,
 								},
 							},
 							ServicePlanSummary{
 								ServicePlan: ServicePlan{
-									Name: "plan-b",
+									ServiceGUID: "service-a-guid",
+									Name:        "plan-c",
+									Public:      true,
 								},
 							},
 						},
 					},
 					ServiceSummary{
 						Service: Service{
+							GUID:        "service-b-guid",
 							Label:       "service-b",
 							Description: "service-b-description",
 						},
 						Plans: []ServicePlanSummary{
 							ServicePlanSummary{
 								ServicePlan: ServicePlan{
-									Name: "plan-a",
+									ServiceGUID: "service-b-guid",
+									Name:        "plan-a",
+									Public:      true,
 								},
 							},
 							ServicePlanSummary{
 								ServicePlan: ServicePlan{
-									Name: "plan-b",
+									ServiceGUID: "service-b-guid",
+									Name:        "plan-d",
+									Public:      true,
 								},
 							},
 						},
 					},
 				))
-				Expect(warnings).To(ConsistOf("get-services-warning", "get-plans-warning", "get-plans-warning"))
+
+				Expect(warnings).To(ConsistOf("get-services-warning", "get-plans-warning"))
 			})
 
-			It("retrieves the services for the correct space", func() {
-				requestedSpaceGUID, _ := fakeCloudControllerClient.GetSpaceServicesArgsForCall(0)
-				Expect(requestedSpaceGUID).To(Equal(spaceGUID))
+			It("uses the IN filter to get all the plans for all services and then match them up", func() {
+				Expect(fakeCloudControllerClient.GetServicePlansCallCount()).To(Equal(1))
+
+				Expect(fakeCloudControllerClient.GetServicePlansArgsForCall(0)).To(ConsistOf(
+					ccv2.Filter{
+						Type:     constant.ServiceGUIDFilter,
+						Operator: constant.InOperator,
+						Values:   []string{"service-a-guid", "service-b-guid"},
+					},
+				))
 			})
 
-			Context("and fetching plans returns an error", func() {
+			It("does not request service plan visibilities", func() {
+				Expect(fakeCloudControllerClient.GetServicePlanVisibilitiesCallCount()).To(Equal(0))
+			})
+		})
+
+		When("there are services with one non-public plan", func() {
+			BeforeEach(func() {
+				services := []ccv2.Service{
+					{
+						GUID:        "service-a-guid",
+						Label:       "service-a",
+						Description: "service-a-description",
+					},
+					{
+						GUID:        "service-b-guid",
+						Label:       "service-b",
+						Description: "service-b-description",
+					},
+				}
+
+				plans := []ccv2.ServicePlan{
+					{Name: "plan-a", ServiceGUID: "service-a-guid", Public: true},
+					{Name: "plan-b", ServiceGUID: "service-a-guid", Public: false},
+					{Name: "plan-c", ServiceGUID: "service-b-guid", Public: true},
+					{Name: "plan-d", ServiceGUID: "service-b-guid", Public: false},
+				}
+
+				broker := ccv2.ServiceBroker{
+					Name: "normal-broker",
+				}
+
+				fakeCloudControllerClient.GetSpaceServicesReturns(services, ccv2.Warnings{"get-services-warning"}, nil)
+				fakeCloudControllerClient.GetServicePlansReturns(plans, ccv2.Warnings{"get-plans-warning"}, nil)
+				fakeCloudControllerClient.GetServiceBrokerReturns(broker, ccv2.Warnings{"get-brokers-warning"}, nil)
+			})
+
+			It("returns summaries excluding non public plans and all warnings", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(servicesSummaries).To(ConsistOf(
+					ServiceSummary{
+						Service: Service{
+							GUID:        "service-a-guid",
+							Label:       "service-a",
+							Description: "service-a-description",
+						},
+						Plans: []ServicePlanSummary{
+							ServicePlanSummary{
+								ServicePlan: ServicePlan{
+									ServiceGUID: "service-a-guid",
+									Name:        "plan-a",
+									Public:      true,
+								},
+							},
+						},
+					},
+					ServiceSummary{
+						Service: Service{
+							GUID:        "service-b-guid",
+							Label:       "service-b",
+							Description: "service-b-description",
+						},
+						Plans: []ServicePlanSummary{
+							ServicePlanSummary{
+								ServicePlan: ServicePlan{
+									ServiceGUID: "service-b-guid",
+									Name:        "plan-c",
+									Public:      true,
+								},
+							},
+						},
+					},
+				))
+
+				Expect(warnings).To(ConsistOf("get-services-warning", "get-plans-warning", "get-brokers-warning", "get-brokers-warning"))
+			})
+		})
+
+		When("there are services with non-public plan but visible to the org", func() {
+			BeforeEach(func() {
+				services := []ccv2.Service{
+					{
+						GUID:        "service-a-guid",
+						Label:       "service-a",
+						Description: "service-a-description",
+					},
+					{
+						GUID:        "service-b-guid",
+						Label:       "service-b",
+						Description: "service-b-description",
+					},
+				}
+
+				plans := []ccv2.ServicePlan{
+					{GUID: "plan-a-guid", ServiceGUID: "service-a-guid", Name: "plan-a", Public: false},
+					{GUID: "plan-b-guid", ServiceGUID: "service-a-guid", Name: "plan-b", Public: false},
+					{GUID: "plan-c-guid", ServiceGUID: "service-b-guid", Name: "plan-c", Public: false},
+					{GUID: "plan-d-guid", ServiceGUID: "service-b-guid", Name: "plan-d", Public: false},
+				}
+
+				visibilities1 := []ccv2.ServicePlanVisibility{
+					{OrganizationGUID: "org-guid-1", ServicePlanGUID: "plan-a-guid"},
+					{OrganizationGUID: "org-guid-1", ServicePlanGUID: "plan-b-guid"},
+				}
+
+				visibilities2 := []ccv2.ServicePlanVisibility{
+					{OrganizationGUID: "org-guid-1", ServicePlanGUID: "plan-c-guid"},
+				}
+
+				broker := ccv2.ServiceBroker{
+					Name: "normal-broker",
+				}
+
+				fakeCloudControllerClient.GetSpaceServicesReturns(services, ccv2.Warnings{"get-services-warning"}, nil)
+				fakeCloudControllerClient.GetServicePlansReturns(plans, ccv2.Warnings{"get-plans-warning"}, nil)
+				fakeCloudControllerClient.GetServiceBrokerReturns(broker, ccv2.Warnings{"get-brokers-warning"}, nil)
+				fakeCloudControllerClient.GetServicePlanVisibilitiesReturnsOnCall(0, visibilities1, ccv2.Warnings{"get-visibilities-a-warning"}, nil)
+				fakeCloudControllerClient.GetServicePlanVisibilitiesReturnsOnCall(1, visibilities2, ccv2.Warnings{"get-visibilities-b-warning"}, nil)
+			})
+
+			It("returns summaries with plans visible for the org", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(servicesSummaries).To(ConsistOf(
+					ServiceSummary{
+						Service: Service{
+							GUID:        "service-a-guid",
+							Label:       "service-a",
+							Description: "service-a-description",
+						},
+						Plans: []ServicePlanSummary{
+							ServicePlanSummary{
+								ServicePlan: ServicePlan{
+									GUID:        "plan-a-guid",
+									ServiceGUID: "service-a-guid",
+									Name:        "plan-a",
+									Public:      false,
+								},
+							},
+							ServicePlanSummary{
+								ServicePlan: ServicePlan{
+									ServiceGUID: "service-a-guid",
+									GUID:        "plan-b-guid",
+									Name:        "plan-b",
+									Public:      false,
+								},
+							},
+						},
+					},
+					ServiceSummary{
+						Service: Service{
+							GUID:        "service-b-guid",
+							Label:       "service-b",
+							Description: "service-b-description",
+						},
+						Plans: []ServicePlanSummary{
+							ServicePlanSummary{
+								ServicePlan: ServicePlan{
+									ServiceGUID: "service-b-guid",
+									GUID:        "plan-c-guid",
+									Name:        "plan-c",
+									Public:      false,
+								},
+							},
+						},
+					},
+				))
+			})
+
+			It("returns all warnings", func() {
+				Expect(warnings).To(ConsistOf(
+					"get-services-warning",
+					"get-plans-warning",
+					"get-brokers-warning",
+					"get-visibilities-a-warning",
+					"get-brokers-warning",
+					"get-visibilities-b-warning",
+				))
+			})
+
+			It("gets service plans using IN filter for all services at once", func() {
+				Expect(fakeCloudControllerClient.GetServicePlansCallCount()).To(Equal(1))
+
+				Expect(fakeCloudControllerClient.GetServicePlansArgsForCall(0)).To(ConsistOf(
+					ccv2.Filter{
+						Type:     constant.ServiceGUIDFilter,
+						Operator: constant.InOperator,
+						Values:   []string{"service-a-guid", "service-b-guid"},
+					},
+				))
+			})
+
+			It("gets plan visibilities for the non-public plan for the org", func() {
+				Expect(fakeCloudControllerClient.GetServicePlanVisibilitiesCallCount()).To(Equal(2))
+
+				Expect(fakeCloudControllerClient.GetServicePlanVisibilitiesArgsForCall(0)).To(ConsistOf(
+					ccv2.Filter{
+						Type:     constant.ServicePlanGUIDFilter,
+						Operator: constant.InOperator,
+						Values:   []string{"plan-a-guid", "plan-b-guid"},
+					},
+					ccv2.Filter{
+						Type:     constant.OrganizationGUIDFilter,
+						Operator: constant.EqualOperator,
+						Values:   []string{organizationGUID},
+					},
+				))
+
+				Expect(fakeCloudControllerClient.GetServicePlanVisibilitiesArgsForCall(1)).To(ConsistOf(
+					ccv2.Filter{
+						Type:     constant.ServicePlanGUIDFilter,
+						Operator: constant.InOperator,
+						Values:   []string{"plan-c-guid", "plan-d-guid"},
+					},
+					ccv2.Filter{
+						Type:     constant.OrganizationGUIDFilter,
+						Operator: constant.EqualOperator,
+						Values:   []string{organizationGUID},
+					},
+				))
+			})
+
+			When("getting visibilities fails", func() {
 				BeforeEach(func() {
-					fakeCloudControllerClient.GetServicePlansReturns([]ccv2.ServicePlan{}, ccv2.Warnings{"get-plans-warning"}, errors.New("plan-oops"))
+					fakeCloudControllerClient.GetServicePlanVisibilitiesReturnsOnCall(0, []ccv2.ServicePlanVisibility{}, ccv2.Warnings{"get-visibilities-warning"}, errors.New("oopsie"))
 				})
 
-				It("returns the error and all warnings", func() {
-					Expect(err).To(MatchError("plan-oops"))
-					Expect(warnings).To(ConsistOf("get-services-warning", "get-plans-warning"))
+				It("returns errors and warnings", func() {
+					Expect(err).To(MatchError(errors.New("oopsie")))
+					Expect(warnings).To(ConsistOf("get-services-warning", "get-plans-warning", "get-brokers-warning", "get-visibilities-warning"))
 				})
 			})
 		})
+
+		When("when there are space scoped services", func() {
+			BeforeEach(func() {
+				services := []ccv2.Service{
+					{
+						GUID:              "service-a-guid",
+						Label:             "service-a",
+						Description:       "service-a-description",
+						ServiceBrokerGUID: "broker-a-guid",
+					},
+					{
+						GUID:              "service-b-guid",
+						Label:             "service-b",
+						Description:       "service-b-description",
+						ServiceBrokerGUID: "broker-b-guid",
+					},
+				}
+
+				plans := []ccv2.ServicePlan{
+					{GUID: "plan-a-guid", ServiceGUID: "service-a-guid", Name: "plan-a", Public: false},
+					{GUID: "plan-b-guid", ServiceGUID: "service-a-guid", Name: "plan-b", Public: false},
+					{GUID: "plan-c-guid", ServiceGUID: "service-b-guid", Name: "plan-c", Public: false},
+					{GUID: "plan-d-guid", ServiceGUID: "service-b-guid", Name: "plan-d", Public: false},
+				}
+
+				brokerA := ccv2.ServiceBroker{
+					GUID:      "broker-a-guid",
+					Name:      "broker-a",
+					SpaceGUID: spaceGUID,
+				}
+
+				brokerB := ccv2.ServiceBroker{
+					GUID:      "broker-b-guid",
+					Name:      "broker-b",
+					SpaceGUID: "different-space-guid",
+				}
+
+				fakeCloudControllerClient.GetSpaceServicesReturns(services, ccv2.Warnings{"get-services-warning"}, nil)
+				fakeCloudControllerClient.GetServicePlansReturns(plans, ccv2.Warnings{"get-plans-warning"}, nil)
+				fakeCloudControllerClient.GetServiceBrokerReturnsOnCall(0, brokerA, ccv2.Warnings{"get-broker-a-warning"}, nil)
+				fakeCloudControllerClient.GetServiceBrokerReturnsOnCall(1, brokerB, ccv2.Warnings{"get-broker-b-warning"}, nil)
+			})
+
+			It("returns summaries including plans only for brokers scoped to the current space", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(servicesSummaries).To(ConsistOf(
+					ServiceSummary{
+						Service: Service{
+							GUID:              "service-a-guid",
+							Label:             "service-a",
+							Description:       "service-a-description",
+							ServiceBrokerGUID: "broker-a-guid",
+						},
+						Plans: []ServicePlanSummary{
+							ServicePlanSummary{
+								ServicePlan: ServicePlan{
+									GUID:        "plan-a-guid",
+									ServiceGUID: "service-a-guid",
+									Name:        "plan-a",
+									Public:      false,
+								},
+							},
+							ServicePlanSummary{
+								ServicePlan: ServicePlan{
+									GUID:        "plan-b-guid",
+									ServiceGUID: "service-a-guid",
+									Name:        "plan-b",
+									Public:      false,
+								},
+							},
+						},
+					},
+				))
+			})
+
+			It("gets all plans at once using IN operator for service GUIDs", func() {
+				Expect(fakeCloudControllerClient.GetServicePlansCallCount()).To(Equal(1))
+
+				Expect(fakeCloudControllerClient.GetServicePlansArgsForCall(0)).To(ConsistOf(
+					ccv2.Filter{
+						Type:     constant.ServiceGUIDFilter,
+						Operator: constant.InOperator,
+						Values:   []string{"service-a-guid", "service-b-guid"},
+					},
+				))
+			})
+
+			It("fetches brokers by their GUIDs", func() {
+				Expect(fakeCloudControllerClient.GetServiceBrokerArgsForCall(0)).To(Equal("broker-a-guid"))
+				Expect(fakeCloudControllerClient.GetServiceBrokerArgsForCall(1)).To(Equal("broker-b-guid"))
+			})
+
+			It("returns warnings", func() {
+				Expect(warnings).To(ConsistOf("get-services-warning", "get-plans-warning", "get-broker-a-warning", "get-broker-b-warning"))
+			})
+
+			When("getting broker fails with an error", func() {
+				BeforeEach(func() {
+					fakeCloudControllerClient.GetServiceBrokerReturnsOnCall(0, ccv2.ServiceBroker{}, ccv2.Warnings{"get-brokers-warning"}, errors.New("oopsie"))
+				})
+
+				It("returns error and warnings", func() {
+					Expect(err).To(MatchError(errors.New("oopsie")))
+					Expect(warnings).To(ConsistOf("get-services-warning", "get-plans-warning", "get-brokers-warning"))
+				})
+			})
+		})
+
 	})
 
 	Describe("GetServiceSummaryByName", func() {
@@ -298,13 +692,14 @@ var _ = Describe("Service Summary Actions", func() {
 			BeforeEach(func() {
 				services = []ccv2.Service{
 					{
+						GUID:        "service-a-guid",
 						Label:       "service",
 						Description: "service-description",
 					},
 				}
 				plans := []ccv2.ServicePlan{
-					{Name: "plan-a"},
-					{Name: "plan-b"},
+					{Name: "plan-a", ServiceGUID: "service-a-guid", Public: true},
+					{Name: "plan-b", ServiceGUID: "service-a-guid", Public: true},
 				}
 
 				fakeCloudControllerClient.GetServicesStub = func(filters ...ccv2.Filter) ([]ccv2.Service, ccv2.Warnings, error) {
@@ -329,22 +724,28 @@ var _ = Describe("Service Summary Actions", func() {
 				Expect(serviceSummary).To(Equal(
 					ServiceSummary{
 						Service: Service{
+							GUID:        "service-a-guid",
 							Label:       "service",
 							Description: "service-description",
 						},
 						Plans: []ServicePlanSummary{
 							ServicePlanSummary{
 								ServicePlan: ServicePlan{
-									Name: "plan-a",
+									ServiceGUID: "service-a-guid",
+									Name:        "plan-a",
+									Public:      true,
 								},
 							},
 							ServicePlanSummary{
 								ServicePlan: ServicePlan{
-									Name: "plan-b",
+									ServiceGUID: "service-a-guid",
+									Name:        "plan-b",
+									Public:      true,
 								},
 							},
 						},
 					}))
+
 				Expect(warnings).To(ConsistOf("get-services-warning", "get-plans-warning"))
 			})
 
@@ -360,24 +761,24 @@ var _ = Describe("Service Summary Actions", func() {
 				})
 			})
 		})
+
+		AfterEach(func() {
+			Expect(fakeCloudControllerClient.GetServiceBrokerCallCount()).To(Equal(0))
+		})
 	})
 
 	Describe("GetServiceSummaryForSpaceByName", func() {
 		var (
-			serviceName    string
-			spaceGUID      string
-			serviceSummary ServiceSummary
-			warnings       Warnings
-			err            error
+			serviceName      = "service"
+			spaceGUID        = "space-123"
+			organizationGUID = "org-guid-123"
+			serviceSummary   ServiceSummary
+			warnings         Warnings
+			err              error
 		)
 
-		BeforeEach(func() {
-			serviceName = "service"
-			spaceGUID = "space-123"
-		})
-
 		JustBeforeEach(func() {
-			serviceSummary, warnings, err = actor.GetServiceSummaryForSpaceByName(spaceGUID, serviceName)
+			serviceSummary, warnings, err = actor.GetServiceSummaryForSpaceByName(spaceGUID, serviceName, organizationGUID)
 		})
 
 		When("there is no service matching the provided name", func() {
@@ -402,7 +803,7 @@ var _ = Describe("Service Summary Actions", func() {
 			})
 		})
 
-		When("the service exists", func() {
+		When("the service exists with all plans public", func() {
 			var services []ccv2.Service
 
 			BeforeEach(func() {
@@ -413,8 +814,8 @@ var _ = Describe("Service Summary Actions", func() {
 					},
 				}
 				plans := []ccv2.ServicePlan{
-					{Name: "plan-a"},
-					{Name: "plan-b"},
+					{Name: "plan-a", Public: true},
+					{Name: "plan-b", Public: true},
 				}
 
 				fakeCloudControllerClient.GetSpaceServicesStub = func(guid string, filters ...ccv2.Filter) ([]ccv2.Service, ccv2.Warnings, error) {
@@ -445,12 +846,14 @@ var _ = Describe("Service Summary Actions", func() {
 						Plans: []ServicePlanSummary{
 							ServicePlanSummary{
 								ServicePlan: ServicePlan{
-									Name: "plan-a",
+									Name:   "plan-a",
+									Public: true,
 								},
 							},
 							ServicePlanSummary{
 								ServicePlan: ServicePlan{
-									Name: "plan-b",
+									Name:   "plan-b",
+									Public: true,
 								},
 							},
 						},
@@ -467,6 +870,178 @@ var _ = Describe("Service Summary Actions", func() {
 				It("returns the error and all warnings", func() {
 					Expect(err).To(MatchError("plan-oops"))
 					Expect(warnings).To(ConsistOf("get-services-warning", "get-plans-warning"))
+				})
+			})
+		})
+
+		When("the service exists with one non-public plan", func() {
+			var services []ccv2.Service
+
+			BeforeEach(func() {
+				services = []ccv2.Service{
+					{
+						Label:       "service",
+						Description: "service-description",
+					},
+				}
+				plans := []ccv2.ServicePlan{
+					{GUID: "plan-a-guid", Name: "plan-a", Public: true},
+					{GUID: "plan-b-guid", Name: "plan-b", Public: false},
+				}
+
+				broker := ccv2.ServiceBroker{
+					Name: "normal-broker",
+				}
+
+				fakeCloudControllerClient.GetSpaceServicesStub = func(guid string, filters ...ccv2.Filter) ([]ccv2.Service, ccv2.Warnings, error) {
+					filterToMatch := ccv2.Filter{
+						Type:     constant.LabelFilter,
+						Operator: constant.EqualOperator,
+						Values:   []string{"service"},
+					}
+
+					if len(filters) == 1 && reflect.DeepEqual(filters[0], filterToMatch) && spaceGUID == guid {
+						return services, ccv2.Warnings{"get-services-warning"}, nil
+					}
+
+					return []ccv2.Service{}, nil, nil
+				}
+
+				fakeCloudControllerClient.GetServicePlansReturns(plans, ccv2.Warnings{"get-plans-warning"}, nil)
+				fakeCloudControllerClient.GetServiceBrokerReturns(broker, ccv2.Warnings{"get-brokers-warning"}, nil)
+			})
+
+			It("returns service summary excluding non public plans and all warnings", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(serviceSummary).To(Equal(
+					ServiceSummary{
+						Service: Service{
+							Label:       "service",
+							Description: "service-description",
+						},
+						Plans: []ServicePlanSummary{
+							ServicePlanSummary{
+								ServicePlan: ServicePlan{
+									GUID:   "plan-a-guid",
+									Name:   "plan-a",
+									Public: true,
+								},
+							},
+						},
+					}))
+				Expect(warnings).To(ConsistOf("get-services-warning", "get-plans-warning", "get-brokers-warning"))
+			})
+
+			When("the service broker is space-scoped", func() {
+				BeforeEach(func() {
+					services[0].ServiceBrokerGUID = "broker-a-guid"
+
+					broker := ccv2.ServiceBroker{
+						GUID:      "broker-a-guid",
+						Name:      "broker-a",
+						SpaceGUID: spaceGUID,
+					}
+
+					fakeCloudControllerClient.GetServiceBrokerReturns(broker, ccv2.Warnings{"get-brokers-warning"}, nil)
+				})
+
+				It("returns summaries with all plans related to this space-scoped broker", func() {
+					Expect(err).NotTo(HaveOccurred())
+					Expect(serviceSummary).To(Equal(
+						ServiceSummary{
+							Service: Service{
+								Label:             "service",
+								Description:       "service-description",
+								ServiceBrokerGUID: "broker-a-guid",
+							},
+							Plans: []ServicePlanSummary{
+								ServicePlanSummary{
+									ServicePlan: ServicePlan{
+										GUID:   "plan-a-guid",
+										Name:   "plan-a",
+										Public: true,
+									},
+								},
+								ServicePlanSummary{
+									ServicePlan: ServicePlan{
+										GUID:   "plan-b-guid",
+										Name:   "plan-b",
+										Public: false,
+									},
+								},
+							},
+						}))
+				})
+
+				It("returns all warnings", func() {
+					Expect(warnings).To(ConsistOf(
+						"get-services-warning",
+						"get-plans-warning",
+						"get-brokers-warning",
+					))
+				})
+			})
+
+			When("the non-public plan is visible to the org", func() {
+				BeforeEach(func() {
+					visibilities := []ccv2.ServicePlanVisibility{
+						{OrganizationGUID: "org-guid-1", ServicePlanGUID: "plan-b-guid"},
+					}
+
+					fakeCloudControllerClient.GetServicePlanVisibilitiesReturns(visibilities, ccv2.Warnings{"get-visibilities-warning"}, nil)
+				})
+
+				It("returns summaries with plans visible for the org", func() {
+					Expect(err).NotTo(HaveOccurred())
+					Expect(serviceSummary).To(Equal(
+						ServiceSummary{
+							Service: Service{
+								Label:       "service",
+								Description: "service-description",
+							},
+							Plans: []ServicePlanSummary{
+								ServicePlanSummary{
+									ServicePlan: ServicePlan{
+										GUID:   "plan-a-guid",
+										Name:   "plan-a",
+										Public: true,
+									},
+								},
+								ServicePlanSummary{
+									ServicePlan: ServicePlan{
+										GUID:   "plan-b-guid",
+										Name:   "plan-b",
+										Public: false,
+									},
+								},
+							},
+						}))
+				})
+
+				It("returns all warnings", func() {
+					Expect(warnings).To(ConsistOf(
+						"get-services-warning",
+						"get-plans-warning",
+						"get-brokers-warning",
+						"get-visibilities-warning",
+					))
+				})
+
+				It("gets plan visibilities for the non-public plan for the org", func() {
+					Expect(fakeCloudControllerClient.GetServicePlanVisibilitiesCallCount()).To(Equal(1))
+
+					Expect(fakeCloudControllerClient.GetServicePlanVisibilitiesArgsForCall(0)).To(ConsistOf(
+						ccv2.Filter{
+							Type:     constant.ServicePlanGUIDFilter,
+							Operator: constant.InOperator,
+							Values:   []string{"plan-b-guid"},
+						},
+						ccv2.Filter{
+							Type:     constant.OrganizationGUIDFilter,
+							Operator: constant.EqualOperator,
+							Values:   []string{organizationGUID},
+						},
+					))
 				})
 			})
 		})

--- a/actor/v2action/v2actionfakes/fake_cloud_controller_client.go
+++ b/actor/v2action/v2actionfakes/fake_cloud_controller_client.go
@@ -721,6 +721,21 @@ type FakeCloudControllerClient struct {
 		result2 ccv2.Warnings
 		result3 error
 	}
+	GetServiceBrokerStub        func(string) (ccv2.ServiceBroker, ccv2.Warnings, error)
+	getServiceBrokerMutex       sync.RWMutex
+	getServiceBrokerArgsForCall []struct {
+		arg1 string
+	}
+	getServiceBrokerReturns struct {
+		result1 ccv2.ServiceBroker
+		result2 ccv2.Warnings
+		result3 error
+	}
+	getServiceBrokerReturnsOnCall map[int]struct {
+		result1 ccv2.ServiceBroker
+		result2 ccv2.Warnings
+		result3 error
+	}
 	GetServiceBrokersStub        func(...ccv2.Filter) ([]ccv2.ServiceBroker, ccv2.Warnings, error)
 	getServiceBrokersMutex       sync.RWMutex
 	getServiceBrokersArgsForCall []struct {
@@ -4555,6 +4570,72 @@ func (fake *FakeCloudControllerClient) GetServiceBindingsReturnsOnCall(i int, re
 	}{result1, result2, result3}
 }
 
+func (fake *FakeCloudControllerClient) GetServiceBroker(arg1 string) (ccv2.ServiceBroker, ccv2.Warnings, error) {
+	fake.getServiceBrokerMutex.Lock()
+	ret, specificReturn := fake.getServiceBrokerReturnsOnCall[len(fake.getServiceBrokerArgsForCall)]
+	fake.getServiceBrokerArgsForCall = append(fake.getServiceBrokerArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("GetServiceBroker", []interface{}{arg1})
+	fake.getServiceBrokerMutex.Unlock()
+	if fake.GetServiceBrokerStub != nil {
+		return fake.GetServiceBrokerStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	fakeReturns := fake.getServiceBrokerReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeCloudControllerClient) GetServiceBrokerCallCount() int {
+	fake.getServiceBrokerMutex.RLock()
+	defer fake.getServiceBrokerMutex.RUnlock()
+	return len(fake.getServiceBrokerArgsForCall)
+}
+
+func (fake *FakeCloudControllerClient) GetServiceBrokerCalls(stub func(string) (ccv2.ServiceBroker, ccv2.Warnings, error)) {
+	fake.getServiceBrokerMutex.Lock()
+	defer fake.getServiceBrokerMutex.Unlock()
+	fake.GetServiceBrokerStub = stub
+}
+
+func (fake *FakeCloudControllerClient) GetServiceBrokerArgsForCall(i int) string {
+	fake.getServiceBrokerMutex.RLock()
+	defer fake.getServiceBrokerMutex.RUnlock()
+	argsForCall := fake.getServiceBrokerArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeCloudControllerClient) GetServiceBrokerReturns(result1 ccv2.ServiceBroker, result2 ccv2.Warnings, result3 error) {
+	fake.getServiceBrokerMutex.Lock()
+	defer fake.getServiceBrokerMutex.Unlock()
+	fake.GetServiceBrokerStub = nil
+	fake.getServiceBrokerReturns = struct {
+		result1 ccv2.ServiceBroker
+		result2 ccv2.Warnings
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeCloudControllerClient) GetServiceBrokerReturnsOnCall(i int, result1 ccv2.ServiceBroker, result2 ccv2.Warnings, result3 error) {
+	fake.getServiceBrokerMutex.Lock()
+	defer fake.getServiceBrokerMutex.Unlock()
+	fake.GetServiceBrokerStub = nil
+	if fake.getServiceBrokerReturnsOnCall == nil {
+		fake.getServiceBrokerReturnsOnCall = make(map[int]struct {
+			result1 ccv2.ServiceBroker
+			result2 ccv2.Warnings
+			result3 error
+		})
+	}
+	fake.getServiceBrokerReturnsOnCall[i] = struct {
+		result1 ccv2.ServiceBroker
+		result2 ccv2.Warnings
+		result3 error
+	}{result1, result2, result3}
+}
+
 func (fake *FakeCloudControllerClient) GetServiceBrokers(arg1 ...ccv2.Filter) ([]ccv2.ServiceBroker, ccv2.Warnings, error) {
 	fake.getServiceBrokersMutex.Lock()
 	ret, specificReturn := fake.getServiceBrokersReturnsOnCall[len(fake.getServiceBrokersArgsForCall)]
@@ -7838,6 +7919,8 @@ func (fake *FakeCloudControllerClient) Invocations() map[string][][]interface{} 
 	defer fake.getServiceMutex.RUnlock()
 	fake.getServiceBindingsMutex.RLock()
 	defer fake.getServiceBindingsMutex.RUnlock()
+	fake.getServiceBrokerMutex.RLock()
+	defer fake.getServiceBrokerMutex.RUnlock()
 	fake.getServiceBrokersMutex.RLock()
 	defer fake.getServiceBrokersMutex.RUnlock()
 	fake.getServiceInstanceMutex.RLock()

--- a/api/cloudcontroller/ccv2/internal/api_routes.go
+++ b/api/cloudcontroller/ccv2/internal/api_routes.go
@@ -55,6 +55,7 @@ const (
 	GetSecurityGroupStagingSpacesRequest                 = "GetSecurityGroupStagingSpaces"
 	GetServiceBindingRequest                             = "GetServiceBinding"
 	GetServiceBindingsRequest                            = "GetServiceBindings"
+	GetServiceBrokerRequest                              = "GetServiceBroker"
 	GetServiceBrokersRequest                             = "GetServiceBrokers"
 	GetServiceInstanceRequest                            = "GetServiceInstance"
 	GetServiceInstanceServiceBindingsRequest             = "GetServiceInstanceServiceBindings"
@@ -174,6 +175,7 @@ var APIRoutes = rata.Routes{
 	{Path: "/v2/service_bindings", Method: http.MethodPost, Name: PostServiceBindingRequest},
 	{Path: "/v2/service_bindings/:service_binding_guid", Method: http.MethodDelete, Name: DeleteServiceBindingRequest},
 	{Path: "/v2/service_bindings/:service_binding_guid", Method: http.MethodGet, Name: GetServiceBindingRequest},
+	{Path: "/v2/service_brokers/:service_broker_guid", Method: http.MethodGet, Name: GetServiceBrokerRequest},
 	{Path: "/v2/service_brokers", Method: http.MethodGet, Name: GetServiceBrokersRequest},
 	{Path: "/v2/service_brokers", Method: http.MethodPost, Name: PostServiceBrokerRequest},
 	{Path: "/v2/service_instances", Method: http.MethodGet, Name: GetServiceInstancesRequest},

--- a/api/cloudcontroller/ccv2/service.go
+++ b/api/cloudcontroller/ccv2/service.go
@@ -23,6 +23,8 @@ type Service struct {
 	DocumentationURL string
 	// ServiceBrokerName is name of the service broker associated with the service
 	ServiceBrokerName string
+	// ServiceBrokerGUID is guid of the service broker associated with the service
+	ServiceBrokerGUID string
 	// Extra is a field with extra data pertaining to the service.
 	Extra ServiceExtra
 }
@@ -57,6 +59,7 @@ func (service *Service) UnmarshalJSON(data []byte) error {
 			Description       string `json:"description"`
 			DocumentationURL  string `json:"documentation_url"`
 			ServiceBrokerName string `json:"service_broker_name"`
+			ServiceBrokerGUID string `json:"service_broker_guid"`
 			Extra             string `json:"extra"`
 		}
 	}
@@ -71,6 +74,7 @@ func (service *Service) UnmarshalJSON(data []byte) error {
 	service.Description = ccService.Entity.Description
 	service.DocumentationURL = ccService.Entity.DocumentationURL
 	service.ServiceBrokerName = ccService.Entity.ServiceBrokerName
+	service.ServiceBrokerGUID = ccService.Entity.ServiceBrokerGUID
 
 	// We explicitly unmarshal the Extra field to type string because CC returns
 	// a stringified JSON object ONLY for the 'extra' key (see test stub JSON

--- a/api/cloudcontroller/ccv2/service_broker.go
+++ b/api/cloudcontroller/ccv2/service_broker.go
@@ -90,6 +90,25 @@ func (client *Client) CreateServiceBroker(brokerName, username, password, url, s
 	return serviceBroker, response.Warnings, err
 }
 
+// GetServiceBroker returns the service broker with the given GUID.
+func (client *Client) GetServiceBroker(serviceBrokerGUID string) (ServiceBroker, Warnings, error) {
+	request, err := client.newHTTPRequest(requestOptions{
+		RequestName: internal.GetServiceBrokerRequest,
+		URIParams:   Params{"service_broker_guid": serviceBrokerGUID},
+	})
+	if err != nil {
+		return ServiceBroker{}, nil, err
+	}
+
+	var serviceBroker ServiceBroker
+	response := cloudcontroller.Response{
+		DecodeJSONResponseInto: &serviceBroker,
+	}
+
+	err = client.connection.Make(request, &response)
+	return serviceBroker, response.Warnings, err
+}
+
 // GetServiceBrokers returns back a list of Service Brokers given the provided
 // filters.
 func (client *Client) GetServiceBrokers(filters ...Filter) ([]ServiceBroker, Warnings, error) {

--- a/api/cloudcontroller/ccv2/service_broker_test.go
+++ b/api/cloudcontroller/ccv2/service_broker_test.go
@@ -18,6 +18,99 @@ var _ = Describe("Service Broker", func() {
 		client = NewTestClient()
 	})
 
+	Describe("GetServiceBroker", func() {
+		var (
+			serviceBroker ServiceBroker
+			warnings      Warnings
+			executeErr    error
+		)
+
+		JustBeforeEach(func() {
+			serviceBroker, warnings, executeErr = client.GetServiceBroker("broker-guid")
+		})
+
+		When("the cc returns back a service broker", func() {
+			BeforeEach(func() {
+				response := `
+					{
+						"metadata": {
+							"guid": "broker-guid"
+						},
+						"entity": {
+							"name":"some-broker-name"
+						}
+					}
+				`
+
+				server.AppendHandlers(
+					CombineHandlers(
+						VerifyRequest(http.MethodGet, "/v2/service_brokers/broker-guid"),
+						RespondWith(http.StatusOK, response, http.Header{"X-Cf-Warnings": {"this is a warning"}}),
+					),
+				)
+			})
+
+			It("returns the service broker", func() {
+				Expect(executeErr).NotTo(HaveOccurred())
+				Expect(serviceBroker).To(Equal(ServiceBroker{
+					GUID: "broker-guid",
+					Name: "some-broker-name",
+				}))
+				Expect(warnings).To(ConsistOf(Warnings{"this is a warning"}))
+			})
+
+		})
+
+		When("the cc returns 404 not found", func() {
+			BeforeEach(func() {
+				response := `{
+					"description": "The broker is not found.",
+					"error_code": "CF-BrokenNotFound",
+					"code": 90004
+				}`
+				server.AppendHandlers(
+					CombineHandlers(
+						VerifyRequest(http.MethodGet, "/v2/service_brokers/broker-guid"),
+						RespondWith(http.StatusNotFound, response, http.Header{"X-Cf-Warnings": {"this is a warning"}}),
+					),
+				)
+			})
+
+			It("returns an error and warnings", func() {
+				Expect(executeErr).To(MatchError(ccerror.ResourceNotFoundError{Message: "The broker is not found."}))
+				Expect(warnings).To(ConsistOf("this is a warning"))
+			})
+		})
+
+		When("the cc returns error", func() {
+			BeforeEach(func() {
+				response := `{
+					"description": "The broker is broken.",
+					"error_code": "CF-BrokenBroker",
+					"code": 90003
+				}`
+				server.AppendHandlers(
+					CombineHandlers(
+						VerifyRequest(http.MethodGet, "/v2/service_brokers/broker-guid"),
+						RespondWith(http.StatusTeapot, response, http.Header{"X-Cf-Warnings": {"this is a warning"}}),
+					),
+				)
+			})
+
+			It("returns an error and warnings", func() {
+				Expect(executeErr).To(MatchError(ccerror.V2UnexpectedResponseError{
+					V2ErrorResponse: ccerror.V2ErrorResponse{
+						Code:        90003,
+						Description: "The broker is broken.",
+						ErrorCode:   "CF-BrokenBroker",
+					},
+					ResponseCode: http.StatusTeapot,
+				}))
+				Expect(warnings).To(ConsistOf("this is a warning"))
+			})
+		})
+	})
+
 	Describe("GetServiceBrokers", func() {
 		var (
 			serviceBrokers []ServiceBroker

--- a/api/cloudcontroller/ccv2/service_test.go
+++ b/api/cloudcontroller/ccv2/service_test.go
@@ -30,6 +30,7 @@ var _ = Describe("Service", func() {
 							"label": "some-service",
 							"description": "some-description",
 							"service_broker_name": "service-broker",
+							"service_broker_guid": "service-broker-guid",
 							"extra": "{\"provider\":{\"name\":\"The name\"},\"listing\":{\"imageUrl\":\"http://catgifpage.com/cat.gif\",\"blurb\":\"fake broker that is fake\",\"longDescription\":\"A long time ago, in a galaxy far far away...\"},\"displayName\":\"The Fake Broker\",\"shareable\":true}"
 						}
 					}`
@@ -50,6 +51,7 @@ var _ = Describe("Service", func() {
 						Label:             "some-service",
 						Description:       "some-description",
 						ServiceBrokerName: "service-broker",
+						ServiceBrokerGUID: "service-broker-guid",
 						Extra: ServiceExtra{
 							Shareable: true,
 						},

--- a/command/v6/marketplace_command.go
+++ b/command/v6/marketplace_command.go
@@ -17,10 +17,10 @@ import (
 
 type ServicesSummariesActor interface {
 	GetServicesSummaries() ([]v2action.ServiceSummary, v2action.Warnings, error)
-	GetServicesSummariesForSpace(spaceGUID string) ([]v2action.ServiceSummary, v2action.Warnings, error)
+	GetServicesSummariesForSpace(spaceGUID string, organizationGUID string) ([]v2action.ServiceSummary, v2action.Warnings, error)
 
 	GetServiceSummaryByName(serviceName string) (v2action.ServiceSummary, v2action.Warnings, error)
-	GetServiceSummaryForSpaceByName(spaceGUID, serviceName string) (v2action.ServiceSummary, v2action.Warnings, error)
+	GetServiceSummaryForSpaceByName(spaceGUID, serviceName string, organizationGUID string) (v2action.ServiceSummary, v2action.Warnings, error)
 }
 
 type MarketplaceCommand struct {
@@ -80,7 +80,10 @@ func (cmd *MarketplaceCommand) marketplace() error {
 			"SpaceName": cmd.Config.TargetedSpace().Name,
 			"Username":  user.Name,
 		})
-		serviceSummaries, warnings, err := cmd.Actor.GetServicesSummariesForSpace(cmd.Config.TargetedSpace().GUID)
+		serviceSummaries, warnings, err := cmd.Actor.GetServicesSummariesForSpace(
+			cmd.Config.TargetedSpace().GUID,
+			cmd.Config.TargetedOrganization().GUID,
+		)
 		cmd.UI.DisplayWarnings(warnings)
 		if err != nil {
 			return err
@@ -99,7 +102,7 @@ func (cmd *MarketplaceCommand) marketplace() error {
 				"Username":    user.Name,
 			})
 
-		serviceSummary, warnings, err := cmd.Actor.GetServiceSummaryForSpaceByName(cmd.Config.TargetedSpace().GUID, cmd.ServiceName)
+		serviceSummary, warnings, err := cmd.Actor.GetServiceSummaryForSpaceByName(cmd.Config.TargetedSpace().GUID, cmd.ServiceName, cmd.Config.TargetedOrganization().GUID)
 		cmd.UI.DisplayWarnings(warnings)
 		if err != nil {
 			return err

--- a/command/v6/marketplace_command_test.go
+++ b/command/v6/marketplace_command_test.go
@@ -431,7 +431,7 @@ var _ = Describe("marketplace Command", func() {
 			fakeSharedActor.IsOrgTargetedReturns(true)
 			fakeSharedActor.IsSpaceTargetedReturns(true)
 
-			fakeConfig.TargetedOrganizationReturns(configv3.Organization{Name: "org-a"})
+			fakeConfig.TargetedOrganizationReturns(configv3.Organization{GUID: "org-guid", Name: "org-a"})
 			fakeConfig.TargetedSpaceReturns(configv3.Space{Name: "space-a", GUID: "space-guid"})
 		})
 
@@ -500,6 +500,13 @@ var _ = Describe("marketplace Command", func() {
 
 					It("outputs any warnings", func() {
 						Expect(testUI.Err).To(Say("warning"))
+					})
+
+					It("gets services for the correct space", func() {
+						spaceGUID, serviceName, orgGUID := fakeActor.GetServiceSummaryForSpaceByNameArgsForCall(0)
+						Expect(spaceGUID).To(Equal("space-guid"))
+						Expect(serviceName).To(Equal("service-a"))
+						Expect(orgGUID).To(Equal("org-guid"))
 					})
 				})
 
@@ -676,7 +683,9 @@ var _ = Describe("marketplace Command", func() {
 					})
 
 					It("gets services for the correct space", func() {
-						Expect(fakeActor.GetServicesSummariesForSpaceArgsForCall(0)).To(Equal("space-guid"))
+						spaceGUID, orgGUID := fakeActor.GetServicesSummariesForSpaceArgsForCall(0)
+						Expect(spaceGUID).To(Equal("space-guid"))
+						Expect(orgGUID).To(Equal("org-guid"))
 					})
 
 					It("outputs a header", func() {
@@ -728,7 +737,9 @@ var _ = Describe("marketplace Command", func() {
 					})
 
 					It("gets services for the correct space", func() {
-						Expect(fakeActor.GetServicesSummariesForSpaceArgsForCall(0)).To(Equal("space-guid"))
+						spaceGUID, orgGUID := fakeActor.GetServicesSummariesForSpaceArgsForCall(0)
+						Expect(spaceGUID).To(Equal("space-guid"))
+						Expect(orgGUID).To(Equal("org-guid"))
 					})
 
 					It("outputs a header", func() {

--- a/command/v6/v6fakes/fake_services_summaries_actor.go
+++ b/command/v6/v6fakes/fake_services_summaries_actor.go
@@ -24,11 +24,12 @@ type FakeServicesSummariesActor struct {
 		result2 v2action.Warnings
 		result3 error
 	}
-	GetServiceSummaryForSpaceByNameStub        func(string, string) (v2action.ServiceSummary, v2action.Warnings, error)
+	GetServiceSummaryForSpaceByNameStub        func(string, string, string) (v2action.ServiceSummary, v2action.Warnings, error)
 	getServiceSummaryForSpaceByNameMutex       sync.RWMutex
 	getServiceSummaryForSpaceByNameArgsForCall []struct {
 		arg1 string
 		arg2 string
+		arg3 string
 	}
 	getServiceSummaryForSpaceByNameReturns struct {
 		result1 v2action.ServiceSummary
@@ -54,10 +55,11 @@ type FakeServicesSummariesActor struct {
 		result2 v2action.Warnings
 		result3 error
 	}
-	GetServicesSummariesForSpaceStub        func(string) ([]v2action.ServiceSummary, v2action.Warnings, error)
+	GetServicesSummariesForSpaceStub        func(string, string) ([]v2action.ServiceSummary, v2action.Warnings, error)
 	getServicesSummariesForSpaceMutex       sync.RWMutex
 	getServicesSummariesForSpaceArgsForCall []struct {
 		arg1 string
+		arg2 string
 	}
 	getServicesSummariesForSpaceReturns struct {
 		result1 []v2action.ServiceSummary
@@ -139,17 +141,18 @@ func (fake *FakeServicesSummariesActor) GetServiceSummaryByNameReturnsOnCall(i i
 	}{result1, result2, result3}
 }
 
-func (fake *FakeServicesSummariesActor) GetServiceSummaryForSpaceByName(arg1 string, arg2 string) (v2action.ServiceSummary, v2action.Warnings, error) {
+func (fake *FakeServicesSummariesActor) GetServiceSummaryForSpaceByName(arg1 string, arg2 string, arg3 string) (v2action.ServiceSummary, v2action.Warnings, error) {
 	fake.getServiceSummaryForSpaceByNameMutex.Lock()
 	ret, specificReturn := fake.getServiceSummaryForSpaceByNameReturnsOnCall[len(fake.getServiceSummaryForSpaceByNameArgsForCall)]
 	fake.getServiceSummaryForSpaceByNameArgsForCall = append(fake.getServiceSummaryForSpaceByNameArgsForCall, struct {
 		arg1 string
 		arg2 string
-	}{arg1, arg2})
-	fake.recordInvocation("GetServiceSummaryForSpaceByName", []interface{}{arg1, arg2})
+		arg3 string
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("GetServiceSummaryForSpaceByName", []interface{}{arg1, arg2, arg3})
 	fake.getServiceSummaryForSpaceByNameMutex.Unlock()
 	if fake.GetServiceSummaryForSpaceByNameStub != nil {
-		return fake.GetServiceSummaryForSpaceByNameStub(arg1, arg2)
+		return fake.GetServiceSummaryForSpaceByNameStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
@@ -164,17 +167,17 @@ func (fake *FakeServicesSummariesActor) GetServiceSummaryForSpaceByNameCallCount
 	return len(fake.getServiceSummaryForSpaceByNameArgsForCall)
 }
 
-func (fake *FakeServicesSummariesActor) GetServiceSummaryForSpaceByNameCalls(stub func(string, string) (v2action.ServiceSummary, v2action.Warnings, error)) {
+func (fake *FakeServicesSummariesActor) GetServiceSummaryForSpaceByNameCalls(stub func(string, string, string) (v2action.ServiceSummary, v2action.Warnings, error)) {
 	fake.getServiceSummaryForSpaceByNameMutex.Lock()
 	defer fake.getServiceSummaryForSpaceByNameMutex.Unlock()
 	fake.GetServiceSummaryForSpaceByNameStub = stub
 }
 
-func (fake *FakeServicesSummariesActor) GetServiceSummaryForSpaceByNameArgsForCall(i int) (string, string) {
+func (fake *FakeServicesSummariesActor) GetServiceSummaryForSpaceByNameArgsForCall(i int) (string, string, string) {
 	fake.getServiceSummaryForSpaceByNameMutex.RLock()
 	defer fake.getServiceSummaryForSpaceByNameMutex.RUnlock()
 	argsForCall := fake.getServiceSummaryForSpaceByNameArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeServicesSummariesActor) GetServiceSummaryForSpaceByNameReturns(result1 v2action.ServiceSummary, result2 v2action.Warnings, result3 error) {
@@ -264,16 +267,17 @@ func (fake *FakeServicesSummariesActor) GetServicesSummariesReturnsOnCall(i int,
 	}{result1, result2, result3}
 }
 
-func (fake *FakeServicesSummariesActor) GetServicesSummariesForSpace(arg1 string) ([]v2action.ServiceSummary, v2action.Warnings, error) {
+func (fake *FakeServicesSummariesActor) GetServicesSummariesForSpace(arg1 string, arg2 string) ([]v2action.ServiceSummary, v2action.Warnings, error) {
 	fake.getServicesSummariesForSpaceMutex.Lock()
 	ret, specificReturn := fake.getServicesSummariesForSpaceReturnsOnCall[len(fake.getServicesSummariesForSpaceArgsForCall)]
 	fake.getServicesSummariesForSpaceArgsForCall = append(fake.getServicesSummariesForSpaceArgsForCall, struct {
 		arg1 string
-	}{arg1})
-	fake.recordInvocation("GetServicesSummariesForSpace", []interface{}{arg1})
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("GetServicesSummariesForSpace", []interface{}{arg1, arg2})
 	fake.getServicesSummariesForSpaceMutex.Unlock()
 	if fake.GetServicesSummariesForSpaceStub != nil {
-		return fake.GetServicesSummariesForSpaceStub(arg1)
+		return fake.GetServicesSummariesForSpaceStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
@@ -288,17 +292,17 @@ func (fake *FakeServicesSummariesActor) GetServicesSummariesForSpaceCallCount() 
 	return len(fake.getServicesSummariesForSpaceArgsForCall)
 }
 
-func (fake *FakeServicesSummariesActor) GetServicesSummariesForSpaceCalls(stub func(string) ([]v2action.ServiceSummary, v2action.Warnings, error)) {
+func (fake *FakeServicesSummariesActor) GetServicesSummariesForSpaceCalls(stub func(string, string) ([]v2action.ServiceSummary, v2action.Warnings, error)) {
 	fake.getServicesSummariesForSpaceMutex.Lock()
 	defer fake.getServicesSummariesForSpaceMutex.Unlock()
 	fake.GetServicesSummariesForSpaceStub = stub
 }
 
-func (fake *FakeServicesSummariesActor) GetServicesSummariesForSpaceArgsForCall(i int) string {
+func (fake *FakeServicesSummariesActor) GetServicesSummariesForSpaceArgsForCall(i int) (string, string) {
 	fake.getServicesSummariesForSpaceMutex.RLock()
 	defer fake.getServicesSummariesForSpaceMutex.RUnlock()
 	argsForCall := fake.getServicesSummariesForSpaceArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeServicesSummariesActor) GetServicesSummariesForSpaceReturns(result1 []v2action.ServiceSummary, result2 v2action.Warnings, result3 error) {

--- a/integration/helpers/service_broker.go
+++ b/integration/helpers/service_broker.go
@@ -144,6 +144,12 @@ func (b ServiceBroker) Create() {
 	Eventually(CF("service-brokers")).Should(And(Exit(0), Say(b.Name)))
 }
 
+func (b ServiceBroker) CreateSpaceScoped() {
+	appURI := fmt.Sprintf("http://%s.%s", b.Name, b.AppsDomain)
+	Eventually(CF("create-service-broker", b.Name, "username", "password", appURI, "--space-scoped")).Should(Exit(0))
+	Eventually(CF("service-brokers")).Should(And(Exit(0), Say(b.Name)))
+}
+
 func (b ServiceBroker) Update() {
 	appURI := fmt.Sprintf("http://%s.%s", b.Name, b.AppsDomain)
 	Eventually(CF("update-service-broker", b.Name, "username", "password", appURI)).Should(Exit(0))
@@ -200,6 +206,17 @@ func CreateBroker(domain, serviceName, planName string) ServiceBroker {
 	broker.Push()
 	broker.Configure(true)
 	broker.Create()
+
+	return broker
+}
+
+func CreateSpaceScopedBroker(domain, serviceName, planName string) ServiceBroker {
+	service := serviceName
+	servicePlan := planName
+	broker := NewServiceBroker(NewServiceBrokerName(), NewAssets().ServiceBroker, domain, service, servicePlan)
+	broker.Push()
+	broker.Configure(true)
+	broker.CreateSpaceScoped()
 
 	return broker
 }

--- a/integration/shared/isolated/enable_service_access_command_test.go
+++ b/integration/shared/isolated/enable_service_access_command_test.go
@@ -260,7 +260,7 @@ var _ = Describe("enable service access command", func() {
 						It("displays an informative message, exits 1", func() {
 							session := helpers.CF("enable-service-access", service, "-b", "non-existent-broker")
 							Eventually(session).Should(Say("Enabling access to all plans of service %s from broker %s for all orgs as admin...", service, "non-existent-broker"))
-							Eventually(session.Err).Should(Say("Service broker 'non-existent-broker' not found"))
+							Eventually(session.Err).Should(Say("Service broker with name 'non-existent-broker' not found"))
 							Eventually(session.Err).Should(Say("TIP: Use 'cf service-brokers' to see a list of available brokers."))
 							Eventually(session).Should(Say("FAILED"))
 							Eventually(session).Should(Exit(1))

--- a/integration/shared/isolated/purge_service_offering_command_test.go
+++ b/integration/shared/isolated/purge_service_offering_command_test.go
@@ -239,7 +239,7 @@ var _ = Describe("purge-service-offering command", func() {
 				It("prints a warning that this flag is no longer supported", func() {
 					session := helpers.CF("purge-service-offering", service, "-b", "non-existent-broker")
 
-					Eventually(session.Err).Should(Say("Service broker 'non-existent-broker' not found"))
+					Eventually(session.Err).Should(Say("Service broker with name 'non-existent-broker' not found"))
 					Eventually(session.Err).Should(Say("TIP: Use 'cf service-brokers' to see a list of available brokers."))
 					Eventually(session).Should(Say("FAILED"))
 					Eventually(session).Should(Exit(1))

--- a/integration/shared/isolated/service_access_command_test.go
+++ b/integration/shared/isolated/service_access_command_test.go
@@ -52,7 +52,7 @@ var _ = Describe("service-access command", func() {
 			It("shows an error message", func() {
 				session := helpers.CF("service-access", "-b", "non-existent-broker")
 				Eventually(session).Should(Say(`Getting service access for broker non-existent-broker as %s\.\.\.`, userName))
-				Eventually(session.Err).Should(Say(`Service broker 'non-existent-broker' not found\.`))
+				Eventually(session.Err).Should(Say(`Service broker with name 'non-existent-broker' not found\.`))
 				Eventually(session.Err).Should(Say(`TIP: Use 'cf service-brokers' to see a list of available brokers\.`))
 				Eventually(session).Should(Exit(1))
 			})


### PR DESCRIPTION
Currently executing the `cf marketplace` command will give you
a list of services and related to them plans. If you have the admin role
it will list the disabeled plans aswell.

This commit fixes this issue and `cf marketplace` will be showing
only the plans that are available in the current space.

Co-authored-by: Florent Flament <fflament@pivotal.io>
Co-authored-by: William Martin <wmartin@pivotal.io>
Co-authored-by: Aarti Kriplani <akriplani@pivotal.io>

[fixes #967]