### PR TITLE
ref #117 README - more clearly show `cf login` issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Follow these download links for [Mac OS X 64 bit](https://packages.cloudfoundry.
 
 ## Known Issues
 
-* In Cygwin and Git Bash on Windows, interactive password prompts (in `cf login`) do not work ([issue #171](https://github.com/cloudfoundry/cli/issues/171)). Please use alternative commands (`cf api` and `cf auth` to `cf login`) to work around this.
+* On Windows in Cygwin and Git Bash, interactive password prompts (in `cf login`) do not work ([issue #171](https://github.com/cloudfoundry/cli/issues/171)). Please use alternative commands ( non-interactive authentification `cf auth` or `cf api` intead of `cf login`) to work around this. Or use Windows `cmd` command line.
 * On Windows, `cf ssh` may not display correctly if the `TERM` is not set. We've found that setting `TERM` to `msys` fixes some of these issues.
 * On Windows, `cf ssh` will hang when run from the MINGW32 or MINGW64 shell. A workaround is to use PowerShell instead.
 * CF CLI/GoLang do not use OpenSSL. Custom/Self Signed Certificates need to be [installed in specific locations](https://docs.cloudfoundry.org/cf-cli/self-signed.html) in order to `login`/`auth` without `--skip-ssl-validation`.


### PR DESCRIPTION
ref #117 README - more clearly show `cf login` can fail on Windows in Git Bash

This is not code change, but README update. Merge or please make such or similar change,
so that new users don't run into such issue as https://github.com/cloudfoundry-samples/cf-sample-app-spring/issues/18 "login rejected"

I am signing CLA today as paul.verest@...com ( on GitHub @paulvi )

---

Thank you for contributing to the CF CLI! Please read the following:


* If you haven't yet, please review our contributing guidelines: https://github.com/cloudfoundry/cli/blob/master/.github/CONTRIBUTING.md
* We're not allowed to accept any PRs without a signed CLA, no matter how small.
If your contribution falls under a company CLA but your membership is not public, expect delays while we confirm.
* All new code requires tests to protect against regressions.
* Contributions must confirm to our [style guide](https://github.com/cloudfoundry/cli/wiki/CLI-Product-Specific-Style-Guide). Please reach out to us if you have questions.


## Does this PR modify CLI v6 or v7?

Please see the contribution doc above or review [Architecture Guide](https://github.com/cloudfoundry/cli/wiki/Architecture-Guide).

## Description of the Change


We must be able to understand the design of your change from this description.
Keep in mind that the maintainer reviewing this PR may not be familiar with or
have worked with the code here recently, so please walk us through the concepts.


## Why Is This PR Valuable?

What benefits will be realized by the code change? What users would want this change? What user need is this change addressing? 

## Why Should This Be In Core?

Explain why this functionality should be in the cf CLI, as opposed to a plugin. 

## Applicable Issues

List any applicable Github Issues here

## How Urgent Is The Change?

Is the change urgent? If so, explain why it is time-sensitive.

## Other Relevant Parties

Who else is affected by the change? 
