### PR TITLE
Match timezone abbrs. with more than 3 chars in app_command_test

### DIFF
--- a/integration/v7/isolated/app_command_test.go
+++ b/integration/v7/isolated/app_command_test.go
@@ -116,7 +116,7 @@ applications:
 						Eventually(session).Should(Say(`name:\s+%s`, appName))
 						Eventually(session).Should(Say(`requested state:\s+started`))
 						Eventually(session).Should(Say(`routes:\s+%s\.%s`, appName, domainName))
-						Eventually(session).Should(Say(`last uploaded:\s+\w{3} \d{1,2} \w{3} \d{2}:\d{2}:\d{2} \w{3} \d{4}`))
+						Eventually(session).Should(Say(`last uploaded:\s+\w{3} \d{1,2} \w{3} \d{2}:\d{2}:\d{2} \w{3,5} \d{4}`))
 						Eventually(session).Should(Say(`stack:\s+cflinuxfs`))
 						Eventually(session).Should(Say(`buildpacks:\s+staticfile`))
 						Eventually(session).Should(Say(`type:\s+web`))


### PR DESCRIPTION
The test fails on my local machine because `EEST` does not match.

```
• Failure [28.278 seconds]
app command
          No future change is possible.  Bailing out early after 0.011s.
          Got stuck at:

              last uploaded:     Thu 13 Jun 08:47:07 EEST 2019
              stack:             cflinuxfs3
              buildpacks:        staticfile

              type:           web
              instances:      2/2
              memory usage:   128M
                   state     since                  cpu    memory      disk        details
              #0   running   2019-06-13T05:47:13Z   0.0%   0 of 128M   0 of 128M
              #1   running   2019-06-13T05:47:15Z   0.0%   0 of 128M   0 of 128M

          Waiting for:
              last uploaded:\s+\w{3} \d{1,2} \w{3} \d{2}:\d{2}:\d{2} \w{3} \d{4}

          /Users/pivotal/go/src/code.cloudfoundry.org/cli/integration/v7/isolated/app_command_test.go:119
```

After a quick search it looks like the most timezone abbreviations are between 3 and 5 chars.