### PR TITLE
Indicate whether service instances have an upgrade available

### DIFF
--- a/actor/v2action/service_instance_summary.go
+++ b/actor/v2action/service_instance_summary.go
@@ -49,6 +49,16 @@ func (s ServiceInstanceSummary) IsSharedTo() bool {
 	return s.ServiceInstanceShareType == ServiceInstanceIsSharedTo
 }
 
+func (s ServiceInstanceSummary) UpgradeAvailable() string {
+	if s.ServicePlan.MaintenanceInfo.Version == "" {
+		return ""
+	}
+	if s.ServicePlan.MaintenanceInfo.Version == s.ServiceInstance.MaintenanceInfo.Version {
+		return "no"
+	}
+	return "yes"
+}
+
 type BoundApplication struct {
 	AppName            string
 	LastOperation      LastOperation
@@ -90,10 +100,12 @@ func (actor Actor) GetServiceInstancesSummaryBySpace(spaceGUID string) ([]Servic
 
 		instanceSummary.Name = serviceInstance.Name
 		instanceSummary.ServicePlan.Name = serviceInstance.ServicePlan.Name
+		instanceSummary.ServicePlan.MaintenanceInfo = serviceInstance.ServicePlan.MaintenanceInfo
 		instanceSummary.Service.Label = serviceInstance.ServicePlan.Service.Label
 		instanceSummary.LastOperation = serviceInstance.LastOperation
 		instanceSummary.Service.ServiceBrokerName = serviceGUIDToBrokerName[serviceInstance.ServicePlan.Service.GUID]
 		instanceSummary.ServiceInstance.Type = discoverServiceInstanceType(serviceInstance)
+		instanceSummary.ServiceInstance.MaintenanceInfo = serviceInstance.MaintenanceInfo
 		instanceSummary.BoundApplications = findServiceInstanceBoundApplications(serviceInstance.Name, spaceSummary.Applications)
 
 		serviceInstanceSummaries = append(serviceInstanceSummaries, instanceSummary)

--- a/actor/v2action/service_instance_summary_test.go
+++ b/actor/v2action/service_instance_summary_test.go
@@ -10,6 +10,7 @@ import (
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv2/constant"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
@@ -80,6 +81,19 @@ var _ = Describe("Service Instance Summary Actions", func() {
 				})
 			})
 		})
+
+		DescribeTable("UpgradeAvailable",
+			func(versionFromPlan, versionFromServiceInstance, expectedResult string) {
+				summary.MaintenanceInfo.Version = versionFromServiceInstance
+				summary.ServicePlan.MaintenanceInfo.Version = versionFromPlan
+				Expect(summary.UpgradeAvailable()).To(Equal(expectedResult))
+			},
+			Entry("values are the same", "2.0.0", "2.0.0", "no"),
+			Entry("values are different", "3.0.0", "2.0.0", "yes"),
+			Entry("values are both empty", "", "", ""),
+			Entry("plan has value but instance does not", "1.0.0", "", "yes"),
+			Entry("instance has value but plan does not", "", "1.0.0", ""),
+		)
 	})
 
 	Describe("GetServiceInstanceSummaryByNameAndSpace", func() {
@@ -895,9 +909,15 @@ var _ = Describe("Service Instance Summary Actions", func() {
 						ServiceInstances: []ccv2.SpaceSummaryServiceInstance{
 							{
 								Name: "managed-service-instance",
+								MaintenanceInfo: ccv2.MaintenanceInfo{
+									Version: "2.0.0",
+								},
 								ServicePlan: ccv2.SpaceSummaryServicePlan{
 									GUID: "plan-guid",
 									Name: "simple-plan",
+									MaintenanceInfo: ccv2.MaintenanceInfo{
+										Version: "3.0.0",
+									},
 									Service: ccv2.SpaceSummaryService{
 										GUID:              "service-guid-1",
 										Label:             "service-label",
@@ -933,9 +953,15 @@ var _ = Describe("Service Instance Summary Actions", func() {
 								State:       "succeeded",
 								Description: "a description",
 							},
+							MaintenanceInfo: ccv2.MaintenanceInfo{
+								Version: "2.0.0",
+							},
 						},
 						ServicePlan: ServicePlan{
 							Name: "simple-plan",
+							MaintenanceInfo: ccv2.MaintenanceInfo{
+								Version: "3.0.0",
+							},
 						},
 						Service: Service{
 							Label:             "service-label",

--- a/api/cloudcontroller/ccv2/service_instance.go
+++ b/api/cloudcontroller/ccv2/service_instance.go
@@ -48,6 +48,9 @@ type ServiceInstance struct {
 	// LastOperation is the status of the last operation requested on the service
 	// instance.
 	LastOperation LastOperation
+
+	// MaintenanceInfo is the maintenance version of this service instance
+	MaintenanceInfo MaintenanceInfo
 }
 
 // Managed returns true if the Service Instance is a managed service.
@@ -60,15 +63,16 @@ func (serviceInstance *ServiceInstance) UnmarshalJSON(data []byte) error {
 	var ccServiceInstance struct {
 		Metadata internal.Metadata
 		Entity   struct {
-			Name            string        `json:"name"`
-			SpaceGUID       string        `json:"space_guid"`
-			ServiceGUID     string        `json:"service_guid"`
-			ServicePlanGUID string        `json:"service_plan_guid"`
-			Type            string        `json:"type"`
-			Tags            []string      `json:"tags"`
-			DashboardURL    string        `json:"dashboard_url"`
-			RouteServiceURL string        `json:"route_service_url"`
-			LastOperation   LastOperation `json:"last_operation"`
+			Name            string          `json:"name"`
+			SpaceGUID       string          `json:"space_guid"`
+			ServiceGUID     string          `json:"service_guid"`
+			ServicePlanGUID string          `json:"service_plan_guid"`
+			Type            string          `json:"type"`
+			Tags            []string        `json:"tags"`
+			DashboardURL    string          `json:"dashboard_url"`
+			RouteServiceURL string          `json:"route_service_url"`
+			LastOperation   LastOperation   `json:"last_operation"`
+			MaintenanceInfo MaintenanceInfo `json:"maintenance_info"`
 		}
 	}
 	err := cloudcontroller.DecodeJSON(data, &ccServiceInstance)
@@ -86,6 +90,7 @@ func (serviceInstance *ServiceInstance) UnmarshalJSON(data []byte) error {
 	serviceInstance.DashboardURL = ccServiceInstance.Entity.DashboardURL
 	serviceInstance.RouteServiceURL = ccServiceInstance.Entity.RouteServiceURL
 	serviceInstance.LastOperation = ccServiceInstance.Entity.LastOperation
+	serviceInstance.MaintenanceInfo = ccServiceInstance.Entity.MaintenanceInfo
 	return nil
 }
 

--- a/api/cloudcontroller/ccv2/service_instance_test.go
+++ b/api/cloudcontroller/ccv2/service_instance_test.go
@@ -250,7 +250,8 @@ var _ = Describe("Service Instance", func() {
 						"description": "service broker-provided description",
 						"updated_at": "updated-at-time",
 						"created_at": "created-at-time"
-					}
+					},
+					"maintenance_info": { "version": "2.0.0" }
 				}
 			}`
 
@@ -284,6 +285,7 @@ var _ = Describe("Service Instance", func() {
 						UpdatedAt:   "updated-at-time",
 						CreatedAt:   "created-at-time",
 					},
+					MaintenanceInfo: MaintenanceInfo{Version: "2.0.0"},
 				}))
 				Expect(warnings).To(ConsistOf(Warnings{"this is a warning"}))
 			})

--- a/api/cloudcontroller/ccv2/space_summary.go
+++ b/api/cloudcontroller/ccv2/space_summary.go
@@ -20,16 +20,18 @@ type SpaceSummaryService struct {
 
 // SpaceSummaryServicePlan represents a service plan inside a space
 type SpaceSummaryServicePlan struct {
-	GUID    string              `json:"guid"`
-	Name    string              `json:"name"`
-	Service SpaceSummaryService `json:"service"`
+	GUID            string              `json:"guid"`
+	Name            string              `json:"name"`
+	Service         SpaceSummaryService `json:"service"`
+	MaintenanceInfo MaintenanceInfo     `json:"maintenance_info"`
 }
 
 // SpaceSummaryServiceInstance represents a service instance inside a space
 type SpaceSummaryServiceInstance struct {
-	LastOperation LastOperation           `json:"last_operation"`
-	Name          string                  `json:"name"`
-	ServicePlan   SpaceSummaryServicePlan `json:"service_plan"`
+	LastOperation   LastOperation           `json:"last_operation"`
+	Name            string                  `json:"name"`
+	ServicePlan     SpaceSummaryServicePlan `json:"service_plan"`
+	MaintenanceInfo MaintenanceInfo         `json:"maintenance_info"`
 }
 
 // SpaceSummary represents a service instance inside a space

--- a/api/cloudcontroller/ccv2/space_summary_test.go
+++ b/api/cloudcontroller/ccv2/space_summary_test.go
@@ -50,9 +50,15 @@ var _ = Describe("SpaceSummary", func() {
 									"updated_at": "some time",
 									"created_at": "some time"
 							 },
+							 "maintenance_info": {
+							   "version": "2.0.0"
+						   },
 							 "service_plan": {
 									"guid": "plan-guid",
 									"name": "simple-plan",
+									"maintenance_info": {
+									  "version": "3.0.0"
+									},
 									"service": {
 										 "guid": "service-guid",
 										 "label": "service-label"
@@ -82,9 +88,15 @@ var _ = Describe("SpaceSummary", func() {
 					ServiceInstances: []SpaceSummaryServiceInstance{
 						{
 							Name: "service-instance-name",
+							MaintenanceInfo: MaintenanceInfo{
+								Version: "2.0.0",
+							},
 							ServicePlan: SpaceSummaryServicePlan{
 								GUID: "plan-guid",
 								Name: "simple-plan",
+								MaintenanceInfo: MaintenanceInfo{
+									Version: "3.0.0",
+								},
 								Service: SpaceSummaryService{
 									GUID:  "service-guid",
 									Label: "service-label",

--- a/api/cloudcontroller/ccversion/minimum_version.go
+++ b/api/cloudcontroller/ccversion/minimum_version.go
@@ -12,6 +12,7 @@ const (
 	MinVersionMultiServiceRegistrationV2             = "2.125.0"
 	MinVersionUpdateServiceNameWhenPlanNotVisibleV2  = "2.131.0"
 	MinVersionUpdateServiceInstanceMaintenanceInfoV2 = "2.135.0"
+	MinVersionMaintenanceInfoInSummaryV2             = "2.137.0"
 
 	MinVersionShareServiceV3     = "3.36.0"
 	MinVersionZeroDowntimePushV3 = "3.57.0"

--- a/command/v6/services_command.go
+++ b/command/v6/services_command.go
@@ -81,6 +81,7 @@ func (cmd ServicesCommand) Execute(args []string) error {
 		cmd.UI.TranslateText("bound apps"),
 		cmd.UI.TranslateText("last operation"),
 		cmd.UI.TranslateText("broker"),
+		cmd.UI.TranslateText("upgrade available"),
 	}}
 
 	var boundAppNames []string
@@ -96,13 +97,17 @@ func (cmd ServicesCommand) Execute(args []string) error {
 			boundAppNames = append(boundAppNames, boundApplication.AppName)
 		}
 
-		table = append(table, []string{
-			summary.Name,
-			serviceLabel,
-			summary.ServicePlan.Name,
-			strings.Join(boundAppNames, ", "),
-			fmt.Sprintf("%s %s", summary.LastOperation.Type, summary.LastOperation.State),
-			summary.Service.ServiceBrokerName},
+		table = append(
+			table,
+			[]string{
+				summary.Name,
+				serviceLabel,
+				summary.ServicePlan.Name,
+				strings.Join(boundAppNames, ", "),
+				fmt.Sprintf("%s %s", summary.LastOperation.Type, summary.LastOperation.State),
+				summary.Service.ServiceBrokerName,
+				summary.UpgradeAvailable(),
+			},
 		)
 	}
 	cmd.UI.DisplayTableWithHeader("", table, 3)

--- a/command/v6/services_command_test.go
+++ b/command/v6/services_command_test.go
@@ -138,8 +138,16 @@ var _ = Describe("services Command", func() {
 										State: "some-state",
 									},
 									Type: constant.ManagedService,
+									MaintenanceInfo: ccv2.MaintenanceInfo{
+										Version: "2.0.0",
+									},
 								},
-								ServicePlan: v2action.ServicePlan{Name: "some-plan"},
+								ServicePlan: v2action.ServicePlan{
+									Name: "some-plan",
+									MaintenanceInfo: ccv2.MaintenanceInfo{
+										Version: "3.0.0",
+									},
+								},
 								Service: v2action.Service{
 									Label:             "some-service-1",
 									ServiceBrokerName: "broker-1",
@@ -159,6 +167,15 @@ var _ = Describe("services Command", func() {
 								ServiceInstance: v2action.ServiceInstance{
 									Name: "instance-2",
 									Type: constant.ManagedService,
+									MaintenanceInfo: ccv2.MaintenanceInfo{
+										Version: "2.0.0",
+									},
+								},
+								ServicePlan: v2action.ServicePlan{
+									Name: "some-plan",
+									MaintenanceInfo: ccv2.MaintenanceInfo{
+										Version: "2.0.0",
+									},
 								},
 								Service: v2action.Service{
 									Label:             "some-service-2",
@@ -171,14 +188,13 @@ var _ = Describe("services Command", func() {
 					)
 				})
 
-				It("displays all the services and apps in alphanumeric sorted order together with the org & space & warnings", func() {
+				It("displays all the services and apps in alphanumeric sorted order together with the org & space & warnings & upgrades", func() {
 					Expect(executeErr).ToNot(HaveOccurred())
-					Expect(testUI.Out).To(Say("Getting services in org %s / space %s as %s...", "some-org",
-						"some-space", fakeUser.Name))
-					Expect(testUI.Out).To(Say(`name\s+service\s+plan\s+bound apps\s+last operation\s+broker`))
-					Expect(testUI.Out).To(Say(`instance-1\s+some-service-1\s+some-plan\s+app-1, app-2\s+some-type some-state\s+broker-1`))
-					Expect(testUI.Out).To(Say(`instance-2\s+some-service-2\s+broker-2`))
-					Expect(testUI.Out).To(Say(`instance-3\s+user-provided\s+`))
+					Expect(testUI.Out).To(Say("Getting services in org %s / space %s as %s...", "some-org", "some-space", fakeUser.Name))
+					Expect(testUI.Out).To(Say(`name\s+service\s+plan\s+bound apps\s+last operation\s+broker\s+upgrade available`))
+					Expect(testUI.Out).To(Say(`instance-1\s+some-service-1\s+some-plan\s+app-1, app-2\s+some-type some-state\s+broker-1\s+yes`))
+					Expect(testUI.Out).To(Say(`instance-2\s+some-service-2\s+some-plan\s+broker-2\s+no`))
+					Expect(testUI.Out).To(Say(`instance-3\s+user-provided\s+$`))
 					Expect(testUI.Err).To(Say("get-summary-warnings"))
 				})
 			})

--- a/integration/assets/service_broker/broker_config.json
+++ b/integration/assets/service_broker/broker_config.json
@@ -59,7 +59,7 @@
                 },
                 "schemas": "<fake-plan-schema>",
                 "maintenance_info" : {
-                  "version": "1.2.3"
+                  "version": "<fake-maintenance-info-version>"
                 }
               },
               {

--- a/integration/helpers/service_broker.go
+++ b/integration/helpers/service_broker.go
@@ -59,8 +59,9 @@ type ServiceBroker struct {
 			RedirectUri string `json:"redirect_uri"`
 		}
 	}
-	SyncPlans  []Plan
-	AsyncPlans []Plan
+	SyncPlans              []Plan
+	AsyncPlans             []Plan
+	MaintenanceInfoVersion string
 }
 
 // NewServiceBroker constructs a new ServiceBroker with given attributes. planName will be used
@@ -86,6 +87,7 @@ func NewServiceBroker(name string, path string, appsDomain string, serviceName s
 	b.Service.DashboardClient.ID = RandomName()
 	b.Service.DashboardClient.Secret = RandomName()
 	b.Service.DashboardClient.RedirectUri = RandomName()
+	b.MaintenanceInfoVersion = "1.2.3"
 	return b
 }
 
@@ -112,6 +114,7 @@ func NewAsynchServiceBroker(name string, path string, appsDomain string, service
 	b.Service.DashboardClient.ID = RandomName()
 	b.Service.DashboardClient.Secret = RandomName()
 	b.Service.DashboardClient.RedirectUri = RandomName()
+	b.MaintenanceInfoVersion = "1.2.3"
 	return b
 }
 
@@ -146,6 +149,12 @@ func (b ServiceBroker) Configure(shareable bool) {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(resp.StatusCode).To(Equal(http.StatusOK))
 	defer resp.Body.Close()
+}
+
+func (b ServiceBroker) UpdateMaintenanceInfo(version string) {
+	b.MaintenanceInfoVersion = version
+	b.Configure(true)
+	b.Update()
 }
 
 // Create creates a service broker with 'cf create-service-broker' and asserts that it exists.
@@ -204,6 +213,7 @@ func (b ServiceBroker) ToJSON(shareable bool) string {
 		"\"<shareable-service>\"", fmt.Sprintf("%t", shareable),
 		"\"<bindable>\"", fmt.Sprintf("%t", b.Service.Bindable),
 		"\"<requires>\"", b.Service.Requires,
+		"<fake-maintenance-info-version>", b.MaintenanceInfoVersion,
 	)
 
 	return replacer.Replace(string(bytes))


### PR DESCRIPTION
Adds a new column `upgrade available` with `yes`, `no` or ` ` (blank) values to the output of `cf services` command, indicating whether the service instance can be upgraded to a new version of plan/maintenance_info.

```
→ ./cf services
Getting services in org acceptance / space dev as admin...

name   service            plan    bound apps   last operation     broker            upgrade available
s1     overview-service   small                create succeeded   overview-broker   yes
```

More info [here](https://www.pivotaltracker.com/story/show/164497483)