### PR TITLE
Refactor set-label commands to use a shared api layer

### DIFF
--- a/actor/v7action/cloud_controller_client.go
+++ b/actor/v7action/cloud_controller_client.go
@@ -76,6 +76,7 @@ type CloudControllerClient interface {
 	UpdateOrganization(org ccv3.Organization) (ccv3.Organization, ccv3.Warnings, error)
 	UpdateOrganizationDefaultIsolationSegmentRelationship(orgGUID string, isolationSegmentGUID string) (ccv3.Relationship, ccv3.Warnings, error)
 	UpdateProcess(process ccv3.Process) (ccv3.Process, ccv3.Warnings, error)
+	UpdateResourceMetadata(resource string, resourceGUID string, metadata ccv3.Metadata) (ccv3.ResourceMetadata, ccv3.Warnings, error)
 	UpdateSpace(space ccv3.Space) (ccv3.Space, ccv3.Warnings, error)
 	UpdateSpaceApplyManifest(spaceGUID string, rawManifest []byte, query ...ccv3.Query) (ccv3.JobURL, ccv3.Warnings, error)
 	UpdateSpaceIsolationSegmentRelationship(spaceGUID string, isolationSegmentGUID string) (ccv3.Relationship, ccv3.Warnings, error)

--- a/actor/v7action/label.go
+++ b/actor/v7action/label.go
@@ -34,8 +34,10 @@ func (actor *Actor) UpdateApplicationLabelsByApplicationName(appName string, spa
 	if err != nil {
 		return appWarnings, err
 	}
-	app.Metadata = &Metadata{Labels: labels}
-	_, updateWarnings, err := actor.UpdateApplication(app)
+	_, updateWarnings, err := actor.CloudControllerClient.UpdateResourceMetadata("app", app.GUID, ccv3.Metadata{Labels: labels})
+	if err != nil {
+		return append(appWarnings, updateWarnings...), err
+	}
 	return append(appWarnings, updateWarnings...), err
 }
 
@@ -44,8 +46,10 @@ func (actor *Actor) UpdateOrganizationLabelsByOrganizationName(orgName string, l
 	if err != nil {
 		return warnings, err
 	}
-	org.Metadata = &Metadata{Labels: labels}
-	_, updateWarnings, err := actor.UpdateOrganization(org)
+	_, updateWarnings, err := actor.CloudControllerClient.UpdateResourceMetadata("org", org.GUID, ccv3.Metadata{Labels: labels})
+	if err != nil {
+		return append(warnings, updateWarnings...), err
+	}
 	return append(warnings, updateWarnings...), err
 }
 
@@ -54,7 +58,9 @@ func (actor *Actor) UpdateSpaceLabelsBySpaceName(spaceName string, orgGUID strin
 	if err != nil {
 		return warnings, err
 	}
-	space.Metadata = &ccv3.Metadata{Labels: labels}
-	_, updateWarnings, err := actor.CloudControllerClient.UpdateSpace(ccv3.Space(space))
+	_, updateWarnings, err := actor.CloudControllerClient.UpdateResourceMetadata("space", space.GUID, ccv3.Metadata{Labels: labels})
+	if err != nil {
+		return append(warnings, updateWarnings...), err
+	}
 	return append(warnings, updateWarnings...), err
 }

--- a/actor/v7action/v7actionfakes/fake_cloud_controller_client.go
+++ b/actor/v7action/v7actionfakes/fake_cloud_controller_client.go
@@ -986,6 +986,23 @@ type FakeCloudControllerClient struct {
 		result2 ccv3.Warnings
 		result3 error
 	}
+	UpdateResourceMetadataStub        func(string, string, ccv3.Metadata) (ccv3.ResourceMetadata, ccv3.Warnings, error)
+	updateResourceMetadataMutex       sync.RWMutex
+	updateResourceMetadataArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 ccv3.Metadata
+	}
+	updateResourceMetadataReturns struct {
+		result1 ccv3.ResourceMetadata
+		result2 ccv3.Warnings
+		result3 error
+	}
+	updateResourceMetadataReturnsOnCall map[int]struct {
+		result1 ccv3.ResourceMetadata
+		result2 ccv3.Warnings
+		result3 error
+	}
 	UpdateSpaceStub        func(ccv3.Space) (ccv3.Space, ccv3.Warnings, error)
 	updateSpaceMutex       sync.RWMutex
 	updateSpaceArgsForCall []struct {
@@ -5419,6 +5436,74 @@ func (fake *FakeCloudControllerClient) UpdateProcessReturnsOnCall(i int, result1
 	}{result1, result2, result3}
 }
 
+func (fake *FakeCloudControllerClient) UpdateResourceMetadata(arg1 string, arg2 string, arg3 ccv3.Metadata) (ccv3.ResourceMetadata, ccv3.Warnings, error) {
+	fake.updateResourceMetadataMutex.Lock()
+	ret, specificReturn := fake.updateResourceMetadataReturnsOnCall[len(fake.updateResourceMetadataArgsForCall)]
+	fake.updateResourceMetadataArgsForCall = append(fake.updateResourceMetadataArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 ccv3.Metadata
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("UpdateResourceMetadata", []interface{}{arg1, arg2, arg3})
+	fake.updateResourceMetadataMutex.Unlock()
+	if fake.UpdateResourceMetadataStub != nil {
+		return fake.UpdateResourceMetadataStub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	fakeReturns := fake.updateResourceMetadataReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeCloudControllerClient) UpdateResourceMetadataCallCount() int {
+	fake.updateResourceMetadataMutex.RLock()
+	defer fake.updateResourceMetadataMutex.RUnlock()
+	return len(fake.updateResourceMetadataArgsForCall)
+}
+
+func (fake *FakeCloudControllerClient) UpdateResourceMetadataCalls(stub func(string, string, ccv3.Metadata) (ccv3.ResourceMetadata, ccv3.Warnings, error)) {
+	fake.updateResourceMetadataMutex.Lock()
+	defer fake.updateResourceMetadataMutex.Unlock()
+	fake.UpdateResourceMetadataStub = stub
+}
+
+func (fake *FakeCloudControllerClient) UpdateResourceMetadataArgsForCall(i int) (string, string, ccv3.Metadata) {
+	fake.updateResourceMetadataMutex.RLock()
+	defer fake.updateResourceMetadataMutex.RUnlock()
+	argsForCall := fake.updateResourceMetadataArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeCloudControllerClient) UpdateResourceMetadataReturns(result1 ccv3.ResourceMetadata, result2 ccv3.Warnings, result3 error) {
+	fake.updateResourceMetadataMutex.Lock()
+	defer fake.updateResourceMetadataMutex.Unlock()
+	fake.UpdateResourceMetadataStub = nil
+	fake.updateResourceMetadataReturns = struct {
+		result1 ccv3.ResourceMetadata
+		result2 ccv3.Warnings
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeCloudControllerClient) UpdateResourceMetadataReturnsOnCall(i int, result1 ccv3.ResourceMetadata, result2 ccv3.Warnings, result3 error) {
+	fake.updateResourceMetadataMutex.Lock()
+	defer fake.updateResourceMetadataMutex.Unlock()
+	fake.UpdateResourceMetadataStub = nil
+	if fake.updateResourceMetadataReturnsOnCall == nil {
+		fake.updateResourceMetadataReturnsOnCall = make(map[int]struct {
+			result1 ccv3.ResourceMetadata
+			result2 ccv3.Warnings
+			result3 error
+		})
+	}
+	fake.updateResourceMetadataReturnsOnCall[i] = struct {
+		result1 ccv3.ResourceMetadata
+		result2 ccv3.Warnings
+		result3 error
+	}{result1, result2, result3}
+}
+
 func (fake *FakeCloudControllerClient) UpdateSpace(arg1 ccv3.Space) (ccv3.Space, ccv3.Warnings, error) {
 	fake.updateSpaceMutex.Lock()
 	ret, specificReturn := fake.updateSpaceReturnsOnCall[len(fake.updateSpaceArgsForCall)]
@@ -6036,6 +6121,8 @@ func (fake *FakeCloudControllerClient) Invocations() map[string][][]interface{} 
 	defer fake.updateOrganizationDefaultIsolationSegmentRelationshipMutex.RUnlock()
 	fake.updateProcessMutex.RLock()
 	defer fake.updateProcessMutex.RUnlock()
+	fake.updateResourceMetadataMutex.RLock()
+	defer fake.updateResourceMetadataMutex.RUnlock()
 	fake.updateSpaceMutex.RLock()
 	defer fake.updateSpaceMutex.RUnlock()
 	fake.updateSpaceApplyManifestMutex.RLock()

--- a/api/cloudcontroller/ccv3/metadata.go
+++ b/api/cloudcontroller/ccv3/metadata.go
@@ -1,10 +1,67 @@
 package ccv3
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
+
+	"code.cloudfoundry.org/cli/api/cloudcontroller"
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/internal"
 	"code.cloudfoundry.org/cli/types"
 )
 
 // Metadata is used for custom tagging of API resources
 type Metadata struct {
 	Labels map[string]types.NullString `json:"labels,omitempty"`
+}
+
+type ResourceMetadata struct {
+	Metadata *Metadata `json:"metadata,omitempty"`
+}
+
+func (client *Client) UpdateResourceMetadata(resource string, resourceGUID string, metadata Metadata) (ResourceMetadata, Warnings, error) {
+	metadataBtyes, err := json.Marshal(ResourceMetadata{Metadata: &metadata})
+	if err != nil {
+		return ResourceMetadata{}, nil, err
+	}
+
+	var request *cloudcontroller.Request
+
+	switch resource {
+	case "app":
+		request, err = client.newHTTPRequest(requestOptions{
+			RequestName: internal.PatchApplicationRequest,
+			Body:        bytes.NewReader(metadataBtyes),
+			URIParams:   map[string]string{"app_guid": resourceGUID},
+		})
+	case "org":
+		request, err = client.newHTTPRequest(requestOptions{
+			RequestName: internal.PatchOrganizationRequest,
+			Body:        bytes.NewReader(metadataBtyes),
+			URIParams:   map[string]string{"organization_guid": resourceGUID},
+		})
+	case "space":
+		request, err = client.newHTTPRequest(requestOptions{
+			RequestName: internal.PatchSpaceRequest,
+			Body:        bytes.NewReader(metadataBtyes),
+			URIParams:   map[string]string{"space_guid": resourceGUID},
+		})
+	default:
+		return ResourceMetadata{}, nil, errors.New("unknown resource type requested")
+	}
+
+	if err != nil {
+		return ResourceMetadata{}, nil, err
+	}
+
+	var responseMetadata ResourceMetadata
+	response := cloudcontroller.Response{
+		DecodeJSONResponseInto: &responseMetadata,
+	}
+	err = client.connection.Make(request, &response)
+
+	if err != nil {
+		return ResourceMetadata{}, nil, err
+	}
+	return responseMetadata, nil, err
 }

--- a/api/cloudcontroller/ccv3/metadata_test.go
+++ b/api/cloudcontroller/ccv3/metadata_test.go
@@ -1,0 +1,333 @@
+package ccv3_test
+
+import (
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccerror"
+	"net/http"
+
+	. "code.cloudfoundry.org/cli/api/cloudcontroller/ccv3"
+	"code.cloudfoundry.org/cli/types"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/ghttp"
+)
+
+var _ = Describe("Metadata", func() {
+	var client *Client
+
+	BeforeEach(func() {
+		client, _ = NewTestClient()
+	})
+
+	Describe("UpdateResourceMetadata", func() {
+		var (
+			metadataToUpdate Metadata
+			resourceGUID     string
+			updatedMetadata  ResourceMetadata
+			warnings         Warnings
+			executeErr       error
+		)
+
+		When("updating metadata on an app", func() {
+			JustBeforeEach(func() {
+				resourceGUID = "some-guid"
+				updatedMetadata, warnings, executeErr = client.UpdateResourceMetadata("app", resourceGUID, metadataToUpdate)
+			})
+
+			When("the space is updated successfully", func() {
+				BeforeEach(func() {
+					response := `{
+					"guid": "some-guid",
+					"name": "some-space-name",
+					"metadata": {
+						"labels": {
+							"k1":"v1",
+							"k2":"v2"
+						}
+					}
+				}`
+
+					expectedBody := map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"labels": map[string]string{
+								"k1": "v1",
+								"k2": "v2",
+							},
+						},
+					}
+
+					server.AppendHandlers(
+						CombineHandlers(
+							VerifyRequest(http.MethodPatch, "/v3/apps/some-guid"),
+							VerifyJSONRepresenting(expectedBody),
+							RespondWith(http.StatusOK, response, http.Header{"X-Cf-Warnings": {"this is a warning"}}),
+						),
+					)
+
+					metadataToUpdate = Metadata{
+						Labels: map[string]types.NullString{
+							"k1": types.NewNullString("v1"),
+							"k2": types.NewNullString("v2"),
+						},
+					}
+				})
+
+				It("should include the labels in the JSON", func() {
+					Expect(executeErr).ToNot(HaveOccurred())
+					Expect(server.ReceivedRequests()).To(HaveLen(3))
+					Expect(len(warnings)).To(Equal(0))
+					Expect(updatedMetadata.Metadata.Labels).To(BeEquivalentTo(
+						map[string]types.NullString{
+							"k1": types.NewNullString("v1"),
+							"k2": types.NewNullString("v2"),
+						}))
+				})
+
+			})
+
+			When("Cloud Controller returns errors and warnings", func() {
+				BeforeEach(func() {
+					response := `{
+  "errors": [
+    {
+      "code": 10008,
+      "detail": "Metadata key error: label 'invalid*key' contains invalid characters",
+      "title": "CF-UnprocessableEntity"
+    }
+  ]
+}`
+					expectedBody := map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"labels": map[string]string{
+								"invalid*key": "v1",
+								"k2":          "v2",
+							},
+						},
+					}
+
+					server.AppendHandlers(
+						CombineHandlers(
+							VerifyRequest(http.MethodPatch, "/v3/apps/some-guid"),
+							VerifyJSONRepresenting(expectedBody),
+							RespondWith(http.StatusUnprocessableEntity, response, http.Header{}),
+						),
+					)
+
+					metadataToUpdate = Metadata{
+						Labels: map[string]types.NullString{
+							"invalid*key": types.NewNullString("v1"),
+							"k2":          types.NewNullString("v2"),
+						},
+					}
+				})
+
+				It("returns the error and all warnings", func() {
+					Expect(executeErr).To(MatchError(ccerror.UnprocessableEntityError{
+						Message: "Metadata key error: label 'invalid*key' contains invalid characters",
+					}))
+				})
+			})
+		})
+
+		When("updating metadata on an organization", func() {
+			JustBeforeEach(func() {
+				resourceGUID = "some-guid"
+				updatedMetadata, warnings, executeErr = client.UpdateResourceMetadata("org", resourceGUID, metadataToUpdate)
+			})
+
+			When("the organization is updated successfully", func() {
+				BeforeEach(func() {
+					response := `{
+					"guid": "some-guid",
+					"name": "some-org-name",
+					"metadata": {
+						"labels": {
+							"k1":"v1",
+							"k2":"v2"
+						}
+					}
+				}`
+
+					expectedBody := map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"labels": map[string]string{
+								"k1": "v1",
+								"k2": "v2",
+							},
+						},
+					}
+
+					server.AppendHandlers(
+						CombineHandlers(
+							VerifyRequest(http.MethodPatch, "/v3/organizations/some-guid"),
+							VerifyJSONRepresenting(expectedBody),
+							RespondWith(http.StatusOK, response, http.Header{"X-Cf-Warnings": {"this is a warning"}}),
+						),
+					)
+
+					metadataToUpdate = Metadata{
+						Labels: map[string]types.NullString{
+							"k1": types.NewNullString("v1"),
+							"k2": types.NewNullString("v2"),
+						},
+					}
+				})
+
+				It("should include the labels in the JSON", func() {
+					Expect(executeErr).ToNot(HaveOccurred())
+					Expect(server.ReceivedRequests()).To(HaveLen(3))
+					Expect(len(warnings)).To(Equal(0))
+					Expect(updatedMetadata.Metadata.Labels).To(BeEquivalentTo(
+						map[string]types.NullString{
+							"k1": types.NewNullString("v1"),
+							"k2": types.NewNullString("v2"),
+						}))
+				})
+
+			})
+
+			When("Cloud Controller returns errors and warnings", func() {
+				BeforeEach(func() {
+					response := `{
+  "errors": [
+    {
+      "code": 10008,
+      "detail": "Metadata key error: label 'invalid*key' contains invalid characters",
+      "title": "CF-UnprocessableEntity"
+    }
+  ]
+}`
+					expectedBody := map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"labels": map[string]string{
+								"invalid*key": "v1",
+								"k2":          "v2",
+							},
+						},
+					}
+
+					server.AppendHandlers(
+						CombineHandlers(
+							VerifyRequest(http.MethodPatch, "/v3/organizations/some-guid"),
+							VerifyJSONRepresenting(expectedBody),
+							RespondWith(http.StatusUnprocessableEntity, response, http.Header{}),
+						),
+					)
+
+					metadataToUpdate = Metadata{
+						Labels: map[string]types.NullString{
+							"invalid*key": types.NewNullString("v1"),
+							"k2":          types.NewNullString("v2"),
+						},
+					}
+				})
+
+				It("returns the error and all warnings", func() {
+					Expect(executeErr).To(MatchError(ccerror.UnprocessableEntityError{
+						Message: "Metadata key error: label 'invalid*key' contains invalid characters",
+					}))
+				})
+			})
+		})
+
+		When("updating metadata on a space", func() {
+			JustBeforeEach(func() {
+				resourceGUID = "some-guid"
+				updatedMetadata, warnings, executeErr = client.UpdateResourceMetadata("space", resourceGUID, metadataToUpdate)
+			})
+
+			When("the space is updated successfully", func() {
+				BeforeEach(func() {
+					response := `{
+					"guid": "some-guid",
+					"name": "some-space-name",
+					"metadata": {
+						"labels": {
+							"k1":"v1",
+							"k2":"v2"
+						}
+					}
+				}`
+
+					expectedBody := map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"labels": map[string]string{
+								"k1": "v1",
+								"k2": "v2",
+							},
+						},
+					}
+
+					server.AppendHandlers(
+						CombineHandlers(
+							VerifyRequest(http.MethodPatch, "/v3/spaces/some-guid"),
+							VerifyJSONRepresenting(expectedBody),
+							RespondWith(http.StatusOK, response, http.Header{"X-Cf-Warnings": {"this is a warning"}}),
+						),
+					)
+
+					metadataToUpdate = Metadata{
+						Labels: map[string]types.NullString{
+							"k1": types.NewNullString("v1"),
+							"k2": types.NewNullString("v2"),
+						},
+					}
+				})
+
+				It("should include the labels in the JSON", func() {
+					Expect(executeErr).ToNot(HaveOccurred())
+					Expect(server.ReceivedRequests()).To(HaveLen(3))
+					Expect(len(warnings)).To(Equal(0))
+					Expect(updatedMetadata.Metadata.Labels).To(BeEquivalentTo(
+						map[string]types.NullString{
+							"k1": types.NewNullString("v1"),
+							"k2": types.NewNullString("v2"),
+						}))
+				})
+
+			})
+
+			When("Cloud Controller returns errors and warnings", func() {
+				BeforeEach(func() {
+					response := `{
+  "errors": [
+    {
+      "code": 10008,
+      "detail": "Metadata key error: label 'invalid*key' contains invalid characters",
+      "title": "CF-UnprocessableEntity"
+    }
+  ]
+}`
+					expectedBody := map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"labels": map[string]string{
+								"invalid*key": "v1",
+								"k2":          "v2",
+							},
+						},
+					}
+
+					server.AppendHandlers(
+						CombineHandlers(
+							VerifyRequest(http.MethodPatch, "/v3/spaces/some-guid"),
+							VerifyJSONRepresenting(expectedBody),
+							RespondWith(http.StatusUnprocessableEntity, response, http.Header{}),
+						),
+					)
+
+					metadataToUpdate = Metadata{
+						Labels: map[string]types.NullString{
+							"invalid*key": types.NewNullString("v1"),
+							"k2":          types.NewNullString("v2"),
+						},
+					}
+				})
+
+				It("returns the error and all warnings", func() {
+					Expect(executeErr).To(MatchError(ccerror.UnprocessableEntityError{
+						Message: "Metadata key error: label 'invalid*key' contains invalid characters",
+					}))
+				})
+			})
+		})
+	})
+})


### PR DESCRIPTION
## Does this PR modify CLI v6 or v7?

This modifies the **v7** CLI.

## Description of the Change

The APIs for updating metadata on API resources in Cloud Controller
follow a consistent interface. This means that apart from the endpoint
URL, the structure of the PATCH requests to these endpoints is uniform
so we should be able to share much of the API layer across resources
when adding/updating labels (and later annotations).

See the following API docs:
https://v3-apidocs.cloudfoundry.org/version/3.71.0/index.html#metadata

## Why Is This PR Valuable?

This should simplify the addition of new supported resources for `cf set-label`.

## Why Should This Be In Core?

It affects core cf cli functionality.

## Applicable Issues

This refactor comes from the following discussion in PR #1631:
https://github.com/cloudfoundry/cli/pull/1631#discussion_r280255971

CAPI Story:
[#165803403](https://www.pivotaltracker.com/story/show/165803403)

## How Urgent Is The Change?

Not urgent, but if you like this approach I believe it will simplify future label stories.

## Other Relevant Parties

I solo-ed on this, but want to tag some CAPIs that may have worked on `cf set-label` previously / be interested:
@monamohebbi @ericpromislow @cwlbraa 