### PR TITLE
Add origin flag to login command

### DIFF
--- a/command/v6/login_command.go
+++ b/command/v6/login_command.go
@@ -92,7 +92,8 @@ type LoginCommand struct {
 	SSO               bool        `long:"sso" description:"Prompt for a one-time passcode to login"`
 	SSOPasscode       string      `long:"sso-passcode" description:"One-time passcode"`
 	Username          string      `short:"u" description:"Username"`
-	usage             interface{} `usage:"CF_NAME login [-a API_URL] [-u USERNAME] [-p PASSWORD] [-o ORG] [-s SPACE] [--sso | --sso-passcode PASSCODE]\n\nWARNING:\n   Providing your password as a command line option is highly discouraged\n   Your password may be visible to others and may be recorded in your shell history\n\nEXAMPLES:\n   CF_NAME login (omit username and password to login interactively -- CF_NAME will prompt for both)\n   CF_NAME login -u name@example.com -p pa55woRD (specify username and password as arguments)\n   CF_NAME login -u name@example.com -p \"my password\" (use quotes for passwords with a space)\n   CF_NAME login -u name@example.com -p \"\\\"password\\\"\" (escape quotes if used in password)\n   CF_NAME login --sso (CF_NAME will provide a url to obtain a one-time passcode to login)"`
+	Origin            string      `long:"origin" description:"Indicates the identity provider to be used for login"`
+	usage             interface{} `usage:"CF_NAME login [-a API_URL] [-u USERNAME] [-p PASSWORD] [-o ORG] [-s SPACE] [--sso | --sso-passcode PASSCODE] [--origin ORIGIN]\n\nWARNING:\n   Providing your password as a command line option is highly discouraged\n   Your password may be visible to others and may be recorded in your shell history\n\nEXAMPLES:\n   CF_NAME login (omit username and password to login interactively -- CF_NAME will prompt for both)\n   CF_NAME login -u name@example.com -p pa55woRD (specify username and password as arguments)\n   CF_NAME login -u name@example.com -p \"my password\" (use quotes for passwords with a space)\n   CF_NAME login -u name@example.com -p \"\\\"password\\\"\" (escape quotes if used in password)\n   CF_NAME login --sso (CF_NAME will provide a url to obtain a one-time passcode to login)\n   CF_NAME login --origin ldap"`
 	relatedCommands   interface{} `related_commands:"api, auth, target"`
 
 	UI           command.UI
@@ -121,6 +122,19 @@ func (cmd *LoginCommand) Execute(args []string) error {
 		return translatableerror.UnrefactoredCommandError{}
 	}
 	cmd.UI.DisplayWarning("Using experimental login command, some behavior may be different")
+
+	if cmd.Origin != "" {
+		if cmd.SSO {
+			return translatableerror.ArgumentCombinationError{
+				Args: []string{"--sso", "--origin"},
+			}
+		}
+		if cmd.SSOPasscode != "" {
+			return translatableerror.ArgumentCombinationError{
+				Args: []string{"--sso-passcode", "--origin"},
+			}
+		}
+	}
 
 	err := cmd.getAPI()
 	if err != nil {
@@ -334,7 +348,7 @@ func (cmd *LoginCommand) authenticate() error {
 
 		cmd.UI.DisplayText("Authenticating...")
 
-		err = cmd.Actor.Authenticate(promptedCredentials, "", constant.GrantTypePassword)
+		err = cmd.Actor.Authenticate(promptedCredentials, cmd.Origin, constant.GrantTypePassword)
 
 		if err != nil {
 			cmd.UI.DisplayWarning(translatableerror.ConvertToTranslatableError(err).Error())

--- a/integration/shared/experimental/login_command_test.go
+++ b/integration/shared/experimental/login_command_test.go
@@ -36,7 +36,7 @@ var _ = Describe("login command", func() {
 				Expect(session).Should(Say("login - Log user in"))
 
 				Expect(session).Should(Say("USAGE:\n"))
-				Expect(session).Should(Say(`cf login \[-a API_URL\] \[-u USERNAME\] \[-p PASSWORD\] \[-o ORG\] \[-s SPACE\] \[--sso | --sso-passcode PASSCODE\]`))
+				Expect(session).Should(Say(`cf login \[-a API_URL\] \[-u USERNAME\] \[-p PASSWORD\] \[-o ORG\] \[-s SPACE\] \[--sso | --sso-passcode PASSCODE\] \[--origin ORIGIN\]`))
 
 				Expect(session).Should(Say("WARNING:\n"))
 				Expect(session).Should(Say("Providing your password as a command line option is highly discouraged\n"))
@@ -48,6 +48,7 @@ var _ = Describe("login command", func() {
 				Expect(session).Should(Say(regexp.QuoteMeta("cf login -u name@example.com -p \"my password\" (use quotes for passwords with a space)")))
 				Expect(session).Should(Say(regexp.QuoteMeta("cf login -u name@example.com -p \"\\\"password\\\"\" (escape quotes if used in password)")))
 				Expect(session).Should(Say(regexp.QuoteMeta("cf login --sso (cf will provide a url to obtain a one-time passcode to login)")))
+				Expect(session).Should(Say(regexp.QuoteMeta("cf login --origin ldap")))
 
 				Expect(session).Should(Say("ALIAS:\n"))
 				Expect(session).Should(Say("l"))
@@ -1305,6 +1306,42 @@ var _ = Describe("login command", func() {
 			It("re-authenticates using the custom client", func() {
 				session := helpers.CF("orgs")
 				Eventually(session).Should(Exit(0))
+			})
+		})
+	})
+
+	Describe("Setting the identity provider to be used", func() {
+		When("the user provides the --origin flag", func() {
+			It("logs in successfully", func() {
+				username, password := helpers.GetCredentials()
+				session := helpers.CF("login", "-u", username, "-p", password, "--origin", "uaa")
+				Eventually(session).Should(Say("API endpoint:\\s+" + helpers.GetAPI()))
+				Eventually(session).Should(Say(`Authenticating\.\.\.`))
+				Eventually(session).Should(Say(`OK`))
+				Eventually(session).Should(Say(`API endpoint:\s+` + helpers.GetAPI() + `\s+\(API version: \d\.\d{1,3}\.\d{1,3}\)`))
+				Eventually(session).Should(Say("User:\\s+" + username))
+				Eventually(session).Should(Exit(0))
+			})
+		})
+
+		When("the user provides the --origin flag and --sso flag", func() {
+			It("rejects the command", func() {
+				username, password := helpers.GetCredentials()
+				session := helpers.CF("login", "-u", username, "-p", password, "--sso", "--origin", "uaa")
+
+				Eventually(session.Err).Should(Say(`Incorrect Usage: The following arguments cannot be used together: --sso, --origin`))
+
+				Eventually(session).Should(Exit(1))
+			})
+		})
+		When("the user provides the --origin flag and --sso-passcode flag", func() {
+			It("rejects the command", func() {
+				username, password := helpers.GetCredentials()
+				session := helpers.CF("login", "-u", username, "-p", password, "--sso-passcode", "some-passcode", "--origin", "uaa")
+
+				Eventually(session.Err).Should(Say(`Incorrect Usage: The following arguments cannot be used together: --sso-passcode, --origin`))
+
+				Eventually(session).Should(Exit(1))
 			})
 		})
 	})


### PR DESCRIPTION
This pull request includes scenarios outlined in the template doc under "Proposed cf login command".

- add --origin flag to LoginCommand struct (v6) and pass value in
  Authenticate call
- add integration tests for happy path and rejection in case of
  combination with sso flag
- change expected usage and help texts for login command in integration
  tests

## Does this PR modify CLI v6 or v7?
v6

## Description of the Change

The UAA allows the login with multiple origins (e.g. uaa, ldap, someSamlProvider, someOidcProvider). The command "cf auth" already provides the parameter "--origin" with which the user can specify it for login. This PR adds the parameter to command "cf login".

## Why Is This PR Valuable?

Everybody who uses multiple origins for login to the UAA will benefit.

## Why Should This Be In Core?

It is a UAA feature.

## Applicable Issues

#1599 