### PR TITLE
Support removing labels from buildpacks

### DIFF
--- a/command/v7/set_label_command_test.go
+++ b/command/v7/set_label_command_test.go
@@ -619,7 +619,7 @@ var _ = Describe("set-label command", func() {
 						)
 					})
 
-					It("sets the provided labels on the org", func() {
+					It("sets the provided labels on the buildpack", func() {
 						name, stack, labels := fakeActor.UpdateBuildpackLabelsByBuildpackNameAndStackArgsForCall(0)
 						Expect(name).To(Equal(resourceName), "failed to pass buildpack name")
 						Expect(stack).To(Equal(""), "failed to pass buildpack stack")
@@ -631,6 +631,17 @@ var _ = Describe("set-label command", func() {
 
 					It("prints the flavor text in lowercase", func() {
 						Expect(testUI.Out).To(Say(regexp.QuoteMeta(`Setting label(s) for buildpack %s`), resourceName))
+					})
+
+					When("setting the stack argument", func() {
+						BeforeEach(func() {
+							cmd.BuildpackStack = "cflinuxfs3"
+						})
+
+						It("does not display an argument combination error", func() {
+							Expect(executeErr).ToNot(HaveOccurred())
+						})
+
 					})
 				})
 			})

--- a/command/v7/unset_label_command_test.go
+++ b/command/v7/unset_label_command_test.go
@@ -5,6 +5,9 @@ import (
 	"regexp"
 
 	"code.cloudfoundry.org/cli/command/flag"
+	"code.cloudfoundry.org/cli/command/translatableerror"
+
+	"strings"
 
 	"code.cloudfoundry.org/cli/actor/v7action"
 	"code.cloudfoundry.org/cli/command/commandfakes"
@@ -27,6 +30,21 @@ var _ = Describe("unset-label command", func() {
 		fakeActor       *v7fakes.FakeUnsetLabelActor
 		executeErr      error
 	)
+
+	verifyStackArgNotAllowed := func() {
+		BeforeEach(func() {
+			cmd.BuildpackStack = "cflinuxfs3"
+		})
+
+		It("displays an argument combination error", func() {
+			argumentCombinationError := translatableerror.ArgumentCombinationError{
+				Args: []string{strings.ToLower(cmd.RequiredArgs.ResourceType), "--stack, -s"},
+			}
+
+			Expect(executeErr).To(MatchError(argumentCombinationError))
+		})
+
+	}
 
 	When("unsetting labels on apps", func() {
 		BeforeEach(func() {
@@ -145,6 +163,243 @@ var _ = Describe("unset-label command", func() {
 				})
 			})
 		})
+
+		When("the --stack flag is specified", func() {
+			verifyStackArgNotAllowed()
+		})
+	})
+
+	When("Unsetting labels on buildpacks", func() {
+		var resourceName string
+
+		BeforeEach(func() {
+			testUI = ui.NewTestUI(nil, NewBuffer(), NewBuffer())
+			fakeConfig = new(commandfakes.FakeConfig)
+			fakeSharedActor = new(commandfakes.FakeSharedActor)
+			fakeActor = new(v7fakes.FakeUnsetLabelActor)
+			resourceName = "some-buildpack"
+			cmd = UnsetLabelCommand{
+				Actor:       fakeActor,
+				UI:          testUI,
+				Config:      fakeConfig,
+				SharedActor: fakeSharedActor,
+			}
+			cmd.RequiredArgs = flag.UnsetLabelArgs{
+				ResourceType: "buildpack",
+				ResourceName: resourceName,
+			}
+			cmd.RequiredArgs.LabelKeys = []string{"some-label", "some-other-key"}
+		})
+
+		JustBeforeEach(func() {
+			executeErr = cmd.Execute(nil)
+		})
+
+		When("checking target succeeds", func() {
+			var buildpackName = "some-buildpack"
+
+			BeforeEach(func() {
+				fakeSharedActor.CheckTargetReturns(nil)
+			})
+
+			It("doesn't error", func() {
+				Expect(executeErr).ToNot(HaveOccurred())
+			})
+
+			It("checks that the user is logged in", func() {
+				Expect(fakeSharedActor.CheckTargetCallCount()).To(Equal(1))
+				checkOrg, checkSpace := fakeSharedActor.CheckTargetArgsForCall(0)
+				Expect(checkOrg).To(BeFalse())
+				Expect(checkSpace).To(BeFalse())
+			})
+
+			When("checking target succeeds", func() {
+				BeforeEach(func() {
+					fakeSharedActor.CheckTargetReturns(nil)
+				})
+
+				When("fetching the current user's name fails", func() {
+					BeforeEach(func() {
+						fakeConfig.CurrentUserReturns(configv3.User{}, errors.New("boom"))
+					})
+
+					It("returns an error", func() {
+						Expect(executeErr).To(MatchError("boom"))
+					})
+				})
+
+				When("fetching current user's name succeeds", func() {
+					BeforeEach(func() {
+						fakeConfig.CurrentUserReturns(configv3.User{Name: "some-user"}, nil)
+					})
+
+					When("all the provided labels are valid", func() {
+						BeforeEach(func() {
+							cmd.RequiredArgs = flag.UnsetLabelArgs{
+								ResourceType: "buildpack",
+								ResourceName: buildpackName,
+								LabelKeys:    []string{"FOO", "ENV"},
+							}
+
+							fakeActor.UpdateBuildpackLabelsByBuildpackNameAndStackReturns(
+								v7action.Warnings([]string{"some-warning-1", "some-warning-2"}),
+								nil,
+							)
+						})
+
+						When("updating the buildpack labels succeeds", func() {
+							When("the stack is specified", func() {
+								BeforeEach(func() {
+									cmd.BuildpackStack = "globinski"
+								})
+
+								It("unsets the provided labels on the buildpack", func() {
+									Expect(fakeActor.UpdateBuildpackLabelsByBuildpackNameAndStackCallCount()).To(Equal(1))
+									name, stack, labels := fakeActor.UpdateBuildpackLabelsByBuildpackNameAndStackArgsForCall(0)
+									Expect(name).To(Equal(resourceName), "failed to pass buildpack name")
+									Expect(stack).To(Equal("globinski"), "failed to pass stack name")
+									Expect(labels).To(BeEquivalentTo(map[string]types.NullString{
+										"FOO": types.NewNullString(),
+										"ENV": types.NewNullString(),
+									}))
+								})
+
+								It("displays a message", func() {
+									Expect(executeErr).ToNot(HaveOccurred())
+
+									Expect(fakeSharedActor.CheckTargetCallCount()).To(Equal(1))
+
+									Expect(testUI.Out).To(Say(regexp.QuoteMeta(`Removing label(s) for buildpack %s with stack %s as some-user...`), resourceName, cmd.BuildpackStack))
+									Expect(testUI.Out).To(Say("OK"))
+								})
+
+								It("prints all warnings", func() {
+									Expect(testUI.Err).To(Say("some-warning-1"))
+									Expect(testUI.Err).To(Say("some-warning-2"))
+								})
+							})
+
+							When("the stack is not specified", func() {
+								It("unsets the provided labels on the buildpack", func() {
+									Expect(fakeActor.UpdateBuildpackLabelsByBuildpackNameAndStackCallCount()).To(Equal(1))
+									name, stack, labels := fakeActor.UpdateBuildpackLabelsByBuildpackNameAndStackArgsForCall(0)
+									Expect(name).To(Equal(resourceName), "failed to pass buildpack name")
+									Expect(stack).To(Equal(""), "failed to pass stack name")
+									Expect(labels).To(BeEquivalentTo(map[string]types.NullString{
+										"FOO": types.NewNullString(),
+										"ENV": types.NewNullString(),
+									}))
+								})
+
+								It("displays a message", func() {
+									Expect(executeErr).ToNot(HaveOccurred())
+
+									Expect(fakeSharedActor.CheckTargetCallCount()).To(Equal(1))
+
+									Expect(testUI.Out).To(Say(regexp.QuoteMeta(`Removing label(s) for buildpack %s as some-user...`), resourceName))
+									Expect(testUI.Out).To(Say("OK"))
+								})
+
+								It("prints all warnings", func() {
+									Expect(testUI.Err).To(Say("some-warning-1"))
+									Expect(testUI.Err).To(Say("some-warning-2"))
+								})
+							})
+						})
+					})
+
+					When("the resource type is not lowercase", func() {
+						BeforeEach(func() {
+							cmd.RequiredArgs = flag.UnsetLabelArgs{
+								ResourceType: "bUiLdPaCk",
+								ResourceName: buildpackName,
+								LabelKeys:    []string{"FOO", "ENV"},
+							}
+
+							fakeActor.UpdateBuildpackLabelsByBuildpackNameAndStackReturns(
+								v7action.Warnings([]string{"some-warning-1", "some-warning-2"}),
+								nil,
+							)
+						})
+
+						When("updating the buildpack labels succeeds", func() {
+							When("the stack is specified", func() {
+								BeforeEach(func() {
+									cmd.BuildpackStack = "globinski"
+								})
+
+								It("does not display an argument combination error", func() {
+									Expect(executeErr).ToNot(HaveOccurred())
+								})
+
+								It("unsets the provided labels on the buildpack", func() {
+									Expect(fakeActor.UpdateBuildpackLabelsByBuildpackNameAndStackCallCount()).To(Equal(1))
+									name, stack, labels := fakeActor.UpdateBuildpackLabelsByBuildpackNameAndStackArgsForCall(0)
+									Expect(name).To(Equal(resourceName), "failed to pass buildpack name")
+									Expect(stack).To(Equal("globinski"), "failed to pass stack name")
+									Expect(labels).To(BeEquivalentTo(map[string]types.NullString{
+										"FOO": types.NewNullString(),
+										"ENV": types.NewNullString(),
+									}))
+								})
+
+								It("displays a message", func() {
+									Expect(executeErr).ToNot(HaveOccurred())
+
+									Expect(fakeSharedActor.CheckTargetCallCount()).To(Equal(1))
+
+									Expect(testUI.Out).To(Say(regexp.QuoteMeta(`Removing label(s) for buildpack %s with stack globinski as some-user...`), resourceName))
+									Expect(testUI.Out).To(Say("OK"))
+								})
+
+								It("prints all warnings", func() {
+									Expect(testUI.Err).To(Say("some-warning-1"))
+									Expect(testUI.Err).To(Say("some-warning-2"))
+								})
+							})
+
+							When("the stack is not specified", func() {
+								It("unsets the provided labels on the buildpack", func() {
+									Expect(fakeActor.UpdateBuildpackLabelsByBuildpackNameAndStackCallCount()).To(Equal(1))
+									name, stack, labels := fakeActor.UpdateBuildpackLabelsByBuildpackNameAndStackArgsForCall(0)
+									Expect(name).To(Equal(resourceName), "failed to pass buildpack name")
+									Expect(stack).To(Equal(""), "failed to pass stack name")
+									Expect(labels).To(BeEquivalentTo(map[string]types.NullString{
+										"FOO": types.NewNullString(),
+										"ENV": types.NewNullString(),
+									}))
+								})
+
+								It("displays a message", func() {
+									Expect(executeErr).ToNot(HaveOccurred())
+
+									Expect(fakeSharedActor.CheckTargetCallCount()).To(Equal(1))
+
+									Expect(testUI.Out).To(Say(regexp.QuoteMeta(`Removing label(s) for buildpack %s as some-user...`), resourceName))
+									Expect(testUI.Out).To(Say("OK"))
+								})
+
+								It("prints all warnings", func() {
+									Expect(testUI.Err).To(Say("some-warning-1"))
+									Expect(testUI.Err).To(Say("some-warning-2"))
+								})
+							})
+						})
+					})
+				})
+
+				When("fetching the current user's name fails", func() {
+					BeforeEach(func() {
+						fakeConfig.CurrentUserReturns(configv3.User{}, errors.New("could not get user"))
+						cmd.RequiredArgs.LabelKeys = []string{"some-label", "some-other-key"}
+					})
+
+					It("returns the error", func() {
+						Expect(executeErr).To(MatchError("could not get user"))
+					})
+				})
+			})
+		})
 	})
 
 	When("Unsetting labels on orgs", func() {
@@ -225,6 +480,10 @@ var _ = Describe("unset-label command", func() {
 				It("returns the error", func() {
 					Expect(executeErr).To(MatchError("could not get user"))
 				})
+			})
+
+			When("the --stack flag is specified", func() {
+				verifyStackArgNotAllowed()
 			})
 		})
 	})
@@ -344,6 +603,10 @@ var _ = Describe("unset-label command", func() {
 					Expect(executeErr).To(MatchError("could not get user"))
 				})
 			})
+		})
+
+		When("the --stack flag is specified", func() {
+			verifyStackArgNotAllowed()
 		})
 	})
 })

--- a/command/v7/v7fakes/fake_unset_label_actor.go
+++ b/command/v7/v7fakes/fake_unset_label_actor.go
@@ -25,6 +25,21 @@ type FakeUnsetLabelActor struct {
 		result1 v7action.Warnings
 		result2 error
 	}
+	UpdateBuildpackLabelsByBuildpackNameAndStackStub        func(string, string, map[string]types.NullString) (v7action.Warnings, error)
+	updateBuildpackLabelsByBuildpackNameAndStackMutex       sync.RWMutex
+	updateBuildpackLabelsByBuildpackNameAndStackArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 map[string]types.NullString
+	}
+	updateBuildpackLabelsByBuildpackNameAndStackReturns struct {
+		result1 v7action.Warnings
+		result2 error
+	}
+	updateBuildpackLabelsByBuildpackNameAndStackReturnsOnCall map[int]struct {
+		result1 v7action.Warnings
+		result2 error
+	}
 	UpdateOrganizationLabelsByOrganizationNameStub        func(string, map[string]types.NullString) (v7action.Warnings, error)
 	updateOrganizationLabelsByOrganizationNameMutex       sync.RWMutex
 	updateOrganizationLabelsByOrganizationNameArgsForCall []struct {
@@ -118,6 +133,71 @@ func (fake *FakeUnsetLabelActor) UpdateApplicationLabelsByApplicationNameReturns
 		})
 	}
 	fake.updateApplicationLabelsByApplicationNameReturnsOnCall[i] = struct {
+		result1 v7action.Warnings
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeUnsetLabelActor) UpdateBuildpackLabelsByBuildpackNameAndStack(arg1 string, arg2 string, arg3 map[string]types.NullString) (v7action.Warnings, error) {
+	fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.Lock()
+	ret, specificReturn := fake.updateBuildpackLabelsByBuildpackNameAndStackReturnsOnCall[len(fake.updateBuildpackLabelsByBuildpackNameAndStackArgsForCall)]
+	fake.updateBuildpackLabelsByBuildpackNameAndStackArgsForCall = append(fake.updateBuildpackLabelsByBuildpackNameAndStackArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 map[string]types.NullString
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("UpdateBuildpackLabelsByBuildpackNameAndStack", []interface{}{arg1, arg2, arg3})
+	fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.Unlock()
+	if fake.UpdateBuildpackLabelsByBuildpackNameAndStackStub != nil {
+		return fake.UpdateBuildpackLabelsByBuildpackNameAndStackStub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.updateBuildpackLabelsByBuildpackNameAndStackReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeUnsetLabelActor) UpdateBuildpackLabelsByBuildpackNameAndStackCallCount() int {
+	fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.RLock()
+	defer fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.RUnlock()
+	return len(fake.updateBuildpackLabelsByBuildpackNameAndStackArgsForCall)
+}
+
+func (fake *FakeUnsetLabelActor) UpdateBuildpackLabelsByBuildpackNameAndStackCalls(stub func(string, string, map[string]types.NullString) (v7action.Warnings, error)) {
+	fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.Lock()
+	defer fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.Unlock()
+	fake.UpdateBuildpackLabelsByBuildpackNameAndStackStub = stub
+}
+
+func (fake *FakeUnsetLabelActor) UpdateBuildpackLabelsByBuildpackNameAndStackArgsForCall(i int) (string, string, map[string]types.NullString) {
+	fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.RLock()
+	defer fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.RUnlock()
+	argsForCall := fake.updateBuildpackLabelsByBuildpackNameAndStackArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeUnsetLabelActor) UpdateBuildpackLabelsByBuildpackNameAndStackReturns(result1 v7action.Warnings, result2 error) {
+	fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.Lock()
+	defer fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.Unlock()
+	fake.UpdateBuildpackLabelsByBuildpackNameAndStackStub = nil
+	fake.updateBuildpackLabelsByBuildpackNameAndStackReturns = struct {
+		result1 v7action.Warnings
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeUnsetLabelActor) UpdateBuildpackLabelsByBuildpackNameAndStackReturnsOnCall(i int, result1 v7action.Warnings, result2 error) {
+	fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.Lock()
+	defer fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.Unlock()
+	fake.UpdateBuildpackLabelsByBuildpackNameAndStackStub = nil
+	if fake.updateBuildpackLabelsByBuildpackNameAndStackReturnsOnCall == nil {
+		fake.updateBuildpackLabelsByBuildpackNameAndStackReturnsOnCall = make(map[int]struct {
+			result1 v7action.Warnings
+			result2 error
+		})
+	}
+	fake.updateBuildpackLabelsByBuildpackNameAndStackReturnsOnCall[i] = struct {
 		result1 v7action.Warnings
 		result2 error
 	}{result1, result2}
@@ -257,6 +337,8 @@ func (fake *FakeUnsetLabelActor) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.updateApplicationLabelsByApplicationNameMutex.RLock()
 	defer fake.updateApplicationLabelsByApplicationNameMutex.RUnlock()
+	fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.RLock()
+	defer fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.RUnlock()
 	fake.updateOrganizationLabelsByOrganizationNameMutex.RLock()
 	defer fake.updateOrganizationLabelsByOrganizationNameMutex.RUnlock()
 	fake.updateSpaceLabelsBySpaceNameMutex.RLock()

--- a/integration/v7/isolated/unset_label_command_test.go
+++ b/integration/v7/isolated/unset_label_command_test.go
@@ -33,6 +33,9 @@ var _ = Describe("unset-label command", func() {
 			Eventually(session).Should(Say(`\s+cf unset-label app dora ci_signature_sha2`))
 			Eventually(session).Should(Say("RESOURCES:"))
 			Eventually(session).Should(Say(`\s+app`))
+			Eventually(session).Should(Say(`\s+buildpack`))
+			Eventually(session).Should(Say(`\s+org`))
+			Eventually(session).Should(Say(`\s+space`))
 			Eventually(session).Should(Say("SEE ALSO:"))
 			Eventually(session).Should(Say(`\s+set-label, labels`))
 			Eventually(session).Should(Exit(0))
@@ -90,6 +93,136 @@ var _ = Describe("unset-label command", func() {
 				Expect(json.Unmarshal(appJSON, &app)).To(Succeed())
 				Expect(len(app.Metadata.Labels)).To(Equal(1))
 				Expect(app.Metadata.Labels["some-key"]).To(Equal("some-value"))
+			})
+		})
+
+		When("unsetting labels from a buildpack", func() {
+			var (
+				buildpackName string
+				buildpackGUID string
+				stacks        []string
+			)
+			BeforeEach(func() {
+				buildpackName = helpers.NewBuildpackName()
+			})
+
+			When("there is only one instance of the given buildpack", func() {
+
+				BeforeEach(func() {
+					stacks = helpers.FetchStacks()
+					helpers.BuildpackWithStack(func(buildpackPath string) {
+						session := helpers.CF("create-buildpack", buildpackName, buildpackPath, "98")
+						Eventually(session).Should(Exit(0))
+					}, stacks[0])
+					buildpackGUID = helpers.BuildpackGUIDByNameAndStack(buildpackName, stacks[0])
+					session := helpers.CF("set-label", "buildpack", buildpackName, "pci=true", "public-facing=false")
+					Eventually(session).Should(Exit(0))
+				})
+				AfterEach(func() {
+					deleteResourceByGUID(buildpackGUID, "buildpacks")
+				})
+
+				It("unsets the specified labels on the buildpack", func() {
+					session := helpers.CF("unset-label", "buildpack", buildpackName, "public-facing", "pci")
+					Eventually(session).Should(Say(regexp.QuoteMeta(`Removing label(s) for buildpack %s as %s...`), buildpackName, username))
+					Consistently(session).ShouldNot(Say("\n\nOK"))
+					Eventually(session).Should(Say("OK"))
+					Eventually(session).Should(Exit(0))
+
+					// verify the labels are deleted
+					session = helpers.CF("curl", fmt.Sprintf("/v3/buildpacks/%s", buildpackGUID))
+					Eventually(session).Should(Exit(0))
+					buildpackJSON := session.Out.Contents()
+
+					var buildpack commonResource
+					Expect(json.Unmarshal(buildpackJSON, &buildpack)).To(Succeed())
+					Expect(len(buildpack.Metadata.Labels)).To(Equal(0))
+				})
+			})
+
+			When("the buildpack is unknown", func() {
+				It("displays an error", func() {
+					session := helpers.CF("unset-label", "buildpack", "non-existent-buildpack", "some-key=some-value")
+					Eventually(session.Err).Should(Say("Buildpack non-existent-buildpack not found"))
+					Eventually(session).Should(Say("FAILED"))
+					Eventually(session).Should(Exit(1))
+				})
+			})
+
+			When("the buildpack exists for multiple stacks", func() {
+				var buildpackGUIDs [2]string
+				BeforeEach(func() {
+					stacks = helpers.EnsureMinimumNumberOfStacks(2)
+					for i := 0; i < 2; i++ {
+
+						helpers.BuildpackWithStack(func(buildpackPath string) {
+							createSession := helpers.CF("create-buildpack", buildpackName, buildpackPath, fmt.Sprintf("%d", 98+i))
+							Eventually(createSession).Should(Exit(0))
+						}, stacks[i])
+						buildpackGUIDs[i] = helpers.BuildpackGUIDByNameAndStack(buildpackName, stacks[i])
+						session := helpers.CF("set-label", "buildpack",
+							buildpackName, "-s", stacks[i],
+							fmt.Sprintf("pci%d=true", i),
+							fmt.Sprintf("public-facing%d=false", i))
+						Eventually(session).Should(Exit(0))
+					}
+				})
+				AfterEach(func() {
+					for i := 0; i < 2; i++ {
+						deleteResourceByGUID(buildpackGUIDs[i], "buildpacks")
+					}
+				})
+
+				When("stack is not specified", func() {
+					It("displays an error", func() {
+						session := helpers.CF("unset-label", "buildpack", buildpackName, "pci1")
+						Eventually(session.Err).Should(Say(fmt.Sprintf("Multiple buildpacks named %s found. Specify a stack name by using a '-s' flag.", buildpackName)))
+						Eventually(session).Should(Say("FAILED"))
+						Eventually(session).Should(Exit(1))
+					})
+				})
+
+				When("stack is specified", func() {
+					When("the label is invalid", func() {
+						It("gives an error message", func() {
+							badLabel := "^^snorky"
+							session := helpers.CF("unset-label", "buildpack", buildpackName, badLabel, "--stack", stacks[0])
+							Eventually(session).Should(Say(regexp.QuoteMeta(fmt.Sprintf("Removing label(s) for buildpack %s with stack %s as %s...", buildpackName, stacks[0], username))))
+							Eventually(session.Err).Should(Say(regexp.QuoteMeta(fmt.Sprintf("Metadata label key error: '%s' contains invalid characters", badLabel))))
+							Eventually(session).Should(Say("FAILED"))
+							Eventually(session).Should(Exit(1))
+						})
+					})
+
+					It("deletes the specified labels from the correct buildpack", func() {
+						var buildpack commonResource
+
+						session := helpers.CF("unset-label", "buildpack", buildpackName, "pci0", "--stack", stacks[0])
+						Eventually(session).Should(Say(regexp.QuoteMeta(`Removing label(s) for buildpack %s with stack %s as %s...`), buildpackName, stacks[0], username))
+						Eventually(session).Should(Say("OK"))
+						Eventually(session).Should(Exit(0))
+
+						session = helpers.CF("curl", fmt.Sprintf("/v3/buildpacks/%s", buildpackGUIDs[0]))
+						Eventually(session).Should(Exit(0))
+						buildpackJSON := session.Out.Contents()
+						Expect(json.Unmarshal(buildpackJSON, &buildpack)).To(Succeed())
+						Expect(len(buildpack.Metadata.Labels)).To(Equal(1))
+						Expect(buildpack.Metadata.Labels["public-facing0"]).To(Equal("false"))
+
+						session = helpers.CF("unset-label", "buildpack", buildpackName, "pci1", "--stack", stacks[1])
+						Eventually(session).Should(Say(regexp.QuoteMeta(`Removing label(s) for buildpack %s with stack %s as %s...`), buildpackName, stacks[1], username))
+						Eventually(session).Should(Say("OK"))
+						Eventually(session).Should(Exit(0))
+
+						session = helpers.CF("curl", fmt.Sprintf("/v3/buildpacks/%s", buildpackGUIDs[1]))
+						Eventually(session).Should(Exit(0))
+						buildpackJSON = session.Out.Contents()
+						buildpack = commonResource{}
+						Expect(json.Unmarshal(buildpackJSON, &buildpack)).To(Succeed())
+						Expect(len(buildpack.Metadata.Labels)).To(Equal(1))
+						Expect(buildpack.Metadata.Labels["public-facing1"]).To(Equal("false"))
+					})
+				})
 			})
 		})
 


### PR DESCRIPTION
WARNING:
This PR builds on top of #1736. Please make sure it is merged first.

Relevant commits:
"App operator can delete labels from buildpacks  …"

Diff for this PR on its actual base branch:

`git diff origin/set-stack-labels origin/unset-buildpack-labels-166986384`

Implements story https://www.pivotaltracker.com/story/show/166986384

### Does this PR modify CLI v6 or v7?

v7

### Description of the Change
Implements `cf unset-label buildpack BUILDBACK_NAME [-s STACK_NAME] LABELS...`