### PR TITLE
Implement space-scoped service brokers for V3/V7

### DIFF
--- a/actor/v7action/cloud_controller_client.go
+++ b/actor/v7action/cloud_controller_client.go
@@ -25,7 +25,7 @@ type CloudControllerClient interface {
 	CreateIsolationSegment(isolationSegment ccv3.IsolationSegment) (ccv3.IsolationSegment, ccv3.Warnings, error)
 	CreatePackage(pkg ccv3.Package) (ccv3.Package, ccv3.Warnings, error)
 	CreateRoute(route ccv3.Route) (ccv3.Route, ccv3.Warnings, error)
-	CreateServiceBroker(ccv3.ServiceBroker) (ccv3.Warnings, error)
+	CreateServiceBroker(name, username, password, url, spaceGUID string) (ccv3.Warnings, error)
 	DeleteApplication(guid string) (ccv3.JobURL, ccv3.Warnings, error)
 	DeleteApplicationProcessInstance(appGUID string, processType string, instanceIndex int) (ccv3.Warnings, error)
 	DeleteBuildpack(buildpackGUID string) (ccv3.JobURL, ccv3.Warnings, error)

--- a/actor/v7action/service_broker.go
+++ b/actor/v7action/service_broker.go
@@ -4,8 +4,6 @@ import (
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3"
 )
 
-type ServiceBrokerCredentials = ccv3.ServiceBrokerCredentials
-type ServiceBrokerCredentialsData = ccv3.ServiceBrokerCredentialsData
 type ServiceBroker = ccv3.ServiceBroker
 
 func (actor Actor) GetServiceBrokers() ([]ServiceBroker, Warnings, error) {
@@ -17,7 +15,7 @@ func (actor Actor) GetServiceBrokers() ([]ServiceBroker, Warnings, error) {
 	return serviceBrokers, Warnings(warnings), nil
 }
 
-func (actor Actor) CreateServiceBroker(serviceBroker ServiceBroker) (Warnings, error) {
-	warnings, err := actor.CloudControllerClient.CreateServiceBroker(serviceBroker)
+func (actor Actor) CreateServiceBroker(name, username, password, url, spaceGUID string) (Warnings, error) {
+	warnings, err := actor.CloudControllerClient.CreateServiceBroker(name, username, password, url, spaceGUID)
 	return Warnings(warnings), err
 }

--- a/actor/v7action/service_broker_test.go
+++ b/actor/v7action/service_broker_test.go
@@ -6,7 +6,6 @@ import (
 	. "code.cloudfoundry.org/cli/actor/v7action"
 	"code.cloudfoundry.org/cli/actor/v7action/v7actionfakes"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3"
-	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/constant"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -80,25 +79,21 @@ var _ = Describe("Service Broker Actions", func() {
 	})
 
 	Describe("CreateServiceBroker", func() {
+		const (
+			name      = "name"
+			url       = "url"
+			username  = "username"
+			password  = "password"
+			spaceGUID = "space-guid"
+		)
+
 		var (
 			warnings       Warnings
 			executionError error
-
-			serviceBroker = ServiceBroker{
-				Name: "name",
-				URL:  "url",
-				Credentials: ServiceBrokerCredentials{
-					Type: constant.BasicCredentials,
-					Data: ServiceBrokerCredentialsData{
-						Username: "username",
-						Password: "password",
-					},
-				},
-			}
 		)
 
 		JustBeforeEach(func() {
-			warnings, executionError = actor.CreateServiceBroker(serviceBroker)
+			warnings, executionError = actor.CreateServiceBroker(name, username, password, url, spaceGUID)
 		})
 
 		When("the client request is successful", func() {
@@ -114,8 +109,12 @@ var _ = Describe("Service Broker Actions", func() {
 
 			It("passes the service broker credentials to the client", func() {
 				Expect(fakeCloudControllerClient.CreateServiceBrokerCallCount()).To(Equal(1))
-				Expect(fakeCloudControllerClient.CreateServiceBrokerArgsForCall(0)).
-					To(Equal(serviceBroker))
+				n, u, p, l, s := fakeCloudControllerClient.CreateServiceBrokerArgsForCall(0)
+				Expect(n).To(Equal(name))
+				Expect(u).To(Equal(username))
+				Expect(p).To(Equal(password))
+				Expect(l).To(Equal(url))
+				Expect(s).To(Equal(spaceGUID))
 			})
 		})
 

--- a/actor/v7action/v7actionfakes/fake_cloud_controller_client.go
+++ b/actor/v7action/v7actionfakes/fake_cloud_controller_client.go
@@ -2,11 +2,11 @@
 package v7actionfakes
 
 import (
-	"io"
-	"sync"
+	io "io"
+	sync "sync"
 
-	"code.cloudfoundry.org/cli/actor/v7action"
-	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3"
+	v7action "code.cloudfoundry.org/cli/actor/v7action"
+	ccv3 "code.cloudfoundry.org/cli/api/cloudcontroller/ccv3"
 )
 
 type FakeCloudControllerClient struct {
@@ -225,10 +225,14 @@ type FakeCloudControllerClient struct {
 		result2 ccv3.Warnings
 		result3 error
 	}
-	CreateServiceBrokerStub        func(ccv3.ServiceBroker) (ccv3.Warnings, error)
+	CreateServiceBrokerStub        func(string, string, string, string, string) (ccv3.Warnings, error)
 	createServiceBrokerMutex       sync.RWMutex
 	createServiceBrokerArgsForCall []struct {
-		arg1 ccv3.ServiceBroker
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 string
+		arg5 string
 	}
 	createServiceBrokerReturns struct {
 		result1 ccv3.Warnings
@@ -2303,16 +2307,20 @@ func (fake *FakeCloudControllerClient) CreateRouteReturnsOnCall(i int, result1 c
 	}{result1, result2, result3}
 }
 
-func (fake *FakeCloudControllerClient) CreateServiceBroker(arg1 ccv3.ServiceBroker) (ccv3.Warnings, error) {
+func (fake *FakeCloudControllerClient) CreateServiceBroker(arg1 string, arg2 string, arg3 string, arg4 string, arg5 string) (ccv3.Warnings, error) {
 	fake.createServiceBrokerMutex.Lock()
 	ret, specificReturn := fake.createServiceBrokerReturnsOnCall[len(fake.createServiceBrokerArgsForCall)]
 	fake.createServiceBrokerArgsForCall = append(fake.createServiceBrokerArgsForCall, struct {
-		arg1 ccv3.ServiceBroker
-	}{arg1})
-	fake.recordInvocation("CreateServiceBroker", []interface{}{arg1})
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 string
+		arg5 string
+	}{arg1, arg2, arg3, arg4, arg5})
+	fake.recordInvocation("CreateServiceBroker", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.createServiceBrokerMutex.Unlock()
 	if fake.CreateServiceBrokerStub != nil {
-		return fake.CreateServiceBrokerStub(arg1)
+		return fake.CreateServiceBrokerStub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -2327,17 +2335,17 @@ func (fake *FakeCloudControllerClient) CreateServiceBrokerCallCount() int {
 	return len(fake.createServiceBrokerArgsForCall)
 }
 
-func (fake *FakeCloudControllerClient) CreateServiceBrokerCalls(stub func(ccv3.ServiceBroker) (ccv3.Warnings, error)) {
+func (fake *FakeCloudControllerClient) CreateServiceBrokerCalls(stub func(string, string, string, string, string) (ccv3.Warnings, error)) {
 	fake.createServiceBrokerMutex.Lock()
 	defer fake.createServiceBrokerMutex.Unlock()
 	fake.CreateServiceBrokerStub = stub
 }
 
-func (fake *FakeCloudControllerClient) CreateServiceBrokerArgsForCall(i int) ccv3.ServiceBroker {
+func (fake *FakeCloudControllerClient) CreateServiceBrokerArgsForCall(i int) (string, string, string, string, string) {
 	fake.createServiceBrokerMutex.RLock()
 	defer fake.createServiceBrokerMutex.RUnlock()
 	argsForCall := fake.createServiceBrokerArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
 func (fake *FakeCloudControllerClient) CreateServiceBrokerReturns(result1 ccv3.Warnings, result2 error) {

--- a/api/cloudcontroller/ccv3/service_broker.go
+++ b/api/cloudcontroller/ccv3/service_broker.go
@@ -10,42 +10,72 @@ import (
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/internal"
 )
 
-// ServiceBroker represents a Cloud Controller V3 Service Broker.
+// ServiceBroker represents Service Broker data
 type ServiceBroker struct {
+	// GUID is a unique service broker identifier.
+	GUID string
+	// Name is the name of the service broker.
+	Name string
+	// URL is the url of the service broker.
+	URL string
+}
+
+// serviceBrokerPresentation represents a Cloud Controller V3 Service Broker.
+type serviceBrokerPresentation struct {
 	// GUID is a unique service broker identifier.
 	GUID string `json:"guid,omitempty"`
 	// Name is the name of the service broker.
 	Name string `json:"name"`
 	// URL is the url of the service broker.
 	URL string `json:"url"`
-	// SpaceGUID references which space this service broker belongs to. Empty if
-	// not space-scoped.
-	SpaceGUID string `json:"space_guid,omitempty"`
 	// Credentials contains the credentials for authenticating with the service broker.
-	Credentials ServiceBrokerCredentials `json:"credentials"`
+	Credentials serviceBrokerCredentials `json:"credentials"`
+	// This is the relationship for the space GUID
+	Relationships *serviceBrokerRelationships `json:"relationships,omitempty"`
 }
 
-// ServiceBrokerCredentials represents a data structure for the Credentials
+// serviceBrokerCredentials represents a data structure for the Credentials
 // of V3 Service Broker.
-type ServiceBrokerCredentials struct {
+type serviceBrokerCredentials struct {
 	// Type is the type of credentials for the service broker, e.g. "basic"
 	Type constant.ServiceBrokerCredentialsType `json:"type"`
 	// Data is the credentials data of the service broker of a particular type.
-	Data ServiceBrokerCredentialsData `json:"data"`
+	Data serviceBrokerCredentialsData `json:"data"`
 }
 
-// ServiceBrokerCredentialsData represents a data structure for the Credentials Data
+// serviceBrokerCredentialsData represents a data structure for the Credentials Data
 // of V3 Service Broker Credentials.
-type ServiceBrokerCredentialsData struct {
+type serviceBrokerCredentialsData struct {
 	// Username is the Basic Auth username for the service broker.
 	Username string `json:"username"`
 	// Password is the Basic Auth password for the service broker.
 	Password string `json:"password"`
 }
 
+// serviceBrokerRelationships represents a data structure for the relationships data
+// of V3 Service Broker Relationships.
+type serviceBrokerRelationships struct {
+	// Space represents the space that a space-scoped broker is in
+	Space serviceBrokerRelationshipsSpace `json:"space"`
+}
+
+// serviceBrokerRelationshipsSpace represents a data structure for the relationships space data
+// of V3 Service Broker Relationships.
+type serviceBrokerRelationshipsSpace struct {
+	// Data holds the space GUID object
+	Data serviceBrokerRelationshipsSpaceData `json:"data"`
+}
+
+// serviceBrokerRelationshipsSpaceData represents a data structure for the relationships space GUID data
+// of V3 Service Broker Relationships.
+type serviceBrokerRelationshipsSpaceData struct {
+	// GUID is the space guid associated with a space-scoped broker
+	GUID string `json:"guid"`
+}
+
 // CreateServiceBroker registers a new service broker.
-func (client *Client) CreateServiceBroker(credentials ServiceBroker) (Warnings, error) {
-	bodyBytes, err := json.Marshal(credentials)
+func (client *Client) CreateServiceBroker(name, username, password, brokerURL, spaceGUID string) (Warnings, error) {
+	bodyBytes, err := json.Marshal(newServiceBroker(name, username, password, brokerURL, spaceGUID))
 	if err != nil {
 		return nil, err
 	}
@@ -74,12 +104,12 @@ func (client *Client) GetServiceBrokers() ([]ServiceBroker, Warnings, error) {
 	}
 
 	var fullList []ServiceBroker
-	warnings, err := client.paginate(request, ServiceBroker{}, func(item interface{}) error {
-		if serviceBroker, ok := item.(ServiceBroker); ok {
-			fullList = append(fullList, serviceBroker)
+	warnings, err := client.paginate(request, serviceBrokerPresentation{}, func(item interface{}) error {
+		if serviceBroker, ok := item.(serviceBrokerPresentation); ok {
+			fullList = append(fullList, extractServiceBrokerData(serviceBroker))
 		} else {
 			return ccerror.UnknownObjectInListError{
-				Expected:   ServiceBroker{},
+				Expected:   serviceBrokerPresentation{},
 				Unexpected: item,
 			}
 		}
@@ -87,4 +117,38 @@ func (client *Client) GetServiceBrokers() ([]ServiceBroker, Warnings, error) {
 	})
 
 	return fullList, warnings, err
+}
+
+func newServiceBroker(name, username, password, brokerURL, spaceGUID string) serviceBrokerPresentation {
+	sbp := serviceBrokerPresentation{
+		Name: name,
+		URL:  brokerURL,
+		Credentials: serviceBrokerCredentials{
+			Type: constant.BasicCredentials,
+			Data: serviceBrokerCredentialsData{
+				Username: username,
+				Password: password,
+			},
+		},
+	}
+
+	if spaceGUID != "" {
+		sbp.Relationships = &serviceBrokerRelationships{
+			Space: serviceBrokerRelationshipsSpace{
+				Data: serviceBrokerRelationshipsSpaceData{
+					GUID: spaceGUID,
+				},
+			},
+		}
+	}
+
+	return sbp
+}
+
+func extractServiceBrokerData(sbp serviceBrokerPresentation) ServiceBroker {
+	return ServiceBroker{
+		Name: sbp.Name,
+		URL:  sbp.URL,
+		GUID: sbp.GUID,
+	}
 }

--- a/command/v7/create_service_broker_command_test.go
+++ b/command/v7/create_service_broker_command_test.go
@@ -3,9 +3,7 @@ package v7_test
 import (
 	"errors"
 
-	"code.cloudfoundry.org/cli/actor/actionerror"
 	"code.cloudfoundry.org/cli/actor/v7action"
-	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/constant"
 	"code.cloudfoundry.org/cli/command/commandfakes"
 	"code.cloudfoundry.org/cli/command/flag"
 	v7 "code.cloudfoundry.org/cli/command/v7"
@@ -63,55 +61,51 @@ var _ = Describe("create-service-broker Command", func() {
 
 	When("checking target fails", func() {
 		BeforeEach(func() {
-			fakeSharedActor.CheckTargetReturns(actionerror.NoOrganizationTargetedError{BinaryName: binaryName})
+			fakeSharedActor.CheckTargetReturns(errors.New("an error occurred"))
 		})
 
 		It("returns an error", func() {
-			Expect(executeErr).To(MatchError(actionerror.NoOrganizationTargetedError{BinaryName: binaryName}))
+			Expect(executeErr).To(MatchError("an error occurred"))
+		})
+	})
 
+	When("fetching the current user fails", func() {
+		BeforeEach(func() {
+			fakeConfig.CurrentUserReturns(configv3.User{}, errors.New("an error occurred"))
+		})
+
+		It("return an error", func() {
+			Expect(executeErr).To(MatchError("an error occurred"))
+		})
+	})
+
+	When("fetching the current user succeeds", func() {
+		BeforeEach(func() {
+			fakeConfig.CurrentUserReturns(configv3.User{Name: "steve"}, nil)
+		})
+
+		It("checks that there is a valid target", func() {
 			Expect(fakeSharedActor.CheckTargetCallCount()).To(Equal(1))
 			checkTargetedOrg, checkTargetedSpace := fakeSharedActor.CheckTargetArgsForCall(0)
 			Expect(checkTargetedOrg).To(BeFalse())
 			Expect(checkTargetedSpace).To(BeFalse())
 		})
-	})
-
-	When("the user is not logged in", func() {
-		var expectedErr error
-
-		BeforeEach(func() {
-			expectedErr = errors.New("some current user error")
-			fakeConfig.CurrentUserReturns(configv3.User{}, expectedErr)
-		})
-
-		It("return an error", func() {
-			Expect(executeErr).To(Equal(expectedErr))
-		})
-	})
-
-	When("the user is logged in", func() {
-		BeforeEach(func() {
-			fakeConfig.CurrentUserReturns(configv3.User{Name: "steve"}, nil)
-		})
 
 		It("displays a message with the username", func() {
-			Expect(testUI.Out).To(Say("Creating service broker %s as %s...", args.ServiceBroker, "steve"))
+			Expect(testUI.Out).To(Say(`Creating service broker %s as %s\.\.\.`, args.ServiceBroker, "steve"))
 		})
 
-		It("calls the CreateServiceBrokerActor", func() {
+		It("passes the data to the actor layer", func() {
 			Expect(fakeActor.CreateServiceBrokerCallCount()).To(Equal(1))
-			credentials := fakeActor.CreateServiceBrokerArgsForCall(0)
-			Expect(credentials).To(Equal(v7action.ServiceBroker{
-				Name: "service-broker-name",
-				URL:  "https://example.org/super-broker",
-				Credentials: v7action.ServiceBrokerCredentials{
-					Type: constant.BasicCredentials,
-					Data: v7action.ServiceBrokerCredentialsData{
-						Username: "username",
-						Password: "password",
-					},
-				},
-			}))
+
+			n, u, p, l, s := fakeActor.CreateServiceBrokerArgsForCall(0)
+
+			Expect(n).To(Equal("service-broker-name"))
+			Expect(u).To(Equal("username"))
+			Expect(p).To(Equal("password"))
+			Expect(l).To(Equal("https://example.org/super-broker"))
+			Expect(s).To(Equal(""))
+
 		})
 
 		It("displays the warnings", func() {
@@ -122,7 +116,7 @@ var _ = Describe("create-service-broker Command", func() {
 			Expect(testUI.Out).To(Say("OK"))
 		})
 
-		When("calling the CreateServiceBrokerActor returns an error", func() {
+		When("the actor returns an error", func() {
 			BeforeEach(func() {
 				fakeActor.CreateServiceBrokerReturns(v7action.Warnings{"service-broker-warnings"}, errors.New("fake create-service-broker error"))
 			})
@@ -131,6 +125,35 @@ var _ = Describe("create-service-broker Command", func() {
 				Expect(testUI.Out).NotTo(Say("OK"))
 				Expect(executeErr).To(MatchError("fake create-service-broker error"))
 				Expect(testUI.Err).To(Say("service-broker-warnings"))
+			})
+		})
+
+		When("creating a space scoped broker", func() {
+			BeforeEach(func() {
+				cmd.SpaceScoped = true
+				fakeConfig.TargetedSpaceReturns(configv3.Space{
+					Name: "fake-space-name",
+					GUID: "fake-space-guid",
+				})
+				fakeConfig.TargetedOrganizationNameReturns("fake-org-name")
+			})
+
+			It("checks that a space is targeted", func() {
+				Expect(fakeSharedActor.CheckTargetCallCount()).To(Equal(1))
+				checkTargetedOrg, checkTargetedSpace := fakeSharedActor.CheckTargetArgsForCall(0)
+				Expect(checkTargetedOrg).To(BeTrue())
+				Expect(checkTargetedSpace).To(BeTrue())
+			})
+
+			It("displays the space name in the message", func() {
+				Expect(testUI.Out).To(Say(`Creating service broker %s in org %s / space %s as %s\.\.\.`, args.ServiceBroker, "fake-org-name", "fake-space-name", "steve"))
+			})
+
+			It("looks up the space guid and passes it to the actor", func() {
+				Expect(fakeActor.CreateServiceBrokerCallCount()).To(Equal(1))
+
+				_, _, _, _, s := fakeActor.CreateServiceBrokerArgsForCall(0)
+				Expect(s).To(Equal("fake-space-guid"))
 			})
 		})
 	})

--- a/command/v7/v7fakes/fake_create_service_broker_actor.go
+++ b/command/v7/v7fakes/fake_create_service_broker_actor.go
@@ -2,18 +2,21 @@
 package v7fakes
 
 import (
-	"sync"
+	sync "sync"
 
-	"code.cloudfoundry.org/cli/actor/v7action"
-	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3"
+	v7action "code.cloudfoundry.org/cli/actor/v7action"
 	v7 "code.cloudfoundry.org/cli/command/v7"
 )
 
 type FakeCreateServiceBrokerActor struct {
-	CreateServiceBrokerStub        func(ccv3.ServiceBroker) (v7action.Warnings, error)
+	CreateServiceBrokerStub        func(string, string, string, string, string) (v7action.Warnings, error)
 	createServiceBrokerMutex       sync.RWMutex
 	createServiceBrokerArgsForCall []struct {
-		arg1 ccv3.ServiceBroker
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 string
+		arg5 string
 	}
 	createServiceBrokerReturns struct {
 		result1 v7action.Warnings
@@ -27,16 +30,20 @@ type FakeCreateServiceBrokerActor struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeCreateServiceBrokerActor) CreateServiceBroker(arg1 ccv3.ServiceBroker) (v7action.Warnings, error) {
+func (fake *FakeCreateServiceBrokerActor) CreateServiceBroker(arg1 string, arg2 string, arg3 string, arg4 string, arg5 string) (v7action.Warnings, error) {
 	fake.createServiceBrokerMutex.Lock()
 	ret, specificReturn := fake.createServiceBrokerReturnsOnCall[len(fake.createServiceBrokerArgsForCall)]
 	fake.createServiceBrokerArgsForCall = append(fake.createServiceBrokerArgsForCall, struct {
-		arg1 ccv3.ServiceBroker
-	}{arg1})
-	fake.recordInvocation("CreateServiceBroker", []interface{}{arg1})
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 string
+		arg5 string
+	}{arg1, arg2, arg3, arg4, arg5})
+	fake.recordInvocation("CreateServiceBroker", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.createServiceBrokerMutex.Unlock()
 	if fake.CreateServiceBrokerStub != nil {
-		return fake.CreateServiceBrokerStub(arg1)
+		return fake.CreateServiceBrokerStub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -51,17 +58,17 @@ func (fake *FakeCreateServiceBrokerActor) CreateServiceBrokerCallCount() int {
 	return len(fake.createServiceBrokerArgsForCall)
 }
 
-func (fake *FakeCreateServiceBrokerActor) CreateServiceBrokerCalls(stub func(ccv3.ServiceBroker) (v7action.Warnings, error)) {
+func (fake *FakeCreateServiceBrokerActor) CreateServiceBrokerCalls(stub func(string, string, string, string, string) (v7action.Warnings, error)) {
 	fake.createServiceBrokerMutex.Lock()
 	defer fake.createServiceBrokerMutex.Unlock()
 	fake.CreateServiceBrokerStub = stub
 }
 
-func (fake *FakeCreateServiceBrokerActor) CreateServiceBrokerArgsForCall(i int) ccv3.ServiceBroker {
+func (fake *FakeCreateServiceBrokerActor) CreateServiceBrokerArgsForCall(i int) (string, string, string, string, string) {
 	fake.createServiceBrokerMutex.RLock()
 	defer fake.createServiceBrokerMutex.RUnlock()
 	argsForCall := fake.createServiceBrokerArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
 func (fake *FakeCreateServiceBrokerActor) CreateServiceBrokerReturns(result1 v7action.Warnings, result2 error) {

--- a/integration/shared/isolated/create_service_broker_command_test.go
+++ b/integration/shared/isolated/create_service_broker_command_test.go
@@ -13,7 +13,6 @@ var _ = Describe("create-service-broker command", func() {
 	var brokerName string
 
 	BeforeEach(func() {
-		// TODO: remove that when capi-release is cut with v3 create-service-broker functionality
 		helpers.SkipIfV7AndVersionLessThan("3.72.0")
 
 		brokerName = helpers.NewServiceBrokerName()
@@ -93,9 +92,7 @@ var _ = Describe("create-service-broker command", func() {
 
 			When("the --space-scoped flag is passed", func() {
 				BeforeEach(func() {
-					// TODO: replace skip with versioned skip when
-					// https://www.pivotaltracker.com/story/show/166063310 is resolved.
-					helpers.SkipIfV7()
+					helpers.SkipIfV7AndVersionLessThan("3.74.0")
 				})
 
 				When("no org or space is targeted", func() {


### PR DESCRIPTION
Building on the V3/V7 implementation of the `create-service-broker`, we have added the `--space-scoped` flag to create space-scoped service brokers.

Niki & George, on behalf of the SAPI Team