### PR TITLE
Fix case sensitivity in 'copy_source' command while specifying space name.

### DIFF
--- a/cf/commands/application/copy_source.go
+++ b/cf/commands/application/copy_source.go
@@ -106,13 +106,22 @@ func (cmd *CopySource) Execute(c flags.FlagContext) error {
 
 	var targetOrgName, targetSpaceName, spaceGUID, copyStr string
 	if targetOrg != "" && targetSpace != "" {
-		spaceGUID, err = cmd.findSpaceGUID(targetOrg, targetSpace)
+		var org models.Organization
+		var space models.Space
+
+		org, err := cmd.orgRepo.FindByName(targetOrg)
 		if err != nil {
 			return err
 		}
 
-		targetOrgName = targetOrg
-		targetSpaceName = targetSpace
+		space, err = cmd.spaceRepo.FindByNameInOrg(targetSpace,org.GUID)
+		spaceGUID = space.GUID
+		if err != nil {
+			return err
+		}
+
+		targetOrgName = org.Name
+		targetSpaceName = space.Name
 	} else if targetSpace != "" {
 		var space models.Space
 		space, err = cmd.spaceRepo.FindByName(targetSpace)

--- a/cf/commands/application/copy_source.go
+++ b/cf/commands/application/copy_source.go
@@ -3,6 +3,7 @@ package application
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"code.cloudfoundry.org/cli/cf/api/applications"
 	"code.cloudfoundry.org/cli/cf/api/authentication"
@@ -107,19 +108,29 @@ func (cmd *CopySource) Execute(c flags.FlagContext) error {
 	var targetOrgName, targetSpaceName, spaceGUID, copyStr string
 	if targetOrg != "" && targetSpace != "" {
 		var org models.Organization
-		var space models.Space
-
 		org, err := cmd.orgRepo.FindByName(targetOrg)
 		if err != nil {
 			return err
 		}
-
-		space, err = cmd.spaceRepo.FindByNameInOrg(targetSpace,org.GUID)
-		spaceGUID = space.GUID
-		if err != nil {
-			return err
+		//Get the matching space in the org by name
+		var space models.SpaceFields
+		var foundSpace bool
+		for _, s := range org.Spaces {
+			if strings.EqualFold(s.Name, targetSpace) {
+				space = s
+				foundSpace = true
+			}
 		}
-
+		//If no matching space is found
+		if !foundSpace {
+			return errors.New(T("Could not find space {{.Space}} in organization {{.Org}}",
+				map[string]interface{}{
+					"Space": terminal.EntityNameColor(targetSpace),
+					"Org":   terminal.EntityNameColor(targetOrg),
+				},
+			))
+		}
+		spaceGUID = space.GUID
 		targetOrgName = org.Name
 		targetSpaceName = space.Name
 	} else if targetSpace != "" {
@@ -130,7 +141,7 @@ func (cmd *CopySource) Execute(c flags.FlagContext) error {
 		}
 		spaceGUID = space.GUID
 		targetOrgName = cmd.config.OrganizationFields().Name
-		targetSpaceName = targetSpace
+		targetSpaceName = space.Name
 	} else {
 		spaceGUID = cmd.config.SpaceFields().GUID
 		targetOrgName = cmd.config.OrganizationFields().Name
@@ -159,33 +170,6 @@ func (cmd *CopySource) Execute(c flags.FlagContext) error {
 
 	cmd.ui.Ok()
 	return nil
-}
-
-func (cmd *CopySource) findSpaceGUID(targetOrg, targetSpace string) (string, error) {
-	org, err := cmd.orgRepo.FindByName(targetOrg)
-	if err != nil {
-		return "", err
-	}
-
-	var space models.SpaceFields
-	var foundSpace bool
-	for _, s := range org.Spaces {
-		if s.Name == targetSpace {
-			space = s
-			foundSpace = true
-		}
-	}
-
-	if !foundSpace {
-		return "", fmt.Errorf(T("Could not find space {{.Space}} in organization {{.Org}}",
-			map[string]interface{}{
-				"Space": terminal.EntityNameColor(targetSpace),
-				"Org":   terminal.EntityNameColor(targetOrg),
-			},
-		))
-	}
-
-	return space.GUID, nil
 }
 
 func buildCopyString(sourceAppName, targetAppName, targetOrgName, targetSpaceName, username string) string {


### PR DESCRIPTION
Fix for https://github.com/cloudfoundry/cli/issues/1605

## Description of the Change

The copy_source command currently is case-sensitive. As described in the linked Github bug, the CLI is sensitive to the case of the space name. Also, upon further notice, the CLI seems to output the targetSpace and targetOrg as such based on the case entered by the user instead of showing the actual names of the space/org. 

The current change addresses the case-sensitive space name issue and also prints the actual space and org name during execution.

## Why Is This PR Valuable?

Although this PR is tiny, it makes sure all users that make use of copy-source command  get to see the right space and org details regardless of the case in which they typed in(if the space/org exists) & get to see the error if not.

## Applicable Issues

Fixes https://github.com/cloudfoundry/cli/issues/1605

https://www.pivotaltracker.com/story/show/165097075