### PR TITLE
Reuse fake service brokers to improve test speed.

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -53,6 +53,7 @@ ginkgo -r -randomizeAllSpecs -slowSpecThreshold=120 integration/shared/global in
 - `CF_INT_CLIENT_ID` - the ID for the integration client credentials identity.
 - `CF_INT_CLIENT_SECRET` - the secret for the integration client credentials identity.
 - `CF_CLI_EXPERIMENTAL` - Will enable both experimental functionality of the CF CLI and tests for that functionality. Will default to `false` if not set.
+- `KEEP_FAKE_SERVICE_BROKERS` - If `true`, will not delete any deployed reusable fake service broker apps. Useful for local development: allows for faster test suite re-runs. Will default to `false` if not set.
 
 ### The test suite does not cleanup after itself!
 In order to focus on clean test code and performance of each test, we have decided to not cleanup after each test. However, in order to facilitate [clean up scripts](https://github.com/cloudfoundry/cli/blob/master/bin/cleanup-integration), we are trying to keep consistent naming across organizations, spaces, etc.

--- a/integration/helpers/config.go
+++ b/integration/helpers/config.go
@@ -44,11 +44,32 @@ func SetHomeDir() string {
 	homeDir, err := ioutil.TempDir("", "cli-integration-test")
 	Expect(err).NotTo(HaveOccurred())
 
-	Expect(os.Setenv("CF_HOME", homeDir)).To(Succeed())
-	Expect(os.Setenv("CF_PLUGIN_HOME", homeDir)).To(Succeed())
+	setHomeDirsTo(homeDir, homeDir)
 
 	GinkgoWriter.Write([]byte(fmt.Sprintln("\nHOME DIR>", homeDir)))
 	return homeDir
+}
+
+// WithRandomHomeDir sets CF_HOME and CF_PLUGIN_HOME to a temp directory and outputs
+// the created directory through GinkgoWriter. Then it executes the provided function
+// 'action'. Finally, it’s restoring the previous CF_HOME and CF_PLUGIN_HOME.
+func WithRandomHomeDir(action func()) {
+	oldHomeDir, oldPluginHomeDir := getHomeDirs()
+	homeDir := SetHomeDir()
+	action()
+	setHomeDirsTo(oldHomeDir, oldPluginHomeDir)
+	DestroyHomeDir(homeDir)
+}
+
+func getHomeDirs() (string, string) {
+	homeDir := os.Getenv("CF_HOME")
+	pluginHomeDir := os.Getenv("CF_PLUGIN_HOME")
+	return homeDir, pluginHomeDir
+}
+
+func setHomeDirsTo(homeDir string, pluginHomeDir string) {
+	Expect(os.Setenv("CF_HOME", homeDir)).To(Succeed())
+	Expect(os.Setenv("CF_PLUGIN_HOME", pluginHomeDir)).To(Succeed())
 }
 
 // SetupSynchronizedSuite runs a setup function in its own CF context, creating

--- a/integration/helpers/fakeservicebroker/deployment.go
+++ b/integration/helpers/fakeservicebroker/deployment.go
@@ -2,46 +2,69 @@ package fakeservicebroker
 
 import (
 	"code.cloudfoundry.org/cli/integration/helpers"
+	"fmt"
+	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gbytes"
 	. "github.com/onsi/gomega/gexec"
+	"net/http"
 )
 
 const (
+	itsOrg             = "fakeservicebroker"
+	itsSpace           = "integration"
 	defaultMemoryLimit = "256M"
 	defaultBrokerPath  = "../../assets/service_broker"
 )
 
-func (f *FakeServiceBroker) pushApp() {
-	if helpers.V7 {
-		// cf start on V7 currently does not stage the app before starting after a push --no-start
-		Eventually(helpers.CF(
-			"push", f.name,
-			"-p", defaultBrokerPath,
-			"-m", defaultMemoryLimit,
-			"--no-route",
-		)).Should(Exit(0))
-	} else {
-		Eventually(helpers.CF(
-			"push", f.name,
-			"--no-start",
-			"-m", defaultMemoryLimit,
-			"-p", defaultBrokerPath,
-			"--no-route",
-		)).Should(Exit(0))
+func (f *FakeServiceBroker) pushAppIfNecessary() {
+	if !f.reusable {
+		f.pushApp()
+		return
 	}
 
-	Eventually(helpers.CF(
-		"map-route",
-		f.name,
-		f.domain,
-		"--hostname", f.name,
-	)).Should(Exit(0))
+	if f.alreadyPushedApp() {
+		return
+	}
 
-	Eventually(helpers.CF("start", f.name)).Should(Exit(0))
+	f.pushReusableApp()
+}
+
+func (f *FakeServiceBroker) pushApp() {
+	Eventually(helpers.CF(
+		"push", f.name,
+		"-p", defaultBrokerPath,
+		"-m", defaultMemoryLimit,
+	)).Should(Exit(0))
+}
+
+func (f *FakeServiceBroker) pushReusableApp() {
+	helpers.CreateOrgAndSpaceUnlessExists(itsOrg, itsSpace)
+	helpers.WithRandomHomeDir(func() {
+		helpers.SetAPI()
+		helpers.LoginCF()
+		helpers.TargetOrgAndSpace(itsOrg, itsSpace)
+
+		f.pushApp()
+	})
+}
+
+func (f *FakeServiceBroker) alreadyPushedApp() bool {
+	resp, err := http.Get(f.URL("/config"))
+	Expect(err).ToNot(HaveOccurred())
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}
+
+func generateReusableBrokerName(suffix string) string {
+	return fmt.Sprintf("fake-service-broker-%s%02d", suffix, ginkgo.GinkgoParallelNode())
 }
 
 func (f *FakeServiceBroker) register() {
+	if f.reusable {
+		f.deregisterIgnoringFailures()
+	}
+
 	Eventually(helpers.CF("create-service-broker", f.name, "username", "password", f.URL())).Should(Exit(0))
 	Eventually(helpers.CF("service-brokers")).Should(And(Exit(0), Say(f.name)))
 }
@@ -51,7 +74,24 @@ func (f *FakeServiceBroker) update() {
 	Eventually(helpers.CF("service-brokers")).Should(And(Exit(0), Say(f.name)))
 }
 
+func (f *FakeServiceBroker) cleanup() {
+	f.deregisterIgnoringFailures()
+	f.deleteAppIgnoringFailures()
+}
+
 func (f *FakeServiceBroker) deleteApp() {
+	if f.reusable {
+		return
+	}
+
+	Eventually(helpers.CF("delete", f.name, "-f", "-r")).Should(Exit(0))
+}
+
+func (f *FakeServiceBroker) deleteAppIgnoringFailures() {
+	if f.reusable {
+		return
+	}
+
 	Eventually(helpers.CF("delete", f.name, "-f", "-r")).Should(Exit(0))
 }
 
@@ -59,4 +99,14 @@ func (f *FakeServiceBroker) deregister() {
 	Eventually(helpers.CF("purge-service-offering", f.ServiceName(), "-b", f.name, "-f")).Should(Exit(0))
 	Eventually(helpers.CF("delete-service-broker", f.name, "-f")).Should(Exit(0))
 	Eventually(helpers.CF("service-brokers")).Should(And(Exit(0), Not(Say(f.name))))
+}
+
+func (f *FakeServiceBroker) deregisterIgnoringFailures() {
+	Eventually(helpers.CF("purge-service-offering", f.ServiceName(), "-b", f.name, "-f")).Should(Exit())
+	Eventually(helpers.CF("delete-service-broker", f.name, "-f")).Should(Exit())
+}
+
+func (f *FakeServiceBroker) stopReusing() *FakeServiceBroker {
+	f.reusable = false
+	return f
 }

--- a/integration/shared/isolated/create_service_broker_command_test.go
+++ b/integration/shared/isolated/create_service_broker_command_test.go
@@ -71,7 +71,7 @@ var _ = Describe("create-service-broker command", func() {
 					orgName = helpers.NewOrgName()
 					spaceName = helpers.NewSpaceName()
 					helpers.SetupCF(orgName, spaceName)
-					broker = fakeservicebroker.New().Deploy()
+					broker = fakeservicebroker.New().WithName(brokerName).Deploy()
 					helpers.ClearTarget()
 				})
 
@@ -123,7 +123,7 @@ var _ = Describe("create-service-broker command", func() {
 						spaceName = helpers.NewSpaceName()
 						helpers.SetupCF(orgName, spaceName)
 
-						broker = fakeservicebroker.New().Deploy()
+						broker = fakeservicebroker.New().WithName(brokerName).Deploy()
 					})
 
 					AfterEach(func() {

--- a/integration/shared/isolated/create_service_command_test.go
+++ b/integration/shared/isolated/create_service_command_test.go
@@ -330,7 +330,7 @@ var _ = Describe("create-service command", func() {
 					broker1 = fakeservicebroker.New().Register()
 					service = broker1.ServiceName()
 					servicePlan = broker1.ServicePlanName()
-					broker2 = fakeservicebroker.New()
+					broker2 = fakeservicebroker.New().WithNameSuffix("other")
 					broker2.Services[0].Name = service
 					broker2.Services[0].Plans[0].Name = servicePlan
 					broker2.Register()

--- a/integration/shared/isolated/disable_service_access_command_test.go
+++ b/integration/shared/isolated/disable_service_access_command_test.go
@@ -239,7 +239,7 @@ var _ = Describe("disable service access command", func() {
 
 				BeforeEach(func() {
 					helpers.SkipIfVersionLessThan(ccversion.MinVersionMultiServiceRegistrationV2)
-					secondBroker = fakeservicebroker.New()
+					secondBroker = fakeservicebroker.New().WithNameSuffix("other")
 					secondBroker.Services[0].Name = broker.ServiceName()
 					secondBroker.Register()
 					Eventually(helpers.CF("enable-service-access", broker.ServiceName(), "-b", broker.Name())).Should(Exit(0))
@@ -284,7 +284,7 @@ var _ = Describe("disable service access command", func() {
 				helpers.SetupCF(orgName, spaceName)
 
 				broker1 = fakeservicebroker.New().Register()
-				broker2 = fakeservicebroker.New()
+				broker2 = fakeservicebroker.New().WithNameSuffix("other")
 				broker2.Services[0].Name = broker1.ServiceName()
 				broker2.Services[0].Plans[0].Name = broker1.ServicePlanName()
 				broker2.Register()

--- a/integration/shared/isolated/enable_service_access_command_test.go
+++ b/integration/shared/isolated/enable_service_access_command_test.go
@@ -213,7 +213,7 @@ var _ = Describe("enable service access command", func() {
 			When("two services with the same name are registered", func() {
 				BeforeEach(func() {
 					helpers.SkipIfVersionLessThan(ccversion.MinVersionMultiServiceRegistrationV2)
-					secondBroker = fakeservicebroker.New()
+					secondBroker = fakeservicebroker.New().WithNameSuffix("other")
 					secondBroker.Services[0].Name = service
 					secondBroker.Services[0].Plans[0].Name = servicePlan
 					secondBroker.Register()

--- a/integration/shared/isolated/isolated_suite_test.go
+++ b/integration/shared/isolated/isolated_suite_test.go
@@ -1,6 +1,7 @@
 package isolated
 
 import (
+	"code.cloudfoundry.org/cli/integration/helpers/fakeservicebroker"
 	"fmt"
 	"os"
 	"testing"
@@ -53,6 +54,9 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 			helpers.EnableFeatureFlag("service_instance_sharing")
 		}
 	})
+
+	fakeservicebroker.Setup()
+
 	GinkgoWriter.Write([]byte("==============================End of Global FIRST Node Synchronized Before Each=============================="))
 
 	return nil
@@ -74,6 +78,7 @@ var _ = SynchronizedAfterSuite(func() {
 	homeDir = helpers.SetHomeDir()
 	helpers.SetAPI()
 	helpers.LoginCF()
+	fakeservicebroker.Cleanup()
 	helpers.QuickDeleteOrg(ReadOnlyOrg)
 	helpers.DestroyHomeDir(homeDir)
 	GinkgoWriter.Write([]byte(fmt.Sprintf("==============================End of Global Node %d Synchronized After Each==============================", GinkgoParallelNode())))

--- a/integration/shared/isolated/marketplace_command_test.go
+++ b/integration/shared/isolated/marketplace_command_test.go
@@ -64,7 +64,7 @@ var _ = Describe("marketplace command", func() {
 
 						broker1 = fakeservicebroker.New().Register()
 						enableServiceAccess(broker1)
-						broker2 = fakeservicebroker.New().Register()
+						broker2 = fakeservicebroker.New().WithNameSuffix("other").Register()
 						enableServiceAccess(broker2)
 
 						helpers.LogoutCF()
@@ -135,7 +135,7 @@ var _ = Describe("marketplace command", func() {
 						helpers.CreateOrgAndSpace(org2, space2)
 						helpers.TargetOrgAndSpace(org2, space2)
 
-						broker2 = fakeservicebroker.New().Register()
+						broker2 = fakeservicebroker.New().WithNameSuffix("other").Register()
 						enableServiceAccess(broker2)
 					})
 

--- a/integration/shared/isolated/purge_service_offering_command_test.go
+++ b/integration/shared/isolated/purge_service_offering_command_test.go
@@ -248,7 +248,7 @@ var _ = Describe("purge-service-offering command", func() {
 						helpers.SetupCF(orgName, spaceName)
 
 						broker1 = fakeservicebroker.New().Register()
-						broker2 = fakeservicebroker.New()
+						broker2 = fakeservicebroker.New().WithNameSuffix("other")
 						broker2.Services[0].Name = broker1.ServiceName()
 						broker2.Register()
 

--- a/integration/shared/isolated/service_access_command_test.go
+++ b/integration/shared/isolated/service_access_command_test.go
@@ -145,7 +145,7 @@ var _ = Describe("service-access command", func() {
 				BeforeEach(func() {
 					helpers.SetupCF(orgName, spaceName)
 
-					otherBroker = fakeservicebroker.New().WithName(helpers.GenerateLowerName(helpers.NewServiceBrokerName, broker.Name()))
+					otherBroker = fakeservicebroker.New().WithNameSuffix("other")
 					otherBroker.Services[0].Plans[1].Name = helpers.GenerateLowerName(helpers.NewPlanName, otherBroker.Services[0].Plans[0].Name)
 					otherBroker.Register()
 
@@ -207,6 +207,12 @@ var _ = Describe("service-access command", func() {
 
 						By("displaying brokers that were enabled in the provided org")
 						session = helpers.CF("service-access", "-o", otherOrgName)
+						Eventually(session).Should(Say(`broker:\s+%s`, broker.Name()))
+						Eventually(session).Should(Say(`%s\s+%s\s+limited\s+%s`,
+							broker.Services[0].Name,
+							broker.Services[0].Plans[0].Name,
+							otherOrgName,
+						))
 						Eventually(session).Should(Say(`broker:\s+%s`, otherBroker.Name()))
 						Eventually(session).Should(Say(`%s\s+%s\s+all`,
 							otherBroker.Services[0].Name,
@@ -215,12 +221,6 @@ var _ = Describe("service-access command", func() {
 						Eventually(session).Should(Say(`%s\s+%s\s+all`,
 							otherBroker.Services[0].Name,
 							otherBroker.Services[0].Plans[0].Name,
-						))
-						Eventually(session).Should(Say(`broker:\s+%s`, broker.Name()))
-						Eventually(session).Should(Say(`%s\s+%s\s+limited\s+%s`,
-							broker.Services[0].Name,
-							broker.Services[0].Plans[0].Name,
-							otherOrgName,
 						))
 
 						Eventually(session).Should(Exit(0))

--- a/integration/v6/isolated/bind_route_service_command_test.go
+++ b/integration/v6/isolated/bind_route_service_command_test.go
@@ -53,6 +53,7 @@ var _ = Describe("bind-route-service command", func() {
 				domain              string
 				host                string
 				serviceInstanceName string
+				broker              *fakeservicebroker.FakeServiceBroker
 			)
 
 			BeforeEach(func() {
@@ -64,7 +65,7 @@ var _ = Describe("bind-route-service command", func() {
 				domain = helpers.DefaultSharedDomain()
 
 				serviceInstanceName = helpers.PrefixedRandomName("instance")
-				broker := fakeservicebroker.New()
+				broker = fakeservicebroker.New()
 				broker.Services[0].Requires = []string{"route_forwarding"}
 				broker.Register()
 
@@ -74,6 +75,7 @@ var _ = Describe("bind-route-service command", func() {
 			})
 
 			AfterEach(func() {
+				broker.Destroy()
 				helpers.QuickDeleteOrg(orgName)
 			})
 


### PR DESCRIPTION
This speeds up our service-related integration tests. Works both for isolated tests running in parallel and for global test suite.