### PR TITLE
Show the maintenance description in `cf service` output

### DIFF
--- a/actor/v2action/service_instance_summary.go
+++ b/actor/v2action/service_instance_summary.go
@@ -49,14 +49,13 @@ func (s ServiceInstanceSummary) IsSharedTo() bool {
 	return s.ServiceInstanceShareType == ServiceInstanceIsSharedTo
 }
 
-func (s ServiceInstanceSummary) UpgradeAvailable() string {
-	if s.ServicePlan.MaintenanceInfo.Version == "" {
-		return ""
-	}
-	if s.ServicePlan.MaintenanceInfo.Version == s.ServiceInstance.MaintenanceInfo.Version {
-		return "no"
-	}
-	return "yes"
+func (s ServiceInstanceSummary) UpgradeSupported() bool {
+	return s.ServicePlan.MaintenanceInfo.Version != ""
+}
+
+func (s ServiceInstanceSummary) UpgradeAvailable() bool {
+	return s.UpgradeSupported() &&
+		s.ServicePlan.MaintenanceInfo.Version != s.ServiceInstance.MaintenanceInfo.Version
 }
 
 type BoundApplication struct {

--- a/actor/v2action/service_instance_summary_test.go
+++ b/actor/v2action/service_instance_summary_test.go
@@ -83,16 +83,25 @@ var _ = Describe("Service Instance Summary Actions", func() {
 		})
 
 		DescribeTable("UpgradeAvailable",
-			func(versionFromPlan, versionFromServiceInstance, expectedResult string) {
+			func(versionFromPlan, versionFromServiceInstance string, expectedResult bool) {
 				summary.MaintenanceInfo.Version = versionFromServiceInstance
 				summary.ServicePlan.MaintenanceInfo.Version = versionFromPlan
 				Expect(summary.UpgradeAvailable()).To(Equal(expectedResult))
 			},
-			Entry("values are the same", "2.0.0", "2.0.0", "no"),
-			Entry("values are different", "3.0.0", "2.0.0", "yes"),
-			Entry("values are both empty", "", "", ""),
-			Entry("plan has value but instance does not", "1.0.0", "", "yes"),
-			Entry("instance has value but plan does not", "", "1.0.0", ""),
+			Entry("values are the same", "2.0.0", "2.0.0", false),
+			Entry("values are different", "3.0.0", "2.0.0", true),
+			Entry("values are both empty", "", "", false),
+			Entry("plan has value but instance does not", "1.0.0", "", true),
+			Entry("instance has value but plan does not", "", "1.0.0", false),
+		)
+
+		DescribeTable("UpgradeSupported",
+			func(versionFromPlan string, expectedResult bool) {
+				summary.ServicePlan.MaintenanceInfo.Version = versionFromPlan
+				Expect(summary.UpgradeSupported()).To(Equal(expectedResult))
+			},
+			Entry("plan has value", "1.0.0", true),
+			Entry("plan does not have value", "", false),
 		)
 	})
 

--- a/api/cloudcontroller/ccv2/service_instance.go
+++ b/api/cloudcontroller/ccv2/service_instance.go
@@ -253,7 +253,8 @@ func (client *Client) GetUserProvidedServiceInstances(filters ...Filter) ([]Serv
 }
 
 type MaintenanceInfo struct {
-	Version string `json:"version"`
+	Version     string `json:"version"`
+	Description string `json:"description,omitempty"`
 }
 
 type updateServiceInstanceRequestBody struct {

--- a/api/cloudcontroller/ccv2/service_plan_test.go
+++ b/api/cloudcontroller/ccv2/service_plan_test.go
@@ -32,7 +32,8 @@ var _ = Describe("Service Plan", func() {
 						"description": "some-description",
 						"free": true,
 						"maintenance_info": {
-						  "version": "1.2.3"
+              "version": "1.2.3",
+              "description": "fake description for maintenance info"
 						}
 					}
 				}`
@@ -57,7 +58,8 @@ var _ = Describe("Service Plan", func() {
 					Description: "some-description",
 					Free:        true,
 					MaintenanceInfo: MaintenanceInfo{
-						Version: "1.2.3",
+						Version:     "1.2.3",
+						Description: "fake description for maintenance info",
 					},
 				}))
 				Expect(warnings).To(ConsistOf(Warnings{"this is a warning"}))

--- a/api/cloudcontroller/ccversion/minimum_version.go
+++ b/api/cloudcontroller/ccversion/minimum_version.go
@@ -12,7 +12,7 @@ const (
 	MinVersionMultiServiceRegistrationV2             = "2.125.0"
 	MinVersionUpdateServiceNameWhenPlanNotVisibleV2  = "2.131.0"
 	MinVersionUpdateServiceInstanceMaintenanceInfoV2 = "2.135.0"
-	MinVersionMaintenanceInfoInSummaryV2             = "2.137.0"
+	MinVersionMaintenanceInfoInSummaryV2             = "2.138.0"
 
 	MinVersionShareServiceV3     = "3.36.0"
 	MinVersionZeroDowntimePushV3 = "3.57.0"

--- a/command/api_version_warning.go
+++ b/command/api_version_warning.go
@@ -16,7 +16,7 @@ func WarnIfCLIVersionBelowAPIDefinedMinimum(config Config, apiVersion string, ui
 	minVer := config.MinCLIVersion()
 	currentVer := config.BinaryVersion()
 
-	isOutdated, err := checkVersionOutdated(currentVer, minVer)
+	isOutdated, err := CheckVersionOutdated(currentVer, minVer)
 	if err != nil {
 		return err
 	}
@@ -35,7 +35,7 @@ func WarnIfCLIVersionBelowAPIDefinedMinimum(config Config, apiVersion string, ui
 }
 
 func WarnIfAPIVersionBelowSupportedMinimum(apiVersion string, ui UI) error {
-	isOutdated, err := checkVersionOutdated(apiVersion, ccversion.MinSupportedV2ClientVersion)
+	isOutdated, err := CheckVersionOutdated(apiVersion, ccversion.MinSupportedV2ClientVersion)
 	if err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func checkVersionNewerThan(current, maximum string) (bool, error) {
 	return false, nil
 }
 
-func checkVersionOutdated(current string, minimum string) (bool, error) {
+func CheckVersionOutdated(current string, minimum string) (bool, error) {
 	if current == version.DefaultVersion || minimum == "" {
 		return false, nil
 	}

--- a/command/minimum_version_check.go
+++ b/command/minimum_version_check.go
@@ -12,7 +12,7 @@ func MinimumCCAPIVersionCheck(current string, minimum string, customCommand ...s
 		command = customCommand[0]
 	}
 
-	isOutdated, err := checkVersionOutdated(current, minimum)
+	isOutdated, err := CheckVersionOutdated(current, minimum)
 	if err != nil {
 		return err
 	}
@@ -36,7 +36,7 @@ func MinimumUAAAPIVersionCheck(current string, minimum string, customCommand ...
 		command = customCommand[0]
 	}
 
-	isOutdated, err := checkVersionOutdated(current, minimum)
+	isOutdated, err := CheckVersionOutdated(current, minimum)
 	if err != nil {
 		return err
 	}

--- a/command/v6/service_command.go
+++ b/command/v6/service_command.go
@@ -245,7 +245,7 @@ func (cmd ServiceCommand) displayUpgradeInformation(serviceInstanceSummary v2act
 		return
 	}
 
-	cmd.UI.DisplayText("Showing available upgrade details for this service....")
+	cmd.UI.DisplayText("Showing available upgrade details for this service...")
 	cmd.UI.DisplayNewline()
 	cmd.UI.DisplayText("upgrade description: {{.Description}}", map[string]interface{}{
 		"Description": serviceInstanceSummary.ServicePlan.MaintenanceInfo.Description,

--- a/command/v6/service_command.go
+++ b/command/v6/service_command.go
@@ -93,6 +93,7 @@ func (cmd ServiceCommand) displayServiceInstanceSummary() error {
 		cmd.displayManagedServiceInstanceSummary(serviceInstanceSummary)
 		cmd.displayManagedServiceInstanceLastOperation(serviceInstanceSummary)
 		cmd.displayBoundApplicationsIfExists(serviceInstanceSummary)
+		cmd.displayUpgradeInformation(serviceInstanceSummary)
 		return nil
 	}
 
@@ -218,4 +219,28 @@ func (cmd ServiceCommand) displayBoundApplicationsIfExists(serviceInstanceSummar
 	}
 
 	cmd.UI.DisplayTableWithHeader("", boundAppsTable, 3)
+}
+
+func (cmd ServiceCommand) displayUpgradeInformation(serviceInstanceSummary v2action.ServiceInstanceSummary) {
+	cmd.UI.DisplayNewline()
+
+	if !serviceInstanceSummary.UpgradeSupported() {
+		cmd.UI.DisplayText("Upgrades are not supported by this broker.")
+		return
+	}
+
+	if !serviceInstanceSummary.UpgradeAvailable() {
+		cmd.UI.DisplayText("There is no upgrade available for this service.")
+		return
+	}
+
+	cmd.UI.DisplayText("Showing available upgrade details for this service....")
+	cmd.UI.DisplayNewline()
+	cmd.UI.DisplayText("upgrade description: {{.Description}}", map[string]interface{}{
+		"Description": serviceInstanceSummary.ServicePlan.MaintenanceInfo.Description,
+	})
+	cmd.UI.DisplayNewline()
+	cmd.UI.DisplayText("TIP: You can upgrade using 'cf update-service {{.InstanceName}} --upgrade'", map[string]interface{}{
+		"InstanceName": serviceInstanceSummary.Name,
+	})
 }

--- a/command/v6/service_command_test.go
+++ b/command/v6/service_command_test.go
@@ -773,7 +773,7 @@ var _ = Describe("service Command", func() {
 								Expect(testUI.Out).To(Say("There are no bound apps for this service."))
 
 								Expect(testUI.Out).To(Say("\n\n"), "Expect an empty line between 'bound apps' and 'upgrade available' messages")
-								Expect(testUI.Out).To(Say("Showing available upgrade details for this service...."))
+								Expect(testUI.Out).To(Say("Showing available upgrade details for this service..."))
 								Expect(testUI.Out).To(Say("\n\n"), "Expect an empty line between messages")
 								Expect(testUI.Out).To(Say("upgrade description: This is the maintenance description"))
 								Expect(testUI.Out).To(Say("\n\n"), "Expect an empty line before tips")
@@ -792,7 +792,7 @@ var _ = Describe("service Command", func() {
 							It("should not output anything about upgrades", func() {
 								Consistently(testUI.Out).ShouldNot(Say("There is no upgrade available for this service."))
 								Consistently(testUI.Out).ShouldNot(Say("Upgrades are not supported by this broker."))
-								Consistently(testUI.Out).ShouldNot(Say("Showing available upgrade details for this service...."))
+								Consistently(testUI.Out).ShouldNot(Say("Showing available upgrade details for this service..."))
 								Consistently(testUI.Out).ShouldNot(Say("upgrade description: This is the maintenance description"))
 								Consistently(testUI.Out).ShouldNot(Say("TIP: You can upgrade using 'cf update-service some-service-instance --upgrade'"))
 							})

--- a/command/v6/services_command.go
+++ b/command/v6/services_command.go
@@ -106,7 +106,7 @@ func (cmd ServicesCommand) Execute(args []string) error {
 				strings.Join(boundAppNames, ", "),
 				fmt.Sprintf("%s %s", summary.LastOperation.Type, summary.LastOperation.State),
 				summary.Service.ServiceBrokerName,
-				summary.UpgradeAvailable(),
+				upgradeAvailableSummary(summary),
 			},
 		)
 	}
@@ -131,4 +131,14 @@ func sortBoundApps(serviceInstance v2action.ServiceInstanceSummary) {
 		func(i, j int) bool {
 			return sorting.LessIgnoreCase(serviceInstance.BoundApplications[i].AppName, serviceInstance.BoundApplications[j].AppName)
 		})
+}
+
+func upgradeAvailableSummary(s v2action.ServiceInstanceSummary) string {
+	if s.UpgradeSupported() {
+		if s.UpgradeAvailable() {
+			return "yes"
+		}
+		return "no"
+	}
+	return ""
 }

--- a/command/v6/services_command_test.go
+++ b/command/v6/services_command_test.go
@@ -7,6 +7,7 @@ import (
 	"code.cloudfoundry.org/cli/actor/v2action"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv2"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv2/constant"
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccversion"
 	"code.cloudfoundry.org/cli/command/commandfakes"
 	. "code.cloudfoundry.org/cli/command/v6"
 	"code.cloudfoundry.org/cli/command/v6/v6fakes"
@@ -43,6 +44,8 @@ var _ = Describe("services Command", func() {
 
 		binaryName = "faceman"
 		fakeConfig.BinaryNameReturns(binaryName)
+
+		fakeActor.CloudControllerAPIVersionReturns(ccversion.MinVersionMaintenanceInfoInSummaryV2)
 	})
 
 	JustBeforeEach(func() {
@@ -196,6 +199,16 @@ var _ = Describe("services Command", func() {
 					Expect(testUI.Out).To(Say(`instance-2\s+some-service-2\s+some-plan\s+broker-2\s+no`))
 					Expect(testUI.Out).To(Say(`instance-3\s+user-provided\s+$`))
 					Expect(testUI.Err).To(Say("get-summary-warnings"))
+				})
+
+				When("CC version is too old to show upgrade information", func() {
+					BeforeEach(func() {
+						fakeActor.CloudControllerAPIVersionReturns(ccversion.MinSupportedV2ClientVersion)
+					})
+
+					It("shows a tip with a minimum service upgrade version required", func() {
+						Expect(testUI.Out).To(Say("TIP: Please upgrade to CC API v%s or higher for individual service upgrades", ccversion.MinVersionMaintenanceInfoInSummaryV2))
+					})
 				})
 			})
 		})

--- a/command/v6/v6fakes/fake_service_actor.go
+++ b/command/v6/v6fakes/fake_service_actor.go
@@ -2,13 +2,23 @@
 package v6fakes
 
 import (
-	"sync"
+	sync "sync"
 
-	"code.cloudfoundry.org/cli/actor/v2action"
+	v2action "code.cloudfoundry.org/cli/actor/v2action"
 	v6 "code.cloudfoundry.org/cli/command/v6"
 )
 
 type FakeServiceActor struct {
+	CloudControllerAPIVersionStub        func() string
+	cloudControllerAPIVersionMutex       sync.RWMutex
+	cloudControllerAPIVersionArgsForCall []struct {
+	}
+	cloudControllerAPIVersionReturns struct {
+		result1 string
+	}
+	cloudControllerAPIVersionReturnsOnCall map[int]struct {
+		result1 string
+	}
 	GetServiceInstanceByNameAndSpaceStub        func(string, string) (v2action.ServiceInstance, v2action.Warnings, error)
 	getServiceInstanceByNameAndSpaceMutex       sync.RWMutex
 	getServiceInstanceByNameAndSpaceArgsForCall []struct {
@@ -43,6 +53,58 @@ type FakeServiceActor struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeServiceActor) CloudControllerAPIVersion() string {
+	fake.cloudControllerAPIVersionMutex.Lock()
+	ret, specificReturn := fake.cloudControllerAPIVersionReturnsOnCall[len(fake.cloudControllerAPIVersionArgsForCall)]
+	fake.cloudControllerAPIVersionArgsForCall = append(fake.cloudControllerAPIVersionArgsForCall, struct {
+	}{})
+	fake.recordInvocation("CloudControllerAPIVersion", []interface{}{})
+	fake.cloudControllerAPIVersionMutex.Unlock()
+	if fake.CloudControllerAPIVersionStub != nil {
+		return fake.CloudControllerAPIVersionStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.cloudControllerAPIVersionReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeServiceActor) CloudControllerAPIVersionCallCount() int {
+	fake.cloudControllerAPIVersionMutex.RLock()
+	defer fake.cloudControllerAPIVersionMutex.RUnlock()
+	return len(fake.cloudControllerAPIVersionArgsForCall)
+}
+
+func (fake *FakeServiceActor) CloudControllerAPIVersionCalls(stub func() string) {
+	fake.cloudControllerAPIVersionMutex.Lock()
+	defer fake.cloudControllerAPIVersionMutex.Unlock()
+	fake.CloudControllerAPIVersionStub = stub
+}
+
+func (fake *FakeServiceActor) CloudControllerAPIVersionReturns(result1 string) {
+	fake.cloudControllerAPIVersionMutex.Lock()
+	defer fake.cloudControllerAPIVersionMutex.Unlock()
+	fake.CloudControllerAPIVersionStub = nil
+	fake.cloudControllerAPIVersionReturns = struct {
+		result1 string
+	}{result1}
+}
+
+func (fake *FakeServiceActor) CloudControllerAPIVersionReturnsOnCall(i int, result1 string) {
+	fake.cloudControllerAPIVersionMutex.Lock()
+	defer fake.cloudControllerAPIVersionMutex.Unlock()
+	fake.CloudControllerAPIVersionStub = nil
+	if fake.cloudControllerAPIVersionReturnsOnCall == nil {
+		fake.cloudControllerAPIVersionReturnsOnCall = make(map[int]struct {
+			result1 string
+		})
+	}
+	fake.cloudControllerAPIVersionReturnsOnCall[i] = struct {
+		result1 string
+	}{result1}
 }
 
 func (fake *FakeServiceActor) GetServiceInstanceByNameAndSpace(arg1 string, arg2 string) (v2action.ServiceInstance, v2action.Warnings, error) {
@@ -182,6 +244,8 @@ func (fake *FakeServiceActor) GetServiceInstanceSummaryByNameAndSpaceReturnsOnCa
 func (fake *FakeServiceActor) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.cloudControllerAPIVersionMutex.RLock()
+	defer fake.cloudControllerAPIVersionMutex.RUnlock()
 	fake.getServiceInstanceByNameAndSpaceMutex.RLock()
 	defer fake.getServiceInstanceByNameAndSpaceMutex.RUnlock()
 	fake.getServiceInstanceSummaryByNameAndSpaceMutex.RLock()

--- a/command/v6/v6fakes/fake_service_instances_actor.go
+++ b/command/v6/v6fakes/fake_service_instances_actor.go
@@ -2,13 +2,23 @@
 package v6fakes
 
 import (
-	"sync"
+	sync "sync"
 
-	"code.cloudfoundry.org/cli/actor/v2action"
+	v2action "code.cloudfoundry.org/cli/actor/v2action"
 	v6 "code.cloudfoundry.org/cli/command/v6"
 )
 
 type FakeServiceInstancesActor struct {
+	CloudControllerAPIVersionStub        func() string
+	cloudControllerAPIVersionMutex       sync.RWMutex
+	cloudControllerAPIVersionArgsForCall []struct {
+	}
+	cloudControllerAPIVersionReturns struct {
+		result1 string
+	}
+	cloudControllerAPIVersionReturnsOnCall map[int]struct {
+		result1 string
+	}
 	GetServiceInstancesSummaryBySpaceStub        func(string) ([]v2action.ServiceInstanceSummary, v2action.Warnings, error)
 	getServiceInstancesSummaryBySpaceMutex       sync.RWMutex
 	getServiceInstancesSummaryBySpaceArgsForCall []struct {
@@ -26,6 +36,58 @@ type FakeServiceInstancesActor struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeServiceInstancesActor) CloudControllerAPIVersion() string {
+	fake.cloudControllerAPIVersionMutex.Lock()
+	ret, specificReturn := fake.cloudControllerAPIVersionReturnsOnCall[len(fake.cloudControllerAPIVersionArgsForCall)]
+	fake.cloudControllerAPIVersionArgsForCall = append(fake.cloudControllerAPIVersionArgsForCall, struct {
+	}{})
+	fake.recordInvocation("CloudControllerAPIVersion", []interface{}{})
+	fake.cloudControllerAPIVersionMutex.Unlock()
+	if fake.CloudControllerAPIVersionStub != nil {
+		return fake.CloudControllerAPIVersionStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.cloudControllerAPIVersionReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeServiceInstancesActor) CloudControllerAPIVersionCallCount() int {
+	fake.cloudControllerAPIVersionMutex.RLock()
+	defer fake.cloudControllerAPIVersionMutex.RUnlock()
+	return len(fake.cloudControllerAPIVersionArgsForCall)
+}
+
+func (fake *FakeServiceInstancesActor) CloudControllerAPIVersionCalls(stub func() string) {
+	fake.cloudControllerAPIVersionMutex.Lock()
+	defer fake.cloudControllerAPIVersionMutex.Unlock()
+	fake.CloudControllerAPIVersionStub = stub
+}
+
+func (fake *FakeServiceInstancesActor) CloudControllerAPIVersionReturns(result1 string) {
+	fake.cloudControllerAPIVersionMutex.Lock()
+	defer fake.cloudControllerAPIVersionMutex.Unlock()
+	fake.CloudControllerAPIVersionStub = nil
+	fake.cloudControllerAPIVersionReturns = struct {
+		result1 string
+	}{result1}
+}
+
+func (fake *FakeServiceInstancesActor) CloudControllerAPIVersionReturnsOnCall(i int, result1 string) {
+	fake.cloudControllerAPIVersionMutex.Lock()
+	defer fake.cloudControllerAPIVersionMutex.Unlock()
+	fake.CloudControllerAPIVersionStub = nil
+	if fake.cloudControllerAPIVersionReturnsOnCall == nil {
+		fake.cloudControllerAPIVersionReturnsOnCall = make(map[int]struct {
+			result1 string
+		})
+	}
+	fake.cloudControllerAPIVersionReturnsOnCall[i] = struct {
+		result1 string
+	}{result1}
 }
 
 func (fake *FakeServiceInstancesActor) GetServiceInstancesSummaryBySpace(arg1 string) ([]v2action.ServiceInstanceSummary, v2action.Warnings, error) {
@@ -97,6 +159,8 @@ func (fake *FakeServiceInstancesActor) GetServiceInstancesSummaryBySpaceReturnsO
 func (fake *FakeServiceInstancesActor) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.cloudControllerAPIVersionMutex.RLock()
+	defer fake.cloudControllerAPIVersionMutex.RUnlock()
 	fake.getServiceInstancesSummaryBySpaceMutex.RLock()
 	defer fake.getServiceInstancesSummaryBySpaceMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/integration/helpers/fakeservicebroker/configuration.go
+++ b/integration/helpers/fakeservicebroker/configuration.go
@@ -108,8 +108,9 @@ type plan struct {
 	MaintenanceInfo *maintenanceInfo `json:"maintenance_info,omitempty"`
 }
 
-func (p *plan) SetMaintenanceInfoVersion(version string) {
+func (p *plan) SetMaintenanceInfo(version, description string) {
 	p.MaintenanceInfo.Version = version
+	p.MaintenanceInfo.Description = description
 }
 
 func (p *plan) RemoveMaintenanceInfo() {
@@ -117,7 +118,8 @@ func (p *plan) RemoveMaintenanceInfo() {
 }
 
 type maintenanceInfo struct {
-	Version string `json:"version"`
+	Version     string `json:"version"`
+	Description string `json:"description"`
 }
 
 type responseMock struct {

--- a/integration/helpers/fakeservicebroker/fakeservicebroker.go
+++ b/integration/helpers/fakeservicebroker/fakeservicebroker.go
@@ -44,7 +44,8 @@ func New() *FakeServiceBroker {
 						ID:          helpers.RandomName(),
 						Description: helpers.PrefixedRandomName("fake plan description"),
 						MaintenanceInfo: &maintenanceInfo{
-							Version: "2.0.0",
+							Version:     "2.0.0",
+							Description: "OS image update.\nExpect downtime.",
 						},
 					},
 					{
@@ -52,7 +53,8 @@ func New() *FakeServiceBroker {
 						ID:          helpers.RandomName(),
 						Description: helpers.PrefixedRandomName("fake plan description"),
 						MaintenanceInfo: &maintenanceInfo{
-							Version: "2.0.0",
+							Version:     "2.0.0",
+							Description: "OS image update.\nExpect downtime.",
 						},
 					},
 				},

--- a/integration/shared/isolated/service_command_test.go
+++ b/integration/shared/isolated/service_command_test.go
@@ -446,7 +446,7 @@ var _ = Describe("service command", func() {
 
 						session = helpers.CF("service", serviceInstanceName)
 						Eventually(session).Should(Say(`name:\s+%s`, serviceInstanceName))
-						Eventually(session).Should(Say("Showing available upgrade details for this service...."))
+						Eventually(session).Should(Say("Showing available upgrade details for this service..."))
 						Eventually(session).Should(Say("upgrade description: Stemcell update.\nExpect downtime."))
 						Eventually(session).Should(Say(`TIP: You can upgrade using 'cf update-service %s --upgrade'`, serviceInstanceName))
 					})

--- a/integration/shared/isolated/services_command_test.go
+++ b/integration/shared/isolated/services_command_test.go
@@ -175,7 +175,7 @@ var _ = Describe("services command", func() {
 
 			service = broker.ServiceName()
 			planWithMaintenanceInfo = broker.Services[0].Plans[0].Name
-			broker.Services[0].Plans[0].SetMaintenanceInfoVersion("1.2.3")
+			broker.Services[0].Plans[0].SetMaintenanceInfo("1.2.3", "")
 			planWithNoMaintenanceInfo = broker.Services[0].Plans[1].Name
 			broker.Services[0].Plans[1].RemoveMaintenanceInfo()
 
@@ -186,7 +186,7 @@ var _ = Describe("services command", func() {
 			Eventually(helpers.CF("create-service", service, planWithNoMaintenanceInfo, serviceInstanceWithNoMaintenanceInfo)).Should(Exit(0))
 			Eventually(helpers.CF("create-service", service, planWithMaintenanceInfo, serviceInstanceWithOldMaintenanceInfo)).Should(Exit(0))
 
-			broker.Services[0].Plans[0].SetMaintenanceInfoVersion("2.0.0")
+			broker.Services[0].Plans[0].SetMaintenanceInfo("2.0.0", "")
 			broker.Update()
 			Eventually(helpers.CF("create-service", service, planWithMaintenanceInfo, serviceInstanceWithNewMaintenanceInfo)).Should(Exit(0))
 


### PR DESCRIPTION
* If there is maintenance available, the description of that maintenance is shown in `cf service` output
* Don't show upgrade info in service command when not supported by CC (version not high enough)
* Show tip with min version for upgrade on `cf services` command 

Example output:
```
→ cf service s1
Showing info of service s1 in org acceptance / space dev as admin...

...

Showing available upgrade details for this service....

upgrade description: This is the maintenance description

TIP: You can upgrade using cf update-service s1 --upgrade
```

More info in the following stories:
[#166439959](https://www.pivotaltracker.com/story/show/166439959)
[#166470101](https://www.pivotaltracker.com/story/show/166470101)
[#166282598](https://www.pivotaltracker.com/story/show/166282598)