### PR TITLE
Show stack labels 167250651

### DIFF
--- a/actor/v7action/label.go
+++ b/actor/v7action/label.go
@@ -88,3 +88,12 @@ func (actor *Actor) UpdateSpaceLabelsBySpaceName(spaceName string, orgGUID strin
 	_, updateWarnings, err := actor.CloudControllerClient.UpdateResourceMetadata("space", space.GUID, ccv3.Metadata{Labels: labels})
 	return append(warnings, updateWarnings...), err
 }
+
+func (actor *Actor) UpdateStackLabelsByStackName(stackName string, labels map[string]types.NullString) (Warnings, error) {
+	stack, warnings, err := actor.GetStackByName(stackName)
+	if err != nil {
+		return warnings, err
+	}
+	_, updateWarnings, err := actor.CloudControllerClient.UpdateResourceMetadata("stack", stack.GUID, ccv3.Metadata{Labels: labels})
+	return append(warnings, updateWarnings...), err
+}

--- a/actor/v7action/label.go
+++ b/actor/v7action/label.go
@@ -41,6 +41,18 @@ func (actor *Actor) GetSpaceLabels(spaceName string, orgGUID string) (map[string
 	return labels, warnings, nil
 }
 
+func (actor *Actor) GetBuildpackLabels(buildpackName string, buildpackStack string) (map[string]types.NullString, Warnings, error) {
+	var labels map[string]types.NullString
+	resource, warnings, err := actor.GetBuildpackByNameAndStack(buildpackName, buildpackStack)
+	if err != nil {
+		return labels, warnings, err
+	}
+	if resource.Metadata != nil {
+		labels = resource.Metadata.Labels
+	}
+	return labels, warnings, nil
+}
+
 func (actor *Actor) UpdateApplicationLabelsByApplicationName(appName string, spaceGUID string, labels map[string]types.NullString) (Warnings, error) {
 	app, appWarnings, err := actor.GetApplicationByNameAndSpace(appName, spaceGUID)
 	if err != nil {

--- a/actor/v7action/label.go
+++ b/actor/v7action/label.go
@@ -54,12 +54,11 @@ func (actor *Actor) GetBuildpackLabels(buildpackName string, buildpackStack stri
 }
 
 func (actor *Actor) UpdateApplicationLabelsByApplicationName(appName string, spaceGUID string, labels map[string]types.NullString) (Warnings, error) {
-	app, appWarnings, err := actor.GetApplicationByNameAndSpace(appName, spaceGUID)
+	app, warnings, err := actor.GetApplicationByNameAndSpace(appName, spaceGUID)
 	if err != nil {
-		return appWarnings, err
+		return warnings, err
 	}
-	_, updateWarnings, err := actor.CloudControllerClient.UpdateResourceMetadata("app", app.GUID, ccv3.Metadata{Labels: labels})
-	return append(appWarnings, updateWarnings...), err
+	return actor.updateResourceMetadata("app", app.GUID, ccv3.Metadata{Labels: labels}, warnings)
 }
 
 func (actor *Actor) UpdateBuildpackLabelsByBuildpackNameAndStack(buildpackName string, stack string, labels map[string]types.NullString) (Warnings, error) {
@@ -67,8 +66,7 @@ func (actor *Actor) UpdateBuildpackLabelsByBuildpackNameAndStack(buildpackName s
 	if err != nil {
 		return warnings, err
 	}
-	_, updateWarnings, err := actor.CloudControllerClient.UpdateResourceMetadata("buildpack", buildpack.GUID, ccv3.Metadata{Labels: labels})
-	return append(warnings, updateWarnings...), err
+	return actor.updateResourceMetadata("buildpack", buildpack.GUID, ccv3.Metadata{Labels: labels}, warnings)
 }
 
 func (actor *Actor) UpdateOrganizationLabelsByOrganizationName(orgName string, labels map[string]types.NullString) (Warnings, error) {
@@ -76,8 +74,7 @@ func (actor *Actor) UpdateOrganizationLabelsByOrganizationName(orgName string, l
 	if err != nil {
 		return warnings, err
 	}
-	_, updateWarnings, err := actor.CloudControllerClient.UpdateResourceMetadata("org", org.GUID, ccv3.Metadata{Labels: labels})
-	return append(warnings, updateWarnings...), err
+	return actor.updateResourceMetadata("org", org.GUID, ccv3.Metadata{Labels: labels}, warnings)
 }
 
 func (actor *Actor) UpdateSpaceLabelsBySpaceName(spaceName string, orgGUID string, labels map[string]types.NullString) (Warnings, error) {
@@ -85,7 +82,11 @@ func (actor *Actor) UpdateSpaceLabelsBySpaceName(spaceName string, orgGUID strin
 	if err != nil {
 		return warnings, err
 	}
-	_, updateWarnings, err := actor.CloudControllerClient.UpdateResourceMetadata("space", space.GUID, ccv3.Metadata{Labels: labels})
+	return actor.updateResourceMetadata("space", space.GUID, ccv3.Metadata{Labels: labels}, warnings)
+}
+
+func (actor *Actor) updateResourceMetadata(resourceType string, resourceGUID string, payload ccv3.Metadata, warnings Warnings) (Warnings, error) {
+	_, updateWarnings, err := actor.CloudControllerClient.UpdateResourceMetadata(resourceType, resourceGUID, payload)
 	return append(warnings, updateWarnings...), err
 }
 

--- a/actor/v7action/label.go
+++ b/actor/v7action/label.go
@@ -47,10 +47,16 @@ func (actor *Actor) UpdateApplicationLabelsByApplicationName(appName string, spa
 		return appWarnings, err
 	}
 	_, updateWarnings, err := actor.CloudControllerClient.UpdateResourceMetadata("app", app.GUID, ccv3.Metadata{Labels: labels})
-	if err != nil {
-		return append(appWarnings, updateWarnings...), err
-	}
 	return append(appWarnings, updateWarnings...), err
+}
+
+func (actor *Actor) UpdateBuildpackLabelsByBuildpackNameAndStack(buildpackName string, stack string, labels map[string]types.NullString) (Warnings, error) {
+	buildpack, warnings, err := actor.GetBuildpackByNameAndStack(buildpackName, stack)
+	if err != nil {
+		return warnings, err
+	}
+	_, updateWarnings, err := actor.CloudControllerClient.UpdateResourceMetadata("buildpack", buildpack.GUID, ccv3.Metadata{Labels: labels})
+	return append(warnings, updateWarnings...), err
 }
 
 func (actor *Actor) UpdateOrganizationLabelsByOrganizationName(orgName string, labels map[string]types.NullString) (Warnings, error) {
@@ -59,9 +65,6 @@ func (actor *Actor) UpdateOrganizationLabelsByOrganizationName(orgName string, l
 		return warnings, err
 	}
 	_, updateWarnings, err := actor.CloudControllerClient.UpdateResourceMetadata("org", org.GUID, ccv3.Metadata{Labels: labels})
-	if err != nil {
-		return append(warnings, updateWarnings...), err
-	}
 	return append(warnings, updateWarnings...), err
 }
 
@@ -71,8 +74,5 @@ func (actor *Actor) UpdateSpaceLabelsBySpaceName(spaceName string, orgGUID strin
 		return warnings, err
 	}
 	_, updateWarnings, err := actor.CloudControllerClient.UpdateResourceMetadata("space", space.GUID, ccv3.Metadata{Labels: labels})
-	if err != nil {
-		return append(warnings, updateWarnings...), err
-	}
 	return append(warnings, updateWarnings...), err
 }

--- a/api/cloudcontroller/ccv3/buildpack.go
+++ b/api/cloudcontroller/ccv3/buildpack.go
@@ -34,16 +34,19 @@ type Buildpack struct {
 	State string
 	// Links are links to related resources.
 	Links APILinks
+	// Metadata is used for custom tagging of API resources
+	Metadata *Metadata
 }
 
 // MarshalJSON converts a Package into a Cloud Controller Package.
 func (buildpack Buildpack) MarshalJSON() ([]byte, error) {
 	ccBuildpack := struct {
-		Name     string `json:"name,omitempty"`
-		Stack    string `json:"stack,omitempty"`
-		Position *int   `json:"position,omitempty"`
-		Enabled  *bool  `json:"enabled,omitempty"`
-		Locked   *bool  `json:"locked,omitempty"`
+		Name     string    `json:"name,omitempty"`
+		Stack    string    `json:"stack,omitempty"`
+		Position *int      `json:"position,omitempty"`
+		Enabled  *bool     `json:"enabled,omitempty"`
+		Locked   *bool     `json:"locked,omitempty"`
+		Metadata *Metadata `json:"metadata,omitempty"`
 	}{
 		Name:  buildpack.Name,
 		Stack: buildpack.Stack,
@@ -73,6 +76,7 @@ func (buildpack *Buildpack) UnmarshalJSON(data []byte) error {
 		Enabled  types.NullBool `json:"enabled"`
 		Locked   types.NullBool `json:"locked"`
 		Position types.NullInt  `json:"position"`
+		Metadata *Metadata      `json:"metadata"`
 	}
 
 	err := cloudcontroller.DecodeJSON(data, &ccBuildpack)
@@ -89,6 +93,7 @@ func (buildpack *Buildpack) UnmarshalJSON(data []byte) error {
 	buildpack.Stack = ccBuildpack.Stack
 	buildpack.State = ccBuildpack.State
 	buildpack.Links = ccBuildpack.Links
+	buildpack.Metadata = ccBuildpack.Metadata
 
 	return nil
 }

--- a/api/cloudcontroller/ccv3/buildpack_test.go
+++ b/api/cloudcontroller/ccv3/buildpack_test.go
@@ -58,7 +58,11 @@ var _ = Describe("Buildpacks", func() {
 							"stack": "windows64",
 							"position": 1,
 							"enabled": true,
-							"locked": false
+							"locked": false,
+							"unlocked": false,
+							"metadata": {
+								"labels": {}
+							}
 						},
 						{
 							"guid": "guid2",
@@ -67,7 +71,10 @@ var _ = Describe("Buildpacks", func() {
 							"stack": "cflinuxfs3",
 							"position": 2,
 							"enabled": false,
-							"locked": true
+							"locked": true,
+							"metadata": {
+								"labels": {}
+							}
 						}
 					]
 				}`, server.URL())
@@ -83,7 +90,10 @@ var _ = Describe("Buildpacks", func() {
 							"stack": "cflinuxfs2",
 							"position": 3,
 							"enabled": true,
-							"locked": false
+							"locked": false,
+							"metadata": {
+								"labels": {}
+							}
 						}
 					]
 				}`
@@ -119,6 +129,7 @@ var _ = Describe("Buildpacks", func() {
 						Locked:   types.NullBool{Value: false, IsSet: true},
 						Stack:    "windows64",
 						State:    "AWAITING_UPLOAD",
+						Metadata: &Metadata{Labels: map[string]types.NullString{}},
 					},
 					Buildpack{
 						Name:     "staticfile_buildpack",
@@ -128,6 +139,7 @@ var _ = Describe("Buildpacks", func() {
 						Locked:   types.NullBool{Value: true, IsSet: true},
 						Stack:    "cflinuxfs3",
 						State:    "AWAITING_UPLOAD",
+						Metadata: &Metadata{Labels: map[string]types.NullString{}},
 					},
 					Buildpack{
 						Name:     "go_buildpack",
@@ -137,6 +149,7 @@ var _ = Describe("Buildpacks", func() {
 						Locked:   types.NullBool{Value: false, IsSet: true},
 						Stack:    "cflinuxfs2",
 						State:    "AWAITING_UPLOAD",
+						Metadata: &Metadata{Labels: map[string]types.NullString{}},
 					},
 				))
 				Expect(warnings).To(ConsistOf("this is a warning", "this is another warning"))

--- a/api/cloudcontroller/ccv3/internal/api_routes.go
+++ b/api/cloudcontroller/ccv3/internal/api_routes.go
@@ -67,6 +67,7 @@ const (
 	PatchProcessRequest                                         = "PatchProcess"
 	PatchSpaceRelationshipIsolationSegmentRequest               = "PatchSpaceRelationshipIsolationSegment"
 	PatchSpaceRequest                                           = "PatchSpace"
+	PatchStackRequest                                           = "PatchStack"
 	PostApplicationActionApplyManifest                          = "PostApplicationActionApplyM"
 	PostApplicationActionRestartRequest                         = "PostApplicationActionRestart"
 	PostApplicationActionStartRequest                           = "PostApplicationActionStart"
@@ -180,5 +181,6 @@ var APIRoutes = []Route{
 	{Resource: SpacesResource, Path: "/:space_guid/relationships/isolation_segment", Method: http.MethodPatch, Name: PatchSpaceRelationshipIsolationSegmentRequest},
 	{Resource: SpacesResource, Path: "/:space_guid/routes", Method: http.MethodDelete, Name: DeleteOrphanedRoutesRequest},
 	{Resource: StacksResource, Path: "/", Method: http.MethodGet, Name: GetStacksRequest},
+	{Resource: StacksResource, Path: "/:stack_guid", Method: http.MethodPatch, Name: PatchStackRequest},
 	{Resource: TasksResource, Path: "/:task_guid/cancel", Method: http.MethodPut, Name: PutTaskCancelRequest},
 }

--- a/api/cloudcontroller/ccv3/metadata.go
+++ b/api/cloudcontroller/ccv3/metadata.go
@@ -3,7 +3,7 @@ package ccv3
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
+	"fmt"
 
 	"code.cloudfoundry.org/cli/api/cloudcontroller"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/internal"
@@ -52,8 +52,14 @@ func (client *Client) UpdateResourceMetadata(resource string, resourceGUID strin
 			Body:        bytes.NewReader(metadataBtyes),
 			URIParams:   map[string]string{"space_guid": resourceGUID},
 		})
+	case "stack":
+		request, err = client.newHTTPRequest(requestOptions{
+			RequestName: internal.PatchStackRequest,
+			Body:        bytes.NewReader(metadataBtyes),
+			URIParams:   map[string]string{"stack_guid": resourceGUID},
+		})
 	default:
-		return ResourceMetadata{}, nil, errors.New("unknown resource type requested")
+		return ResourceMetadata{}, nil, fmt.Errorf("unknown resource type (%s) requested", resource)
 	}
 
 	if err != nil {

--- a/api/cloudcontroller/ccv3/metadata.go
+++ b/api/cloudcontroller/ccv3/metadata.go
@@ -34,6 +34,12 @@ func (client *Client) UpdateResourceMetadata(resource string, resourceGUID strin
 			Body:        bytes.NewReader(metadataBtyes),
 			URIParams:   map[string]string{"app_guid": resourceGUID},
 		})
+	case "buildpack":
+		request, err = client.newHTTPRequest(requestOptions{
+			RequestName: internal.PatchBuildpackRequest,
+			Body:        bytes.NewReader(metadataBtyes),
+			URIParams:   map[string]string{"buildpack_guid": resourceGUID},
+		})
 	case "org":
 		request, err = client.newHTTPRequest(requestOptions{
 			RequestName: internal.PatchOrganizationRequest,

--- a/api/cloudcontroller/ccv3/stack.go
+++ b/api/cloudcontroller/ccv3/stack.go
@@ -12,6 +12,9 @@ type Stack struct {
 	Name string `json:"name"`
 	// Description is the description for the stack
 	Description string `json:"description"`
+
+	// Metadata is used for custom tagging of API resources
+	Metadata *Metadata `json:"metadata,omitempty"`
 }
 
 // GetStacks lists stacks with optional filters.

--- a/command/translatableerror/buildpack_not_found_error.go
+++ b/command/translatableerror/buildpack_not_found_error.go
@@ -7,9 +7,9 @@ type BuildpackNotFoundError struct {
 
 func (e BuildpackNotFoundError) Error() string {
 	if len(e.StackName) == 0 {
-		return "Buildpack '{{.BuildpackName}}' not found"
+		return "Buildpack {{.BuildpackName}} not found"
 	}
-	return "Buildpack '{{.BuildpackName}}' with stack '{{.StackName}}' not found"
+	return "Buildpack {{.BuildpackName}} with stack {{.StackName}} not found"
 }
 
 func (e BuildpackNotFoundError) Translate(translate func(string, ...interface{}) string) string {

--- a/command/translatableerror/buildpack_not_found_error.go
+++ b/command/translatableerror/buildpack_not_found_error.go
@@ -7,9 +7,9 @@ type BuildpackNotFoundError struct {
 
 func (e BuildpackNotFoundError) Error() string {
 	if len(e.StackName) == 0 {
-		return "Buildpack {{.BuildpackName}} not found"
+		return "Buildpack '{{.BuildpackName}}' not found"
 	}
-	return "Buildpack {{.BuildpackName}} with stack {{.StackName}} not found"
+	return "Buildpack '{{.BuildpackName}}' with stack '{{.StackName}}' not found"
 }
 
 func (e BuildpackNotFoundError) Translate(translate func(string, ...interface{}) string) string {

--- a/command/v7/labels_command.go
+++ b/command/v7/labels_command.go
@@ -16,9 +16,10 @@ import (
 type ResourceType string
 
 const (
-	App   ResourceType = "app"
-	Org   ResourceType = "org"
-	Space ResourceType = "space"
+	App       ResourceType = "app"
+	Buildpack ResourceType = "buildpack"
+	Org       ResourceType = "org"
+	Space     ResourceType = "space"
 )
 
 //go:generate counterfeiter . LabelsActor

--- a/command/v7/labels_command.go
+++ b/command/v7/labels_command.go
@@ -9,6 +9,7 @@ import (
 	"code.cloudfoundry.org/cli/actor/v7action"
 	"code.cloudfoundry.org/cli/command"
 	"code.cloudfoundry.org/cli/command/flag"
+	"code.cloudfoundry.org/cli/command/translatableerror"
 	"code.cloudfoundry.org/cli/command/v7/shared"
 	"code.cloudfoundry.org/cli/types"
 	"code.cloudfoundry.org/cli/util/ui"
@@ -62,6 +63,11 @@ func (cmd LabelsCommand) Execute(args []string) error {
 		warnings v7action.Warnings
 	)
 	username, err := cmd.Config.CurrentUserName()
+	if err != nil {
+		return err
+	}
+
+	err = cmd.validateFlags()
 	if err != nil {
 		return err
 	}
@@ -197,4 +203,16 @@ func (cmd LabelsCommand) printLabels(labels map[string]types.NullString) {
 	}
 
 	cmd.UI.DisplayTableWithHeader("", table, ui.DefaultTableSpacePadding)
+}
+
+func (cmd LabelsCommand) validateFlags() error {
+	resourceTypeString := strings.ToLower(cmd.RequiredArgs.ResourceType)
+	if cmd.StackName != "" && ResourceType(resourceTypeString) != Buildpack {
+		return translatableerror.ArgumentCombinationError{
+			Args: []string{
+				cmd.RequiredArgs.ResourceType, "--stack, -s",
+			},
+		}
+	}
+	return nil
 }

--- a/command/v7/labels_command.go
+++ b/command/v7/labels_command.go
@@ -3,6 +3,7 @@ package v7
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"code.cloudfoundry.org/cli/actor/sharedaction"
 	"code.cloudfoundry.org/cli/actor/v7action"
@@ -60,7 +61,9 @@ func (cmd LabelsCommand) Execute(args []string) error {
 	if err != nil {
 		return err
 	}
-	switch ResourceType(cmd.RequiredArgs.ResourceType) {
+
+	resourceTypeString := strings.ToLower(cmd.RequiredArgs.ResourceType)
+	switch ResourceType(resourceTypeString) {
 	case App:
 		labels, warnings, err = cmd.fetchAppLabels(username)
 	case Org:

--- a/command/v7/labels_command.go
+++ b/command/v7/labels_command.go
@@ -21,6 +21,7 @@ const (
 	Buildpack ResourceType = "buildpack"
 	Org       ResourceType = "org"
 	Space     ResourceType = "space"
+	Stack     ResourceType = "stack"
 )
 
 //go:generate counterfeiter . LabelsActor

--- a/command/v7/labels_command_test.go
+++ b/command/v7/labels_command_test.go
@@ -407,5 +407,125 @@ var _ = Describe("labels command", func() {
 				})
 			})
 		})
+
+		Describe("for buildpacks", func() {
+			BeforeEach(func() {
+				fakeConfig.CurrentUserNameReturns("some-user", nil)
+				cmd.RequiredArgs = flag.LabelsArgs{
+					ResourceType: "buildpack",
+					ResourceName: "my-buildpack",
+				}
+				fakeLabelsActor.GetBuildpackLabelsReturns(
+					map[string]types.NullString{
+						"some-other-label": types.NewNullString("some-other-value"),
+						"some-label":       types.NewNullString("some-value"),
+					},
+					v7action.Warnings{},
+					nil)
+			})
+
+			It("doesn't error", func() {
+				Expect(executeErr).ToNot(HaveOccurred())
+			})
+
+			It("checks that the user is logged in", func() {
+				Expect(fakeSharedActor.CheckTargetCallCount()).To(Equal(1))
+				checkOrg, checkSpace := fakeSharedActor.CheckTargetArgsForCall(0)
+				Expect(checkOrg).To(BeFalse())
+				Expect(checkSpace).To(BeFalse())
+			})
+
+			It("displays a message that it is retrieving the labels", func() {
+				Expect(executeErr).ToNot(HaveOccurred())
+				Expect(fakeSharedActor.CheckTargetCallCount()).To(Equal(1))
+				Expect(testUI.Out).To(Say(regexp.QuoteMeta(`Getting labels for buildpack my-buildpack as some-user...`)))
+			})
+
+			It("retrieves the labels associated with the buidpack", func() {
+				Expect(fakeLabelsActor.GetBuildpackLabelsCallCount()).To(Equal(1))
+			})
+
+			It("displays the labels that are associated with the buildpack, alphabetically", func() {
+				Expect(testUI.Out).To(Say(`key\s+value`))
+				Expect(testUI.Out).To(Say(`some-label\s+some-value`))
+				Expect(testUI.Out).To(Say(`some-other-label\s+some-other-value`))
+			})
+
+			When("CAPI returns warnings", func() {
+				BeforeEach(func() {
+					fakeLabelsActor.GetBuildpackLabelsReturns(
+						map[string]types.NullString{
+							"some-other-label": types.NewNullString("some-other-value"),
+							"some-label":       types.NewNullString("some-value"),
+						},
+						v7action.Warnings([]string{"some-warning-1", "some-warning-2"}),
+						nil)
+				})
+
+				It("prints all warnings", func() {
+					Expect(testUI.Err).To(Say("some-warning-1"))
+					Expect(testUI.Err).To(Say("some-warning-2"))
+				})
+			})
+
+			When("there is an error retrieving the buildpack", func() {
+				BeforeEach(func() {
+					fakeLabelsActor.GetBuildpackLabelsReturns(
+						map[string]types.NullString{},
+						v7action.Warnings([]string{"some-warning-1", "some-warning-2"}),
+						errors.New("boom"))
+				})
+
+				It("returns the error", func() {
+					Expect(executeErr).To(MatchError("boom"))
+				})
+
+				It("still prints all warnings", func() {
+					Expect(testUI.Err).To(Say("some-warning-1"))
+					Expect(testUI.Err).To(Say("some-warning-2"))
+				})
+
+				It("doesn't say ok", func() {
+					Expect(testUI.Out).ToNot(Say("OK"))
+				})
+			})
+
+			When("checking targeted org and space fails", func() {
+				BeforeEach(func() {
+					fakeSharedActor.CheckTargetReturns(errors.New("nope"))
+				})
+
+				It("returns an error", func() {
+					Expect(executeErr).To(MatchError("nope"))
+				})
+			})
+
+			When("fetching the current user's name fails", func() {
+				BeforeEach(func() {
+					fakeConfig.CurrentUserNameReturns("some-user", errors.New("boom"))
+				})
+
+				It("returns an error", func() {
+					Expect(executeErr).To(MatchError("boom"))
+				})
+			})
+
+			When("the resource type argument is not lowercase", func() {
+				BeforeEach(func() {
+					cmd.RequiredArgs = flag.LabelsArgs{
+						ResourceType: "Buildpack",
+						ResourceName: "fake-buildpack",
+					}
+					cmd.StackName = "another-great-stack"
+				})
+
+				It("retrieves the labels associated with the buildpack", func() {
+					Expect(fakeLabelsActor.GetBuildpackLabelsCallCount()).To(Equal(1))
+					buildpackName, stackName := fakeLabelsActor.GetBuildpackLabelsArgsForCall(0)
+					Expect(buildpackName).To(Equal("fake-buildpack"))
+					Expect(stackName).To(Equal("another-great-stack"))
+				})
+			})
+		})
 	})
 })

--- a/command/v7/labels_command_test.go
+++ b/command/v7/labels_command_test.go
@@ -408,6 +408,124 @@ var _ = Describe("labels command", func() {
 			})
 		})
 
+		Describe("for stacks", func() {
+			BeforeEach(func() {
+				fakeConfig.CurrentUserNameReturns("some-user", nil)
+				cmd.RequiredArgs = flag.LabelsArgs{
+					ResourceType: "stack",
+					ResourceName: "fake-stack",
+				}
+				fakeLabelsActor.GetStackLabelsReturns(
+					map[string]types.NullString{
+						"some-other-label": types.NewNullString("some-other-value"),
+						"some-label":       types.NewNullString("some-value"),
+					},
+					v7action.Warnings{},
+					nil)
+			})
+
+			It("doesn't error", func() {
+				Expect(executeErr).ToNot(HaveOccurred())
+			})
+
+			It("checks that the user is logged in", func() {
+				Expect(fakeSharedActor.CheckTargetCallCount()).To(Equal(1))
+				checkOrg, checkSpace := fakeSharedActor.CheckTargetArgsForCall(0)
+				Expect(checkOrg).To(BeFalse())
+				Expect(checkSpace).To(BeFalse())
+			})
+
+			It("displays a message that it is retrieving the labels", func() {
+				Expect(executeErr).ToNot(HaveOccurred())
+				Expect(fakeSharedActor.CheckTargetCallCount()).To(Equal(1))
+				Expect(testUI.Out).To(Say(regexp.QuoteMeta(`Getting labels for stack fake-stack as some-user...`)))
+			})
+
+			It("retrieves the labels associated with the stack", func() {
+				Expect(fakeLabelsActor.GetStackLabelsCallCount()).To(Equal(1))
+			})
+
+			It("displays the labels that are associated with the stack, alphabetically", func() {
+				Expect(testUI.Out).To(Say(`key\s+value`))
+				Expect(testUI.Out).To(Say(`some-label\s+some-value`))
+				Expect(testUI.Out).To(Say(`some-other-label\s+some-other-value`))
+			})
+
+			When("CAPI returns warnings", func() {
+				BeforeEach(func() {
+					fakeLabelsActor.GetStackLabelsReturns(
+						map[string]types.NullString{
+							"some-other-label": types.NewNullString("some-other-value"),
+							"some-label":       types.NewNullString("some-value"),
+						},
+						v7action.Warnings([]string{"some-warning-1", "some-warning-2"}),
+						nil)
+				})
+
+				It("prints all warnings", func() {
+					Expect(testUI.Err).To(Say("some-warning-1"))
+					Expect(testUI.Err).To(Say("some-warning-2"))
+				})
+			})
+
+			When("there is an error retrieving the stack", func() {
+				BeforeEach(func() {
+					fakeLabelsActor.GetStackLabelsReturns(
+						map[string]types.NullString{},
+						v7action.Warnings([]string{"some-warning-1", "some-warning-2"}),
+						errors.New("boom"))
+				})
+
+				It("returns the error", func() {
+					Expect(executeErr).To(MatchError("boom"))
+				})
+
+				It("still prints all warnings", func() {
+					Expect(testUI.Err).To(Say("some-warning-1"))
+					Expect(testUI.Err).To(Say("some-warning-2"))
+				})
+
+				It("doesn't say ok", func() {
+					Expect(testUI.Out).ToNot(Say("OK"))
+				})
+			})
+
+			When("checking targeted stack and space fails", func() {
+				BeforeEach(func() {
+					fakeSharedActor.CheckTargetReturns(errors.New("nope"))
+				})
+
+				It("returns an error", func() {
+					Expect(executeErr).To(MatchError("nope"))
+				})
+			})
+
+			When("fetching the current user's name fails", func() {
+				BeforeEach(func() {
+					fakeConfig.CurrentUserNameReturns("some-user", errors.New("boom"))
+				})
+
+				It("returns an error", func() {
+					Expect(executeErr).To(MatchError("boom"))
+				})
+			})
+
+			When("the resource type argument is not lowercase", func() {
+				BeforeEach(func() {
+					cmd.RequiredArgs = flag.LabelsArgs{
+						ResourceType: "StaCk",
+						ResourceName: "fake-stack",
+					}
+				})
+
+				It("retrieves the labels associated with the stack", func() {
+					Expect(fakeLabelsActor.GetStackLabelsCallCount()).To(Equal(1))
+					stackName := fakeLabelsActor.GetStackLabelsArgsForCall(0)
+					Expect(stackName).To(Equal("fake-stack"))
+				})
+			})
+		})
+
 		Describe("for buildpacks", func() {
 			BeforeEach(func() {
 				fakeConfig.CurrentUserNameReturns("some-user", nil)

--- a/command/v7/labels_command_test.go
+++ b/command/v7/labels_command_test.go
@@ -46,7 +46,6 @@ var _ = Describe("labels command", func() {
 	})
 
 	Describe("listing labels", func() {
-
 		Describe("for apps", func() {
 			BeforeEach(func() {
 				fakeConfig.CurrentUserNameReturns("some-user", nil)
@@ -87,6 +86,22 @@ var _ = Describe("labels command", func() {
 				appName, spaceGUID := fakeLabelsActor.GetApplicationLabelsArgsForCall(0)
 				Expect(appName).To(Equal("dora"))
 				Expect(spaceGUID).To(Equal("some-space-guid"))
+			})
+
+			When("the resource type argument is not lowercase", func() {
+				BeforeEach(func() {
+					cmd.RequiredArgs = flag.LabelsArgs{
+						ResourceType: "ApP",
+						ResourceName: "dora",
+					}
+				})
+
+				It("retrieves the labels associated with the application", func() {
+					Expect(fakeLabelsActor.GetApplicationLabelsCallCount()).To(Equal(1))
+					appName, spaceGUID := fakeLabelsActor.GetApplicationLabelsArgsForCall(0)
+					Expect(appName).To(Equal("dora"))
+					Expect(spaceGUID).To(Equal("some-space-guid"))
+				})
 			})
 
 			It("displays the labels that are associated with the application, alphabetically", func() {
@@ -256,12 +271,27 @@ var _ = Describe("labels command", func() {
 					Expect(executeErr).To(MatchError("boom"))
 				})
 			})
+
+			When("the resource type argument is not lowercase", func() {
+				BeforeEach(func() {
+					cmd.RequiredArgs = flag.LabelsArgs{
+						ResourceType: "OrG",
+						ResourceName: "fake-org",
+					}
+				})
+
+				It("retrieves the labels associated with the org", func() {
+					Expect(fakeLabelsActor.GetOrganizationLabelsCallCount()).To(Equal(1))
+					orgName := fakeLabelsActor.GetOrganizationLabelsArgsForCall(0)
+					Expect(orgName).To(Equal("fake-org"))
+				})
+			})
 		})
 
 		Describe("for spaces", func() {
 			BeforeEach(func() {
 				fakeConfig.CurrentUserNameReturns("some-user", nil)
-				fakeConfig.TargetedOrganizationReturns(configv3.Organization{Name: "fake-org"})
+				fakeConfig.TargetedOrganizationReturns(configv3.Organization{Name: "fake-org", GUID: "some-org-guid"})
 				cmd.RequiredArgs = flag.LabelsArgs{
 					ResourceType: "space",
 					ResourceName: "fake-space",
@@ -358,6 +388,22 @@ var _ = Describe("labels command", func() {
 
 				It("returns an error", func() {
 					Expect(executeErr).To(MatchError("boom"))
+				})
+			})
+
+			When("the resource type argument is not lowercase", func() {
+				BeforeEach(func() {
+					cmd.RequiredArgs = flag.LabelsArgs{
+						ResourceType: "SpAcE",
+						ResourceName: "fake-space",
+					}
+				})
+
+				It("retrieves the labels associated with the space", func() {
+					Expect(fakeLabelsActor.GetSpaceLabelsCallCount()).To(Equal(1))
+					spaceName, orgGUID := fakeLabelsActor.GetSpaceLabelsArgsForCall(0)
+					Expect(spaceName).To(Equal("fake-space"))
+					Expect(orgGUID).To(Equal("some-org-guid"))
 				})
 			})
 		})

--- a/command/v7/set_label_command.go
+++ b/command/v7/set_label_command.go
@@ -77,7 +77,8 @@ func (cmd SetLabelCommand) Execute(args []string) error {
 		return err
 	}
 
-	switch ResourceType(cmd.RequiredArgs.ResourceType) {
+	resourceTypeString := strings.ToLower(cmd.RequiredArgs.ResourceType)
+	switch ResourceType(resourceTypeString) {
 	case App:
 		err = cmd.executeApp(username, labels)
 	case Buildpack:

--- a/command/v7/set_label_command.go
+++ b/command/v7/set_label_command.go
@@ -47,7 +47,8 @@ func (cmd *SetLabelCommand) Setup(config command.Config, ui command.UI) error {
 }
 
 func (cmd SetLabelCommand) ValidateFlags() error {
-	if cmd.BuildpackStack != "" && ResourceType(cmd.RequiredArgs.ResourceType) != Buildpack {
+	resourceTypeString := strings.ToLower(cmd.RequiredArgs.ResourceType)
+	if cmd.BuildpackStack != "" && ResourceType(resourceTypeString) != Buildpack {
 		return translatableerror.ArgumentCombinationError{
 			Args: []string{
 				cmd.RequiredArgs.ResourceType, "--stack, -s",

--- a/command/v7/set_label_command.go
+++ b/command/v7/set_label_command.go
@@ -20,11 +20,12 @@ type SetLabelActor interface {
 	UpdateBuildpackLabelsByBuildpackNameAndStack(string, string, map[string]types.NullString) (v7action.Warnings, error)
 	UpdateOrganizationLabelsByOrganizationName(string, map[string]types.NullString) (v7action.Warnings, error)
 	UpdateSpaceLabelsBySpaceName(string, string, map[string]types.NullString) (v7action.Warnings, error)
+	UpdateStackLabelsByStackName(string, map[string]types.NullString) (v7action.Warnings, error)
 }
 
 type SetLabelCommand struct {
 	RequiredArgs   flag.SetLabelArgs `positional-args:"yes"`
-	usage          interface{}       `usage:"CF_NAME set-label RESOURCE RESOURCE_NAME KEY=VALUE...\n\nEXAMPLES:\n   cf set-label app dora env=production\n   cf set-label org business pci=true public-facing=false\n   cf set-label space business_space public-facing=false owner=jane_doe\n\nRESOURCES:\n   app\n   buildpack\n   org\n   space\n\nSEE ALSO:\n   delete-label, labels"`
+	usage          interface{}       `usage:"CF_NAME set-label RESOURCE RESOURCE_NAME KEY=VALUE...\n\nEXAMPLES:\n   cf set-label app dora env=production\n   cf set-label org business pci=true public-facing=false\n   cf set-label space business_space public-facing=false owner=jane_doe\n\nRESOURCES:\n   app\n   buildpack\n   org\n   space\n   stack\n\nSEE ALSO:\n   unset-label, labels"`
 	BuildpackStack string            `long:"stack" short:"s" description:"Specify stack to disambiguate buildpacks with the same name"`
 
 	UI          command.UI
@@ -87,6 +88,8 @@ func (cmd SetLabelCommand) Execute(args []string) error {
 		err = cmd.executeOrg(username, labels)
 	case Space:
 		err = cmd.executeSpace(username, labels)
+	case Stack:
+		err = cmd.executeStack(username, labels)
 	default:
 		err = fmt.Errorf("Unsupported resource type of '%s'", cmd.RequiredArgs.ResourceType)
 	}
@@ -107,7 +110,7 @@ func (cmd SetLabelCommand) executeApp(username string, labels map[string]types.N
 
 	appName := cmd.RequiredArgs.ResourceName
 
-	preFlavoringText := fmt.Sprintf("Setting label(s) for %s {{.ResourceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.User}}...", cmd.RequiredArgs.ResourceType)
+	preFlavoringText := fmt.Sprintf("Setting label(s) for %s {{.ResourceName}} in org {{.OrgName}} / space {{.SpaceName}} as {{.User}}...", strings.ToLower(cmd.RequiredArgs.ResourceType))
 	cmd.UI.DisplayTextWithFlavor(
 		preFlavoringText,
 		map[string]interface{}{
@@ -136,7 +139,7 @@ func (cmd SetLabelCommand) executeBuildpack(username string, labels map[string]t
 		return err
 	}
 
-	preFlavoringText := fmt.Sprintf("Setting label(s) for %s {{.ResourceName}} as {{.User}}...", cmd.RequiredArgs.ResourceType)
+	preFlavoringText := fmt.Sprintf("Setting label(s) for %s {{.ResourceName}} as {{.User}}...", strings.ToLower(cmd.RequiredArgs.ResourceType))
 	cmd.UI.DisplayTextWithFlavor(
 		preFlavoringText,
 		map[string]interface{}{
@@ -157,7 +160,7 @@ func (cmd SetLabelCommand) executeOrg(username string, labels map[string]types.N
 		return err
 	}
 
-	preFlavoringText := fmt.Sprintf("Setting label(s) for %s {{.ResourceName}} as {{.User}}...", cmd.RequiredArgs.ResourceType)
+	preFlavoringText := fmt.Sprintf("Setting label(s) for %s {{.ResourceName}} as {{.User}}...", strings.ToLower(cmd.RequiredArgs.ResourceType))
 	cmd.UI.DisplayTextWithFlavor(
 		preFlavoringText,
 		map[string]interface{}{
@@ -182,7 +185,7 @@ func (cmd SetLabelCommand) executeSpace(username string, labels map[string]types
 
 	spaceName := cmd.RequiredArgs.ResourceName
 
-	preFlavoringText := fmt.Sprintf("Setting label(s) for %s {{.ResourceName}} in org {{.OrgName}} as {{.User}}...", cmd.RequiredArgs.ResourceType)
+	preFlavoringText := fmt.Sprintf("Setting label(s) for %s {{.ResourceName}} in org {{.OrgName}} as {{.User}}...", strings.ToLower(cmd.RequiredArgs.ResourceType))
 	cmd.UI.DisplayTextWithFlavor(
 		preFlavoringText,
 		map[string]interface{}{
@@ -202,4 +205,25 @@ func (cmd SetLabelCommand) executeSpace(username string, labels map[string]types
 	}
 
 	return nil
+}
+
+func (cmd SetLabelCommand) executeStack(username string, labels map[string]types.NullString) error {
+	err := cmd.SharedActor.CheckTarget(false, false)
+	if err != nil {
+		return err
+	}
+
+	preFlavoringText := fmt.Sprintf("Setting label(s) for %s {{.ResourceName}} as {{.User}}...", strings.ToLower(cmd.RequiredArgs.ResourceType))
+	cmd.UI.DisplayTextWithFlavor(
+		preFlavoringText,
+		map[string]interface{}{
+			"ResourceName": cmd.RequiredArgs.ResourceName,
+			"User":         username,
+		},
+	)
+
+	warnings, err := cmd.Actor.UpdateStackLabelsByStackName(cmd.RequiredArgs.ResourceName, labels)
+	cmd.UI.DisplayWarnings(warnings)
+
+	return err
 }

--- a/command/v7/set_label_command_test.go
+++ b/command/v7/set_label_command_test.go
@@ -207,6 +207,10 @@ var _ = Describe("set-label command", func() {
 							"ENV": types.NewNullString("FAKE"),
 						}))
 					})
+
+					It("prints the flavor text in lowercase", func() {
+						Expect(testUI.Out).To(Say(regexp.QuoteMeta(`Setting label(s) for app %s`), resourceName))
+					})
 				})
 			})
 
@@ -396,6 +400,10 @@ var _ = Describe("set-label command", func() {
 							"ENV": types.NewNullString("FAKE"),
 						}))
 					})
+
+					It("prints the flavor text in lowercase", func() {
+						Expect(testUI.Out).To(Say(regexp.QuoteMeta(`Setting label(s) for org %s`), resourceName))
+					})
 				})
 			})
 
@@ -572,6 +580,10 @@ var _ = Describe("set-label command", func() {
 							"FOO": types.NewNullString("BAR"),
 							"ENV": types.NewNullString("FAKE"),
 						}))
+					})
+
+					It("prints the flavor text in lowercase", func() {
+						Expect(testUI.Out).To(Say(regexp.QuoteMeta(`Setting label(s) for buildpack %s`), resourceName))
 					})
 				})
 			})
@@ -756,6 +768,10 @@ var _ = Describe("set-label command", func() {
 							"ENV": types.NewNullString("FAKE"),
 						}))
 					})
+
+					It("prints the flavor text in lowercase", func() {
+						Expect(testUI.Out).To(Say(regexp.QuoteMeta(`Setting label(s) for space %s`), resourceName))
+					})
 				})
 			})
 
@@ -775,6 +791,179 @@ var _ = Describe("set-label command", func() {
 		})
 
 		When("checking targeted org and space fails", func() {
+			BeforeEach(func() {
+				fakeSharedActor.CheckTargetReturns(errors.New("nope"))
+			})
+
+			It("returns an error", func() {
+				Expect(executeErr).To(MatchError("nope"))
+			})
+		})
+	})
+
+	When("setting labels on stacks", func() {
+		BeforeEach(func() {
+			testUI = ui.NewTestUI(nil, NewBuffer(), NewBuffer())
+			fakeActor = new(v7fakes.FakeSetLabelActor)
+			fakeConfig = new(commandfakes.FakeConfig)
+			fakeConfig.TargetedOrganizationReturns(configv3.Organization{Name: "fake-org", GUID: "some-org-guid"})
+
+			fakeSharedActor = new(commandfakes.FakeSharedActor)
+			resourceName = "some-stack"
+			cmd = SetLabelCommand{
+				Actor:       fakeActor,
+				UI:          testUI,
+				Config:      fakeConfig,
+				SharedActor: fakeSharedActor,
+			}
+			cmd.RequiredArgs = flag.SetLabelArgs{
+				ResourceType: "stack",
+				ResourceName: resourceName,
+			}
+		})
+
+		JustBeforeEach(func() {
+			executeErr = cmd.Execute(nil)
+		})
+
+		It("checks that the user is logged in and targeted to an org", func() {
+			Expect(fakeSharedActor.CheckTargetCallCount()).To(Equal(1))
+			checkOrg, checkSpace := fakeSharedActor.CheckTargetArgsForCall(0)
+			Expect(checkOrg).To(BeFalse())
+			Expect(checkSpace).To(BeFalse())
+		})
+
+		When("checking target succeeds", func() {
+			BeforeEach(func() {
+				fakeSharedActor.CheckTargetReturns(nil)
+			})
+
+			When("fetching current user's name succeeds", func() {
+				BeforeEach(func() {
+					fakeConfig.CurrentUserNameReturns("some-user", nil)
+				})
+
+				When("all the provided labels are valid", func() {
+					BeforeEach(func() {
+						cmd.RequiredArgs = flag.SetLabelArgs{
+							ResourceType: "stack",
+							ResourceName: resourceName,
+							Labels:       []string{"FOO=BAR", "ENV=FAKE"},
+						}
+						fakeActor.UpdateStackLabelsByStackNameReturns(
+							v7action.Warnings([]string{"some-warning-1", "some-warning-2"}),
+							nil,
+						)
+					})
+
+					When("updating the stack labels succeeds", func() {
+						It("sets the provided labels on the stack", func() {
+							Expect(fakeActor.UpdateStackLabelsByStackNameCallCount()).To(Equal(1))
+							stackName, labels := fakeActor.UpdateStackLabelsByStackNameArgsForCall(0)
+							Expect(stackName).To(Equal(resourceName), "failed to pass stack name")
+							Expect(labels).To(BeEquivalentTo(map[string]types.NullString{
+								"FOO": types.NewNullString("BAR"),
+								"ENV": types.NewNullString("FAKE"),
+							}))
+						})
+
+						It("displays a message", func() {
+							Expect(executeErr).ToNot(HaveOccurred())
+							Expect(fakeSharedActor.CheckTargetCallCount()).To(Equal(1))
+							Expect(testUI.Out).To(Say(regexp.QuoteMeta(`Setting label(s) for stack %s as some-user...`), resourceName))
+							Expect(testUI.Out).To(Say("OK"))
+						})
+
+						It("prints all warnings", func() {
+							Expect(testUI.Err).To(Say("some-warning-1"))
+							Expect(testUI.Err).To(Say("some-warning-2"))
+						})
+					})
+				})
+
+				When("updating the application labels fail", func() {
+					BeforeEach(func() {
+						cmd.RequiredArgs = flag.SetLabelArgs{
+							ResourceType: "org",
+							ResourceName: resourceName,
+							Labels:       []string{"FOO=BAR", "ENV=FAKE"},
+						}
+						fakeActor.UpdateOrganizationLabelsByOrganizationNameReturns(
+							v7action.Warnings([]string{"some-warning-1", "some-warning-2"}),
+							errors.New("some-updating-error"),
+						)
+					})
+
+					It("displays warnings and an error message", func() {
+						Expect(testUI.Err).To(Say("some-warning-1"))
+						Expect(testUI.Err).To(Say("some-warning-2"))
+						Expect(executeErr).To(MatchError("some-updating-error"))
+					})
+				})
+
+				When("some provided labels do not have a value part", func() {
+					BeforeEach(func() {
+						cmd.RequiredArgs = flag.SetLabelArgs{
+							ResourceType: "org",
+							ResourceName: resourceName,
+							Labels:       []string{"FOO=BAR", "MISSING_EQUALS", "ENV=FAKE"},
+						}
+					})
+
+					It("complains about the missing equal sign", func() {
+						Expect(executeErr).To(MatchError("Metadata error: no value provided for label 'MISSING_EQUALS'"))
+						Expect(executeErr).To(HaveOccurred())
+					})
+				})
+
+				When("when the --stack flag is specified", func() {
+					checkBuildpackArgFunc()
+				})
+
+				When("the resource type argument is not lowercase", func() {
+					BeforeEach(func() {
+						cmd.RequiredArgs = flag.SetLabelArgs{
+							ResourceType: "sTaCk",
+							ResourceName: resourceName,
+							Labels:       []string{"FOO=BAR", "ENV=FAKE"},
+						}
+						fakeActor.UpdateStackLabelsByStackNameReturns(
+							v7action.Warnings([]string{"some-warning-1", "some-warning-2"}),
+							nil,
+						)
+					})
+
+					It("sets the provided labels on the stack", func() {
+						name, labels := fakeActor.UpdateStackLabelsByStackNameArgsForCall(0)
+						Expect(name).To(Equal(resourceName), "failed to pass stack name")
+						Expect(labels).To(BeEquivalentTo(map[string]types.NullString{
+							"FOO": types.NewNullString("BAR"),
+							"ENV": types.NewNullString("FAKE"),
+						}))
+					})
+
+					It("prints the flavor text in lowercase", func() {
+						Expect(testUI.Out).To(Say(regexp.QuoteMeta(`Setting label(s) for stack %s`), resourceName))
+					})
+				})
+			})
+
+			When("fetching the current user's name fails", func() {
+				BeforeEach(func() {
+					cmd.RequiredArgs = flag.SetLabelArgs{
+						ResourceType: "org",
+						ResourceName: resourceName,
+					}
+					fakeConfig.CurrentUserNameReturns("some-user", errors.New("boom"))
+				})
+
+				It("returns an error", func() {
+					Expect(executeErr).To(MatchError("boom"))
+				})
+			})
+		})
+
+		When("checking targeted org and stack fails", func() {
 			BeforeEach(func() {
 				fakeSharedActor.CheckTargetReturns(errors.New("nope"))
 			})

--- a/command/v7/set_label_command_test.go
+++ b/command/v7/set_label_command_test.go
@@ -3,6 +3,7 @@ package v7_test
 import (
 	"errors"
 	"regexp"
+	"strings"
 
 	"code.cloudfoundry.org/cli/actor/v7action"
 	"code.cloudfoundry.org/cli/command/commandfakes"
@@ -30,6 +31,21 @@ var _ = Describe("set-label command", func() {
 
 		executeErr error
 	)
+
+	checkBuildpackArgFunc := func() {
+		BeforeEach(func() {
+			cmd.BuildpackStack = "cflinuxfs3"
+		})
+
+		It("displays an argument combination error", func() {
+			argumentCombinationError := translatableerror.ArgumentCombinationError{
+				Args: []string{strings.ToLower(cmd.RequiredArgs.ResourceType), "--stack, -s"},
+			}
+
+			Expect(executeErr).To(MatchError(argumentCombinationError))
+		})
+
+	}
 
 	When("setting labels on apps", func() {
 
@@ -219,6 +235,10 @@ var _ = Describe("set-label command", func() {
 				Expect(executeErr).To(MatchError("nope"))
 			})
 		})
+
+		When("when the --stack flag is specified", func() {
+			checkBuildpackArgFunc()
+		})
 	})
 
 	When("setting labels on orgs", func() {
@@ -403,6 +423,10 @@ var _ = Describe("set-label command", func() {
 				Expect(executeErr).To(MatchError("nope"))
 			})
 		})
+
+		When("when the --stack flag is specified", func() {
+			checkBuildpackArgFunc()
+		})
 	})
 
 	When("setting labels on buildpacks", func() {
@@ -576,6 +600,18 @@ var _ = Describe("set-label command", func() {
 				Expect(executeErr).To(MatchError("nope"))
 			})
 		})
+
+		When("setting the stack argument", func() {
+
+			BeforeEach(func() {
+				cmd.BuildpackStack = "cflinuxfs3"
+			})
+
+			It("does not display an argument combination error", func() {
+				Expect(executeErr).ToNot(HaveOccurred())
+			})
+
+		})
 	})
 
 	When("setting labels on spaces", func() {
@@ -695,18 +731,7 @@ var _ = Describe("set-label command", func() {
 				})
 
 				When("when the --stack flag is specified", func() {
-					BeforeEach(func() {
-						cmd.RequiredArgs = flag.SetLabelArgs{
-							ResourceType: "space",
-							ResourceName: resourceName,
-							Labels:       []string{"FOO=BAR", "ENV=FAKE"},
-						}
-						cmd.BuildpackStack = "im-a-stack"
-					})
-
-					It("complains about the --stack flag being present", func() {
-						Expect(executeErr).To(MatchError(translatableerror.ArgumentCombinationError{Args: []string{"space", "--stack, -s"}}))
-					})
+					checkBuildpackArgFunc()
 				})
 
 				When("the resource type argument is not lowercase", func() {

--- a/command/v7/set_label_command_test.go
+++ b/command/v7/set_label_command_test.go
@@ -168,6 +168,30 @@ var _ = Describe("set-label command", func() {
 						Expect(executeErr).To(MatchError(translatableerror.ArgumentCombinationError{Args: []string{"app", "--stack, -s"}}))
 					})
 				})
+
+				When("the resource type argument is not lowercase", func() {
+					BeforeEach(func() {
+						cmd.RequiredArgs = flag.SetLabelArgs{
+							ResourceType: "ApP",
+							ResourceName: resourceName,
+							Labels:       []string{"FOO=BAR", "ENV=FAKE"},
+						}
+						fakeActor.UpdateApplicationLabelsByApplicationNameReturns(
+							v7action.Warnings([]string{"some-warning-1", "some-warning-2"}),
+							nil,
+						)
+					})
+
+					It("sets the provided labels on the app", func() {
+						name, spaceGUID, labels := fakeActor.UpdateApplicationLabelsByApplicationNameArgsForCall(0)
+						Expect(name).To(Equal(resourceName), "failed to pass app name")
+						Expect(spaceGUID).To(Equal("some-space-guid"))
+						Expect(labels).To(BeEquivalentTo(map[string]types.NullString{
+							"FOO": types.NewNullString("BAR"),
+							"ENV": types.NewNullString("FAKE"),
+						}))
+					})
+				})
 			})
 
 			When("fetching the current user's name fails", func() {
@@ -330,6 +354,29 @@ var _ = Describe("set-label command", func() {
 						Expect(executeErr).To(MatchError(translatableerror.ArgumentCombinationError{Args: []string{"org", "--stack, -s"}}))
 					})
 				})
+
+				When("the resource type argument is not lowercase", func() {
+					BeforeEach(func() {
+						cmd.RequiredArgs = flag.SetLabelArgs{
+							ResourceType: "OrG",
+							ResourceName: resourceName,
+							Labels:       []string{"FOO=BAR", "ENV=FAKE"},
+						}
+						fakeActor.UpdateOrganizationLabelsByOrganizationNameReturns(
+							v7action.Warnings([]string{"some-warning-1", "some-warning-2"}),
+							nil,
+						)
+					})
+
+					It("sets the provided labels on the org", func() {
+						name, labels := fakeActor.UpdateOrganizationLabelsByOrganizationNameArgsForCall(0)
+						Expect(name).To(Equal(resourceName), "failed to pass org name")
+						Expect(labels).To(BeEquivalentTo(map[string]types.NullString{
+							"FOO": types.NewNullString("BAR"),
+							"ENV": types.NewNullString("FAKE"),
+						}))
+					})
+				})
 			})
 
 			When("fetching the current user's name fails", func() {
@@ -477,6 +524,30 @@ var _ = Describe("set-label command", func() {
 					It("complains about the missing equal sign", func() {
 						Expect(executeErr).To(MatchError("Metadata error: no value provided for label 'MISSING_EQUALS'"))
 						Expect(executeErr).To(HaveOccurred())
+					})
+				})
+
+				When("the resource type argument is not lowercase", func() {
+					BeforeEach(func() {
+						cmd.RequiredArgs = flag.SetLabelArgs{
+							ResourceType: "bUiLdPaCk",
+							ResourceName: resourceName,
+							Labels:       []string{"FOO=BAR", "ENV=FAKE"},
+						}
+						fakeActor.UpdateBuildpackLabelsByBuildpackNameAndStackReturns(
+							v7action.Warnings([]string{"some-warning-1", "some-warning-2"}),
+							nil,
+						)
+					})
+
+					It("sets the provided labels on the org", func() {
+						name, stack, labels := fakeActor.UpdateBuildpackLabelsByBuildpackNameAndStackArgsForCall(0)
+						Expect(name).To(Equal(resourceName), "failed to pass buildpack name")
+						Expect(stack).To(Equal(""), "failed to pass buildpack stack")
+						Expect(labels).To(BeEquivalentTo(map[string]types.NullString{
+							"FOO": types.NewNullString("BAR"),
+							"ENV": types.NewNullString("FAKE"),
+						}))
 					})
 				})
 			})
@@ -635,6 +706,30 @@ var _ = Describe("set-label command", func() {
 
 					It("complains about the --stack flag being present", func() {
 						Expect(executeErr).To(MatchError(translatableerror.ArgumentCombinationError{Args: []string{"space", "--stack, -s"}}))
+					})
+				})
+
+				When("the resource type argument is not lowercase", func() {
+					BeforeEach(func() {
+						cmd.RequiredArgs = flag.SetLabelArgs{
+							ResourceType: "sPaCe",
+							ResourceName: resourceName,
+							Labels:       []string{"FOO=BAR", "ENV=FAKE"},
+						}
+						fakeActor.UpdateSpaceLabelsBySpaceNameReturns(
+							v7action.Warnings([]string{"some-warning-1", "some-warning-2"}),
+							nil,
+						)
+					})
+
+					It("sets the provided labels on the app", func() {
+						name, orgGUID, labels := fakeActor.UpdateSpaceLabelsBySpaceNameArgsForCall(0)
+						Expect(name).To(Equal(resourceName), "failed to pass space name")
+						Expect(orgGUID).To(Equal("some-org-guid"))
+						Expect(labels).To(BeEquivalentTo(map[string]types.NullString{
+							"FOO": types.NewNullString("BAR"),
+							"ENV": types.NewNullString("FAKE"),
+						}))
 					})
 				})
 			})

--- a/command/v7/set_label_command_test.go
+++ b/command/v7/set_label_command_test.go
@@ -572,7 +572,7 @@ var _ = Describe("set-label command", func() {
 						)
 					})
 
-					It("sets the provided labels on the org", func() {
+					It("sets the provided labels on the buildpack", func() {
 						name, stack, labels := fakeActor.UpdateBuildpackLabelsByBuildpackNameAndStackArgsForCall(0)
 						Expect(name).To(Equal(resourceName), "failed to pass buildpack name")
 						Expect(stack).To(Equal(""), "failed to pass buildpack stack")
@@ -584,6 +584,17 @@ var _ = Describe("set-label command", func() {
 
 					It("prints the flavor text in lowercase", func() {
 						Expect(testUI.Out).To(Say(regexp.QuoteMeta(`Setting label(s) for buildpack %s`), resourceName))
+					})
+
+					When("setting the stack argument", func() {
+						BeforeEach(func() {
+							cmd.BuildpackStack = "cflinuxfs3"
+						})
+
+						It("does not display an argument combination error", func() {
+							Expect(executeErr).ToNot(HaveOccurred())
+						})
+
 					})
 				})
 			})

--- a/command/v7/unset_label_command.go
+++ b/command/v7/unset_label_command.go
@@ -1,11 +1,14 @@
 package v7
 
 import (
+	"strings"
+
 	"code.cloudfoundry.org/cli/actor/sharedaction"
 	"code.cloudfoundry.org/cli/actor/v7action"
 	"code.cloudfoundry.org/cli/cf/errors"
 	"code.cloudfoundry.org/cli/command"
 	"code.cloudfoundry.org/cli/command/flag"
+	"code.cloudfoundry.org/cli/command/translatableerror"
 	"code.cloudfoundry.org/cli/command/v7/shared"
 	"code.cloudfoundry.org/cli/types"
 )
@@ -14,17 +17,19 @@ import (
 
 type UnsetLabelActor interface {
 	UpdateApplicationLabelsByApplicationName(string, string, map[string]types.NullString) (v7action.Warnings, error)
+	UpdateBuildpackLabelsByBuildpackNameAndStack(string, string, map[string]types.NullString) (v7action.Warnings, error)
 	UpdateOrganizationLabelsByOrganizationName(string, map[string]types.NullString) (v7action.Warnings, error)
 	UpdateSpaceLabelsBySpaceName(string, string, map[string]types.NullString) (v7action.Warnings, error)
 }
 
 type UnsetLabelCommand struct {
-	RequiredArgs flag.UnsetLabelArgs `positional-args:"yes"`
-	usage        interface{}         `usage:"CF_NAME unset-label RESOURCE RESOURCE_NAME KEY\n\nEXAMPLES:\n   cf unset-label app dora ci_signature_sha2\n\nRESOURCES:\n   app\n\nSEE ALSO:\n   set-label, labels"`
-	UI           command.UI
-	Config       command.Config
-	SharedActor  command.SharedActor
-	Actor        UnsetLabelActor
+	RequiredArgs   flag.UnsetLabelArgs `positional-args:"yes"`
+	BuildpackStack string              `long:"stack" short:"s" description:"Specify stack to disambiguate buildpacks with the same name"`
+	usage          interface{}         `usage:"CF_NAME unset-label RESOURCE RESOURCE_NAME KEY\n\nEXAMPLES:\n   cf unset-label app dora ci_signature_sha2\n\nRESOURCES:\n   app\n\nSEE ALSO:\n   set-label, labels"`
+	UI             command.UI
+	Config         command.Config
+	SharedActor    command.SharedActor
+	Actor          UnsetLabelActor
 }
 
 func (cmd *UnsetLabelCommand) Setup(config command.Config, ui command.UI) error {
@@ -45,14 +50,22 @@ func (cmd UnsetLabelCommand) Execute(args []string) error {
 		return err
 	}
 
+	err = cmd.validateFlags()
+	if err != nil {
+		return err
+	}
+
 	labels := make(map[string]types.NullString)
 	for _, value := range cmd.RequiredArgs.LabelKeys {
 		labels[value] = types.NewNullString()
 	}
 
-	switch ResourceType(cmd.RequiredArgs.ResourceType) {
+	resourceTypeString := strings.ToLower(cmd.RequiredArgs.ResourceType)
+	switch ResourceType(resourceTypeString) {
 	case App:
 		err = cmd.executeApp(user.Name, labels)
+	case Buildpack:
+		err = cmd.executeBuildpack(user.Name, labels)
 	case Org:
 		err = cmd.executeOrg(user.Name, labels)
 	case Space:
@@ -83,6 +96,24 @@ func (cmd UnsetLabelCommand) executeApp(username string, labels map[string]types
 	})
 
 	warnings, err := cmd.Actor.UpdateApplicationLabelsByApplicationName(cmd.RequiredArgs.ResourceName, cmd.Config.TargetedSpace().GUID, labels)
+
+	cmd.UI.DisplayWarnings(warnings)
+
+	return err
+}
+
+func (cmd UnsetLabelCommand) executeBuildpack(username string, labels map[string]types.NullString) error {
+	err := cmd.SharedActor.CheckTarget(false, false)
+	if err != nil {
+		return err
+	}
+
+	cmd.UI.DisplayTextWithFlavor("Removing label(s) for buildpack {{.ResourceName}} as {{.User}}...", map[string]interface{}{
+		"ResourceName": cmd.RequiredArgs.ResourceName,
+		"User":         username,
+	})
+
+	warnings, err := cmd.Actor.UpdateBuildpackLabelsByBuildpackNameAndStack(cmd.RequiredArgs.ResourceName, cmd.BuildpackStack, labels)
 
 	cmd.UI.DisplayWarnings(warnings)
 
@@ -124,4 +155,16 @@ func (cmd UnsetLabelCommand) executeSpace(username string, labels map[string]typ
 	cmd.UI.DisplayWarnings(warnings)
 
 	return err
+}
+
+func (cmd UnsetLabelCommand) validateFlags() error {
+	resourceTypeString := strings.ToLower(cmd.RequiredArgs.ResourceType)
+	if cmd.BuildpackStack != "" && ResourceType(resourceTypeString) != Buildpack {
+		return translatableerror.ArgumentCombinationError{
+			Args: []string{
+				cmd.RequiredArgs.ResourceType, "--stack, -s",
+			},
+		}
+	}
+	return nil
 }

--- a/command/v7/v7fakes/fake_labels_actor.go
+++ b/command/v7/v7fakes/fake_labels_actor.go
@@ -73,6 +73,21 @@ type FakeLabelsActor struct {
 		result2 v7action.Warnings
 		result3 error
 	}
+	GetStackLabelsStub        func(string) (map[string]types.NullString, v7action.Warnings, error)
+	getStackLabelsMutex       sync.RWMutex
+	getStackLabelsArgsForCall []struct {
+		arg1 string
+	}
+	getStackLabelsReturns struct {
+		result1 map[string]types.NullString
+		result2 v7action.Warnings
+		result3 error
+	}
+	getStackLabelsReturnsOnCall map[int]struct {
+		result1 map[string]types.NullString
+		result2 v7action.Warnings
+		result3 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -344,6 +359,72 @@ func (fake *FakeLabelsActor) GetSpaceLabelsReturnsOnCall(i int, result1 map[stri
 	}{result1, result2, result3}
 }
 
+func (fake *FakeLabelsActor) GetStackLabels(arg1 string) (map[string]types.NullString, v7action.Warnings, error) {
+	fake.getStackLabelsMutex.Lock()
+	ret, specificReturn := fake.getStackLabelsReturnsOnCall[len(fake.getStackLabelsArgsForCall)]
+	fake.getStackLabelsArgsForCall = append(fake.getStackLabelsArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("GetStackLabels", []interface{}{arg1})
+	fake.getStackLabelsMutex.Unlock()
+	if fake.GetStackLabelsStub != nil {
+		return fake.GetStackLabelsStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	fakeReturns := fake.getStackLabelsReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeLabelsActor) GetStackLabelsCallCount() int {
+	fake.getStackLabelsMutex.RLock()
+	defer fake.getStackLabelsMutex.RUnlock()
+	return len(fake.getStackLabelsArgsForCall)
+}
+
+func (fake *FakeLabelsActor) GetStackLabelsCalls(stub func(string) (map[string]types.NullString, v7action.Warnings, error)) {
+	fake.getStackLabelsMutex.Lock()
+	defer fake.getStackLabelsMutex.Unlock()
+	fake.GetStackLabelsStub = stub
+}
+
+func (fake *FakeLabelsActor) GetStackLabelsArgsForCall(i int) string {
+	fake.getStackLabelsMutex.RLock()
+	defer fake.getStackLabelsMutex.RUnlock()
+	argsForCall := fake.getStackLabelsArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeLabelsActor) GetStackLabelsReturns(result1 map[string]types.NullString, result2 v7action.Warnings, result3 error) {
+	fake.getStackLabelsMutex.Lock()
+	defer fake.getStackLabelsMutex.Unlock()
+	fake.GetStackLabelsStub = nil
+	fake.getStackLabelsReturns = struct {
+		result1 map[string]types.NullString
+		result2 v7action.Warnings
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeLabelsActor) GetStackLabelsReturnsOnCall(i int, result1 map[string]types.NullString, result2 v7action.Warnings, result3 error) {
+	fake.getStackLabelsMutex.Lock()
+	defer fake.getStackLabelsMutex.Unlock()
+	fake.GetStackLabelsStub = nil
+	if fake.getStackLabelsReturnsOnCall == nil {
+		fake.getStackLabelsReturnsOnCall = make(map[int]struct {
+			result1 map[string]types.NullString
+			result2 v7action.Warnings
+			result3 error
+		})
+	}
+	fake.getStackLabelsReturnsOnCall[i] = struct {
+		result1 map[string]types.NullString
+		result2 v7action.Warnings
+		result3 error
+	}{result1, result2, result3}
+}
+
 func (fake *FakeLabelsActor) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -355,6 +436,8 @@ func (fake *FakeLabelsActor) Invocations() map[string][][]interface{} {
 	defer fake.getOrganizationLabelsMutex.RUnlock()
 	fake.getSpaceLabelsMutex.RLock()
 	defer fake.getSpaceLabelsMutex.RUnlock()
+	fake.getStackLabelsMutex.RLock()
+	defer fake.getStackLabelsMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/command/v7/v7fakes/fake_labels_actor.go
+++ b/command/v7/v7fakes/fake_labels_actor.go
@@ -26,6 +26,22 @@ type FakeLabelsActor struct {
 		result2 v7action.Warnings
 		result3 error
 	}
+	GetBuildpackLabelsStub        func(string, string) (map[string]types.NullString, v7action.Warnings, error)
+	getBuildpackLabelsMutex       sync.RWMutex
+	getBuildpackLabelsArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
+	getBuildpackLabelsReturns struct {
+		result1 map[string]types.NullString
+		result2 v7action.Warnings
+		result3 error
+	}
+	getBuildpackLabelsReturnsOnCall map[int]struct {
+		result1 map[string]types.NullString
+		result2 v7action.Warnings
+		result3 error
+	}
 	GetOrganizationLabelsStub        func(string) (map[string]types.NullString, v7action.Warnings, error)
 	getOrganizationLabelsMutex       sync.RWMutex
 	getOrganizationLabelsArgsForCall []struct {
@@ -122,6 +138,73 @@ func (fake *FakeLabelsActor) GetApplicationLabelsReturnsOnCall(i int, result1 ma
 		})
 	}
 	fake.getApplicationLabelsReturnsOnCall[i] = struct {
+		result1 map[string]types.NullString
+		result2 v7action.Warnings
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeLabelsActor) GetBuildpackLabels(arg1 string, arg2 string) (map[string]types.NullString, v7action.Warnings, error) {
+	fake.getBuildpackLabelsMutex.Lock()
+	ret, specificReturn := fake.getBuildpackLabelsReturnsOnCall[len(fake.getBuildpackLabelsArgsForCall)]
+	fake.getBuildpackLabelsArgsForCall = append(fake.getBuildpackLabelsArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("GetBuildpackLabels", []interface{}{arg1, arg2})
+	fake.getBuildpackLabelsMutex.Unlock()
+	if fake.GetBuildpackLabelsStub != nil {
+		return fake.GetBuildpackLabelsStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	fakeReturns := fake.getBuildpackLabelsReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeLabelsActor) GetBuildpackLabelsCallCount() int {
+	fake.getBuildpackLabelsMutex.RLock()
+	defer fake.getBuildpackLabelsMutex.RUnlock()
+	return len(fake.getBuildpackLabelsArgsForCall)
+}
+
+func (fake *FakeLabelsActor) GetBuildpackLabelsCalls(stub func(string, string) (map[string]types.NullString, v7action.Warnings, error)) {
+	fake.getBuildpackLabelsMutex.Lock()
+	defer fake.getBuildpackLabelsMutex.Unlock()
+	fake.GetBuildpackLabelsStub = stub
+}
+
+func (fake *FakeLabelsActor) GetBuildpackLabelsArgsForCall(i int) (string, string) {
+	fake.getBuildpackLabelsMutex.RLock()
+	defer fake.getBuildpackLabelsMutex.RUnlock()
+	argsForCall := fake.getBuildpackLabelsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeLabelsActor) GetBuildpackLabelsReturns(result1 map[string]types.NullString, result2 v7action.Warnings, result3 error) {
+	fake.getBuildpackLabelsMutex.Lock()
+	defer fake.getBuildpackLabelsMutex.Unlock()
+	fake.GetBuildpackLabelsStub = nil
+	fake.getBuildpackLabelsReturns = struct {
+		result1 map[string]types.NullString
+		result2 v7action.Warnings
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeLabelsActor) GetBuildpackLabelsReturnsOnCall(i int, result1 map[string]types.NullString, result2 v7action.Warnings, result3 error) {
+	fake.getBuildpackLabelsMutex.Lock()
+	defer fake.getBuildpackLabelsMutex.Unlock()
+	fake.GetBuildpackLabelsStub = nil
+	if fake.getBuildpackLabelsReturnsOnCall == nil {
+		fake.getBuildpackLabelsReturnsOnCall = make(map[int]struct {
+			result1 map[string]types.NullString
+			result2 v7action.Warnings
+			result3 error
+		})
+	}
+	fake.getBuildpackLabelsReturnsOnCall[i] = struct {
 		result1 map[string]types.NullString
 		result2 v7action.Warnings
 		result3 error
@@ -266,6 +349,8 @@ func (fake *FakeLabelsActor) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.getApplicationLabelsMutex.RLock()
 	defer fake.getApplicationLabelsMutex.RUnlock()
+	fake.getBuildpackLabelsMutex.RLock()
+	defer fake.getBuildpackLabelsMutex.RUnlock()
 	fake.getOrganizationLabelsMutex.RLock()
 	defer fake.getOrganizationLabelsMutex.RUnlock()
 	fake.getSpaceLabelsMutex.RLock()

--- a/command/v7/v7fakes/fake_set_label_actor.go
+++ b/command/v7/v7fakes/fake_set_label_actor.go
@@ -69,6 +69,20 @@ type FakeSetLabelActor struct {
 		result1 v7action.Warnings
 		result2 error
 	}
+	UpdateStackLabelsByStackNameStub        func(string, map[string]types.NullString) (v7action.Warnings, error)
+	updateStackLabelsByStackNameMutex       sync.RWMutex
+	updateStackLabelsByStackNameArgsForCall []struct {
+		arg1 string
+		arg2 map[string]types.NullString
+	}
+	updateStackLabelsByStackNameReturns struct {
+		result1 v7action.Warnings
+		result2 error
+	}
+	updateStackLabelsByStackNameReturnsOnCall map[int]struct {
+		result1 v7action.Warnings
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -332,6 +346,70 @@ func (fake *FakeSetLabelActor) UpdateSpaceLabelsBySpaceNameReturnsOnCall(i int, 
 	}{result1, result2}
 }
 
+func (fake *FakeSetLabelActor) UpdateStackLabelsByStackName(arg1 string, arg2 map[string]types.NullString) (v7action.Warnings, error) {
+	fake.updateStackLabelsByStackNameMutex.Lock()
+	ret, specificReturn := fake.updateStackLabelsByStackNameReturnsOnCall[len(fake.updateStackLabelsByStackNameArgsForCall)]
+	fake.updateStackLabelsByStackNameArgsForCall = append(fake.updateStackLabelsByStackNameArgsForCall, struct {
+		arg1 string
+		arg2 map[string]types.NullString
+	}{arg1, arg2})
+	fake.recordInvocation("UpdateStackLabelsByStackName", []interface{}{arg1, arg2})
+	fake.updateStackLabelsByStackNameMutex.Unlock()
+	if fake.UpdateStackLabelsByStackNameStub != nil {
+		return fake.UpdateStackLabelsByStackNameStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.updateStackLabelsByStackNameReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeSetLabelActor) UpdateStackLabelsByStackNameCallCount() int {
+	fake.updateStackLabelsByStackNameMutex.RLock()
+	defer fake.updateStackLabelsByStackNameMutex.RUnlock()
+	return len(fake.updateStackLabelsByStackNameArgsForCall)
+}
+
+func (fake *FakeSetLabelActor) UpdateStackLabelsByStackNameCalls(stub func(string, map[string]types.NullString) (v7action.Warnings, error)) {
+	fake.updateStackLabelsByStackNameMutex.Lock()
+	defer fake.updateStackLabelsByStackNameMutex.Unlock()
+	fake.UpdateStackLabelsByStackNameStub = stub
+}
+
+func (fake *FakeSetLabelActor) UpdateStackLabelsByStackNameArgsForCall(i int) (string, map[string]types.NullString) {
+	fake.updateStackLabelsByStackNameMutex.RLock()
+	defer fake.updateStackLabelsByStackNameMutex.RUnlock()
+	argsForCall := fake.updateStackLabelsByStackNameArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeSetLabelActor) UpdateStackLabelsByStackNameReturns(result1 v7action.Warnings, result2 error) {
+	fake.updateStackLabelsByStackNameMutex.Lock()
+	defer fake.updateStackLabelsByStackNameMutex.Unlock()
+	fake.UpdateStackLabelsByStackNameStub = nil
+	fake.updateStackLabelsByStackNameReturns = struct {
+		result1 v7action.Warnings
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeSetLabelActor) UpdateStackLabelsByStackNameReturnsOnCall(i int, result1 v7action.Warnings, result2 error) {
+	fake.updateStackLabelsByStackNameMutex.Lock()
+	defer fake.updateStackLabelsByStackNameMutex.Unlock()
+	fake.UpdateStackLabelsByStackNameStub = nil
+	if fake.updateStackLabelsByStackNameReturnsOnCall == nil {
+		fake.updateStackLabelsByStackNameReturnsOnCall = make(map[int]struct {
+			result1 v7action.Warnings
+			result2 error
+		})
+	}
+	fake.updateStackLabelsByStackNameReturnsOnCall[i] = struct {
+		result1 v7action.Warnings
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeSetLabelActor) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -343,6 +421,8 @@ func (fake *FakeSetLabelActor) Invocations() map[string][][]interface{} {
 	defer fake.updateOrganizationLabelsByOrganizationNameMutex.RUnlock()
 	fake.updateSpaceLabelsBySpaceNameMutex.RLock()
 	defer fake.updateSpaceLabelsBySpaceNameMutex.RUnlock()
+	fake.updateStackLabelsByStackNameMutex.RLock()
+	defer fake.updateStackLabelsByStackNameMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/command/v7/v7fakes/fake_set_label_actor.go
+++ b/command/v7/v7fakes/fake_set_label_actor.go
@@ -25,6 +25,21 @@ type FakeSetLabelActor struct {
 		result1 v7action.Warnings
 		result2 error
 	}
+	UpdateBuildpackLabelsByBuildpackNameAndStackStub        func(string, string, map[string]types.NullString) (v7action.Warnings, error)
+	updateBuildpackLabelsByBuildpackNameAndStackMutex       sync.RWMutex
+	updateBuildpackLabelsByBuildpackNameAndStackArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 map[string]types.NullString
+	}
+	updateBuildpackLabelsByBuildpackNameAndStackReturns struct {
+		result1 v7action.Warnings
+		result2 error
+	}
+	updateBuildpackLabelsByBuildpackNameAndStackReturnsOnCall map[int]struct {
+		result1 v7action.Warnings
+		result2 error
+	}
 	UpdateOrganizationLabelsByOrganizationNameStub        func(string, map[string]types.NullString) (v7action.Warnings, error)
 	updateOrganizationLabelsByOrganizationNameMutex       sync.RWMutex
 	updateOrganizationLabelsByOrganizationNameArgsForCall []struct {
@@ -118,6 +133,71 @@ func (fake *FakeSetLabelActor) UpdateApplicationLabelsByApplicationNameReturnsOn
 		})
 	}
 	fake.updateApplicationLabelsByApplicationNameReturnsOnCall[i] = struct {
+		result1 v7action.Warnings
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeSetLabelActor) UpdateBuildpackLabelsByBuildpackNameAndStack(arg1 string, arg2 string, arg3 map[string]types.NullString) (v7action.Warnings, error) {
+	fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.Lock()
+	ret, specificReturn := fake.updateBuildpackLabelsByBuildpackNameAndStackReturnsOnCall[len(fake.updateBuildpackLabelsByBuildpackNameAndStackArgsForCall)]
+	fake.updateBuildpackLabelsByBuildpackNameAndStackArgsForCall = append(fake.updateBuildpackLabelsByBuildpackNameAndStackArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 map[string]types.NullString
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("UpdateBuildpackLabelsByBuildpackNameAndStack", []interface{}{arg1, arg2, arg3})
+	fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.Unlock()
+	if fake.UpdateBuildpackLabelsByBuildpackNameAndStackStub != nil {
+		return fake.UpdateBuildpackLabelsByBuildpackNameAndStackStub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.updateBuildpackLabelsByBuildpackNameAndStackReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeSetLabelActor) UpdateBuildpackLabelsByBuildpackNameAndStackCallCount() int {
+	fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.RLock()
+	defer fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.RUnlock()
+	return len(fake.updateBuildpackLabelsByBuildpackNameAndStackArgsForCall)
+}
+
+func (fake *FakeSetLabelActor) UpdateBuildpackLabelsByBuildpackNameAndStackCalls(stub func(string, string, map[string]types.NullString) (v7action.Warnings, error)) {
+	fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.Lock()
+	defer fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.Unlock()
+	fake.UpdateBuildpackLabelsByBuildpackNameAndStackStub = stub
+}
+
+func (fake *FakeSetLabelActor) UpdateBuildpackLabelsByBuildpackNameAndStackArgsForCall(i int) (string, string, map[string]types.NullString) {
+	fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.RLock()
+	defer fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.RUnlock()
+	argsForCall := fake.updateBuildpackLabelsByBuildpackNameAndStackArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeSetLabelActor) UpdateBuildpackLabelsByBuildpackNameAndStackReturns(result1 v7action.Warnings, result2 error) {
+	fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.Lock()
+	defer fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.Unlock()
+	fake.UpdateBuildpackLabelsByBuildpackNameAndStackStub = nil
+	fake.updateBuildpackLabelsByBuildpackNameAndStackReturns = struct {
+		result1 v7action.Warnings
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeSetLabelActor) UpdateBuildpackLabelsByBuildpackNameAndStackReturnsOnCall(i int, result1 v7action.Warnings, result2 error) {
+	fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.Lock()
+	defer fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.Unlock()
+	fake.UpdateBuildpackLabelsByBuildpackNameAndStackStub = nil
+	if fake.updateBuildpackLabelsByBuildpackNameAndStackReturnsOnCall == nil {
+		fake.updateBuildpackLabelsByBuildpackNameAndStackReturnsOnCall = make(map[int]struct {
+			result1 v7action.Warnings
+			result2 error
+		})
+	}
+	fake.updateBuildpackLabelsByBuildpackNameAndStackReturnsOnCall[i] = struct {
 		result1 v7action.Warnings
 		result2 error
 	}{result1, result2}
@@ -257,6 +337,8 @@ func (fake *FakeSetLabelActor) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.updateApplicationLabelsByApplicationNameMutex.RLock()
 	defer fake.updateApplicationLabelsByApplicationNameMutex.RUnlock()
+	fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.RLock()
+	defer fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.RUnlock()
 	fake.updateOrganizationLabelsByOrganizationNameMutex.RLock()
 	defer fake.updateOrganizationLabelsByOrganizationNameMutex.RUnlock()
 	fake.updateSpaceLabelsBySpaceNameMutex.RLock()

--- a/command/v7/v7fakes/fake_unset_label_actor.go
+++ b/command/v7/v7fakes/fake_unset_label_actor.go
@@ -25,6 +25,21 @@ type FakeUnsetLabelActor struct {
 		result1 v7action.Warnings
 		result2 error
 	}
+	UpdateBuildpackLabelsByBuildpackNameAndStackStub        func(string, string, map[string]types.NullString) (v7action.Warnings, error)
+	updateBuildpackLabelsByBuildpackNameAndStackMutex       sync.RWMutex
+	updateBuildpackLabelsByBuildpackNameAndStackArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 map[string]types.NullString
+	}
+	updateBuildpackLabelsByBuildpackNameAndStackReturns struct {
+		result1 v7action.Warnings
+		result2 error
+	}
+	updateBuildpackLabelsByBuildpackNameAndStackReturnsOnCall map[int]struct {
+		result1 v7action.Warnings
+		result2 error
+	}
 	UpdateOrganizationLabelsByOrganizationNameStub        func(string, map[string]types.NullString) (v7action.Warnings, error)
 	updateOrganizationLabelsByOrganizationNameMutex       sync.RWMutex
 	updateOrganizationLabelsByOrganizationNameArgsForCall []struct {
@@ -118,6 +133,71 @@ func (fake *FakeUnsetLabelActor) UpdateApplicationLabelsByApplicationNameReturns
 		})
 	}
 	fake.updateApplicationLabelsByApplicationNameReturnsOnCall[i] = struct {
+		result1 v7action.Warnings
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeUnsetLabelActor) UpdateBuildpackLabelsByBuildpackNameAndStack(arg1 string, arg2 string, arg3 map[string]types.NullString) (v7action.Warnings, error) {
+	fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.Lock()
+	ret, specificReturn := fake.updateBuildpackLabelsByBuildpackNameAndStackReturnsOnCall[len(fake.updateBuildpackLabelsByBuildpackNameAndStackArgsForCall)]
+	fake.updateBuildpackLabelsByBuildpackNameAndStackArgsForCall = append(fake.updateBuildpackLabelsByBuildpackNameAndStackArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 map[string]types.NullString
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("UpdateBuildpackLabelsByBuildpackNameAndStack", []interface{}{arg1, arg2, arg3})
+	fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.Unlock()
+	if fake.UpdateBuildpackLabelsByBuildpackNameAndStackStub != nil {
+		return fake.UpdateBuildpackLabelsByBuildpackNameAndStackStub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.updateBuildpackLabelsByBuildpackNameAndStackReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeUnsetLabelActor) UpdateBuildpackLabelsByBuildpackNameAndStackCallCount() int {
+	fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.RLock()
+	defer fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.RUnlock()
+	return len(fake.updateBuildpackLabelsByBuildpackNameAndStackArgsForCall)
+}
+
+func (fake *FakeUnsetLabelActor) UpdateBuildpackLabelsByBuildpackNameAndStackCalls(stub func(string, string, map[string]types.NullString) (v7action.Warnings, error)) {
+	fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.Lock()
+	defer fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.Unlock()
+	fake.UpdateBuildpackLabelsByBuildpackNameAndStackStub = stub
+}
+
+func (fake *FakeUnsetLabelActor) UpdateBuildpackLabelsByBuildpackNameAndStackArgsForCall(i int) (string, string, map[string]types.NullString) {
+	fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.RLock()
+	defer fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.RUnlock()
+	argsForCall := fake.updateBuildpackLabelsByBuildpackNameAndStackArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeUnsetLabelActor) UpdateBuildpackLabelsByBuildpackNameAndStackReturns(result1 v7action.Warnings, result2 error) {
+	fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.Lock()
+	defer fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.Unlock()
+	fake.UpdateBuildpackLabelsByBuildpackNameAndStackStub = nil
+	fake.updateBuildpackLabelsByBuildpackNameAndStackReturns = struct {
+		result1 v7action.Warnings
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeUnsetLabelActor) UpdateBuildpackLabelsByBuildpackNameAndStackReturnsOnCall(i int, result1 v7action.Warnings, result2 error) {
+	fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.Lock()
+	defer fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.Unlock()
+	fake.UpdateBuildpackLabelsByBuildpackNameAndStackStub = nil
+	if fake.updateBuildpackLabelsByBuildpackNameAndStackReturnsOnCall == nil {
+		fake.updateBuildpackLabelsByBuildpackNameAndStackReturnsOnCall = make(map[int]struct {
+			result1 v7action.Warnings
+			result2 error
+		})
+	}
+	fake.updateBuildpackLabelsByBuildpackNameAndStackReturnsOnCall[i] = struct {
 		result1 v7action.Warnings
 		result2 error
 	}{result1, result2}
@@ -257,6 +337,8 @@ func (fake *FakeUnsetLabelActor) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.updateApplicationLabelsByApplicationNameMutex.RLock()
 	defer fake.updateApplicationLabelsByApplicationNameMutex.RUnlock()
+	fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.RLock()
+	defer fake.updateBuildpackLabelsByBuildpackNameAndStackMutex.RUnlock()
 	fake.updateOrganizationLabelsByOrganizationNameMutex.RLock()
 	defer fake.updateOrganizationLabelsByOrganizationNameMutex.RUnlock()
 	fake.updateSpaceLabelsBySpaceNameMutex.RLock()

--- a/integration/helpers/buildpack.go
+++ b/integration/helpers/buildpack.go
@@ -95,7 +95,7 @@ func DeleteBuildpackIfOnOldCCAPI(buildpackName string) {
 }
 
 type Buildpack struct {
-	Guid  string `json:"guid"`
+	GUID  string `json:"guid"`
 	Name  string `json:"name"`
 	Stack string `json:"stack"`
 }
@@ -116,5 +116,5 @@ func BuildpackGUIDByNameAndStack(buildpackName string, stackName string) string 
 	err := json.Unmarshal(bytes, &buildpacks)
 	Expect(err).ToNot(HaveOccurred())
 
-	return buildpacks.Buildpacks[0].Guid
+	return buildpacks.Buildpacks[0].GUID
 }

--- a/integration/v7/isolated/labels_command_test.go
+++ b/integration/v7/isolated/labels_command_test.go
@@ -43,16 +43,18 @@ var _ = Describe("labels command", func() {
 
 	When("the environment is set up correctly", func() {
 		var (
+			appName       string
+			buildpackName string
 			orgName       string
 			spaceName     string
-			appName       string
+			stackName     string
 			username      string
-			buildpackName string
 		)
 
 		BeforeEach(func() {
 			orgName = helpers.NewOrgName()
 			buildpackName = helpers.NewBuildpackName()
+			stackName = helpers.NewStackName()
 			username, _ = helpers.GetCredentials()
 			helpers.LoginCF()
 			helpers.CreateOrg(orgName)
@@ -102,89 +104,6 @@ var _ = Describe("labels command", func() {
 					session := helpers.CF("labels", "app", "non-existent-app")
 					Eventually(session).Should(Say(regexp.QuoteMeta("Getting labels for app non-existent-app in org %s / space %s as %s...\n\n"), orgName, spaceName, username))
 					Eventually(session.Err).Should(Say("App 'non-existent-app' not found"))
-					Eventually(session).Should(Say("FAILED"))
-					Eventually(session).Should(Exit(1))
-				})
-			})
-		})
-
-		Describe("org labels", func() {
-
-			When("there are labels set on the organization", func() {
-				BeforeEach(func() {
-					session := helpers.CF("set-label", "org", orgName, "some-other-key=some-other-value", "some-key=some-value")
-					Eventually(session).Should(Exit(0))
-				})
-				It("lists the labels", func() {
-					session := helpers.CF("labels", "org", orgName)
-					Eventually(session).Should(Say(regexp.QuoteMeta("Getting labels for org %s as %s...\n\n"), orgName, username))
-					Eventually(session).Should(Say(`key\s+value`))
-					Eventually(session).Should(Say(`some-key\s+some-value`))
-					Eventually(session).Should(Say(`some-other-key\s+some-other-value`))
-					Eventually(session).Should(Exit(0))
-				})
-			})
-
-			When("there are no labels set on the organization", func() {
-				It("indicates that there are no labels", func() {
-					session := helpers.CF("labels", "org", orgName)
-					Eventually(session).Should(Say(regexp.QuoteMeta("Getting labels for org %s as %s...\n\n"), orgName, username))
-					Expect(session).ToNot(Say(`key\s+value`))
-					Eventually(session).Should(Say("No labels found."))
-					Eventually(session).Should(Exit(0))
-				})
-			})
-
-			When("the org does not exist", func() {
-				It("displays an error", func() {
-					session := helpers.CF("labels", "org", "non-existent-org")
-					Eventually(session).Should(Say(regexp.QuoteMeta("Getting labels for org %s as %s...\n\n"), "non-existent-org", username))
-					Eventually(session.Err).Should(Say("Organization 'non-existent-org' not found"))
-					Eventually(session).Should(Say("FAILED"))
-					Eventually(session).Should(Exit(1))
-				})
-			})
-		})
-
-		Describe("space labels", func() {
-			BeforeEach(func() {
-				helpers.TargetOrg(orgName)
-				spaceName = helpers.NewSpaceName()
-				helpers.CreateSpace(spaceName)
-				helpers.TargetOrgAndSpace(orgName, spaceName)
-				helpers.SetupCF(orgName, spaceName)
-			})
-
-			When("there are labels set on the space", func() {
-				BeforeEach(func() {
-					session := helpers.CF("set-label", "space", spaceName, "some-other-key=some-other-value", "some-key=some-value")
-					Eventually(session).Should(Exit(0))
-				})
-				It("lists the labels", func() {
-					session := helpers.CF("labels", "space", spaceName)
-					Eventually(session).Should(Say(regexp.QuoteMeta("Getting labels for space %s in org %s as %s...\n\n"), spaceName, orgName, username))
-					Eventually(session).Should(Say(`key\s+value`))
-					Eventually(session).Should(Say(`some-key\s+some-value`))
-					Eventually(session).Should(Say(`some-other-key\s+some-other-value`))
-					Eventually(session).Should(Exit(0))
-				})
-			})
-
-			When("there are no labels set on the space", func() {
-				It("indicates that there are no labels", func() {
-					session := helpers.CF("labels", "space", spaceName)
-					Eventually(session).Should(Say(regexp.QuoteMeta("Getting labels for space %s in org %s as %s...\n\n"), spaceName, orgName, username))
-					Expect(session).ToNot(Say(`key\s+value`))
-					Eventually(session).Should(Say("No labels found."))
-					Eventually(session).Should(Exit(0))
-				})
-			})
-
-			When("the space does not exist", func() {
-				It("displays an error", func() {
-					session := helpers.CF("labels", "space", "non-existent-space")
-					Eventually(session).Should(Say(regexp.QuoteMeta("Getting labels for space %s in org %s as %s...\n\n"), "non-existent-space", orgName, username))
-					Eventually(session.Err).Should(Say("Space 'non-existent-space' not found"))
 					Eventually(session).Should(Say("FAILED"))
 					Eventually(session).Should(Exit(1))
 				})
@@ -297,6 +216,134 @@ var _ = Describe("labels command", func() {
 					session := helpers.CF("labels", "buildpack", "non-existent-buildpack")
 					Eventually(session).Should(Say(regexp.QuoteMeta("Getting labels for buildpack %s as %s...\n\n"), "non-existent-buildpack", username))
 					Eventually(session.Err).Should(Say("Buildpack non-existent-buildpack not found"))
+					Eventually(session).Should(Say("FAILED"))
+					Eventually(session).Should(Exit(1))
+				})
+			})
+		})
+
+		Describe("org labels", func() {
+
+			When("there are labels set on the organization", func() {
+				BeforeEach(func() {
+					session := helpers.CF("set-label", "org", orgName, "some-other-key=some-other-value", "some-key=some-value")
+					Eventually(session).Should(Exit(0))
+				})
+				It("lists the labels", func() {
+					session := helpers.CF("labels", "org", orgName)
+					Eventually(session).Should(Say(regexp.QuoteMeta("Getting labels for org %s as %s...\n\n"), orgName, username))
+					Eventually(session).Should(Say(`key\s+value`))
+					Eventually(session).Should(Say(`some-key\s+some-value`))
+					Eventually(session).Should(Say(`some-other-key\s+some-other-value`))
+					Eventually(session).Should(Exit(0))
+				})
+			})
+
+			When("there are no labels set on the organization", func() {
+				It("indicates that there are no labels", func() {
+					session := helpers.CF("labels", "org", orgName)
+					Eventually(session).Should(Say(regexp.QuoteMeta("Getting labels for org %s as %s...\n\n"), orgName, username))
+					Expect(session).ToNot(Say(`key\s+value`))
+					Eventually(session).Should(Say("No labels found."))
+					Eventually(session).Should(Exit(0))
+				})
+			})
+
+			When("the org does not exist", func() {
+				It("displays an error", func() {
+					session := helpers.CF("labels", "org", "non-existent-org")
+					Eventually(session).Should(Say(regexp.QuoteMeta("Getting labels for org %s as %s...\n\n"), "non-existent-org", username))
+					Eventually(session.Err).Should(Say("Organization 'non-existent-org' not found"))
+					Eventually(session).Should(Say("FAILED"))
+					Eventually(session).Should(Exit(1))
+				})
+			})
+		})
+
+		Describe("stack labels", func() {
+			BeforeEach(func() {
+				helpers.CreateStack(stackName)
+			})
+			AfterEach(func() {
+				helpers.DeleteStack(stackName)
+			})
+
+			When("there are labels set on the stack", func() {
+				BeforeEach(func() {
+					session := helpers.CF("set-label", "stack", stackName, "some-other-key=some-other-value", "some-key=some-value")
+					Eventually(session).Should(Exit(0))
+				})
+
+				It("lists the labels", func() {
+					session := helpers.CF("labels", "stack", stackName)
+					Eventually(session).Should(Say(regexp.QuoteMeta("Getting labels for stack %s as %s...\n\n"), stackName, username))
+					Eventually(session).Should(Say(`key\s+value`))
+					Eventually(session).Should(Say(`some-key\s+some-value`))
+					Eventually(session).Should(Say(`some-other-key\s+some-other-value`))
+					Eventually(session).Should(Exit(0))
+				})
+			})
+
+			When("there are no labels set on the stack", func() {
+				It("indicates that there are no labels", func() {
+					session := helpers.CF("labels", "stack", stackName)
+					Eventually(session).Should(Say(regexp.QuoteMeta("Getting labels for stack %s as %s...\n\n"), stackName, username))
+					Expect(session).ToNot(Say(`key\s+value`))
+					Eventually(session).Should(Say("No labels found."))
+					Eventually(session).Should(Exit(0))
+				})
+			})
+
+			When("the stack does not exist", func() {
+				It("displays an error", func() {
+					session := helpers.CF("labels", "stack", "non-existent-stack")
+					Eventually(session).Should(Say(regexp.QuoteMeta("Getting labels for stack %s as %s...\n\n"), "non-existent-stack", username))
+					Eventually(session.Err).Should(Say("Stack 'non-existent-stack' not found"))
+					Eventually(session).Should(Say("FAILED"))
+					Eventually(session).Should(Exit(1))
+				})
+			})
+		})
+
+		Describe("space labels", func() {
+			BeforeEach(func() {
+				helpers.TargetOrg(orgName)
+				spaceName = helpers.NewSpaceName()
+				helpers.CreateSpace(spaceName)
+				helpers.TargetOrgAndSpace(orgName, spaceName)
+				helpers.SetupCF(orgName, spaceName)
+			})
+
+			When("there are labels set on the space", func() {
+				BeforeEach(func() {
+					session := helpers.CF("set-label", "space", spaceName, "some-other-key=some-other-value", "some-key=some-value")
+					Eventually(session).Should(Exit(0))
+				})
+				It("lists the labels", func() {
+					session := helpers.CF("labels", "space", spaceName)
+					Eventually(session).Should(Say(regexp.QuoteMeta("Getting labels for space %s in org %s as %s...\n\n"), spaceName, orgName, username))
+					Eventually(session).Should(Say(`key\s+value`))
+					Eventually(session).Should(Say(`some-key\s+some-value`))
+					Eventually(session).Should(Say(`some-other-key\s+some-other-value`))
+					Eventually(session).Should(Exit(0))
+				})
+			})
+
+			When("there are no labels set on the space", func() {
+				It("indicates that there are no labels", func() {
+					session := helpers.CF("labels", "space", spaceName)
+					Eventually(session).Should(Say(regexp.QuoteMeta("Getting labels for space %s in org %s as %s...\n\n"), spaceName, orgName, username))
+					Expect(session).ToNot(Say(`key\s+value`))
+					Eventually(session).Should(Say("No labels found."))
+					Eventually(session).Should(Exit(0))
+				})
+			})
+
+			When("the space does not exist", func() {
+				It("displays an error", func() {
+					session := helpers.CF("labels", "space", "non-existent-space")
+					Eventually(session).Should(Say(regexp.QuoteMeta("Getting labels for space %s in org %s as %s...\n\n"), "non-existent-space", orgName, username))
+					Eventually(session.Err).Should(Say("Space 'non-existent-space' not found"))
 					Eventually(session).Should(Say("FAILED"))
 					Eventually(session).Should(Exit(1))
 				})

--- a/integration/v7/isolated/labels_command_test.go
+++ b/integration/v7/isolated/labels_command_test.go
@@ -216,8 +216,13 @@ var _ = Describe("labels command", func() {
 			})
 
 			When("there are multiple buildpacks with the same name", func() {
-				var newStackName = "my-stack"
+				var (
+					newStackName string
+				)
+
 				BeforeEach(func() {
+					newStackName = helpers.NewStackName()
+					helpers.CreateStack(newStackName)
 					helpers.SetupBuildpackWithStack(buildpackName, newStackName)
 					session := helpers.CF("set-label", "buildpack", buildpackName, "-s", newStackName,
 						"my-stack-some-other-key=some-other-value", "some-key=some-value")
@@ -229,6 +234,7 @@ var _ = Describe("labels command", func() {
 				AfterEach(func() {
 					session := helpers.CF("delete-buildpack", buildpackName, "-s", newStackName, "-f")
 					Eventually(session).Should(Exit(0))
+					helpers.DeleteStack(newStackName)
 				})
 				It("fails when the buildpack is ambiguous", func() {
 					session := helpers.CF("labels", "buildpack", buildpackName)
@@ -290,7 +296,7 @@ var _ = Describe("labels command", func() {
 				It("displays an error", func() {
 					session := helpers.CF("labels", "buildpack", "non-existent-buildpack")
 					Eventually(session).Should(Say(regexp.QuoteMeta("Getting labels for buildpack %s as %s...\n\n"), "non-existent-buildpack", username))
-					Eventually(session.Err).Should(Say("Buildpack 'non-existent-buildpack' not found"))
+					Eventually(session.Err).Should(Say("Buildpack non-existent-buildpack not found"))
 					Eventually(session).Should(Say("FAILED"))
 					Eventually(session).Should(Exit(1))
 				})

--- a/integration/v7/isolated/set_label_command_test.go
+++ b/integration/v7/isolated/set_label_command_test.go
@@ -309,7 +309,7 @@ var _ = Describe("set-label command", func() {
 			When("the buildpack is unknown", func() {
 				It("displays an error", func() {
 					session := helpers.CF("set-label", "buildpack", "non-existent-buildpack", "some-key=some-value")
-					Eventually(session.Err).Should(Say("Buildpack 'non-existent-buildpack' not found"))
+					Eventually(session.Err).Should(Say("Buildpack non-existent-buildpack not found"))
 					Eventually(session).Should(Say("FAILED"))
 					Eventually(session).Should(Exit(1))
 				})
@@ -363,7 +363,7 @@ var _ = Describe("set-label command", func() {
 			When("the buildpack exists in general but does NOT exist for the specified stack", func() {
 				It("displays an error", func() {
 					session := helpers.CF("set-label", "buildpack", buildpackName, "some-key=some-value", "--stack", "FAKE")
-					Eventually(session.Err).Should(Say(fmt.Sprintf("Buildpack '%s' with stack 'FAKE' not found", buildpackName)))
+					Eventually(session.Err).Should(Say(fmt.Sprintf("Buildpack %s with stack FAKE not found", buildpackName)))
 					Eventually(session).Should(Say("FAILED"))
 					Eventually(session).Should(Exit(1))
 				})

--- a/integration/v7/isolated/set_label_command_test.go
+++ b/integration/v7/isolated/set_label_command_test.go
@@ -39,6 +39,7 @@ var _ = Describe("set-label command", func() {
 				Eventually(session).Should(Say(`\s+buildpack`))
 				Eventually(session).Should(Say(`\s+org`))
 				Eventually(session).Should(Say(`\s+space`))
+				Eventually(session).Should(Say(`\s+stack`))
 				Eventually(session).Should(Say("SEE ALSO:"))
 				Eventually(session).Should(Say(`\s+unset-label, labels`))
 
@@ -66,6 +67,10 @@ var _ = Describe("set-label command", func() {
 			helpers.LoginCF()
 			orgName = helpers.NewOrgName()
 			helpers.CreateOrg(orgName)
+		})
+		AfterEach(func() {
+			session := helpers.CF("delete-org", "-f", orgName)
+			Eventually(session).Should(Exit(0))
 		})
 
 		When("assigning label to app", func() {
@@ -268,15 +273,20 @@ var _ = Describe("set-label command", func() {
 		When("assigning label to buildpack", func() {
 			var (
 				buildpackName string
+				stacks        []string
 			)
 
 			BeforeEach(func() {
 				buildpackName = helpers.NewBuildpackName()
-				stacks := helpers.FetchStacks()
+				stacks = helpers.FetchStacks()
 				helpers.BuildpackWithStack(func(buildpackPath string) {
 					session := helpers.CF("create-buildpack", buildpackName, buildpackPath, "98")
 					Eventually(session).Should(Exit(0))
 				}, stacks[0])
+			})
+			AfterEach(func() {
+				buildpackGUID := helpers.BuildpackGUIDByNameAndStack(buildpackName, stacks[0])
+				deleteResourceByGUID(buildpackGUID, "buildpacks")
 			})
 
 			It("sets the specified labels on the buildpack", func() {
@@ -299,7 +309,7 @@ var _ = Describe("set-label command", func() {
 			When("the buildpack is unknown", func() {
 				It("displays an error", func() {
 					session := helpers.CF("set-label", "buildpack", "non-existent-buildpack", "some-key=some-value")
-					Eventually(session.Err).Should(Say("Buildpack non-existent-buildpack not found"))
+					Eventually(session.Err).Should(Say("Buildpack 'non-existent-buildpack' not found"))
 					Eventually(session).Should(Say("FAILED"))
 					Eventually(session).Should(Exit(1))
 				})
@@ -315,6 +325,10 @@ var _ = Describe("set-label command", func() {
 						createSession := helpers.CF("create-buildpack", buildpackName, buildpackPath, "99")
 						Eventually(createSession).Should(Exit(0))
 					}, stacks[1])
+				})
+				AfterEach(func() {
+					buildpackGUID := helpers.BuildpackGUIDByNameAndStack(buildpackName, stacks[1])
+					deleteResourceByGUID(buildpackGUID, "buildpacks")
 				})
 
 				When("stack is not specified", func() {
@@ -349,7 +363,7 @@ var _ = Describe("set-label command", func() {
 			When("the buildpack exists in general but does NOT exist for the specified stack", func() {
 				It("displays an error", func() {
 					session := helpers.CF("set-label", "buildpack", buildpackName, "some-key=some-value", "--stack", "FAKE")
-					Eventually(session.Err).Should(Say(fmt.Sprintf("Buildpack %s with stack FAKE not found", buildpackName)))
+					Eventually(session.Err).Should(Say(fmt.Sprintf("Buildpack '%s' with stack 'FAKE' not found", buildpackName)))
 					Eventually(session).Should(Say("FAILED"))
 					Eventually(session).Should(Exit(1))
 				})
@@ -388,5 +402,83 @@ var _ = Describe("set-label command", func() {
 				})
 			})
 		})
+
+		When("assigning label to stack", func() {
+			var (
+				stackName string
+				stackGUID string
+			)
+
+			BeforeEach(func() {
+				stackName, stackGUID = helpers.CreateStackWithGUID()
+			})
+			AfterEach(func() {
+				deleteResourceByGUID(stackGUID, "stacks")
+			})
+
+			It("sets the specified labels on the stack", func() {
+				session := helpers.CF("set-label", "stack", stackName, "pci=true", "public-facing=false")
+				Eventually(session).Should(Say(regexp.QuoteMeta(`Setting label(s) for stack %s as %s...`), stackName, username))
+				Eventually(session).Should(Say("OK"))
+				Eventually(session).Should(Exit(0))
+
+				session = helpers.CF("curl", fmt.Sprintf("/v3/stacks/%s", stackGUID))
+				Eventually(session).Should(Exit(0))
+				stackJSON := session.Out.Contents()
+				var stack commonResource
+				Expect(json.Unmarshal(stackJSON, &stack)).To(Succeed())
+				Expect(len(stack.Metadata.Labels)).To(Equal(2))
+				Expect(stack.Metadata.Labels["pci"]).To(Equal("true"))
+				Expect(stack.Metadata.Labels["public-facing"]).To(Equal("false"))
+			})
+
+			When("the stack is unknown", func() {
+				It("displays an error", func() {
+					session := helpers.CF("set-label", "stack", "non-existent-stack", "some-key=some-value")
+					Eventually(session.Err).Should(Say("Stack 'non-existent-stack' not found"))
+					Eventually(session).Should(Say("FAILED"))
+					Eventually(session).Should(Exit(1))
+				})
+			})
+
+			When("the label has an empty key and an invalid value", func() {
+				It("displays an error", func() {
+					session := helpers.CF("set-label", "stack", stackName, "=test", "sha2=108&eb90d734")
+					Eventually(session.Err).Should(Say("Metadata label key error: key cannot be empty string, Metadata label value error: '108&eb90d734' contains invalid characters"))
+					Eventually(session).Should(Say("FAILED"))
+					Eventually(session).Should(Exit(1))
+				})
+			})
+
+			When("the label does not include a '=' to separate the key and value", func() {
+				It("displays an error", func() {
+					session := helpers.CF("set-label", "stack", stackName, "test-label")
+					Eventually(session.Err).Should(Say("Metadata error: no value provided for label 'test-label'"))
+					Eventually(session).Should(Say("FAILED"))
+					Eventually(session).Should(Exit(1))
+				})
+			})
+
+			When("more than one value is provided for the same key", func() {
+				It("uses the last value", func() {
+					session := helpers.CF("set-label", "stack", stackName, "owner=sue", "owner=beth")
+					Eventually(session).Should(Exit(0))
+					session = helpers.CF("curl", fmt.Sprintf("/v3/stacks/%s", stackGUID))
+					Eventually(session).Should(Exit(0))
+					stackJSON := session.Out.Contents()
+					var stack commonResource
+					Expect(json.Unmarshal(stackJSON, &stack)).To(Succeed())
+					Expect(len(stack.Metadata.Labels)).To(Equal(1))
+					Expect(stack.Metadata.Labels["owner"]).To(Equal("beth"))
+				})
+			})
+		})
 	})
 })
+
+func deleteResourceByGUID(guid string, urlType string) {
+	session := helpers.CF("curl", "-v", "-X", "DELETE",
+		fmt.Sprintf("/v3/%s/%s", urlType, guid))
+	Eventually(session).Should(Exit(0))
+	Eventually(session).Should(Say(`(?:204 No Content|202 Accepted)`))
+}

--- a/integration/v7/isolated/unset_label_command_test.go
+++ b/integration/v7/isolated/unset_label_command_test.go
@@ -93,6 +93,136 @@ var _ = Describe("unset-label command", func() {
 			})
 		})
 
+		When("unsetting labels from a buildpack", func() {
+			var (
+				buildpackName string
+				buildpackGUID string
+				stacks        []string
+			)
+			BeforeEach(func() {
+				buildpackName = helpers.NewBuildpackName()
+			})
+
+			When("there is only one instance of the given buildpack", func() {
+
+				BeforeEach(func() {
+					stacks = helpers.FetchStacks()
+					helpers.BuildpackWithStack(func(buildpackPath string) {
+						session := helpers.CF("create-buildpack", buildpackName, buildpackPath, "98")
+						Eventually(session).Should(Exit(0))
+					}, stacks[0])
+					buildpackGUID = helpers.BuildpackGUIDByNameAndStack(buildpackName, stacks[0])
+					session := helpers.CF("set-label", "buildpack", buildpackName, "pci=true", "public-facing=false")
+					Eventually(session).Should(Exit(0))
+				})
+				AfterEach(func() {
+					deleteResourceByGUID(buildpackGUID, "buildpacks")
+				})
+
+				It("unsets the specified labels on the buildpack", func() {
+					session := helpers.CF("unset-label", "buildpack", buildpackName, "public-facing", "pci")
+					Eventually(session).Should(Say(regexp.QuoteMeta(`Removing label(s) for buildpack %s as %s...`), buildpackName, username))
+					Consistently(session).ShouldNot(Say("\n\nOK"))
+					Eventually(session).Should(Say("OK"))
+					Eventually(session).Should(Exit(0))
+
+					// verify the labels are deleted
+					session = helpers.CF("curl", fmt.Sprintf("/v3/buildpacks/%s", buildpackGUID))
+					Eventually(session).Should(Exit(0))
+					buildpackJSON := session.Out.Contents()
+
+					var buildpack commonResource
+					Expect(json.Unmarshal(buildpackJSON, &buildpack)).To(Succeed())
+					Expect(len(buildpack.Metadata.Labels)).To(Equal(0))
+				})
+			})
+
+			When("the buildpack is unknown", func() {
+				It("displays an error", func() {
+					session := helpers.CF("unset-label", "buildpack", "non-existent-buildpack", "some-key=some-value")
+					Eventually(session.Err).Should(Say("Buildpack non-existent-buildpack not found"))
+					Eventually(session).Should(Say("FAILED"))
+					Eventually(session).Should(Exit(1))
+				})
+			})
+
+			When("the buildpack exists for multiple stacks", func() {
+				var buildpackGUIDs [2]string
+				BeforeEach(func() {
+					stacks = helpers.EnsureMinimumNumberOfStacks(2)
+					for i := 0; i < 2; i++ {
+
+						helpers.BuildpackWithStack(func(buildpackPath string) {
+							createSession := helpers.CF("create-buildpack", buildpackName, buildpackPath, fmt.Sprintf("%d", 98+i))
+							Eventually(createSession).Should(Exit(0))
+						}, stacks[i])
+						buildpackGUIDs[i] = helpers.BuildpackGUIDByNameAndStack(buildpackName, stacks[i])
+						session := helpers.CF("set-label", "buildpack",
+							buildpackName, "-s", stacks[i],
+							fmt.Sprintf("pci%d=true", i),
+							fmt.Sprintf("public-facing%d=false", i))
+						Eventually(session).Should(Exit(0))
+					}
+				})
+				AfterEach(func() {
+					for i := 0; i < 2; i++ {
+						deleteResourceByGUID(buildpackGUIDs[i], "buildpacks")
+					}
+				})
+
+				When("stack is not specified", func() {
+					It("displays an error", func() {
+						session := helpers.CF("unset-label", "buildpack", buildpackName, "pci1")
+						Eventually(session.Err).Should(Say(fmt.Sprintf("Multiple buildpacks named %s found. Specify a stack name by using a '-s' flag.", buildpackName)))
+						Eventually(session).Should(Say("FAILED"))
+						Eventually(session).Should(Exit(1))
+					})
+				})
+
+				When("stack is specified", func() {
+					When("the label is invalid", func() {
+						It("gives an error message", func() {
+							badLabel := "^^snorky"
+							session := helpers.CF("unset-label", "buildpack", buildpackName, badLabel, "--stack", stacks[0])
+							Eventually(session).Should(Say(regexp.QuoteMeta(fmt.Sprintf("Removing label(s) for buildpack %s as %s...", buildpackName, username))))
+							Eventually(session.Err).Should(Say(regexp.QuoteMeta(fmt.Sprintf("Metadata label key error: '%s' contains invalid characters", badLabel))))
+							Eventually(session).Should(Say("FAILED"))
+							Eventually(session).Should(Exit(1))
+						})
+					})
+
+					It("deletes the specified labels from the correct buildpack", func() {
+						var buildpack commonResource
+
+						session := helpers.CF("unset-label", "buildpack", buildpackName, "pci0", "--stack", stacks[0])
+						Eventually(session).Should(Say(regexp.QuoteMeta(`Removing label(s) for buildpack %s as %s...`), buildpackName, username))
+						Eventually(session).Should(Say("OK"))
+						Eventually(session).Should(Exit(0))
+
+						session = helpers.CF("curl", fmt.Sprintf("/v3/buildpacks/%s", buildpackGUIDs[0]))
+						Eventually(session).Should(Exit(0))
+						buildpackJSON := session.Out.Contents()
+						Expect(json.Unmarshal(buildpackJSON, &buildpack)).To(Succeed())
+						Expect(len(buildpack.Metadata.Labels)).To(Equal(1))
+						Expect(buildpack.Metadata.Labels["public-facing0"]).To(Equal("false"))
+
+						session = helpers.CF("unset-label", "buildpack", buildpackName, "pci1", "--stack", stacks[1])
+						Eventually(session).Should(Say(regexp.QuoteMeta(`Removing label(s) for buildpack %s as %s...`), buildpackName, username))
+						Eventually(session).Should(Say("OK"))
+						Eventually(session).Should(Exit(0))
+
+						session = helpers.CF("curl", fmt.Sprintf("/v3/buildpacks/%s", buildpackGUIDs[1]))
+						Eventually(session).Should(Exit(0))
+						buildpackJSON = session.Out.Contents()
+						buildpack = commonResource{}
+						Expect(json.Unmarshal(buildpackJSON, &buildpack)).To(Succeed())
+						Expect(len(buildpack.Metadata.Labels)).To(Equal(1))
+						Expect(buildpack.Metadata.Labels["public-facing1"]).To(Equal("false"))
+					})
+				})
+			})
+		})
+
 		When("unsetting labels from an org", func() {
 			BeforeEach(func() {
 				session := helpers.CF("set-label", "org", orgName, "pci=true", "public-facing=false")


### PR DESCRIPTION
## WARNING:
This PR builds on top of #1740 Please make sure it is merged first.

Relevant commits:
"Implement `cf labels stack STACKNAME`"

Branch: show-stack-labels-167250651-attempt-2
Diff for this PR on its actual base branch:

`git diff origin/unset-buildpack-labels-166986384 origin/show-stack-labels-167250651-attempt-2`

Implements story https://www.pivotaltracker.com/story/show/167250651

## Does this PR modify CLI v6 or v7?

v7

## Description of the Change

Implements `cf labels stack STACK_NAME`