### PR TITLE
 Add ability to use `cf set-label` to add labels to buildpacks

### DIFF
--- a/actor/v7action/label.go
+++ b/actor/v7action/label.go
@@ -42,12 +42,11 @@ func (actor *Actor) GetSpaceLabels(spaceName string, orgGUID string) (map[string
 }
 
 func (actor *Actor) UpdateApplicationLabelsByApplicationName(appName string, spaceGUID string, labels map[string]types.NullString) (Warnings, error) {
-	app, appWarnings, err := actor.GetApplicationByNameAndSpace(appName, spaceGUID)
+	app, warnings, err := actor.GetApplicationByNameAndSpace(appName, spaceGUID)
 	if err != nil {
-		return appWarnings, err
+		return warnings, err
 	}
-	_, updateWarnings, err := actor.CloudControllerClient.UpdateResourceMetadata("app", app.GUID, ccv3.Metadata{Labels: labels})
-	return append(appWarnings, updateWarnings...), err
+	return actor.updateResourceMetadata("app", app.GUID, ccv3.Metadata{Labels: labels}, warnings)
 }
 
 func (actor *Actor) UpdateBuildpackLabelsByBuildpackNameAndStack(buildpackName string, stack string, labels map[string]types.NullString) (Warnings, error) {
@@ -55,8 +54,7 @@ func (actor *Actor) UpdateBuildpackLabelsByBuildpackNameAndStack(buildpackName s
 	if err != nil {
 		return warnings, err
 	}
-	_, updateWarnings, err := actor.CloudControllerClient.UpdateResourceMetadata("buildpack", buildpack.GUID, ccv3.Metadata{Labels: labels})
-	return append(warnings, updateWarnings...), err
+	return actor.updateResourceMetadata("buildpack", buildpack.GUID, ccv3.Metadata{Labels: labels}, warnings)
 }
 
 func (actor *Actor) UpdateOrganizationLabelsByOrganizationName(orgName string, labels map[string]types.NullString) (Warnings, error) {
@@ -64,8 +62,7 @@ func (actor *Actor) UpdateOrganizationLabelsByOrganizationName(orgName string, l
 	if err != nil {
 		return warnings, err
 	}
-	_, updateWarnings, err := actor.CloudControllerClient.UpdateResourceMetadata("org", org.GUID, ccv3.Metadata{Labels: labels})
-	return append(warnings, updateWarnings...), err
+	return actor.updateResourceMetadata("org", org.GUID, ccv3.Metadata{Labels: labels}, warnings)
 }
 
 func (actor *Actor) UpdateSpaceLabelsBySpaceName(spaceName string, orgGUID string, labels map[string]types.NullString) (Warnings, error) {
@@ -73,6 +70,10 @@ func (actor *Actor) UpdateSpaceLabelsBySpaceName(spaceName string, orgGUID strin
 	if err != nil {
 		return warnings, err
 	}
-	_, updateWarnings, err := actor.CloudControllerClient.UpdateResourceMetadata("space", space.GUID, ccv3.Metadata{Labels: labels})
+	return actor.updateResourceMetadata("space", space.GUID, ccv3.Metadata{Labels: labels}, warnings)
+}
+
+func (actor *Actor) updateResourceMetadata(resourceType string, resourceGUID string, payload ccv3.Metadata, warnings Warnings) (Warnings, error) {
+	_, updateWarnings, err := actor.CloudControllerClient.UpdateResourceMetadata(resourceType, resourceGUID, payload)
 	return append(warnings, updateWarnings...), err
 }

--- a/actor/v7action/label.go
+++ b/actor/v7action/label.go
@@ -47,10 +47,16 @@ func (actor *Actor) UpdateApplicationLabelsByApplicationName(appName string, spa
 		return appWarnings, err
 	}
 	_, updateWarnings, err := actor.CloudControllerClient.UpdateResourceMetadata("app", app.GUID, ccv3.Metadata{Labels: labels})
-	if err != nil {
-		return append(appWarnings, updateWarnings...), err
-	}
 	return append(appWarnings, updateWarnings...), err
+}
+
+func (actor *Actor) UpdateBuildpackLabelsByBuildpackNameAndStack(buildpackName string, stack string, labels map[string]types.NullString) (Warnings, error) {
+	buildpack, warnings, err := actor.GetBuildpackByNameAndStack(buildpackName, stack)
+	if err != nil {
+		return warnings, err
+	}
+	_, updateWarnings, err := actor.CloudControllerClient.UpdateResourceMetadata("buildpack", buildpack.GUID, ccv3.Metadata{Labels: labels})
+	return append(warnings, updateWarnings...), err
 }
 
 func (actor *Actor) UpdateOrganizationLabelsByOrganizationName(orgName string, labels map[string]types.NullString) (Warnings, error) {
@@ -59,9 +65,6 @@ func (actor *Actor) UpdateOrganizationLabelsByOrganizationName(orgName string, l
 		return warnings, err
 	}
 	_, updateWarnings, err := actor.CloudControllerClient.UpdateResourceMetadata("org", org.GUID, ccv3.Metadata{Labels: labels})
-	if err != nil {
-		return append(warnings, updateWarnings...), err
-	}
 	return append(warnings, updateWarnings...), err
 }
 
@@ -71,8 +74,5 @@ func (actor *Actor) UpdateSpaceLabelsBySpaceName(spaceName string, orgGUID strin
 		return warnings, err
 	}
 	_, updateWarnings, err := actor.CloudControllerClient.UpdateResourceMetadata("space", space.GUID, ccv3.Metadata{Labels: labels})
-	if err != nil {
-		return append(warnings, updateWarnings...), err
-	}
 	return append(warnings, updateWarnings...), err
 }

--- a/api/cloudcontroller/ccv3/metadata.go
+++ b/api/cloudcontroller/ccv3/metadata.go
@@ -20,7 +20,7 @@ type ResourceMetadata struct {
 }
 
 func (client *Client) UpdateResourceMetadata(resource string, resourceGUID string, metadata Metadata) (ResourceMetadata, Warnings, error) {
-	metadataBtyes, err := json.Marshal(ResourceMetadata{Metadata: &metadata})
+	metadataBytes, err := json.Marshal(ResourceMetadata{Metadata: &metadata})
 	if err != nil {
 		return ResourceMetadata{}, nil, err
 	}
@@ -31,25 +31,25 @@ func (client *Client) UpdateResourceMetadata(resource string, resourceGUID strin
 	case "app":
 		request, err = client.newHTTPRequest(requestOptions{
 			RequestName: internal.PatchApplicationRequest,
-			Body:        bytes.NewReader(metadataBtyes),
+			Body:        bytes.NewReader(metadataBytes),
 			URIParams:   map[string]string{"app_guid": resourceGUID},
 		})
 	case "buildpack":
 		request, err = client.newHTTPRequest(requestOptions{
 			RequestName: internal.PatchBuildpackRequest,
-			Body:        bytes.NewReader(metadataBtyes),
+			Body:        bytes.NewReader(metadataBytes),
 			URIParams:   map[string]string{"buildpack_guid": resourceGUID},
 		})
 	case "org":
 		request, err = client.newHTTPRequest(requestOptions{
 			RequestName: internal.PatchOrganizationRequest,
-			Body:        bytes.NewReader(metadataBtyes),
+			Body:        bytes.NewReader(metadataBytes),
 			URIParams:   map[string]string{"organization_guid": resourceGUID},
 		})
 	case "space":
 		request, err = client.newHTTPRequest(requestOptions{
 			RequestName: internal.PatchSpaceRequest,
-			Body:        bytes.NewReader(metadataBtyes),
+			Body:        bytes.NewReader(metadataBytes),
 			URIParams:   map[string]string{"space_guid": resourceGUID},
 		})
 	default:

--- a/api/cloudcontroller/ccv3/metadata.go
+++ b/api/cloudcontroller/ccv3/metadata.go
@@ -34,6 +34,12 @@ func (client *Client) UpdateResourceMetadata(resource string, resourceGUID strin
 			Body:        bytes.NewReader(metadataBtyes),
 			URIParams:   map[string]string{"app_guid": resourceGUID},
 		})
+	case "buildpack":
+		request, err = client.newHTTPRequest(requestOptions{
+			RequestName: internal.PatchBuildpackRequest,
+			Body:        bytes.NewReader(metadataBtyes),
+			URIParams:   map[string]string{"buildpack_guid": resourceGUID},
+		})
 	case "org":
 		request, err = client.newHTTPRequest(requestOptions{
 			RequestName: internal.PatchOrganizationRequest,

--- a/command/v7/labels_command.go
+++ b/command/v7/labels_command.go
@@ -17,9 +17,10 @@ import (
 type ResourceType string
 
 const (
-	App   ResourceType = "app"
-	Org   ResourceType = "org"
-	Space ResourceType = "space"
+	App       ResourceType = "app"
+	Buildpack ResourceType = "buildpack"
+	Org       ResourceType = "org"
+	Space     ResourceType = "space"
 )
 
 //go:generate counterfeiter . LabelsActor

--- a/command/v7/labels_command.go
+++ b/command/v7/labels_command.go
@@ -3,6 +3,7 @@ package v7
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"code.cloudfoundry.org/cli/actor/sharedaction"
 	"code.cloudfoundry.org/cli/actor/v7action"
@@ -61,7 +62,9 @@ func (cmd LabelsCommand) Execute(args []string) error {
 	if err != nil {
 		return err
 	}
-	switch ResourceType(cmd.RequiredArgs.ResourceType) {
+
+	resourceTypeString := strings.ToLower(cmd.RequiredArgs.ResourceType)
+	switch ResourceType(resourceTypeString) {
 	case App:
 		labels, warnings, err = cmd.fetchAppLabels(username)
 	case Org:

--- a/command/v7/labels_command_test.go
+++ b/command/v7/labels_command_test.go
@@ -46,7 +46,6 @@ var _ = Describe("labels command", func() {
 	})
 
 	Describe("listing labels", func() {
-
 		Describe("for apps", func() {
 			BeforeEach(func() {
 				fakeConfig.CurrentUserNameReturns("some-user", nil)
@@ -87,6 +86,22 @@ var _ = Describe("labels command", func() {
 				appName, spaceGUID := fakeLabelsActor.GetApplicationLabelsArgsForCall(0)
 				Expect(appName).To(Equal("dora"))
 				Expect(spaceGUID).To(Equal("some-space-guid"))
+			})
+
+			When("the resource type argument is not lowercase", func() {
+				BeforeEach(func() {
+					cmd.RequiredArgs = flag.LabelsArgs{
+						ResourceType: "ApP",
+						ResourceName: "dora",
+					}
+				})
+
+				It("retrieves the labels associated with the application", func() {
+					Expect(fakeLabelsActor.GetApplicationLabelsCallCount()).To(Equal(1))
+					appName, spaceGUID := fakeLabelsActor.GetApplicationLabelsArgsForCall(0)
+					Expect(appName).To(Equal("dora"))
+					Expect(spaceGUID).To(Equal("some-space-guid"))
+				})
 			})
 
 			It("displays the labels that are associated with the application, alphabetically", func() {
@@ -256,12 +271,27 @@ var _ = Describe("labels command", func() {
 					Expect(executeErr).To(MatchError("boom"))
 				})
 			})
+
+			When("the resource type argument is not lowercase", func() {
+				BeforeEach(func() {
+					cmd.RequiredArgs = flag.LabelsArgs{
+						ResourceType: "OrG",
+						ResourceName: "fake-org",
+					}
+				})
+
+				It("retrieves the labels associated with the org", func() {
+					Expect(fakeLabelsActor.GetOrganizationLabelsCallCount()).To(Equal(1))
+					orgName := fakeLabelsActor.GetOrganizationLabelsArgsForCall(0)
+					Expect(orgName).To(Equal("fake-org"))
+				})
+			})
 		})
 
 		Describe("for spaces", func() {
 			BeforeEach(func() {
 				fakeConfig.CurrentUserNameReturns("some-user", nil)
-				fakeConfig.TargetedOrganizationReturns(configv3.Organization{Name: "fake-org"})
+				fakeConfig.TargetedOrganizationReturns(configv3.Organization{Name: "fake-org", GUID: "some-org-guid"})
 				cmd.RequiredArgs = flag.LabelsArgs{
 					ResourceType: "space",
 					ResourceName: "fake-space",
@@ -358,6 +388,22 @@ var _ = Describe("labels command", func() {
 
 				It("returns an error", func() {
 					Expect(executeErr).To(MatchError("boom"))
+				})
+			})
+
+			When("the resource type argument is not lowercase", func() {
+				BeforeEach(func() {
+					cmd.RequiredArgs = flag.LabelsArgs{
+						ResourceType: "SpAcE",
+						ResourceName: "fake-space",
+					}
+				})
+
+				It("retrieves the labels associated with the space", func() {
+					Expect(fakeLabelsActor.GetSpaceLabelsCallCount()).To(Equal(1))
+					spaceName, orgGUID := fakeLabelsActor.GetSpaceLabelsArgsForCall(0)
+					Expect(spaceName).To(Equal("fake-space"))
+					Expect(orgGUID).To(Equal("some-org-guid"))
 				})
 			})
 		})

--- a/command/v7/set_label_command.go
+++ b/command/v7/set_label_command.go
@@ -8,6 +8,7 @@ import (
 	"code.cloudfoundry.org/cli/actor/v7action"
 	"code.cloudfoundry.org/cli/command"
 	"code.cloudfoundry.org/cli/command/flag"
+	"code.cloudfoundry.org/cli/command/translatableerror"
 	"code.cloudfoundry.org/cli/command/v7/shared"
 	"code.cloudfoundry.org/cli/types"
 	"code.cloudfoundry.org/clock"
@@ -17,17 +18,20 @@ import (
 
 type SetLabelActor interface {
 	UpdateApplicationLabelsByApplicationName(string, string, map[string]types.NullString) (v7action.Warnings, error)
+	UpdateBuildpackLabelsByBuildpackNameAndStack(string, string, map[string]types.NullString) (v7action.Warnings, error)
 	UpdateOrganizationLabelsByOrganizationName(string, map[string]types.NullString) (v7action.Warnings, error)
 	UpdateSpaceLabelsBySpaceName(string, string, map[string]types.NullString) (v7action.Warnings, error)
 }
 
 type SetLabelCommand struct {
-	RequiredArgs flag.SetLabelArgs `positional-args:"yes"`
-	usage        interface{}       `usage:"CF_NAME set-label RESOURCE RESOURCE_NAME KEY=VALUE...\n\nEXAMPLES:\n   cf set-label app dora env=production\n   cf set-label org business pci=true public-facing=false\n   cf set-label space business_space public-facing=false owner=jane_doe\n\nRESOURCES:\n   app\n   org\n   space\n\nSEE ALSO:\n   unset-label, labels"`
-	UI           command.UI
-	Config       command.Config
-	SharedActor  command.SharedActor
-	Actor        SetLabelActor
+	RequiredArgs   flag.SetLabelArgs `positional-args:"yes"`
+	usage          interface{}       `usage:"CF_NAME set-label RESOURCE RESOURCE_NAME KEY=VALUE...\n\nEXAMPLES:\n   cf set-label app dora env=production\n   cf set-label org business pci=true public-facing=false\n   cf set-label space business_space public-facing=false owner=jane_doe\n\nRESOURCES:\n   app\n   buildpack\n   org\n   space\n\nSEE ALSO:\n   delete-label, labels"`
+	BuildpackStack string            `long:"stack" short:"s" description:"Specify stack to disambiguate buildpacks with the same name"`
+
+	UI          command.UI
+	Config      command.Config
+	SharedActor command.SharedActor
+	Actor       SetLabelActor
 }
 
 func (cmd *SetLabelCommand) Setup(config command.Config, ui command.UI) error {
@@ -39,6 +43,17 @@ func (cmd *SetLabelCommand) Setup(config command.Config, ui command.UI) error {
 		return err
 	}
 	cmd.Actor = v7action.NewActor(ccClient, config, nil, nil, clock.NewClock())
+	return nil
+}
+
+func (cmd SetLabelCommand) ValidateFlags() error {
+	if cmd.BuildpackStack != "" && ResourceType(cmd.RequiredArgs.ResourceType) != Buildpack {
+		return translatableerror.ArgumentCombinationError{
+			Args: []string{
+				cmd.RequiredArgs.ResourceType, "--stack, -s",
+			},
+		}
+	}
 	return nil
 }
 
@@ -58,9 +73,16 @@ func (cmd SetLabelCommand) Execute(args []string) error {
 		return err
 	}
 
+	err = cmd.ValidateFlags()
+	if err != nil {
+		return err
+	}
+
 	switch ResourceType(cmd.RequiredArgs.ResourceType) {
 	case App:
 		err = cmd.executeApp(username, labels)
+	case Buildpack:
+		err = cmd.executeBuildpack(username, labels)
 	case Org:
 		err = cmd.executeOrg(username, labels)
 	case Space:
@@ -75,29 +97,6 @@ func (cmd SetLabelCommand) Execute(args []string) error {
 
 	cmd.UI.DisplayOK()
 	return nil
-}
-
-func (cmd SetLabelCommand) executeOrg(username string, labels map[string]types.NullString) error {
-	err := cmd.SharedActor.CheckTarget(false, false)
-	if err != nil {
-		return err
-	}
-
-	preFlavoringText := fmt.Sprintf("Setting label(s) for %s {{.ResourceName}} as {{.User}}...", cmd.RequiredArgs.ResourceType)
-	cmd.UI.DisplayTextWithFlavor(
-		preFlavoringText,
-		map[string]interface{}{
-			"ResourceName": cmd.RequiredArgs.ResourceName,
-			"OrgName":      cmd.Config.TargetedOrganization().Name,
-			"User":         username,
-		},
-	)
-
-	warnings, err := cmd.Actor.UpdateOrganizationLabelsByOrganizationName(cmd.RequiredArgs.ResourceName,
-		labels)
-	cmd.UI.DisplayWarnings(warnings)
-
-	return err
 }
 
 func (cmd SetLabelCommand) executeApp(username string, labels map[string]types.NullString) error {
@@ -129,6 +128,50 @@ func (cmd SetLabelCommand) executeApp(username string, labels map[string]types.N
 	}
 
 	return nil
+}
+
+func (cmd SetLabelCommand) executeBuildpack(username string, labels map[string]types.NullString) error {
+	err := cmd.SharedActor.CheckTarget(false, false)
+	if err != nil {
+		return err
+	}
+
+	preFlavoringText := fmt.Sprintf("Setting label(s) for %s {{.ResourceName}} as {{.User}}...", cmd.RequiredArgs.ResourceType)
+	cmd.UI.DisplayTextWithFlavor(
+		preFlavoringText,
+		map[string]interface{}{
+			"ResourceName": cmd.RequiredArgs.ResourceName,
+			"User":         username,
+		},
+	)
+
+	warnings, err := cmd.Actor.UpdateBuildpackLabelsByBuildpackNameAndStack(cmd.RequiredArgs.ResourceName, cmd.BuildpackStack, labels)
+	cmd.UI.DisplayWarnings(warnings)
+
+	return err
+}
+
+func (cmd SetLabelCommand) executeOrg(username string, labels map[string]types.NullString) error {
+	err := cmd.SharedActor.CheckTarget(false, false)
+	if err != nil {
+		return err
+	}
+
+	preFlavoringText := fmt.Sprintf("Setting label(s) for %s {{.ResourceName}} as {{.User}}...", cmd.RequiredArgs.ResourceType)
+	cmd.UI.DisplayTextWithFlavor(
+		preFlavoringText,
+		map[string]interface{}{
+			"ResourceName": cmd.RequiredArgs.ResourceName,
+			"OrgName":      cmd.Config.TargetedOrganization().Name,
+			"User":         username,
+		},
+	)
+
+	warnings, err := cmd.Actor.UpdateOrganizationLabelsByOrganizationName(cmd.RequiredArgs.ResourceName,
+		labels)
+	cmd.UI.DisplayWarnings(warnings)
+
+	return err
 }
 
 func (cmd SetLabelCommand) executeSpace(username string, labels map[string]types.NullString) error {

--- a/command/v7/set_label_command.go
+++ b/command/v7/set_label_command.go
@@ -25,7 +25,7 @@ type SetLabelActor interface {
 
 type SetLabelCommand struct {
 	RequiredArgs   flag.SetLabelArgs `positional-args:"yes"`
-	usage          interface{}       `usage:"CF_NAME set-label RESOURCE RESOURCE_NAME KEY=VALUE...\n\nEXAMPLES:\n   cf set-label app dora env=production\n   cf set-label org business pci=true public-facing=false\n   cf set-label space business_space public-facing=false owner=jane_doe\n\nRESOURCES:\n   app\n   buildpack\n   org\n   space\n\nSEE ALSO:\n   delete-label, labels"`
+	usage          interface{}       `usage:"CF_NAME set-label RESOURCE RESOURCE_NAME KEY=VALUE...\n\nEXAMPLES:\n   cf set-label app dora env=production\n   cf set-label org business pci=true public-facing=false\n   cf set-label space business_space public-facing=false owner=jane_doe\n\nRESOURCES:\n   app\n   buildpack\n   org\n   space\n\nSEE ALSO:\n   unset-label, labels"`
 	BuildpackStack string            `long:"stack" short:"s" description:"Specify stack to disambiguate buildpacks with the same name"`
 
 	UI          command.UI

--- a/command/v7/set_label_command.go
+++ b/command/v7/set_label_command.go
@@ -78,7 +78,8 @@ func (cmd SetLabelCommand) Execute(args []string) error {
 		return err
 	}
 
-	switch ResourceType(cmd.RequiredArgs.ResourceType) {
+	resourceTypeString := strings.ToLower(cmd.RequiredArgs.ResourceType)
+	switch ResourceType(resourceTypeString) {
 	case App:
 		err = cmd.executeApp(username, labels)
 	case Buildpack:

--- a/command/v7/set_label_command.go
+++ b/command/v7/set_label_command.go
@@ -138,10 +138,15 @@ func (cmd SetLabelCommand) executeBuildpack(username string, labels map[string]t
 	}
 
 	preFlavoringText := fmt.Sprintf("Setting label(s) for %s {{.ResourceName}} as {{.User}}...", cmd.RequiredArgs.ResourceType)
+	if cmd.BuildpackStack != "" {
+		preFlavoringText = fmt.Sprintf("Setting label(s) for %s {{.ResourceName}} with stack {{.StackName}} as {{.User}}...", cmd.RequiredArgs.ResourceType)
+	}
+
 	cmd.UI.DisplayTextWithFlavor(
 		preFlavoringText,
 		map[string]interface{}{
 			"ResourceName": cmd.RequiredArgs.ResourceName,
+			"StackName":    cmd.BuildpackStack,
 			"User":         username,
 		},
 	)

--- a/command/v7/set_label_command_test.go
+++ b/command/v7/set_label_command_test.go
@@ -481,13 +481,28 @@ var _ = Describe("set-label command", func() {
 
 							Expect(fakeSharedActor.CheckTargetCallCount()).To(Equal(1))
 
-							Expect(testUI.Out).To(Say(regexp.QuoteMeta(`Setting label(s) for buildpack %s as some-user...`), resourceName))
+							Expect(testUI.Out).To(Say(regexp.QuoteMeta(`Setting label(s) for buildpack %s with stack %s as some-user...`), resourceName, cmd.BuildpackStack))
 							Expect(testUI.Out).To(Say("OK"))
 						})
 
 						It("prints all warnings", func() {
 							Expect(testUI.Err).To(Say("some-warning-1"))
 							Expect(testUI.Err).To(Say("some-warning-2"))
+						})
+
+						When("no stack is provided", func() {
+							BeforeEach(func() {
+								cmd.BuildpackStack = ""
+							})
+
+							It("displays a message that includes the stack name", func() {
+								Expect(executeErr).ToNot(HaveOccurred())
+
+								Expect(fakeSharedActor.CheckTargetCallCount()).To(Equal(1))
+								Expect(testUI.Out).To(Say(regexp.QuoteMeta(`Setting label(s) for buildpack %s as some-user...`), resourceName))
+
+								Expect(testUI.Out).To(Say("OK"))
+							})
 						})
 					})
 				})

--- a/command/v7/set_label_command_test.go
+++ b/command/v7/set_label_command_test.go
@@ -168,6 +168,30 @@ var _ = Describe("set-label command", func() {
 						Expect(executeErr).To(MatchError(translatableerror.ArgumentCombinationError{Args: []string{"app", "--stack, -s"}}))
 					})
 				})
+
+				When("the resource type argument is not lowercase", func() {
+					BeforeEach(func() {
+						cmd.RequiredArgs = flag.SetLabelArgs{
+							ResourceType: "ApP",
+							ResourceName: resourceName,
+							Labels:       []string{"FOO=BAR", "ENV=FAKE"},
+						}
+						fakeActor.UpdateApplicationLabelsByApplicationNameReturns(
+							v7action.Warnings([]string{"some-warning-1", "some-warning-2"}),
+							nil,
+						)
+					})
+
+					It("sets the provided labels on the app", func() {
+						name, spaceGUID, labels := fakeActor.UpdateApplicationLabelsByApplicationNameArgsForCall(0)
+						Expect(name).To(Equal(resourceName), "failed to pass app name")
+						Expect(spaceGUID).To(Equal("some-space-guid"))
+						Expect(labels).To(BeEquivalentTo(map[string]types.NullString{
+							"FOO": types.NewNullString("BAR"),
+							"ENV": types.NewNullString("FAKE"),
+						}))
+					})
+				})
 			})
 
 			When("fetching the current user's name fails", func() {
@@ -330,6 +354,29 @@ var _ = Describe("set-label command", func() {
 						Expect(executeErr).To(MatchError(translatableerror.ArgumentCombinationError{Args: []string{"org", "--stack, -s"}}))
 					})
 				})
+
+				When("the resource type argument is not lowercase", func() {
+					BeforeEach(func() {
+						cmd.RequiredArgs = flag.SetLabelArgs{
+							ResourceType: "OrG",
+							ResourceName: resourceName,
+							Labels:       []string{"FOO=BAR", "ENV=FAKE"},
+						}
+						fakeActor.UpdateOrganizationLabelsByOrganizationNameReturns(
+							v7action.Warnings([]string{"some-warning-1", "some-warning-2"}),
+							nil,
+						)
+					})
+
+					It("sets the provided labels on the org", func() {
+						name, labels := fakeActor.UpdateOrganizationLabelsByOrganizationNameArgsForCall(0)
+						Expect(name).To(Equal(resourceName), "failed to pass org name")
+						Expect(labels).To(BeEquivalentTo(map[string]types.NullString{
+							"FOO": types.NewNullString("BAR"),
+							"ENV": types.NewNullString("FAKE"),
+						}))
+					})
+				})
 			})
 
 			When("fetching the current user's name fails", func() {
@@ -477,6 +524,30 @@ var _ = Describe("set-label command", func() {
 					It("complains about the missing equal sign", func() {
 						Expect(executeErr).To(MatchError("Metadata error: no value provided for label 'MISSING_EQUALS'"))
 						Expect(executeErr).To(HaveOccurred())
+					})
+				})
+
+				When("the resource type argument is not lowercase", func() {
+					BeforeEach(func() {
+						cmd.RequiredArgs = flag.SetLabelArgs{
+							ResourceType: "bUiLdPaCk",
+							ResourceName: resourceName,
+							Labels:       []string{"FOO=BAR", "ENV=FAKE"},
+						}
+						fakeActor.UpdateBuildpackLabelsByBuildpackNameAndStackReturns(
+							v7action.Warnings([]string{"some-warning-1", "some-warning-2"}),
+							nil,
+						)
+					})
+
+					It("sets the provided labels on the org", func() {
+						name, stack, labels := fakeActor.UpdateBuildpackLabelsByBuildpackNameAndStackArgsForCall(0)
+						Expect(name).To(Equal(resourceName), "failed to pass buildpack name")
+						Expect(stack).To(Equal(""), "failed to pass buildpack stack")
+						Expect(labels).To(BeEquivalentTo(map[string]types.NullString{
+							"FOO": types.NewNullString("BAR"),
+							"ENV": types.NewNullString("FAKE"),
+						}))
 					})
 				})
 			})
@@ -635,6 +706,30 @@ var _ = Describe("set-label command", func() {
 
 					It("complains about the --stack flag being present", func() {
 						Expect(executeErr).To(MatchError(translatableerror.ArgumentCombinationError{Args: []string{"space", "--stack, -s"}}))
+					})
+				})
+
+				When("the resource type argument is not lowercase", func() {
+					BeforeEach(func() {
+						cmd.RequiredArgs = flag.SetLabelArgs{
+							ResourceType: "sPaCe",
+							ResourceName: resourceName,
+							Labels:       []string{"FOO=BAR", "ENV=FAKE"},
+						}
+						fakeActor.UpdateSpaceLabelsBySpaceNameReturns(
+							v7action.Warnings([]string{"some-warning-1", "some-warning-2"}),
+							nil,
+						)
+					})
+
+					It("sets the provided labels on the app", func() {
+						name, orgGUID, labels := fakeActor.UpdateSpaceLabelsBySpaceNameArgsForCall(0)
+						Expect(name).To(Equal(resourceName), "failed to pass space name")
+						Expect(orgGUID).To(Equal("some-org-guid"))
+						Expect(labels).To(BeEquivalentTo(map[string]types.NullString{
+							"FOO": types.NewNullString("BAR"),
+							"ENV": types.NewNullString("FAKE"),
+						}))
 					})
 				})
 			})

--- a/command/v7/v7fakes/fake_set_label_actor.go
+++ b/command/v7/v7fakes/fake_set_label_actor.go
@@ -25,6 +25,21 @@ type FakeSetLabelActor struct {
 		result1 v7action.Warnings
 		result2 error
 	}
+	UpdateBuildpackLabelsByBuildpackNameAndStackStub        func(string, string, map[string]types.NullString) (v7action.Warnings, error)
+	updateBuildpackLabelsByBuildpackNameAndStackMutex       sync.RWMutex
+	updateBuildpackLabelsByBuildpackNameAndStackArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 map[string]types.NullString
+	}
+	updateBuildpackLabelsByBuildpackNameAndStackReturns struct {
+		result1 v7action.Warnings
+		result2 error
+	}
+	updateBuildpackLabelsByBuildpackNameAndStackReturnsOnCall map[int]struct {
+		result1 v7action.Warnings
+		result2 error
+	}
 	UpdateOrganizationLabelsByOrganizationNameStub        func(string, map[string]types.NullString) (v7action.Warnings, error)
 	updateOrganizationLabelsByOrganizationNameMutex       sync.RWMutex
 	updateOrganizationLabelsByOrganizationNameArgsForCall []struct {
@@ -118,6 +133,71 @@ func (fake *FakeSetLabelActor) UpdateApplicationLabelsByApplicationNameReturnsOn
 		})
 	}
 	fake.updateApplicationLabelsByApplicationNameReturnsOnCall[i] = struct {
+		result1 v7action.Warnings
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeSetLabelActor) UpdateBuildpackLabelsByBuildpackNameAndStack(arg1 string, arg2 string, arg3 map[string]types.NullString) (v7action.Warnings, error) {
+	fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.Lock()
+	ret, specificReturn := fake.updateBuildpackLabelsByBuildpackNameAndStackReturnsOnCall[len(fake.updateBuildpackLabelsByBuildpackNameAndStackArgsForCall)]
+	fake.updateBuildpackLabelsByBuildpackNameAndStackArgsForCall = append(fake.updateBuildpackLabelsByBuildpackNameAndStackArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 map[string]types.NullString
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("UpdateBuildpackLabelsByBuildpackNameAndStack", []interface{}{arg1, arg2, arg3})
+	fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.Unlock()
+	if fake.UpdateBuildpackLabelsByBuildpackNameAndStackStub != nil {
+		return fake.UpdateBuildpackLabelsByBuildpackNameAndStackStub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.updateBuildpackLabelsByBuildpackNameAndStackReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeSetLabelActor) UpdateBuildpackLabelsByBuildpackNameAndStackCallCount() int {
+	fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.RLock()
+	defer fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.RUnlock()
+	return len(fake.updateBuildpackLabelsByBuildpackNameAndStackArgsForCall)
+}
+
+func (fake *FakeSetLabelActor) UpdateBuildpackLabelsByBuildpackNameAndStackCalls(stub func(string, string, map[string]types.NullString) (v7action.Warnings, error)) {
+	fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.Lock()
+	defer fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.Unlock()
+	fake.UpdateBuildpackLabelsByBuildpackNameAndStackStub = stub
+}
+
+func (fake *FakeSetLabelActor) UpdateBuildpackLabelsByBuildpackNameAndStackArgsForCall(i int) (string, string, map[string]types.NullString) {
+	fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.RLock()
+	defer fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.RUnlock()
+	argsForCall := fake.updateBuildpackLabelsByBuildpackNameAndStackArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeSetLabelActor) UpdateBuildpackLabelsByBuildpackNameAndStackReturns(result1 v7action.Warnings, result2 error) {
+	fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.Lock()
+	defer fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.Unlock()
+	fake.UpdateBuildpackLabelsByBuildpackNameAndStackStub = nil
+	fake.updateBuildpackLabelsByBuildpackNameAndStackReturns = struct {
+		result1 v7action.Warnings
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeSetLabelActor) UpdateBuildpackLabelsByBuildpackNameAndStackReturnsOnCall(i int, result1 v7action.Warnings, result2 error) {
+	fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.Lock()
+	defer fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.Unlock()
+	fake.UpdateBuildpackLabelsByBuildpackNameAndStackStub = nil
+	if fake.updateBuildpackLabelsByBuildpackNameAndStackReturnsOnCall == nil {
+		fake.updateBuildpackLabelsByBuildpackNameAndStackReturnsOnCall = make(map[int]struct {
+			result1 v7action.Warnings
+			result2 error
+		})
+	}
+	fake.updateBuildpackLabelsByBuildpackNameAndStackReturnsOnCall[i] = struct {
 		result1 v7action.Warnings
 		result2 error
 	}{result1, result2}
@@ -257,6 +337,8 @@ func (fake *FakeSetLabelActor) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.updateApplicationLabelsByApplicationNameMutex.RLock()
 	defer fake.updateApplicationLabelsByApplicationNameMutex.RUnlock()
+	fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.RLock()
+	defer fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.RUnlock()
 	fake.updateOrganizationLabelsByOrganizationNameMutex.RLock()
 	defer fake.updateOrganizationLabelsByOrganizationNameMutex.RUnlock()
 	fake.updateSpaceLabelsBySpaceNameMutex.RLock()

--- a/integration/helpers/buildpack.go
+++ b/integration/helpers/buildpack.go
@@ -115,6 +115,14 @@ func BuildpackGUIDByNameAndStack(buildpackName string, stackName string) string 
 	buildpacks := BuildpackList{}
 	err := json.Unmarshal(bytes, &buildpacks)
 	Expect(err).ToNot(HaveOccurred())
-
-	return buildpacks.Buildpacks[0].GUID
+	Expect(len(buildpacks.Buildpacks)).To(BeNumerically(">", 0))
+	if stackName != "" {
+		return buildpacks.Buildpacks[0].GUID
+	}
+	for _, buildpack := range buildpacks.Buildpacks {
+		if buildpack.Stack == "" {
+			return buildpack.GUID
+		}
+	}
+	return ""
 }

--- a/integration/helpers/buildpack.go
+++ b/integration/helpers/buildpack.go
@@ -95,7 +95,7 @@ func DeleteBuildpackIfOnOldCCAPI(buildpackName string) {
 }
 
 type Buildpack struct {
-	Guid  string `json:"guid"`
+	GUID  string `json:"guid"`
 	Name  string `json:"name"`
 	Stack string `json:"stack"`
 }
@@ -116,5 +116,5 @@ func BuildpackGUIDByNameAndStack(buildpackName string, stackName string) string 
 	err := json.Unmarshal(bytes, &buildpacks)
 	Expect(err).ToNot(HaveOccurred())
 
-	return buildpacks.Buildpacks[0].Guid
+	return buildpacks.Buildpacks[0].GUID
 }

--- a/integration/helpers/stack.go
+++ b/integration/helpers/stack.go
@@ -52,9 +52,12 @@ func PreferredStack() string {
 
 // CreateStack creates a new stack with the user provided name. If a name is not provided, a random name is used
 func CreateStack(names ...string) string {
-	name := NewStackName()
+	var name string
+
 	if len(names) > 0 {
 		name = names[0]
+	} else {
+		name = NewStackName()
 	}
 
 	requestBody := fmt.Sprintf(

--- a/integration/v7/isolated/set_label_command_test.go
+++ b/integration/v7/isolated/set_label_command_test.go
@@ -49,10 +49,12 @@ var _ = Describe("set-label command", func() {
 
 	When("the environment is set up correctly", func() {
 		var (
-			orgName   string
-			spaceName string
-			appName   string
-			username  string
+			orgName            string
+			spaceName          string
+			appName            string
+			username           string
+			stackNameBase      string
+			testWithStackCount int
 		)
 
 		type commonResource struct {
@@ -66,6 +68,7 @@ var _ = Describe("set-label command", func() {
 			helpers.LoginCF()
 			orgName = helpers.NewOrgName()
 			helpers.CreateOrg(orgName)
+			stackNameBase = helpers.NewStackName()
 		})
 
 		When("assigning label to app", func() {
@@ -272,119 +275,217 @@ var _ = Describe("set-label command", func() {
 
 			BeforeEach(func() {
 				buildpackName = helpers.NewBuildpackName()
-				stacks := helpers.FetchStacks()
-				helpers.BuildpackWithStack(func(buildpackPath string) {
-					session := helpers.CF("create-buildpack", buildpackName, buildpackPath, "98")
-					Eventually(session).Should(Exit(0))
-				}, stacks[0])
 			})
 
-			It("sets the specified labels on the buildpack", func() {
-				session := helpers.CF("set-label", "buildpack", buildpackName, "pci=true", "public-facing=false")
-				Eventually(session).Should(Say(regexp.QuoteMeta(`Setting label(s) for buildpack %s as %s...`), buildpackName, username))
-				Eventually(session).Should(Say("OK"))
-				Eventually(session).Should(Exit(0))
-
-				buildpackGUID := helpers.BuildpackGUIDByNameAndStack(buildpackName, "")
-				session = helpers.CF("curl", fmt.Sprintf("/v3/buildpacks/%s", buildpackGUID))
-				Eventually(session).Should(Exit(0))
-				buildpackJSON := session.Out.Contents()
-				var buildpack commonResource
-				Expect(json.Unmarshal(buildpackJSON, &buildpack)).To(Succeed())
-				Expect(len(buildpack.Metadata.Labels)).To(Equal(2))
-				Expect(buildpack.Metadata.Labels["pci"]).To(Equal("true"))
-				Expect(buildpack.Metadata.Labels["public-facing"]).To(Equal("false"))
-			})
-
-			When("the buildpack is unknown", func() {
-				It("displays an error", func() {
-					session := helpers.CF("set-label", "buildpack", "non-existent-buildpack", "some-key=some-value")
-					Eventually(session.Err).Should(Say("Buildpack non-existent-buildpack not found"))
-					Eventually(session).Should(Say("FAILED"))
-					Eventually(session).Should(Exit(1))
-				})
-			})
-
-			When("the buildpack exists for multiple stacks", func() {
-				var stacks []string
+			When("the buildpack exists for at most one stack", func() {
+				var (
+					currentStack string
+				)
 
 				BeforeEach(func() {
-					stacks = helpers.EnsureMinimumNumberOfStacks(2)
-
+					currentStack = helpers.PreferredStack()
 					helpers.BuildpackWithStack(func(buildpackPath string) {
-						createSession := helpers.CF("create-buildpack", buildpackName, buildpackPath, "99")
-						Eventually(createSession).Should(Exit(0))
-					}, stacks[1])
-				})
-
-				When("stack is not specified", func() {
-					It("displays an error", func() {
-						session := helpers.CF("set-label", "buildpack", buildpackName, "some-key=some-value")
-						Eventually(session.Err).Should(Say(fmt.Sprintf("Multiple buildpacks named %s found. Specify a stack name by using a '-s' flag.", buildpackName)))
-						Eventually(session).Should(Say("FAILED"))
-						Eventually(session).Should(Exit(1))
-					})
-				})
-
-				When("stack is specified", func() {
-					It("sets the specified labels on the correct buildpack", func() {
-						session := helpers.CF("set-label", "buildpack", buildpackName, "pci=true", "public-facing=false", "--stack", stacks[1])
-						Eventually(session).Should(Say(regexp.QuoteMeta(`Setting label(s) for buildpack %s as %s...`), buildpackName, username))
-						Eventually(session).Should(Say("OK"))
+						session := helpers.CF("create-buildpack", buildpackName, buildpackPath, "98")
 						Eventually(session).Should(Exit(0))
-
-						buildpackGUID := helpers.BuildpackGUIDByNameAndStack(buildpackName, stacks[1])
-						session = helpers.CF("curl", fmt.Sprintf("/v3/buildpacks/%s", buildpackGUID))
-						Eventually(session).Should(Exit(0))
-						buildpackJSON := session.Out.Contents()
-						var buildpack commonResource
-						Expect(json.Unmarshal(buildpackJSON, &buildpack)).To(Succeed())
-						Expect(len(buildpack.Metadata.Labels)).To(Equal(2))
-						Expect(buildpack.Metadata.Labels["pci"]).To(Equal("true"))
-						Expect(buildpack.Metadata.Labels["public-facing"]).To(Equal("false"))
-					})
+					}, currentStack)
 				})
-			})
-
-			When("the buildpack exists in general but does NOT exist for the specified stack", func() {
-				It("displays an error", func() {
-					session := helpers.CF("set-label", "buildpack", buildpackName, "some-key=some-value", "--stack", "FAKE")
-					Eventually(session.Err).Should(Say(fmt.Sprintf("Buildpack %s with stack FAKE not found", buildpackName)))
-					Eventually(session).Should(Say("FAILED"))
-					Eventually(session).Should(Exit(1))
+				AfterEach(func() {
+					helpers.CF("delete-buildpack", buildpackName, "-f", "-s", currentStack)
 				})
-			})
 
-			When("the label has an empty key and an invalid value", func() {
-				It("displays an error", func() {
-					session := helpers.CF("set-label", "buildpack", buildpackName, "=test", "sha2=108&eb90d734")
-					Eventually(session.Err).Should(Say("Metadata label key error: key cannot be empty string, Metadata label value error: '108&eb90d734' contains invalid characters"))
-					Eventually(session).Should(Say("FAILED"))
-					Eventually(session).Should(Exit(1))
-				})
-			})
-
-			When("the label does not include a '=' to separate the key and value", func() {
-				It("displays an error", func() {
-					session := helpers.CF("set-label", "buildpack", buildpackName, "test-label")
-					Eventually(session.Err).Should(Say("Metadata error: no value provided for label 'test-label'"))
-					Eventually(session).Should(Say("FAILED"))
-					Eventually(session).Should(Exit(1))
-				})
-			})
-
-			When("more than one value is provided for the same key", func() {
-				It("uses the last value", func() {
-					session := helpers.CF("set-label", "buildpack", buildpackName, "owner=sue", "owner=beth")
+				It("sets the specified labels on the buildpack", func() {
+					session := helpers.CF("set-label", "buildpack", buildpackName, "pci=true", "public-facing=false")
+					Eventually(session).Should(Say(regexp.QuoteMeta(`Setting label(s) for buildpack %s as %s...`), buildpackName, username))
+					Eventually(session).Should(Say("OK"))
 					Eventually(session).Should(Exit(0))
-					buildpackGUID := helpers.BuildpackGUIDByNameAndStack(buildpackName, "")
+
+					buildpackGUID := helpers.BuildpackGUIDByNameAndStack(buildpackName, currentStack)
 					session = helpers.CF("curl", fmt.Sprintf("/v3/buildpacks/%s", buildpackGUID))
 					Eventually(session).Should(Exit(0))
 					buildpackJSON := session.Out.Contents()
 					var buildpack commonResource
 					Expect(json.Unmarshal(buildpackJSON, &buildpack)).To(Succeed())
-					Expect(len(buildpack.Metadata.Labels)).To(Equal(1))
-					Expect(buildpack.Metadata.Labels["owner"]).To(Equal("beth"))
+					Expect(len(buildpack.Metadata.Labels)).To(Equal(2))
+					Expect(buildpack.Metadata.Labels["pci"]).To(Equal("true"))
+					Expect(buildpack.Metadata.Labels["public-facing"]).To(Equal("false"))
+				})
+
+				When("the buildpack is unknown", func() {
+					It("displays an error", func() {
+						session := helpers.CF("set-label", "buildpack", "non-existent-buildpack", "some-key=some-value")
+						Eventually(session.Err).Should(Say("Buildpack non-existent-buildpack not found"))
+						Eventually(session).Should(Say("FAILED"))
+						Eventually(session).Should(Exit(1))
+					})
+				})
+
+				When("the buildpack exists in general but does NOT exist for the specified stack", func() {
+					It("displays an error", func() {
+						session := helpers.CF("set-label", "buildpack", buildpackName, "some-key=some-value", "--stack", "FAKE")
+						Eventually(session.Err).Should(Say(fmt.Sprintf("Buildpack %s with stack FAKE not found", buildpackName)))
+						Eventually(session).Should(Say("FAILED"))
+						Eventually(session).Should(Exit(1))
+					})
+				})
+
+				When("the label has an empty key and an invalid value", func() {
+					It("displays an error", func() {
+						session := helpers.CF("set-label", "buildpack", buildpackName, "=test", "sha2=108&eb90d734")
+						Eventually(session.Err).Should(Say("Metadata label key error: key cannot be empty string, Metadata label value error: '108&eb90d734' contains invalid characters"))
+						Eventually(session).Should(Say("FAILED"))
+						Eventually(session).Should(Exit(1))
+					})
+				})
+
+				When("the label does not include a '=' to separate the key and value", func() {
+					It("displays an error", func() {
+						session := helpers.CF("set-label", "buildpack", buildpackName, "test-label")
+						Eventually(session.Err).Should(Say("Metadata error: no value provided for label 'test-label'"))
+						Eventually(session).Should(Say("FAILED"))
+						Eventually(session).Should(Exit(1))
+					})
+				})
+
+				When("more than one value is provided for the same key", func() {
+					It("uses the last value", func() {
+						session := helpers.CF("set-label", "buildpack", buildpackName, "owner=sue", "owner=beth")
+						Eventually(session).Should(Exit(0))
+						buildpackGUID := helpers.BuildpackGUIDByNameAndStack(buildpackName, currentStack)
+						session = helpers.CF("curl", fmt.Sprintf("/v3/buildpacks/%s", buildpackGUID))
+						Eventually(session).Should(Exit(0))
+						buildpackJSON := session.Out.Contents()
+						var buildpack commonResource
+						Expect(json.Unmarshal(buildpackJSON, &buildpack)).To(Succeed())
+						Expect(len(buildpack.Metadata.Labels)).To(Equal(1))
+						Expect(buildpack.Metadata.Labels["owner"]).To(Equal("beth"))
+					})
+				})
+
+			})
+
+			When("the buildpack exists for multiple stacks", func() {
+				var (
+					stacks         [3]string
+					buildpackGUIDs [3]string
+				)
+
+				BeforeEach(func() {
+					stacks[0] = helpers.PreferredStack()
+					testWithStackCount += 1
+					stacks[1] = helpers.CreateStack(fmt.Sprintf("%s-%d", stackNameBase, testWithStackCount))
+
+					for i := 0; i < 2; i++ {
+						helpers.BuildpackWithStack(func(buildpackPath string) {
+							createSession := helpers.CF("create-buildpack", buildpackName, buildpackPath,
+								fmt.Sprintf("%d", 95+i))
+							Eventually(createSession).Should(Exit(0))
+							buildpackGUIDs[i] = helpers.BuildpackGUIDByNameAndStack(buildpackName, stacks[i])
+						}, stacks[i])
+					}
+					helpers.CF("curl", "/v3/buildpacks?names="+buildpackName)
+				})
+				AfterEach(func() {
+					helpers.CF("delete-buildpack", buildpackName, "-f", "-s", stacks[0])
+					helpers.CF("delete-buildpack", buildpackName, "-f", "-s", stacks[1])
+					helpers.DeleteStack(stacks[1])
+				})
+
+				When("all buildpacks are stack-scoped", func() {
+					When("no stack is specified", func() {
+						It("displays an error", func() {
+							session := helpers.CF("set-label", "buildpack", buildpackName, "some-key=some-value")
+							Eventually(session.Err).Should(Say(fmt.Sprintf("Multiple buildpacks named %s found. Specify a stack name by using a '-s' flag.", buildpackName)))
+							Eventually(session).Should(Say("FAILED"))
+							Eventually(session).Should(Exit(1))
+						})
+					})
+
+					When("a non-existent stack is specified", func() {
+						It("displays an error", func() {
+							bogusStackName := stacks[0] + "-bogus-" + stacks[1]
+							session := helpers.CF("set-label", "buildpack", buildpackName, "olive=3", "mangosteen=4", "--stack", bogusStackName)
+							Eventually(session.Err).Should(Say(regexp.QuoteMeta(fmt.Sprintf("Buildpack %s with stack %s not found", buildpackName, bogusStackName))))
+							Eventually(session).Should(Say("FAILED"))
+							Eventually(session).Should(Exit(1))
+						})
+					})
+
+					When("an existing stack is specified", func() {
+						It("updates the correct buildpack", func() {
+							session := helpers.CF("set-label", "buildpack", buildpackName, "peach=5", "quince=6", "--stack", stacks[0])
+							Eventually(session).Should(Say(regexp.QuoteMeta(`Setting label(s) for buildpack %s as %s...`), buildpackName, username))
+							Eventually(session).Should(Say("OK"))
+							Eventually(session).Should(Exit(0))
+
+							session = helpers.CF("curl", fmt.Sprintf("/v3/buildpacks/%s", buildpackGUIDs[0]))
+							Eventually(session).Should(Exit(0))
+							buildpackJSON := session.Out.Contents()
+							var buildpack commonResource
+							Expect(json.Unmarshal(buildpackJSON, &buildpack)).To(Succeed())
+							Expect(len(buildpack.Metadata.Labels)).To(Equal(2))
+							Expect(buildpack.Metadata.Labels["peach"]).To(Equal("5"))
+							Expect(buildpack.Metadata.Labels["quince"]).To(Equal("6"))
+						})
+					})
+				})
+
+				When("one of the buildpacks is not stack-scoped", func() {
+					BeforeEach(func() {
+						helpers.BuildpackWithoutStack(func(buildpackPath string) {
+							createSession := helpers.CF("create-buildpack", buildpackName, buildpackPath, "97")
+							Eventually(createSession).Should(Exit(0))
+							buildpackGUIDs[2] = helpers.BuildpackGUIDByNameAndStack(buildpackName, "")
+						})
+					})
+					AfterEach(func() {
+						helpers.CF("delete-buildpack", buildpackName, "-f")
+					})
+
+					When("no stack is specified", func() {
+						It("updates the unscoped buildpack", func() {
+							session := helpers.CF("set-label", "buildpack", buildpackName, "mango=1", "figs=2")
+							Eventually(session).Should(Say(regexp.QuoteMeta(`Setting label(s) for buildpack %s as %s...`), buildpackName, username))
+							Eventually(session).Should(Say("OK"))
+							Eventually(session).Should(Exit(0))
+
+							session = helpers.CF("curl", fmt.Sprintf("/v3/buildpacks/%s", buildpackGUIDs[2]))
+							Eventually(session).Should(Exit(0))
+							buildpackJSON := session.Out.Contents()
+							var buildpack commonResource
+							Expect(json.Unmarshal(buildpackJSON, &buildpack)).To(Succeed())
+							Expect(len(buildpack.Metadata.Labels)).To(Equal(2))
+							Expect(buildpack.Metadata.Labels["mango"]).To(Equal("1"))
+							Expect(buildpack.Metadata.Labels["figs"]).To(Equal("2"))
+						})
+					})
+
+					When("an existing stack is specified", func() {
+						It("updates the correct buildpack", func() {
+							session := helpers.CF("set-label", "buildpack", buildpackName, "tangelo=3", "lemon=4", "--stack", stacks[1])
+							Eventually(session).Should(Say(regexp.QuoteMeta(`Setting label(s) for buildpack %s as %s...`), buildpackName, username))
+							Eventually(session).Should(Say("OK"))
+							Eventually(session).Should(Exit(0))
+
+							session = helpers.CF("curl", fmt.Sprintf("/v3/buildpacks/%s", buildpackGUIDs[1]))
+							Eventually(session).Should(Exit(0))
+							buildpackJSON := session.Out.Contents()
+							var buildpack commonResource
+							Expect(json.Unmarshal(buildpackJSON, &buildpack)).To(Succeed())
+							Expect(len(buildpack.Metadata.Labels)).To(Equal(2))
+							Expect(buildpack.Metadata.Labels["tangelo"]).To(Equal("3"))
+							Expect(buildpack.Metadata.Labels["lemon"]).To(Equal("4"))
+						})
+					})
+
+					When("a non-existent stack is specified", func() {
+						It("displays an error", func() {
+							bogusStackName := stacks[0] + "-bogus-" + stacks[1]
+							session := helpers.CF("set-label", "buildpack", buildpackName, "olive=3", "mangosteen=4", "--stack", bogusStackName)
+							Eventually(session.Err).Should(Say(regexp.QuoteMeta(fmt.Sprintf("Buildpack %s with stack %s not found", buildpackName, bogusStackName))))
+							Eventually(session).Should(Say("FAILED"))
+							Eventually(session).Should(Exit(1))
+						})
+					})
 				})
 			})
 		})

--- a/integration/v7/isolated/set_label_command_test.go
+++ b/integration/v7/isolated/set_label_command_test.go
@@ -413,7 +413,7 @@ var _ = Describe("set-label command", func() {
 					When("an existing stack is specified", func() {
 						It("updates the correct buildpack", func() {
 							session := helpers.CF("set-label", "buildpack", buildpackName, "peach=5", "quince=6", "--stack", stacks[0])
-							Eventually(session).Should(Say(regexp.QuoteMeta(`Setting label(s) for buildpack %s as %s...`), buildpackName, username))
+							Eventually(session).Should(Say(regexp.QuoteMeta(`Setting label(s) for buildpack %s with stack %s as %s...`), buildpackName, stacks[0], username))
 							Eventually(session).Should(Say("OK"))
 							Eventually(session).Should(Exit(0))
 
@@ -462,7 +462,7 @@ var _ = Describe("set-label command", func() {
 					When("an existing stack is specified", func() {
 						It("updates the correct buildpack", func() {
 							session := helpers.CF("set-label", "buildpack", buildpackName, "tangelo=3", "lemon=4", "--stack", stacks[1])
-							Eventually(session).Should(Say(regexp.QuoteMeta(`Setting label(s) for buildpack %s as %s...`), buildpackName, username))
+							Eventually(session).Should(Say(regexp.QuoteMeta(`Setting label(s) for buildpack %s with stack %s as %s...`), buildpackName, stacks[1], username))
 							Eventually(session).Should(Say("OK"))
 							Eventually(session).Should(Exit(0))
 


### PR DESCRIPTION
## Does this PR modify CLI v6 or v7?

This modifies **v7**!

## Description of the Change

We're adding the ability to use `cf set-label` to add labels to buildpacks!
See: https://www.pivotaltracker.com/story/show/166986079

We also included an additional commit since the stories so far have been calling for things like:
> The required arg resource type (space) is case insensitive
> The required arg buildpack is case insensitive.

And this wasn't actually occurring.

## Other Relevant Parties

@ssisil @Gerg @abbyachau @selzoc @sannidhi 
