### PR TITLE
fixed docstrings for HealthChecks

### DIFF
--- a/util/manifest/application.go
+++ b/util/manifest/application.go
@@ -21,9 +21,11 @@ type Application struct {
 	// guaranteed, although CLI only ships strings).
 	EnvironmentVariables    map[string]string
 	HealthCheckHTTPEndpoint string
-	HealthCheckTimeout      uint64
-	// HealthCheckType attribute defines the number of seconds that is allocated
+	// HealthCheckTimeout attribute defines the number of seconds that is allocated
 	// for starting an application.
+	HealthCheckTimeout uint64
+	// HealthCheckType specifies the mechanism used to determine if the application
+	// is healthy (e.g. a port being open, or an HTTP status).
 	HealthCheckType string
 	Hostname        string
 	Instances       types.NullInt


### PR DESCRIPTION
## Does this PR modify CLI v6 or v7?

Non functional change.

## Description of the Change

HealthCheckType had an incorrect docstring meant to describe the field above it. It wasn't clear which field the author originally meant to document so I moved the existing one to the correct field and added a new one on the field they had actually documented.

## Why Is This PR Valuable?

No major user-visible changes, however the fields will be documented for future developers.

## Why Should This Be In Core?

N/A

## Applicable Issues

N/A

## How Urgent Is The Change?

Non-urgent.

## Other Relevant Parties

Anyone generating godoc from this source code for offline consumption.