### PR TITLE
manifests include sidecars

### DIFF
--- a/util/manifest/application.go
+++ b/util/manifest/application.go
@@ -36,6 +36,7 @@ type Application struct {
 	Routes          []string
 	RoutePath       string
 	Services        []string
+	Sidecars        []interface{}
 	StackName       string
 
 	DeprecatedDomain     interface{}
@@ -59,6 +60,7 @@ func (app Application) MarshalYAML() (interface{}, error) {
 		NoRoute:                 app.NoRoute,
 		Path:                    app.Path,
 		Services:                app.Services,
+		Sidecars:                app.Sidecars,
 		StackName:               app.StackName,
 		Timeout:                 app.HealthCheckTimeout,
 	}
@@ -129,6 +131,7 @@ func (app *Application) UnmarshalYAML(unmarshaller func(interface{}) error) erro
 	app.Path = m.Path
 	app.RandomRoute = m.RandomRoute
 	app.Services = m.Services
+	app.Sidecars = m.Sidecars
 	app.StackName = m.StackName
 	app.HealthCheckTimeout = m.Timeout
 	app.EnvironmentVariables = m.EnvironmentVariables

--- a/util/manifest/raw_manifest_application.go
+++ b/util/manifest/raw_manifest_application.go
@@ -23,6 +23,7 @@ type rawManifestApplication struct {
 	RandomRoute             bool               `yaml:"random-route,omitempty"`
 	Routes                  []rawManifestRoute `yaml:"routes,omitempty"`
 	Services                []string           `yaml:"services,omitempty"`
+	Sidecars                []interface{}      `yaml:"sidecars,omitempty"`
 	StackName               string             `yaml:"stack,omitempty"`
 	Timeout                 uint64             `yaml:"timeout,omitempty"`
 }


### PR DESCRIPTION
## Does this PR modify CLI v6 or v7?

Both; though my dev/test is with `cf v3-apply-changes` and `cf v3-push`.

## Description of the Change

`cf v3-apply-changes` recently added support for `sidecars:` in manifests. 

Unfortunately, the `utils/manifests` library does not parse nor print them yet. I need this library so I can modify the test app's manifest, edit its app name, and save it to a temporary file. The rest of the buildpack testing process is managed by libbuildpack.

## Why Is This PR Valuable?

It is required for buildpack testing (via libbuildpack) so we can mutate the manifest.yml to edit the appname, etc. Currently when the manifest is printed it does not include sidecars from the original manifest.

## How Urgent Is The Change?

Relatively urgent to go with the sidecars epic.

## Other Relevant Parties

* Buildpacks team
* Anyone involved in Sidecars