### PR TITLE
Add command for viewing labels for space

### DIFF
--- a/actor/v7action/label.go
+++ b/actor/v7action/label.go
@@ -29,6 +29,18 @@ func (actor *Actor) GetOrganizationLabels(orgName string) (map[string]types.Null
 	return labels, warnings, nil
 }
 
+func (actor *Actor) GetSpaceLabels(spaceName string, orgGUID string) (map[string]types.NullString, Warnings, error) {
+	var labels map[string]types.NullString
+	resource, warnings, err := actor.GetSpaceByNameAndOrganization(spaceName, orgGUID)
+	if err != nil {
+		return labels, warnings, err
+	}
+	if resource.Metadata != nil {
+		labels = resource.Metadata.Labels
+	}
+	return labels, warnings, nil
+}
+
 func (actor *Actor) UpdateApplicationLabelsByApplicationName(appName string, spaceGUID string, labels map[string]types.NullString) (Warnings, error) {
 	app, appWarnings, err := actor.GetApplicationByNameAndSpace(appName, spaceGUID)
 	if err != nil {

--- a/command/v7/labels_command.go
+++ b/command/v7/labels_command.go
@@ -18,11 +18,12 @@ import (
 type LabelsActor interface {
 	GetApplicationLabels(appName string, spaceGUID string) (map[string]types.NullString, v7action.Warnings, error)
 	GetOrganizationLabels(orgName string) (map[string]types.NullString, v7action.Warnings, error)
+	GetSpaceLabels(spaceName string, orgGUID string) (map[string]types.NullString, v7action.Warnings, error)
 }
 
 type LabelsCommand struct {
 	RequiredArgs flag.LabelsArgs `positional-args:"yes"`
-	usage        interface{}     `usage:"CF_NAME labels RESOURCE RESOURCE_NAME\n\nEXAMPLES:\n   cf labels app dora \n\nRESOURCES:\n   app\n   org\n\nSEE ALSO:\n   set-label, delete-label"`
+	usage        interface{}     `usage:"CF_NAME labels RESOURCE RESOURCE_NAME\n\nEXAMPLES:\n   cf labels app dora \n\nRESOURCES:\n   app\n   space\n   org\n\nSEE ALSO:\n   set-label, delete-label"`
 	UI           command.UI
 	Config       command.Config
 	SharedActor  command.SharedActor
@@ -55,6 +56,8 @@ func (cmd LabelsCommand) Execute(args []string) error {
 		labels, warnings, err = cmd.fetchAppLabels(username)
 	case "org":
 		labels, warnings, err = cmd.fetchOrgLabels(username)
+	case "space":
+		labels, warnings, err = cmd.fetchSpaceLabels(username)
 	default:
 		err = fmt.Errorf("Unsupported resource type of '%s'", cmd.RequiredArgs.ResourceType)
 	}
@@ -99,6 +102,23 @@ func (cmd LabelsCommand) fetchOrgLabels(username string) (map[string]types.NullS
 	cmd.UI.DisplayNewline()
 
 	return cmd.Actor.GetOrganizationLabels(cmd.RequiredArgs.ResourceName)
+}
+
+func (cmd LabelsCommand) fetchSpaceLabels(username string) (map[string]types.NullString, v7action.Warnings, error) {
+	err := cmd.SharedActor.CheckTarget(true, false)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cmd.UI.DisplayTextWithFlavor("Getting labels for space {{.SpaceName}} in org {{.OrgName}} as {{.Username}}...", map[string]interface{}{
+		"SpaceName": cmd.RequiredArgs.ResourceName,
+		"OrgName":   cmd.Config.TargetedOrganization().Name,
+		"Username":  username,
+	})
+
+	cmd.UI.DisplayNewline()
+
+	return cmd.Actor.GetSpaceLabels(cmd.RequiredArgs.ResourceName, cmd.Config.TargetedOrganization().GUID)
 }
 
 func (cmd LabelsCommand) printLabels(labels map[string]types.NullString) {

--- a/command/v7/v7fakes/fake_labels_actor.go
+++ b/command/v7/v7fakes/fake_labels_actor.go
@@ -41,6 +41,22 @@ type FakeLabelsActor struct {
 		result2 v7action.Warnings
 		result3 error
 	}
+	GetSpaceLabelsStub        func(string, string) (map[string]types.NullString, v7action.Warnings, error)
+	getSpaceLabelsMutex       sync.RWMutex
+	getSpaceLabelsArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
+	getSpaceLabelsReturns struct {
+		result1 map[string]types.NullString
+		result2 v7action.Warnings
+		result3 error
+	}
+	getSpaceLabelsReturnsOnCall map[int]struct {
+		result1 map[string]types.NullString
+		result2 v7action.Warnings
+		result3 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -178,6 +194,73 @@ func (fake *FakeLabelsActor) GetOrganizationLabelsReturnsOnCall(i int, result1 m
 	}{result1, result2, result3}
 }
 
+func (fake *FakeLabelsActor) GetSpaceLabels(arg1 string, arg2 string) (map[string]types.NullString, v7action.Warnings, error) {
+	fake.getSpaceLabelsMutex.Lock()
+	ret, specificReturn := fake.getSpaceLabelsReturnsOnCall[len(fake.getSpaceLabelsArgsForCall)]
+	fake.getSpaceLabelsArgsForCall = append(fake.getSpaceLabelsArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("GetSpaceLabels", []interface{}{arg1, arg2})
+	fake.getSpaceLabelsMutex.Unlock()
+	if fake.GetSpaceLabelsStub != nil {
+		return fake.GetSpaceLabelsStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	fakeReturns := fake.getSpaceLabelsReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeLabelsActor) GetSpaceLabelsCallCount() int {
+	fake.getSpaceLabelsMutex.RLock()
+	defer fake.getSpaceLabelsMutex.RUnlock()
+	return len(fake.getSpaceLabelsArgsForCall)
+}
+
+func (fake *FakeLabelsActor) GetSpaceLabelsCalls(stub func(string, string) (map[string]types.NullString, v7action.Warnings, error)) {
+	fake.getSpaceLabelsMutex.Lock()
+	defer fake.getSpaceLabelsMutex.Unlock()
+	fake.GetSpaceLabelsStub = stub
+}
+
+func (fake *FakeLabelsActor) GetSpaceLabelsArgsForCall(i int) (string, string) {
+	fake.getSpaceLabelsMutex.RLock()
+	defer fake.getSpaceLabelsMutex.RUnlock()
+	argsForCall := fake.getSpaceLabelsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeLabelsActor) GetSpaceLabelsReturns(result1 map[string]types.NullString, result2 v7action.Warnings, result3 error) {
+	fake.getSpaceLabelsMutex.Lock()
+	defer fake.getSpaceLabelsMutex.Unlock()
+	fake.GetSpaceLabelsStub = nil
+	fake.getSpaceLabelsReturns = struct {
+		result1 map[string]types.NullString
+		result2 v7action.Warnings
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeLabelsActor) GetSpaceLabelsReturnsOnCall(i int, result1 map[string]types.NullString, result2 v7action.Warnings, result3 error) {
+	fake.getSpaceLabelsMutex.Lock()
+	defer fake.getSpaceLabelsMutex.Unlock()
+	fake.GetSpaceLabelsStub = nil
+	if fake.getSpaceLabelsReturnsOnCall == nil {
+		fake.getSpaceLabelsReturnsOnCall = make(map[int]struct {
+			result1 map[string]types.NullString
+			result2 v7action.Warnings
+			result3 error
+		})
+	}
+	fake.getSpaceLabelsReturnsOnCall[i] = struct {
+		result1 map[string]types.NullString
+		result2 v7action.Warnings
+		result3 error
+	}{result1, result2, result3}
+}
+
 func (fake *FakeLabelsActor) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -185,6 +268,8 @@ func (fake *FakeLabelsActor) Invocations() map[string][][]interface{} {
 	defer fake.getApplicationLabelsMutex.RUnlock()
 	fake.getOrganizationLabelsMutex.RLock()
 	defer fake.getOrganizationLabelsMutex.RUnlock()
+	fake.getSpaceLabelsMutex.RLock()
+	defer fake.getSpaceLabelsMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value


### PR DESCRIPTION
## Does this PR modify CLI v6 or v7?

**CLI Version:** v7

## Description of the Change
This adds the ability to view labels on a `space` via `cf labels space {space_name}`.

**CAPI Story:** [#165425041](https://www.pivotaltracker.com/story/show/165425126)

Thank you!