### PR TITLE
Show buildpack labels

### DIFF
--- a/actor/v7action/label.go
+++ b/actor/v7action/label.go
@@ -41,6 +41,18 @@ func (actor *Actor) GetSpaceLabels(spaceName string, orgGUID string) (map[string
 	return labels, warnings, nil
 }
 
+func (actor *Actor) GetBuildpackLabels(buildpackName string, buildpackStack string) (map[string]types.NullString, Warnings, error) {
+	var labels map[string]types.NullString
+	resource, warnings, err := actor.GetBuildpackByNameAndStack(buildpackName, buildpackStack)
+	if err != nil {
+		return labels, warnings, err
+	}
+	if resource.Metadata != nil {
+		labels = resource.Metadata.Labels
+	}
+	return labels, warnings, nil
+}
+
 func (actor *Actor) UpdateApplicationLabelsByApplicationName(appName string, spaceGUID string, labels map[string]types.NullString) (Warnings, error) {
 	app, warnings, err := actor.GetApplicationByNameAndSpace(appName, spaceGUID)
 	if err != nil {

--- a/api/cloudcontroller/ccv3/buildpack.go
+++ b/api/cloudcontroller/ccv3/buildpack.go
@@ -34,16 +34,19 @@ type Buildpack struct {
 	State string
 	// Links are links to related resources.
 	Links APILinks
+	// Metadata is used for custom tagging of API resources
+	Metadata *Metadata
 }
 
 // MarshalJSON converts a Package into a Cloud Controller Package.
 func (buildpack Buildpack) MarshalJSON() ([]byte, error) {
 	ccBuildpack := struct {
-		Name     string `json:"name,omitempty"`
-		Stack    string `json:"stack,omitempty"`
-		Position *int   `json:"position,omitempty"`
-		Enabled  *bool  `json:"enabled,omitempty"`
-		Locked   *bool  `json:"locked,omitempty"`
+		Name     string    `json:"name,omitempty"`
+		Stack    string    `json:"stack,omitempty"`
+		Position *int      `json:"position,omitempty"`
+		Enabled  *bool     `json:"enabled,omitempty"`
+		Locked   *bool     `json:"locked,omitempty"`
+		Metadata *Metadata `json:"metadata,omitempty"`
 	}{
 		Name:  buildpack.Name,
 		Stack: buildpack.Stack,
@@ -73,6 +76,7 @@ func (buildpack *Buildpack) UnmarshalJSON(data []byte) error {
 		Enabled  types.NullBool `json:"enabled"`
 		Locked   types.NullBool `json:"locked"`
 		Position types.NullInt  `json:"position"`
+		Metadata *Metadata      `json:"metadata"`
 	}
 
 	err := cloudcontroller.DecodeJSON(data, &ccBuildpack)
@@ -89,6 +93,7 @@ func (buildpack *Buildpack) UnmarshalJSON(data []byte) error {
 	buildpack.Stack = ccBuildpack.Stack
 	buildpack.State = ccBuildpack.State
 	buildpack.Links = ccBuildpack.Links
+	buildpack.Metadata = ccBuildpack.Metadata
 
 	return nil
 }

--- a/api/cloudcontroller/ccv3/buildpack_test.go
+++ b/api/cloudcontroller/ccv3/buildpack_test.go
@@ -58,7 +58,11 @@ var _ = Describe("Buildpacks", func() {
 							"stack": "windows64",
 							"position": 1,
 							"enabled": true,
-							"locked": false
+							"locked": false,
+							"unlocked": false,
+							"metadata": {
+								"labels": {}
+							}
 						},
 						{
 							"guid": "guid2",
@@ -67,7 +71,10 @@ var _ = Describe("Buildpacks", func() {
 							"stack": "cflinuxfs3",
 							"position": 2,
 							"enabled": false,
-							"locked": true
+							"locked": true,
+							"metadata": {
+								"labels": {}
+							}
 						}
 					]
 				}`, server.URL())
@@ -83,7 +90,10 @@ var _ = Describe("Buildpacks", func() {
 							"stack": "cflinuxfs2",
 							"position": 3,
 							"enabled": true,
-							"locked": false
+							"locked": false,
+							"metadata": {
+								"labels": {}
+							}
 						}
 					]
 				}`
@@ -119,6 +129,7 @@ var _ = Describe("Buildpacks", func() {
 						Locked:   types.NullBool{Value: false, IsSet: true},
 						Stack:    "windows64",
 						State:    "AWAITING_UPLOAD",
+						Metadata: &Metadata{Labels: map[string]types.NullString{}},
 					},
 					Buildpack{
 						Name:     "staticfile_buildpack",
@@ -128,6 +139,7 @@ var _ = Describe("Buildpacks", func() {
 						Locked:   types.NullBool{Value: true, IsSet: true},
 						Stack:    "cflinuxfs3",
 						State:    "AWAITING_UPLOAD",
+						Metadata: &Metadata{Labels: map[string]types.NullString{}},
 					},
 					Buildpack{
 						Name:     "go_buildpack",
@@ -137,6 +149,7 @@ var _ = Describe("Buildpacks", func() {
 						Locked:   types.NullBool{Value: false, IsSet: true},
 						Stack:    "cflinuxfs2",
 						State:    "AWAITING_UPLOAD",
+						Metadata: &Metadata{Labels: map[string]types.NullString{}},
 					},
 				))
 				Expect(warnings).To(ConsistOf("this is a warning", "this is another warning"))

--- a/api/cloudcontroller/ccv3/buildpack_test.go
+++ b/api/cloudcontroller/ccv3/buildpack_test.go
@@ -59,7 +59,6 @@ var _ = Describe("Buildpacks", func() {
 							"position": 1,
 							"enabled": true,
 							"locked": false,
-							"unlocked": false,
 							"metadata": {
 								"labels": {}
 							}

--- a/command/translatableerror/buildpack_not_found_error.go
+++ b/command/translatableerror/buildpack_not_found_error.go
@@ -7,9 +7,9 @@ type BuildpackNotFoundError struct {
 
 func (e BuildpackNotFoundError) Error() string {
 	if len(e.StackName) == 0 {
-		return "Buildpack '{{.BuildpackName}}' not found"
+		return "Buildpack {{.BuildpackName}} not found"
 	}
-	return "Buildpack '{{.BuildpackName}}' with stack '{{.StackName}}' not found"
+	return "Buildpack {{.BuildpackName}} with stack {{.StackName}} not found"
 }
 
 func (e BuildpackNotFoundError) Translate(translate func(string, ...interface{}) string) string {

--- a/command/translatableerror/buildpack_not_found_error.go
+++ b/command/translatableerror/buildpack_not_found_error.go
@@ -7,9 +7,9 @@ type BuildpackNotFoundError struct {
 
 func (e BuildpackNotFoundError) Error() string {
 	if len(e.StackName) == 0 {
-		return "Buildpack {{.BuildpackName}} not found"
+		return "Buildpack '{{.BuildpackName}}' not found"
 	}
-	return "Buildpack {{.BuildpackName}} with stack {{.StackName}} not found"
+	return "Buildpack '{{.BuildpackName}}' with stack '{{.StackName}}' not found"
 }
 
 func (e BuildpackNotFoundError) Translate(translate func(string, ...interface{}) string) string {

--- a/command/v7/labels_command.go
+++ b/command/v7/labels_command.go
@@ -30,11 +30,13 @@ type LabelsActor interface {
 	GetApplicationLabels(appName string, spaceGUID string) (map[string]types.NullString, v7action.Warnings, error)
 	GetOrganizationLabels(orgName string) (map[string]types.NullString, v7action.Warnings, error)
 	GetSpaceLabels(spaceName string, orgGUID string) (map[string]types.NullString, v7action.Warnings, error)
+	GetBuildpackLabels(buildpackName string, buildpackStack string) (map[string]types.NullString, v7action.Warnings, error)
 }
 
 type LabelsCommand struct {
 	RequiredArgs flag.LabelsArgs `positional-args:"yes"`
-	usage        interface{}     `usage:"CF_NAME labels RESOURCE RESOURCE_NAME\n\nEXAMPLES:\n   cf labels app dora \n\nRESOURCES:\n   app\n   space\n   org\n\nSEE ALSO:\n   set-label, unset-label"`
+	StackName    string          `long:"stack" short:"s" description:"required when more than one buildpack has the same name"`
+	usage        interface{}     `usage:"CF_NAME labels RESOURCE RESOURCE_NAME\n\nEXAMPLES:\n   cf labels app dora \n\nRESOURCES:\n   app\n   buildpack\n   org\n   space\n\nSEE ALSO:\n   set-label, unset-label"`
 	UI           command.UI
 	Config       command.Config
 	SharedActor  command.SharedActor
@@ -71,6 +73,8 @@ func (cmd LabelsCommand) Execute(args []string) error {
 		labels, warnings, err = cmd.fetchOrgLabels(username)
 	case Space:
 		labels, warnings, err = cmd.fetchSpaceLabels(username)
+	case Buildpack:
+		labels, warnings, err = cmd.fetchBuildpackLabels(username)
 	default:
 		err = fmt.Errorf("Unsupported resource type of '%s'", cmd.RequiredArgs.ResourceType)
 	}
@@ -132,6 +136,22 @@ func (cmd LabelsCommand) fetchSpaceLabels(username string) (map[string]types.Nul
 	cmd.UI.DisplayNewline()
 
 	return cmd.Actor.GetSpaceLabels(cmd.RequiredArgs.ResourceName, cmd.Config.TargetedOrganization().GUID)
+}
+
+func (cmd LabelsCommand) fetchBuildpackLabels(username string) (map[string]types.NullString, v7action.Warnings, error) {
+	err := cmd.SharedActor.CheckTarget(false, false)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cmd.UI.DisplayTextWithFlavor("Getting labels for buildpack {{.BuildpackName}} as {{.Username}}...", map[string]interface{}{
+		"BuildpackName": cmd.RequiredArgs.ResourceName,
+		"Username":      username,
+	})
+
+	cmd.UI.DisplayNewline()
+
+	return cmd.Actor.GetBuildpackLabels(cmd.RequiredArgs.ResourceName, cmd.StackName)
 }
 
 func (cmd LabelsCommand) printLabels(labels map[string]types.NullString) {

--- a/command/v7/labels_command_test.go
+++ b/command/v7/labels_command_test.go
@@ -407,5 +407,125 @@ var _ = Describe("labels command", func() {
 				})
 			})
 		})
+
+		Describe("for buildpacks", func() {
+			BeforeEach(func() {
+				fakeConfig.CurrentUserNameReturns("some-user", nil)
+				cmd.RequiredArgs = flag.LabelsArgs{
+					ResourceType: "buildpack",
+					ResourceName: "my-buildpack",
+				}
+				fakeLabelsActor.GetBuildpackLabelsReturns(
+					map[string]types.NullString{
+						"some-other-label": types.NewNullString("some-other-value"),
+						"some-label":       types.NewNullString("some-value"),
+					},
+					v7action.Warnings{},
+					nil)
+			})
+
+			It("doesn't error", func() {
+				Expect(executeErr).ToNot(HaveOccurred())
+			})
+
+			It("checks that the user is logged in", func() {
+				Expect(fakeSharedActor.CheckTargetCallCount()).To(Equal(1))
+				checkOrg, checkSpace := fakeSharedActor.CheckTargetArgsForCall(0)
+				Expect(checkOrg).To(BeFalse())
+				Expect(checkSpace).To(BeFalse())
+			})
+
+			It("displays a message that it is retrieving the labels", func() {
+				Expect(executeErr).ToNot(HaveOccurred())
+				Expect(fakeSharedActor.CheckTargetCallCount()).To(Equal(1))
+				Expect(testUI.Out).To(Say(regexp.QuoteMeta(`Getting labels for buildpack my-buildpack as some-user...`)))
+			})
+
+			It("retrieves the labels associated with the buidpack", func() {
+				Expect(fakeLabelsActor.GetBuildpackLabelsCallCount()).To(Equal(1))
+			})
+
+			It("displays the labels that are associated with the buildpack, alphabetically", func() {
+				Expect(testUI.Out).To(Say(`key\s+value`))
+				Expect(testUI.Out).To(Say(`some-label\s+some-value`))
+				Expect(testUI.Out).To(Say(`some-other-label\s+some-other-value`))
+			})
+
+			When("CAPI returns warnings", func() {
+				BeforeEach(func() {
+					fakeLabelsActor.GetBuildpackLabelsReturns(
+						map[string]types.NullString{
+							"some-other-label": types.NewNullString("some-other-value"),
+							"some-label":       types.NewNullString("some-value"),
+						},
+						v7action.Warnings([]string{"some-warning-1", "some-warning-2"}),
+						nil)
+				})
+
+				It("prints all warnings", func() {
+					Expect(testUI.Err).To(Say("some-warning-1"))
+					Expect(testUI.Err).To(Say("some-warning-2"))
+				})
+			})
+
+			When("there is an error retrieving the buildpack", func() {
+				BeforeEach(func() {
+					fakeLabelsActor.GetBuildpackLabelsReturns(
+						map[string]types.NullString{},
+						v7action.Warnings([]string{"some-warning-1", "some-warning-2"}),
+						errors.New("boom"))
+				})
+
+				It("returns the error", func() {
+					Expect(executeErr).To(MatchError("boom"))
+				})
+
+				It("still prints all warnings", func() {
+					Expect(testUI.Err).To(Say("some-warning-1"))
+					Expect(testUI.Err).To(Say("some-warning-2"))
+				})
+
+				It("doesn't say ok", func() {
+					Expect(testUI.Out).ToNot(Say("OK"))
+				})
+			})
+
+			When("checking targeted org and space fails", func() {
+				BeforeEach(func() {
+					fakeSharedActor.CheckTargetReturns(errors.New("nope"))
+				})
+
+				It("returns an error", func() {
+					Expect(executeErr).To(MatchError("nope"))
+				})
+			})
+
+			When("fetching the current user's name fails", func() {
+				BeforeEach(func() {
+					fakeConfig.CurrentUserNameReturns("some-user", errors.New("boom"))
+				})
+
+				It("returns an error", func() {
+					Expect(executeErr).To(MatchError("boom"))
+				})
+			})
+
+			When("the resource type argument is not lowercase", func() {
+				BeforeEach(func() {
+					cmd.RequiredArgs = flag.LabelsArgs{
+						ResourceType: "Buildpack",
+						ResourceName: "fake-buildpack",
+					}
+					cmd.StackName = "another-great-stack"
+				})
+
+				It("retrieves the labels associated with the buildpack", func() {
+					Expect(fakeLabelsActor.GetBuildpackLabelsCallCount()).To(Equal(1))
+					buildpackName, stackName := fakeLabelsActor.GetBuildpackLabelsArgsForCall(0)
+					Expect(buildpackName).To(Equal("fake-buildpack"))
+					Expect(stackName).To(Equal("another-great-stack"))
+				})
+			})
+		})
 	})
 })

--- a/command/v7/labels_command_test.go
+++ b/command/v7/labels_command_test.go
@@ -435,13 +435,33 @@ var _ = Describe("labels command", func() {
 				Expect(checkSpace).To(BeFalse())
 			})
 
-			It("displays a message that it is retrieving the labels", func() {
-				Expect(executeErr).ToNot(HaveOccurred())
-				Expect(fakeSharedActor.CheckTargetCallCount()).To(Equal(1))
-				Expect(testUI.Out).To(Say(regexp.QuoteMeta(`Getting labels for buildpack my-buildpack as some-user...`)))
+			Describe("the getting-labels message", func() {
+				When("the buildpack stack is not specified", func() {
+					BeforeEach(func() {
+						cmd.BuildpackStack = ""
+					})
+
+					It("displays a message that it is retrieving the labels", func() {
+						Expect(executeErr).ToNot(HaveOccurred())
+						Expect(fakeSharedActor.CheckTargetCallCount()).To(Equal(1))
+						Expect(testUI.Out).To(Say(regexp.QuoteMeta(`Getting labels for buildpack my-buildpack as some-user...`)))
+					})
+				})
+
+				When("the buildpack stack is specified", func() {
+					BeforeEach(func() {
+						cmd.BuildpackStack = "omelette"
+					})
+
+					It("displays a message that it is retrieving the labels", func() {
+						Expect(executeErr).ToNot(HaveOccurred())
+						Expect(fakeSharedActor.CheckTargetCallCount()).To(Equal(1))
+						Expect(testUI.Out).To(Say(regexp.QuoteMeta(`Getting labels for buildpack my-buildpack with stack omelette as some-user...`)))
+					})
+				})
 			})
 
-			It("retrieves the labels associated with the buidpack", func() {
+			It("retrieves the labels associated with the buildpack", func() {
 				Expect(fakeLabelsActor.GetBuildpackLabelsCallCount()).To(Equal(1))
 			})
 
@@ -516,7 +536,7 @@ var _ = Describe("labels command", func() {
 						ResourceType: "Buildpack",
 						ResourceName: "fake-buildpack",
 					}
-					cmd.StackName = "another-great-stack"
+					cmd.BuildpackStack = "another-great-stack"
 				})
 
 				It("retrieves the labels associated with the buildpack", func() {

--- a/command/v7/set_label_command_test.go
+++ b/command/v7/set_label_command_test.go
@@ -3,6 +3,7 @@ package v7_test
 import (
 	"errors"
 	"regexp"
+	"strings"
 
 	"code.cloudfoundry.org/cli/actor/v7action"
 	"code.cloudfoundry.org/cli/command/commandfakes"
@@ -30,6 +31,21 @@ var _ = Describe("set-label command", func() {
 
 		executeErr error
 	)
+
+	checkBuildpackArgFunc := func() {
+		BeforeEach(func() {
+			cmd.BuildpackStack = "cflinuxfs3"
+		})
+
+		It("displays an argument combination error", func() {
+			argumentCombinationError := translatableerror.ArgumentCombinationError{
+				Args: []string{strings.ToLower(cmd.RequiredArgs.ResourceType), "--stack, -s"},
+			}
+
+			Expect(executeErr).To(MatchError(argumentCombinationError))
+		})
+
+	}
 
 	When("setting labels on apps", func() {
 
@@ -219,6 +235,10 @@ var _ = Describe("set-label command", func() {
 				Expect(executeErr).To(MatchError("nope"))
 			})
 		})
+
+		When("when the --stack flag is specified", func() {
+			checkBuildpackArgFunc()
+		})
 	})
 
 	When("setting labels on orgs", func() {
@@ -402,6 +422,10 @@ var _ = Describe("set-label command", func() {
 			It("returns an error", func() {
 				Expect(executeErr).To(MatchError("nope"))
 			})
+		})
+
+		When("when the --stack flag is specified", func() {
+			checkBuildpackArgFunc()
 		})
 	})
 
@@ -591,6 +615,18 @@ var _ = Describe("set-label command", func() {
 				Expect(executeErr).To(MatchError("nope"))
 			})
 		})
+
+		When("setting the stack argument", func() {
+
+			BeforeEach(func() {
+				cmd.BuildpackStack = "cflinuxfs3"
+			})
+
+			It("does not display an argument combination error", func() {
+				Expect(executeErr).ToNot(HaveOccurred())
+			})
+
+		})
 	})
 
 	When("setting labels on spaces", func() {
@@ -710,18 +746,7 @@ var _ = Describe("set-label command", func() {
 				})
 
 				When("when the --stack flag is specified", func() {
-					BeforeEach(func() {
-						cmd.RequiredArgs = flag.SetLabelArgs{
-							ResourceType: "space",
-							ResourceName: resourceName,
-							Labels:       []string{"FOO=BAR", "ENV=FAKE"},
-						}
-						cmd.BuildpackStack = "im-a-stack"
-					})
-
-					It("complains about the --stack flag being present", func() {
-						Expect(executeErr).To(MatchError(translatableerror.ArgumentCombinationError{Args: []string{"space", "--stack, -s"}}))
-					})
+					checkBuildpackArgFunc()
 				})
 
 				When("the resource type argument is not lowercase", func() {

--- a/command/v7/set_label_command_test.go
+++ b/command/v7/set_label_command_test.go
@@ -32,7 +32,7 @@ var _ = Describe("set-label command", func() {
 		executeErr error
 	)
 
-	checkBuildpackArgFunc := func() {
+	verifyStackArgNotAllowed := func() {
 		BeforeEach(func() {
 			cmd.BuildpackStack = "cflinuxfs3"
 		})
@@ -44,7 +44,6 @@ var _ = Describe("set-label command", func() {
 
 			Expect(executeErr).To(MatchError(argumentCombinationError))
 		})
-
 	}
 
 	When("setting labels on apps", func() {
@@ -237,7 +236,7 @@ var _ = Describe("set-label command", func() {
 		})
 
 		When("when the --stack flag is specified", func() {
-			checkBuildpackArgFunc()
+			verifyStackArgNotAllowed()
 		})
 	})
 
@@ -425,7 +424,7 @@ var _ = Describe("set-label command", func() {
 		})
 
 		When("when the --stack flag is specified", func() {
-			checkBuildpackArgFunc()
+			verifyStackArgNotAllowed()
 		})
 	})
 
@@ -779,7 +778,7 @@ var _ = Describe("set-label command", func() {
 				})
 
 				When("when the --stack flag is specified", func() {
-					checkBuildpackArgFunc()
+					verifyStackArgNotAllowed()
 				})
 
 				When("the resource type argument is not lowercase", func() {

--- a/command/v7/v7fakes/fake_labels_actor.go
+++ b/command/v7/v7fakes/fake_labels_actor.go
@@ -26,6 +26,22 @@ type FakeLabelsActor struct {
 		result2 v7action.Warnings
 		result3 error
 	}
+	GetBuildpackLabelsStub        func(string, string) (map[string]types.NullString, v7action.Warnings, error)
+	getBuildpackLabelsMutex       sync.RWMutex
+	getBuildpackLabelsArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
+	getBuildpackLabelsReturns struct {
+		result1 map[string]types.NullString
+		result2 v7action.Warnings
+		result3 error
+	}
+	getBuildpackLabelsReturnsOnCall map[int]struct {
+		result1 map[string]types.NullString
+		result2 v7action.Warnings
+		result3 error
+	}
 	GetOrganizationLabelsStub        func(string) (map[string]types.NullString, v7action.Warnings, error)
 	getOrganizationLabelsMutex       sync.RWMutex
 	getOrganizationLabelsArgsForCall []struct {
@@ -122,6 +138,73 @@ func (fake *FakeLabelsActor) GetApplicationLabelsReturnsOnCall(i int, result1 ma
 		})
 	}
 	fake.getApplicationLabelsReturnsOnCall[i] = struct {
+		result1 map[string]types.NullString
+		result2 v7action.Warnings
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeLabelsActor) GetBuildpackLabels(arg1 string, arg2 string) (map[string]types.NullString, v7action.Warnings, error) {
+	fake.getBuildpackLabelsMutex.Lock()
+	ret, specificReturn := fake.getBuildpackLabelsReturnsOnCall[len(fake.getBuildpackLabelsArgsForCall)]
+	fake.getBuildpackLabelsArgsForCall = append(fake.getBuildpackLabelsArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("GetBuildpackLabels", []interface{}{arg1, arg2})
+	fake.getBuildpackLabelsMutex.Unlock()
+	if fake.GetBuildpackLabelsStub != nil {
+		return fake.GetBuildpackLabelsStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	fakeReturns := fake.getBuildpackLabelsReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeLabelsActor) GetBuildpackLabelsCallCount() int {
+	fake.getBuildpackLabelsMutex.RLock()
+	defer fake.getBuildpackLabelsMutex.RUnlock()
+	return len(fake.getBuildpackLabelsArgsForCall)
+}
+
+func (fake *FakeLabelsActor) GetBuildpackLabelsCalls(stub func(string, string) (map[string]types.NullString, v7action.Warnings, error)) {
+	fake.getBuildpackLabelsMutex.Lock()
+	defer fake.getBuildpackLabelsMutex.Unlock()
+	fake.GetBuildpackLabelsStub = stub
+}
+
+func (fake *FakeLabelsActor) GetBuildpackLabelsArgsForCall(i int) (string, string) {
+	fake.getBuildpackLabelsMutex.RLock()
+	defer fake.getBuildpackLabelsMutex.RUnlock()
+	argsForCall := fake.getBuildpackLabelsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeLabelsActor) GetBuildpackLabelsReturns(result1 map[string]types.NullString, result2 v7action.Warnings, result3 error) {
+	fake.getBuildpackLabelsMutex.Lock()
+	defer fake.getBuildpackLabelsMutex.Unlock()
+	fake.GetBuildpackLabelsStub = nil
+	fake.getBuildpackLabelsReturns = struct {
+		result1 map[string]types.NullString
+		result2 v7action.Warnings
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeLabelsActor) GetBuildpackLabelsReturnsOnCall(i int, result1 map[string]types.NullString, result2 v7action.Warnings, result3 error) {
+	fake.getBuildpackLabelsMutex.Lock()
+	defer fake.getBuildpackLabelsMutex.Unlock()
+	fake.GetBuildpackLabelsStub = nil
+	if fake.getBuildpackLabelsReturnsOnCall == nil {
+		fake.getBuildpackLabelsReturnsOnCall = make(map[int]struct {
+			result1 map[string]types.NullString
+			result2 v7action.Warnings
+			result3 error
+		})
+	}
+	fake.getBuildpackLabelsReturnsOnCall[i] = struct {
 		result1 map[string]types.NullString
 		result2 v7action.Warnings
 		result3 error
@@ -266,6 +349,8 @@ func (fake *FakeLabelsActor) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.getApplicationLabelsMutex.RLock()
 	defer fake.getApplicationLabelsMutex.RUnlock()
+	fake.getBuildpackLabelsMutex.RLock()
+	defer fake.getBuildpackLabelsMutex.RUnlock()
 	fake.getOrganizationLabelsMutex.RLock()
 	defer fake.getOrganizationLabelsMutex.RUnlock()
 	fake.getSpaceLabelsMutex.RLock()

--- a/integration/helpers/stack.go
+++ b/integration/helpers/stack.go
@@ -84,11 +84,11 @@ func DeleteStack(name string) {
 	Eventually(session).Should(Exit(0))
 }
 
-// EnsureMinimumNumberOfStacks ensures there are at least 2 stacks in the foundation by creating new ones if there
-// are fewer than 2
+// EnsureMinimumNumberOfStacks ensures there are at least <num> stacks in the foundation by creating new ones if there
+// are fewer than the specified number
 func EnsureMinimumNumberOfStacks(num int) []string {
 	var stacks []string
-	for stacks = FetchStacks(); len(stacks) < 2; {
+	for stacks = FetchStacks(); len(stacks) < num; {
 		stacks = append(stacks, CreateStack())
 	}
 	return stacks

--- a/integration/v7/isolated/labels_command_test.go
+++ b/integration/v7/isolated/labels_command_test.go
@@ -216,8 +216,13 @@ var _ = Describe("labels command", func() {
 			})
 
 			When("there are multiple buildpacks with the same name", func() {
-				var newStackName = "my-stack"
+				var (
+					newStackName string
+				)
+
 				BeforeEach(func() {
+					newStackName = helpers.NewStackName()
+					helpers.CreateStack(newStackName)
 					helpers.SetupBuildpackWithStack(buildpackName, newStackName)
 					session := helpers.CF("set-label", "buildpack", buildpackName, "-s", newStackName,
 						"my-stack-some-other-key=some-other-value", "some-key=some-value")
@@ -229,6 +234,7 @@ var _ = Describe("labels command", func() {
 				AfterEach(func() {
 					session := helpers.CF("delete-buildpack", buildpackName, "-s", newStackName, "-f")
 					Eventually(session).Should(Exit(0))
+					helpers.DeleteStack(newStackName)
 				})
 				It("fails when the buildpack is ambiguous", func() {
 					session := helpers.CF("labels", "buildpack", buildpackName)
@@ -290,7 +296,7 @@ var _ = Describe("labels command", func() {
 				It("displays an error", func() {
 					session := helpers.CF("labels", "buildpack", "non-existent-buildpack")
 					Eventually(session).Should(Say(regexp.QuoteMeta("Getting labels for buildpack %s as %s...\n\n"), "non-existent-buildpack", username))
-					Eventually(session.Err).Should(Say("Buildpack 'non-existent-buildpack' not found"))
+					Eventually(session.Err).Should(Say("Buildpack non-existent-buildpack not found"))
 					Eventually(session).Should(Say("FAILED"))
 					Eventually(session).Should(Exit(1))
 				})

--- a/integration/v7/isolated/labels_command_test.go
+++ b/integration/v7/isolated/labels_command_test.go
@@ -243,14 +243,14 @@ var _ = Describe("labels command", func() {
 				})
 				It("lists the labels for both buildpacks", func() {
 					session := helpers.CF("labels", "buildpack", buildpackName, "-s", newStackName)
-					Eventually(session).Should(Say(regexp.QuoteMeta("Getting labels for buildpack %s as %s...\n\n"), buildpackName, username))
+					Eventually(session).Should(Say(regexp.QuoteMeta("Getting labels for buildpack %s with stack %s as %s...\n\n"), buildpackName, newStackName, username))
 					Eventually(session).Should(Say(`key\s+value`))
 					Eventually(session).Should(Say(`my-stack-some-other-key\s+some-other-value`))
 					Eventually(session).Should(Say(`some-key\s+some-value`))
 					Eventually(session).Should(Exit(0))
 
 					session = helpers.CF("labels", "buildpack", buildpackName, "--stack", "cflinuxfs3")
-					Eventually(session).Should(Say(regexp.QuoteMeta("Getting labels for buildpack %s as %s...\n\n"), buildpackName, username))
+					Eventually(session).Should(Say(regexp.QuoteMeta("Getting labels for buildpack %s with stack cflinuxfs3 as %s...\n\n"), buildpackName, username))
 					Eventually(session).Should(Say(`key\s+value`))
 					Eventually(session).Should(Say(`cfl1\s+var1`))
 					Eventually(session).Should(Say(`cfl2\s+var2`))

--- a/integration/v7/isolated/set_label_command_test.go
+++ b/integration/v7/isolated/set_label_command_test.go
@@ -360,7 +360,6 @@ var _ = Describe("set-label command", func() {
 						Expect(buildpack.Metadata.Labels["owner"]).To(Equal("beth"))
 					})
 				})
-
 			})
 
 			When("the buildpack exists for multiple stacks", func() {


### PR DESCRIPTION
## WARNING: 

This PR builds on top of https://github.com/cloudfoundry/cli/pull/1729 which adds the set-label functionality for a buildpack. Please make sure it is merged first.

Pertinent commits:

[this commit](https://github.com/cloudfoundry/cli/pull/1732/commits/a41b8a3f9f3b1fca2f2a595536ad1f66dce6df7b)

This branch was based off of master, not set-label-buildpack-166986079, so the pertinent diff command is this:

Diff for this PR on its actual base branch:

`git diff master origin/show-buildpack-labels`

## Does this PR modify CLI v6 or v7?

v7

## Description of the Change


App operator should be able to use a new CLI command `cf labels` to view labels for a buildpack 

Tracker Story: https://www.pivotaltracker.com/story/show/166986428
