### PR TITLE
Add ability to delete organization labels

### DIFF
--- a/command/v7/delete_label_command.go
+++ b/command/v7/delete_label_command.go
@@ -3,11 +3,11 @@ package v7
 import (
 	"code.cloudfoundry.org/cli/actor/sharedaction"
 	"code.cloudfoundry.org/cli/actor/v7action"
+	"code.cloudfoundry.org/cli/cf/errors"
 	"code.cloudfoundry.org/cli/command"
 	"code.cloudfoundry.org/cli/command/flag"
 	"code.cloudfoundry.org/cli/command/v7/shared"
 	"code.cloudfoundry.org/cli/types"
-	"fmt"
 )
 
 //go:generate counterfeiter . DeleteLabelActor
@@ -55,7 +55,7 @@ func (cmd DeleteLabelCommand) Execute(args []string) error {
 	case "org":
 		err = cmd.executeOrg(user.Name, labels)
 	default:
-		err = fmt.Errorf("Unsupported resource type of '%s'", cmd.RequiredArgs.ResourceType)
+		err = errors.New(cmd.UI.TranslateText("Unsupported resource type of '{{.ResourceType}}'", map[string]interface{}{"ResourceType": cmd.RequiredArgs.ResourceType}))
 	}
 
 	if err != nil {
@@ -81,9 +81,7 @@ func (cmd DeleteLabelCommand) executeApp(username string, labels map[string]type
 
 	warnings, err := cmd.Actor.UpdateApplicationLabelsByApplicationName(cmd.RequiredArgs.ResourceName, cmd.Config.TargetedSpace().GUID, labels)
 
-	for _, warning := range warnings {
-		cmd.UI.DisplayWarning(warning)
-	}
+	cmd.UI.DisplayWarnings(warnings)
 
 	return err
 }
@@ -101,9 +99,7 @@ func (cmd DeleteLabelCommand) executeOrg(username string, labels map[string]type
 
 	warnings, err := cmd.Actor.UpdateOrganizationLabelsByOrganizationName(cmd.RequiredArgs.ResourceName, labels)
 
-	for _, warning := range warnings {
-		cmd.UI.DisplayWarning(warning)
-	}
+	cmd.UI.DisplayWarnings(warnings)
 
 	return err
 }

--- a/command/v7/delete_label_command_test.go
+++ b/command/v7/delete_label_command_test.go
@@ -1,6 +1,7 @@
 package v7_test
 
 import (
+	"code.cloudfoundry.org/cli/command/flag"
 	"errors"
 	"regexp"
 
@@ -26,116 +27,207 @@ var _ = Describe("delete-label command", func() {
 		executeErr      error
 	)
 
-	BeforeEach(func() {
-		testUI = ui.NewTestUI(nil, NewBuffer(), NewBuffer())
-		fakeConfig = new(commandfakes.FakeConfig)
-		fakeSharedActor = new(commandfakes.FakeSharedActor)
-		fakeActor = new(v7fakes.FakeDeleteLabelActor)
-		cmd = DeleteLabelCommand{
-			UI:          testUI,
-			Config:      fakeConfig,
-			SharedActor: fakeSharedActor,
-			Actor:       fakeActor,
-		}
-	})
-
-	JustBeforeEach(func() {
-		executeErr = cmd.Execute(nil)
-	})
-
-	It("doesn't error", func() {
-		Expect(executeErr).ToNot(HaveOccurred())
-	})
-
-	It("checks that the user is logged in and targeted to an org and space", func() {
-		Expect(fakeSharedActor.CheckTargetCallCount()).To(Equal(1))
-		checkOrg, checkSpace := fakeSharedActor.CheckTargetArgsForCall(0)
-		Expect(checkOrg).To(BeTrue())
-		Expect(checkSpace).To(BeTrue())
-	})
-
-	When("checking the target fails", func() {
+	When("deleting labels on apps", func() {
 		BeforeEach(func() {
-			fakeSharedActor.CheckTargetReturns(errors.New("Target not found"))
+			testUI = ui.NewTestUI(nil, NewBuffer(), NewBuffer())
+			fakeConfig = new(commandfakes.FakeConfig)
+			fakeSharedActor = new(commandfakes.FakeSharedActor)
+			fakeActor = new(v7fakes.FakeDeleteLabelActor)
+			cmd = DeleteLabelCommand{
+				UI:          testUI,
+				Config:      fakeConfig,
+				SharedActor: fakeSharedActor,
+				Actor:       fakeActor,
+			}
+			cmd.RequiredArgs = flag.DeleteLabelArgs{
+				ResourceType: "app",
+			}
 		})
 
-		It("we expect an error to be returned", func() {
-			Expect(executeErr).To(MatchError("Target not found"))
-		})
-	})
-
-	When("checking the target succeeds", func() {
-		var appName string
-
-		BeforeEach(func() {
-			fakeConfig.TargetedOrganizationReturns(configv3.Organization{Name: "fake-org"})
-			fakeConfig.TargetedSpaceReturns(configv3.Space{Name: "fake-space", GUID: "some-space-guid"})
-			appName = "some-app"
-			cmd.RequiredArgs.ResourceName = appName
+		JustBeforeEach(func() {
+			executeErr = cmd.Execute(nil)
 		})
 
-		When("getting the current user succeeds", func() {
+		It("doesn't error", func() {
+			Expect(executeErr).ToNot(HaveOccurred())
+		})
+
+		It("checks that the user is logged in and targeted to an org and space", func() {
+			Expect(fakeSharedActor.CheckTargetCallCount()).To(Equal(1))
+			checkOrg, checkSpace := fakeSharedActor.CheckTargetArgsForCall(0)
+			Expect(checkOrg).To(BeTrue())
+			Expect(checkSpace).To(BeTrue())
+		})
+
+		When("checking the target fails", func() {
 			BeforeEach(func() {
-				fakeConfig.CurrentUserReturns(configv3.User{Name: "some-user"}, nil)
-				cmd.RequiredArgs.LabelKeys = []string{"some-label", "some-other-key"}
+				fakeSharedActor.CheckTargetReturns(errors.New("Target not found"))
 			})
 
-			It("informs the user that labels are being deleted", func() {
-				Expect(testUI.Out).To(Say(regexp.QuoteMeta(`Deleting label(s) for app %s in org fake-org / space fake-space as some-user...`), appName))
+			It("we expect an error to be returned", func() {
+				Expect(executeErr).To(MatchError("Target not found"))
+			})
+		})
+
+		When("checking the target succeeds", func() {
+			var appName string
+
+			BeforeEach(func() {
+				fakeConfig.TargetedOrganizationReturns(configv3.Organization{Name: "fake-org"})
+				fakeConfig.TargetedSpaceReturns(configv3.Space{Name: "fake-space", GUID: "some-space-guid"})
+				appName = "some-app"
+				cmd.RequiredArgs.ResourceName = appName
 			})
 
-			When("updating the app labels succeeds", func() {
+			When("getting the current user succeeds", func() {
 				BeforeEach(func() {
-					fakeActor.UpdateApplicationLabelsByApplicationNameReturns(v7action.Warnings{"some-warning-1", "some-warning-2"},
-						nil)
+					fakeConfig.CurrentUserReturns(configv3.User{Name: "some-user"}, nil)
+					cmd.RequiredArgs.LabelKeys = []string{"some-label", "some-other-key"}
 				})
 
-				It("does not return an error", func() {
-					Expect(executeErr).ToNot(HaveOccurred())
+				It("informs the user that labels are being deleted", func() {
+					Expect(testUI.Out).To(Say(regexp.QuoteMeta(`Deleting label(s) for app %s in org fake-org / space fake-space as some-user...`), appName))
 				})
 
-				It("prints all warnings", func() {
-					Expect(testUI.Err).To(Say("some-warning-1"))
-					Expect(testUI.Err).To(Say("some-warning-2"))
+				When("updating the app labels succeeds", func() {
+					BeforeEach(func() {
+						fakeActor.UpdateApplicationLabelsByApplicationNameReturns(v7action.Warnings{"some-warning-1", "some-warning-2"},
+							nil)
+					})
+
+					It("does not return an error", func() {
+						Expect(executeErr).ToNot(HaveOccurred())
+					})
+
+					It("prints all warnings", func() {
+						Expect(testUI.Err).To(Say("some-warning-1"))
+						Expect(testUI.Err).To(Say("some-warning-2"))
+					})
+
+					It("passes the correct parameters into the actor", func() {
+						expectedMaps := map[string]types.NullString{
+							"some-label":     types.NewNullString(),
+							"some-other-key": types.NewNullString()}
+
+						Expect(fakeActor.UpdateApplicationLabelsByApplicationNameCallCount()).To(Equal(1))
+						actualAppName, spaceGUID, labelsMap := fakeActor.UpdateApplicationLabelsByApplicationNameArgsForCall(0)
+						Expect(actualAppName).To(Equal(appName))
+						Expect(spaceGUID).To(Equal("some-space-guid"))
+						Expect(labelsMap).To(Equal(expectedMaps))
+					})
 				})
 
-				It("passes the correct parameters into the actor", func() {
-					expectedMaps := map[string]types.NullString{
-						"some-label":     types.NewNullString(),
-						"some-other-key": types.NewNullString()}
+				When("updating the app labels fails", func() {
+					BeforeEach(func() {
+						fakeActor.UpdateApplicationLabelsByApplicationNameReturns(v7action.Warnings{"some-warning-1", "some-warning-2"},
+							errors.New("api call failed"))
+					})
 
-					Expect(fakeActor.UpdateApplicationLabelsByApplicationNameCallCount()).To(Equal(1))
-					actualAppName, spaceGUID, labelsMap := fakeActor.UpdateApplicationLabelsByApplicationNameArgsForCall(0)
-					Expect(actualAppName).To(Equal(appName))
-					Expect(spaceGUID).To(Equal("some-space-guid"))
-					Expect(labelsMap).To(Equal(expectedMaps))
+					It("prints all warnings", func() {
+						Expect(testUI.Err).To(Say("some-warning-1"))
+						Expect(testUI.Err).To(Say("some-warning-2"))
+					})
+
+					It("returns the error", func() {
+						Expect(executeErr).To(MatchError("api call failed"))
+					})
 				})
 			})
-
-			When("updating the app labels fails", func() {
+			When("getting the user fails", func() {
 				BeforeEach(func() {
-					fakeActor.UpdateApplicationLabelsByApplicationNameReturns(v7action.Warnings{"some-warning-1", "some-warning-2"},
-						errors.New("api call failed"))
-				})
-
-				It("prints all warnings", func() {
-					Expect(testUI.Err).To(Say("some-warning-1"))
-					Expect(testUI.Err).To(Say("some-warning-2"))
+					fakeConfig.CurrentUserReturns(configv3.User{}, errors.New("could not get user"))
+					cmd.RequiredArgs.LabelKeys = []string{"some-label", "some-other-key"}
 				})
 
 				It("returns the error", func() {
-					Expect(executeErr).To(MatchError("api call failed"))
+					Expect(executeErr).To(MatchError("could not get user"))
 				})
 			})
 		})
-		When("getting the user fails", func() {
+	})
+
+	When("deleting labels on orgs", func() {
+		BeforeEach(func() {
+			testUI = ui.NewTestUI(nil, NewBuffer(), NewBuffer())
+			fakeConfig = new(commandfakes.FakeConfig)
+			fakeSharedActor = new(commandfakes.FakeSharedActor)
+			fakeActor = new(v7fakes.FakeDeleteLabelActor)
+			cmd = DeleteLabelCommand{
+				Actor:       fakeActor,
+				UI:          testUI,
+				Config:      fakeConfig,
+				SharedActor: fakeSharedActor,
+			}
+			cmd.RequiredArgs = flag.DeleteLabelArgs{
+				ResourceType: "org",
+			}
+		})
+
+		JustBeforeEach(func() {
+			executeErr = cmd.Execute(nil)
+		})
+
+		It("doesn't error", func() {
+			Expect(executeErr).ToNot(HaveOccurred())
+		})
+
+		When("checking target succeeds", func() {
+			var orgName = "some-org"
+
 			BeforeEach(func() {
-				fakeConfig.CurrentUserReturns(configv3.User{}, errors.New("could not get user"))
-				cmd.RequiredArgs.LabelKeys = []string{"some-label", "some-other-key"}
+				fakeSharedActor.CheckTargetReturns(nil)
+				cmd.RequiredArgs.ResourceName = orgName
+
 			})
 
-			It("returns the error", func() {
-				Expect(executeErr).To(MatchError("could not get user"))
+			When("fetching current user's name succeeds", func() {
+				BeforeEach(func() {
+					fakeConfig.CurrentUserReturns(configv3.User{Name: "some-user"}, nil)
+					cmd.RequiredArgs.LabelKeys = []string{"some-label", "some-other-key"}
+				})
+
+				It("informs the user that labels are being deleted", func() {
+					Expect(testUI.Out).To(Say(regexp.QuoteMeta(`Deleting label(s) for org %s as some-user...`), orgName))
+				})
+
+				When("updating the org labels succeeds", func() {
+					BeforeEach(func() {
+						fakeActor.UpdateOrganizationLabelsByOrganizationNameReturns(v7action.Warnings{"some-warning-1", "some-warning-2"},
+							nil)
+					})
+
+					It("does not return an error", func() {
+						Expect(executeErr).ToNot(HaveOccurred())
+					})
+
+					It("prints all warnings", func() {
+						Expect(testUI.Err).To(Say("some-warning-1"))
+						Expect(testUI.Err).To(Say("some-warning-2"))
+					})
+
+					It("passes the correct parameters into the actor", func() {
+						expectedMaps := map[string]types.NullString{
+							"some-label":     types.NewNullString(),
+							"some-other-key": types.NewNullString()}
+
+						Expect(fakeActor.UpdateOrganizationLabelsByOrganizationNameCallCount()).To(Equal(1))
+						actualOrgName, labelsMap := fakeActor.UpdateOrganizationLabelsByOrganizationNameArgsForCall(0)
+						Expect(actualOrgName).To(Equal(orgName))
+						Expect(labelsMap).To(Equal(expectedMaps))
+					})
+				})
+
+			})
+
+			When("fetching the current user's name fails", func() {
+				BeforeEach(func() {
+					fakeConfig.CurrentUserReturns(configv3.User{}, errors.New("could not get user"))
+					cmd.RequiredArgs.LabelKeys = []string{"some-label", "some-other-key"}
+				})
+
+				It("returns the error", func() {
+					Expect(executeErr).To(MatchError("could not get user"))
+				})
 			})
 		})
 	})

--- a/command/v7/delete_label_command_test.go
+++ b/command/v7/delete_label_command_test.go
@@ -105,7 +105,7 @@ var _ = Describe("delete-label command", func() {
 					})
 
 					It("passes the correct parameters into the actor", func() {
-						expectedMaps := map[string]types.NullString{
+						expectedMap := map[string]types.NullString{
 							"some-label":     types.NewNullString(),
 							"some-other-key": types.NewNullString()}
 
@@ -113,7 +113,7 @@ var _ = Describe("delete-label command", func() {
 						actualAppName, spaceGUID, labelsMap := fakeActor.UpdateApplicationLabelsByApplicationNameArgsForCall(0)
 						Expect(actualAppName).To(Equal(appName))
 						Expect(spaceGUID).To(Equal("some-space-guid"))
-						Expect(labelsMap).To(Equal(expectedMaps))
+						Expect(labelsMap).To(Equal(expectedMap))
 					})
 				})
 
@@ -165,10 +165,6 @@ var _ = Describe("delete-label command", func() {
 
 		JustBeforeEach(func() {
 			executeErr = cmd.Execute(nil)
-		})
-
-		It("doesn't error", func() {
-			Expect(executeErr).ToNot(HaveOccurred())
 		})
 
 		When("checking target succeeds", func() {

--- a/command/v7/v7fakes/fake_delete_label_actor.go
+++ b/command/v7/v7fakes/fake_delete_label_actor.go
@@ -25,6 +25,20 @@ type FakeDeleteLabelActor struct {
 		result1 v7action.Warnings
 		result2 error
 	}
+	UpdateOrganizationLabelsByOrganizationNameStub        func(string, map[string]types.NullString) (v7action.Warnings, error)
+	updateOrganizationLabelsByOrganizationNameMutex       sync.RWMutex
+	updateOrganizationLabelsByOrganizationNameArgsForCall []struct {
+		arg1 string
+		arg2 map[string]types.NullString
+	}
+	updateOrganizationLabelsByOrganizationNameReturns struct {
+		result1 v7action.Warnings
+		result2 error
+	}
+	updateOrganizationLabelsByOrganizationNameReturnsOnCall map[int]struct {
+		result1 v7action.Warnings
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -94,11 +108,77 @@ func (fake *FakeDeleteLabelActor) UpdateApplicationLabelsByApplicationNameReturn
 	}{result1, result2}
 }
 
+func (fake *FakeDeleteLabelActor) UpdateOrganizationLabelsByOrganizationName(arg1 string, arg2 map[string]types.NullString) (v7action.Warnings, error) {
+	fake.updateOrganizationLabelsByOrganizationNameMutex.Lock()
+	ret, specificReturn := fake.updateOrganizationLabelsByOrganizationNameReturnsOnCall[len(fake.updateOrganizationLabelsByOrganizationNameArgsForCall)]
+	fake.updateOrganizationLabelsByOrganizationNameArgsForCall = append(fake.updateOrganizationLabelsByOrganizationNameArgsForCall, struct {
+		arg1 string
+		arg2 map[string]types.NullString
+	}{arg1, arg2})
+	fake.recordInvocation("UpdateOrganizationLabelsByOrganizationName", []interface{}{arg1, arg2})
+	fake.updateOrganizationLabelsByOrganizationNameMutex.Unlock()
+	if fake.UpdateOrganizationLabelsByOrganizationNameStub != nil {
+		return fake.UpdateOrganizationLabelsByOrganizationNameStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.updateOrganizationLabelsByOrganizationNameReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeDeleteLabelActor) UpdateOrganizationLabelsByOrganizationNameCallCount() int {
+	fake.updateOrganizationLabelsByOrganizationNameMutex.RLock()
+	defer fake.updateOrganizationLabelsByOrganizationNameMutex.RUnlock()
+	return len(fake.updateOrganizationLabelsByOrganizationNameArgsForCall)
+}
+
+func (fake *FakeDeleteLabelActor) UpdateOrganizationLabelsByOrganizationNameCalls(stub func(string, map[string]types.NullString) (v7action.Warnings, error)) {
+	fake.updateOrganizationLabelsByOrganizationNameMutex.Lock()
+	defer fake.updateOrganizationLabelsByOrganizationNameMutex.Unlock()
+	fake.UpdateOrganizationLabelsByOrganizationNameStub = stub
+}
+
+func (fake *FakeDeleteLabelActor) UpdateOrganizationLabelsByOrganizationNameArgsForCall(i int) (string, map[string]types.NullString) {
+	fake.updateOrganizationLabelsByOrganizationNameMutex.RLock()
+	defer fake.updateOrganizationLabelsByOrganizationNameMutex.RUnlock()
+	argsForCall := fake.updateOrganizationLabelsByOrganizationNameArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeDeleteLabelActor) UpdateOrganizationLabelsByOrganizationNameReturns(result1 v7action.Warnings, result2 error) {
+	fake.updateOrganizationLabelsByOrganizationNameMutex.Lock()
+	defer fake.updateOrganizationLabelsByOrganizationNameMutex.Unlock()
+	fake.UpdateOrganizationLabelsByOrganizationNameStub = nil
+	fake.updateOrganizationLabelsByOrganizationNameReturns = struct {
+		result1 v7action.Warnings
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeDeleteLabelActor) UpdateOrganizationLabelsByOrganizationNameReturnsOnCall(i int, result1 v7action.Warnings, result2 error) {
+	fake.updateOrganizationLabelsByOrganizationNameMutex.Lock()
+	defer fake.updateOrganizationLabelsByOrganizationNameMutex.Unlock()
+	fake.UpdateOrganizationLabelsByOrganizationNameStub = nil
+	if fake.updateOrganizationLabelsByOrganizationNameReturnsOnCall == nil {
+		fake.updateOrganizationLabelsByOrganizationNameReturnsOnCall = make(map[int]struct {
+			result1 v7action.Warnings
+			result2 error
+		})
+	}
+	fake.updateOrganizationLabelsByOrganizationNameReturnsOnCall[i] = struct {
+		result1 v7action.Warnings
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeDeleteLabelActor) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.updateApplicationLabelsByApplicationNameMutex.RLock()
 	defer fake.updateApplicationLabelsByApplicationNameMutex.RUnlock()
+	fake.updateOrganizationLabelsByOrganizationNameMutex.RLock()
+	defer fake.updateOrganizationLabelsByOrganizationNameMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/integration/v7/isolated/delete_label_command_test.go
+++ b/integration/v7/isolated/delete_label_command_test.go
@@ -39,43 +39,76 @@ var _ = Describe("delete-label command", func() {
 			username  string
 		)
 
-		type AppResource struct {
+		type commonResource struct {
 			Metadata struct {
 				Labels map[string]string
 			}
 		}
 
 		BeforeEach(func() {
-			orgName = helpers.NewOrgName()
-			spaceName = helpers.NewSpaceName()
-			appName = helpers.PrefixedRandomName("app")
-
 			username, _ = helpers.GetCredentials()
-			helpers.SetupCF(orgName, spaceName)
-			helpers.WithHelloWorldApp(func(appDir string) {
-				Eventually(helpers.CF("push", appName, "-p", appDir)).Should(Exit(0))
-			})
-
-			session := helpers.CF("set-label", "app", appName, "some-key=some-value", "some-other-key=some-other-value", "some-third-key=other")
-			Eventually(session).Should(Exit(0))
+			helpers.LoginCF()
+			orgName = helpers.NewOrgName()
+			helpers.CreateOrg(orgName)
 		})
 
-		It("sets the specified labels on the app", func() {
-			session := helpers.CF("delete-label", "app", appName, "some-other-key", "some-third-key")
-			Eventually(session).Should(Say(regexp.QuoteMeta(`Deleting label(s) for app %s in org %s / space %s as %s...`), appName, orgName, spaceName, username))
-			Consistently(session).ShouldNot(Say("\n\nOK"))
-			Eventually(session).Should(Say("OK"))
-			Eventually(session).Should(Exit(0))
+		When("deleting labels from an app", func() {
+			BeforeEach(func() {
+				spaceName = helpers.NewSpaceName()
+				appName = helpers.PrefixedRandomName("app")
 
-			appGuid := helpers.AppGUID(appName)
-			session = helpers.CF("curl", fmt.Sprintf("/v3/apps/%s", appGuid))
-			Eventually(session).Should(Exit(0))
-			appJSON := session.Out.Contents()
+				helpers.SetupCF(orgName, spaceName)
+				helpers.WithHelloWorldApp(func(appDir string) {
+					Eventually(helpers.CF("push", appName, "-p", appDir)).Should(Exit(0))
+				})
 
-			var app AppResource
-			Expect(json.Unmarshal(appJSON, &app)).To(Succeed())
-			Expect(len(app.Metadata.Labels)).To(Equal(1))
-			Expect(app.Metadata.Labels["some-key"]).To(Equal("some-value"))
+				session := helpers.CF("set-label", "app", appName, "some-key=some-value", "some-other-key=some-other-value", "some-third-key=other")
+				Eventually(session).Should(Exit(0))
+			})
+
+			It("deletes the specified labels on the app", func() {
+				session := helpers.CF("delete-label", "app", appName, "some-other-key", "some-third-key")
+				Eventually(session).Should(Say(regexp.QuoteMeta(`Deleting label(s) for app %s in org %s / space %s as %s...`), appName, orgName, spaceName, username))
+				Consistently(session).ShouldNot(Say("\n\nOK"))
+				Eventually(session).Should(Say("OK"))
+				Eventually(session).Should(Exit(0))
+
+				appGuid := helpers.AppGUID(appName)
+				session = helpers.CF("curl", fmt.Sprintf("/v3/apps/%s", appGuid))
+				Eventually(session).Should(Exit(0))
+				appJSON := session.Out.Contents()
+
+				var app commonResource
+				Expect(json.Unmarshal(appJSON, &app)).To(Succeed())
+				Expect(len(app.Metadata.Labels)).To(Equal(1))
+				Expect(app.Metadata.Labels["some-key"]).To(Equal("some-value"))
+			})
+		})
+
+		When("Deleting labels from an org", func() {
+			BeforeEach(func() {
+				session := helpers.CF("set-label", "org", orgName, "pci=true", "public-facing=false")
+				Eventually(session).Should(Exit(0))
+			})
+
+			It("deletes the specified labels on the org", func() {
+				session := helpers.CF("delete-label", "org", orgName, "public-facing")
+				Eventually(session).Should(Say(regexp.QuoteMeta(`Deleting label(s) for org %s as %s...`), orgName, username))
+				Consistently(session).ShouldNot(Say("\n\nOK"))
+				Eventually(session).Should(Say("OK"))
+				Eventually(session).Should(Exit(0))
+
+				orgGUID := helpers.GetOrgGUID(orgName)
+				session = helpers.CF("curl", fmt.Sprintf("/v3/organizations/%s", orgGUID))
+				Eventually(session).Should(Exit(0))
+				orgJSON := session.Out.Contents()
+
+				var org commonResource
+				Expect(json.Unmarshal(orgJSON, &org)).To(Succeed())
+				Expect(len(org.Metadata.Labels)).To(Equal(1))
+				Expect(org.Metadata.Labels["pci"]).To(Equal("true"))
+			})
+
 		})
 	})
 })


### PR DESCRIPTION
Does this PR modify CLI v6 or v7?
CLI Version: v7

Description of the Change
This adds the ability to delete labels from organization resources.

CAPI Story: #164992581 (https://www.pivotaltracker.com/story/show/164995011)

Thank you!
Mona & @andymoe 