### PR TITLE
Fix CI flake with fakeservicebroker and leftover service instances

### DIFF
--- a/integration/helpers/commonisolated/common_isolated_setup.go
+++ b/integration/helpers/commonisolated/common_isolated_setup.go
@@ -1,0 +1,107 @@
+package commonisolated
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccversion"
+	"code.cloudfoundry.org/cli/integration/helpers"
+	"code.cloudfoundry.org/cli/integration/helpers/fakeservicebroker"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	CFEventuallyTimeout   = 300 * time.Second
+	CFConsistentlyTimeout = 500 * time.Millisecond
+	RealIsolationSegment  = "persistent_isolation_segment"
+	DockerImage           = "cloudfoundry/diego-docker-app-custom"
+)
+
+func CommonTestIsolated(t *testing.T) {
+	RegisterFailHandler(Fail)
+	var reporters []Reporter
+
+	prBuilderReporter := helpers.GetPRBuilderReporter()
+	if prBuilderReporter != nil {
+		reporters = append(reporters, prBuilderReporter)
+	}
+
+	RunSpecsWithDefaultAndCustomReporters(t, "Isolated Integration Suite", reporters)
+}
+
+func CommonGinkgoSetup(
+	// Per suite Level
+	failureSummaryFilename string,
+	apiURL *string,
+	skipSSLValidation *bool,
+	readOnlyOrg *string,
+	readOnlySpace *string,
+
+	// Per test level
+	homeDir *string,
+) interface{} {
+	var _ = SynchronizedBeforeSuite(func() []byte {
+		_, _ = GinkgoWriter.Write([]byte("==============================Global FIRST Node Synchronized Before Each=============================="))
+		SetDefaultEventuallyTimeout(CFEventuallyTimeout)
+		SetDefaultConsistentlyDuration(CFConsistentlyTimeout)
+
+		helpers.SetupSynchronizedSuite(func() {
+			helpers.EnableFeatureFlag("diego_docker")
+
+			if helpers.IsVersionMet(ccversion.MinVersionShareServiceV3) {
+				helpers.EnableFeatureFlag("service_instance_sharing")
+			}
+		})
+
+		fakeservicebroker.Setup()
+
+		_, _ = GinkgoWriter.Write([]byte("==============================End of Global FIRST Node Synchronized Before Each=============================="))
+
+		return nil
+	}, func(_ []byte) {
+		_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("==============================Global Node %d Synchronized Before Each==============================", GinkgoParallelNode())))
+		// Ginkgo Globals
+		SetDefaultEventuallyTimeout(CFEventuallyTimeout)
+		SetDefaultConsistentlyDuration(CFConsistentlyTimeout)
+
+		// Setup common environment variables
+		helpers.TurnOffColors()
+
+		*readOnlyOrg, *readOnlySpace = helpers.SetupReadOnlyOrgAndSpace()
+		_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("==============================End of Global Node %d Synchronized Before Each==============================", GinkgoParallelNode())))
+	})
+
+	var _ = SynchronizedAfterSuite(func() {
+		_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("==============================Global Node %d Synchronized After Each==============================", GinkgoParallelNode())))
+		*homeDir = helpers.SetHomeDir()
+		helpers.SetAPI()
+		helpers.LoginCF()
+		fakeservicebroker.Cleanup()
+		helpers.QuickDeleteOrg(*readOnlyOrg)
+		helpers.DestroyHomeDir(*homeDir)
+		_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("==============================End of Global Node %d Synchronized After Each==============================", GinkgoParallelNode())))
+	}, func() {
+		outputRoot := os.Getenv(helpers.PRBuilderOutputEnvVar)
+		if outputRoot != "" {
+			helpers.WriteFailureSummary(outputRoot, failureSummaryFilename)
+		}
+	})
+
+	var _ = BeforeEach(func() {
+		_, _ = GinkgoWriter.Write([]byte("==============================Global Before Each=============================="))
+		*homeDir = helpers.SetHomeDir()
+		*apiURL, *skipSSLValidation = helpers.SetAPI()
+		_, _ = GinkgoWriter.Write([]byte("==============================End of Global Before Each=============================="))
+	})
+
+	var _ = AfterEach(func() {
+		_, _ = GinkgoWriter.Write([]byte("==============================Global After Each==============================\n"))
+		helpers.DestroyHomeDir(*homeDir)
+		_, _ = GinkgoWriter.Write([]byte("==============================End of Global After Each=============================="))
+	})
+
+	return nil
+}

--- a/integration/helpers/fakeservicebroker/fakeservicebroker.go
+++ b/integration/helpers/fakeservicebroker/fakeservicebroker.go
@@ -148,6 +148,7 @@ func (f *FakeServiceBroker) Async() *FakeServiceBroker {
 
 func (f *FakeServiceBroker) Deploy() *FakeServiceBroker {
 	f.pushAppIfNecessary()
+	f.deregisterIgnoringFailures()
 	f.configure()
 	return f
 }

--- a/integration/shared/isolated/fakeservicebroker_test.go
+++ b/integration/shared/isolated/fakeservicebroker_test.go
@@ -1,0 +1,49 @@
+package isolated_test
+
+import (
+	"code.cloudfoundry.org/cli/integration/helpers"
+	"code.cloudfoundry.org/cli/integration/helpers/fakeservicebroker"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("FakeServiceBroker", func() {
+	var broker *fakeservicebroker.FakeServiceBroker
+
+	BeforeEach(func() {
+		helpers.SetupCFWithGeneratedOrgAndSpaceNames()
+	})
+
+	AfterEach(func() {
+		if broker != nil {
+			broker.Destroy()
+		}
+	})
+
+	It("can create and reuse a service broker and use it, and dispose of it", func() {
+		broker = fakeservicebroker.New().Async().Register()
+		service := broker.ServiceName()
+		servicePlan := broker.ServicePlanName()
+		serviceInstance := helpers.PrefixedRandomName("si")
+
+		Eventually(helpers.CF("enable-service-access", service)).Should(Exit(0))
+		Eventually(helpers.CF("create-service", service, servicePlan, serviceInstance)).Should(Exit(0))
+
+		broker.Destroy()
+		broker = nil
+	})
+
+	It("can reuse and reconfigure the broker that has service instances", func() {
+		broker = fakeservicebroker.New().Async().Register()
+
+		service := broker.ServiceName()
+		servicePlan := broker.ServicePlanName()
+		serviceInstance := helpers.PrefixedRandomName("si")
+
+		Eventually(helpers.CF("enable-service-access", service)).Should(Exit(0))
+		Eventually(helpers.CF("create-service", service, servicePlan, serviceInstance)).Should(Exit(0))
+
+		broker = fakeservicebroker.New().Async().Register()
+	})
+})

--- a/integration/shared/isolated/isolated_suite_test.go
+++ b/integration/shared/isolated/isolated_suite_test.go
@@ -1,23 +1,14 @@
 package isolated
 
 import (
-	"fmt"
-	"os"
+	"code.cloudfoundry.org/cli/integration/helpers/commonisolated"
 	"testing"
-	"time"
-
-	"code.cloudfoundry.org/cli/integration/helpers/fakeservicebroker"
-
-	"code.cloudfoundry.org/cli/api/cloudcontroller/ccversion"
-	"code.cloudfoundry.org/cli/integration/helpers"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 const (
-	CFEventuallyTimeout   = 300 * time.Second
-	CFConsistentlyTimeout = 500 * time.Millisecond
-	RealIsolationSegment  = "persistent_isolation_segment"
+	CFEventuallyTimeout   = commonisolated.CFEventuallyTimeout
+	CFConsistentlyTimeout = commonisolated.CFConsistentlyTimeout
+	RealIsolationSegment  = commonisolated.RealIsolationSegment
 )
 
 var (
@@ -32,73 +23,14 @@ var (
 )
 
 func TestIsolated(t *testing.T) {
-	RegisterFailHandler(Fail)
-	reporters := []Reporter{}
-
-	prBuilderReporter := helpers.GetPRBuilderReporter()
-	if prBuilderReporter != nil {
-		reporters = append(reporters, prBuilderReporter)
-	}
-
-	RunSpecsWithDefaultAndCustomReporters(t, "Isolated Integration Suite", reporters)
+	commonisolated.CommonTestIsolated(t)
 }
 
-var _ = SynchronizedBeforeSuite(func() []byte {
-	GinkgoWriter.Write([]byte("==============================Global FIRST Node Synchronized Before Each=============================="))
-	SetDefaultEventuallyTimeout(CFEventuallyTimeout)
-	SetDefaultConsistentlyDuration(CFConsistentlyTimeout)
-
-	helpers.SetupSynchronizedSuite(func() {
-		helpers.EnableFeatureFlag("diego_docker")
-
-		if helpers.IsVersionMet(ccversion.MinVersionShareServiceV3) {
-			helpers.EnableFeatureFlag("service_instance_sharing")
-		}
-	})
-
-	fakeservicebroker.Setup()
-
-	GinkgoWriter.Write([]byte("==============================End of Global FIRST Node Synchronized Before Each=============================="))
-
-	return nil
-}, func(_ []byte) {
-	GinkgoWriter.Write([]byte(fmt.Sprintf("==============================Global Node %d Synchronized Before Each==============================", GinkgoParallelNode())))
-	// Ginkgo Globals
-	SetDefaultEventuallyTimeout(CFEventuallyTimeout)
-	SetDefaultConsistentlyDuration(CFConsistentlyTimeout)
-
-	// Setup common environment variables
-	helpers.TurnOffColors()
-
-	ReadOnlyOrg, ReadOnlySpace = helpers.SetupReadOnlyOrgAndSpace()
-	GinkgoWriter.Write([]byte(fmt.Sprintf("==============================End of Global Node %d Synchronized Before Each==============================", GinkgoParallelNode())))
-})
-
-var _ = SynchronizedAfterSuite(func() {
-	GinkgoWriter.Write([]byte(fmt.Sprintf("==============================Global Node %d Synchronized After Each==============================", GinkgoParallelNode())))
-	homeDir = helpers.SetHomeDir()
-	helpers.SetAPI()
-	helpers.LoginCF()
-	fakeservicebroker.Cleanup()
-	helpers.QuickDeleteOrg(ReadOnlyOrg)
-	helpers.DestroyHomeDir(homeDir)
-	GinkgoWriter.Write([]byte(fmt.Sprintf("==============================End of Global Node %d Synchronized After Each==============================", GinkgoParallelNode())))
-}, func() {
-	outputRoot := os.Getenv(helpers.PRBuilderOutputEnvVar)
-	if outputRoot != "" {
-		helpers.WriteFailureSummary(outputRoot, "summary_isi.txt")
-	}
-})
-
-var _ = BeforeEach(func() {
-	GinkgoWriter.Write([]byte("==============================Global Before Each=============================="))
-	homeDir = helpers.SetHomeDir()
-	apiURL, skipSSLValidation = helpers.SetAPI()
-	GinkgoWriter.Write([]byte("==============================End of Global Before Each=============================="))
-})
-
-var _ = AfterEach(func() {
-	GinkgoWriter.Write([]byte("==============================Global After Each==============================\n"))
-	helpers.DestroyHomeDir(homeDir)
-	GinkgoWriter.Write([]byte("==============================End of Global After Each=============================="))
-})
+var _ = commonisolated.CommonGinkgoSetup(
+	"summary_isi.txt",
+	&apiURL,
+	&skipSSLValidation,
+	&ReadOnlyOrg,
+	&ReadOnlySpace,
+	&homeDir,
+)

--- a/integration/v6/isolated/isolated_suite_test.go
+++ b/integration/v6/isolated/isolated_suite_test.go
@@ -1,23 +1,13 @@
 package isolated
 
 import (
-	"fmt"
-	"os"
+	"code.cloudfoundry.org/cli/integration/helpers/commonisolated"
 	"testing"
-	"time"
-
-	"code.cloudfoundry.org/cli/api/cloudcontroller/ccversion"
-	"code.cloudfoundry.org/cli/integration/helpers"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 const (
-	CFEventuallyTimeout   = 300 * time.Second
-	CFConsistentlyTimeout = 500 * time.Millisecond
-	RealIsolationSegment  = "persistent_isolation_segment"
-	DockerImage           = "cloudfoundry/diego-docker-app-custom"
-	PublicDockerImage     = "cloudfoundry/diego-docker-app-custom"
+	RealIsolationSegment = commonisolated.RealIsolationSegment
+	DockerImage          = commonisolated.DockerImage
 )
 
 var (
@@ -27,74 +17,19 @@ var (
 	ReadOnlyOrg       string
 	ReadOnlySpace     string
 
-	// Per Test Level
+	// Per test
 	homeDir string
 )
 
 func TestIsolated(t *testing.T) {
-	RegisterFailHandler(Fail)
-	reporters := []Reporter{}
-
-	prBuilderReporter := helpers.GetPRBuilderReporter()
-	if prBuilderReporter != nil {
-		reporters = append(reporters, prBuilderReporter)
-	}
-
-	RunSpecsWithDefaultAndCustomReporters(t, "Isolated Integration Suite", reporters)
+	commonisolated.CommonTestIsolated(t)
 }
 
-var _ = SynchronizedBeforeSuite(func() []byte {
-	GinkgoWriter.Write([]byte("==============================Global FIRST Node Synchronized Before Each=============================="))
-	SetDefaultEventuallyTimeout(CFEventuallyTimeout)
-	SetDefaultConsistentlyDuration(CFConsistentlyTimeout)
-
-	helpers.SetupSynchronizedSuite(func() {
-		helpers.EnableFeatureFlag("diego_docker")
-
-		if helpers.IsVersionMet(ccversion.MinVersionShareServiceV3) {
-			helpers.EnableFeatureFlag("service_instance_sharing")
-		}
-	})
-	GinkgoWriter.Write([]byte("==============================End of Global FIRST Node Synchronized Before Each=============================="))
-
-	return nil
-}, func(_ []byte) {
-	GinkgoWriter.Write([]byte(fmt.Sprintf("==============================Global Node %d Synchronized Before Each==============================", GinkgoParallelNode())))
-	// Ginkgo Globals
-	SetDefaultEventuallyTimeout(CFEventuallyTimeout)
-	SetDefaultConsistentlyDuration(CFConsistentlyTimeout)
-
-	// Setup common environment variables
-	helpers.TurnOffColors()
-
-	ReadOnlyOrg, ReadOnlySpace = helpers.SetupReadOnlyOrgAndSpace()
-	GinkgoWriter.Write([]byte(fmt.Sprintf("==============================End of Global Node %d Synchronized Before Each==============================", GinkgoParallelNode())))
-})
-
-var _ = SynchronizedAfterSuite(func() {
-	GinkgoWriter.Write([]byte(fmt.Sprintf("==============================Global Node %d Synchronized After Each==============================", GinkgoParallelNode())))
-	homeDir = helpers.SetHomeDir()
-	helpers.SetAPI()
-	helpers.LoginCF()
-	helpers.QuickDeleteOrg(ReadOnlyOrg)
-	helpers.DestroyHomeDir(homeDir)
-	GinkgoWriter.Write([]byte(fmt.Sprintf("==============================End of Global Node %d Synchronized After Each==============================", GinkgoParallelNode())))
-}, func() {
-	outputRoot := os.Getenv(helpers.PRBuilderOutputEnvVar)
-	if outputRoot != "" {
-		helpers.WriteFailureSummary(outputRoot, "summary_ivi.txt")
-	}
-})
-
-var _ = BeforeEach(func() {
-	GinkgoWriter.Write([]byte("==============================Global Before Each=============================="))
-	homeDir = helpers.SetHomeDir()
-	apiURL, skipSSLValidation = helpers.SetAPI()
-	GinkgoWriter.Write([]byte("==============================End of Global Before Each=============================="))
-})
-
-var _ = AfterEach(func() {
-	GinkgoWriter.Write([]byte("==============================Global After Each==============================\n"))
-	helpers.DestroyHomeDir(homeDir)
-	GinkgoWriter.Write([]byte("==============================End of Global After Each=============================="))
-})
+var _ = commonisolated.CommonGinkgoSetup(
+	"summary_ivi.txt",
+	&apiURL,
+	&skipSSLValidation,
+	&ReadOnlyOrg,
+	&ReadOnlySpace,
+	&homeDir,
+)

--- a/integration/v7/isolated/isolated_suite_test.go
+++ b/integration/v7/isolated/isolated_suite_test.go
@@ -1,22 +1,13 @@
 package isolated
 
 import (
-	"fmt"
-	"os"
+	"code.cloudfoundry.org/cli/integration/helpers/commonisolated"
 	"testing"
-	"time"
-
-	"code.cloudfoundry.org/cli/api/cloudcontroller/ccversion"
-	"code.cloudfoundry.org/cli/integration/helpers"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 const (
-	CFEventuallyTimeout   = 300 * time.Second
-	CFConsistentlyTimeout = 500 * time.Millisecond
-	RealIsolationSegment  = "persistent_isolation_segment"
-	DockerImage           = "cloudfoundry/diego-docker-app-custom"
+	RealIsolationSegment = commonisolated.RealIsolationSegment
+	DockerImage          = commonisolated.DockerImage
 )
 
 var (
@@ -26,74 +17,19 @@ var (
 	ReadOnlyOrg       string
 	ReadOnlySpace     string
 
-	// Per Test Level
+	// Per test
 	homeDir string
 )
 
 func TestIsolated(t *testing.T) {
-	RegisterFailHandler(Fail)
-	reporters := []Reporter{}
-
-	prBuilderReporter := helpers.GetPRBuilderReporter()
-	if prBuilderReporter != nil {
-		reporters = append(reporters, prBuilderReporter)
-	}
-
-	RunSpecsWithDefaultAndCustomReporters(t, "Isolated Integration Suite", reporters)
+	commonisolated.CommonTestIsolated(t)
 }
 
-var _ = SynchronizedBeforeSuite(func() []byte {
-	GinkgoWriter.Write([]byte("==============================Global FIRST Node Synchronized Before Each=============================="))
-	SetDefaultEventuallyTimeout(CFEventuallyTimeout)
-	SetDefaultConsistentlyDuration(CFConsistentlyTimeout)
-
-	helpers.SetupSynchronizedSuite(func() {
-		helpers.EnableFeatureFlag("diego_docker")
-
-		if helpers.IsVersionMet(ccversion.MinVersionShareServiceV3) {
-			helpers.EnableFeatureFlag("service_instance_sharing")
-		}
-	})
-	GinkgoWriter.Write([]byte("==============================End of Global FIRST Node Synchronized Before Each=============================="))
-
-	return nil
-}, func(_ []byte) {
-	GinkgoWriter.Write([]byte(fmt.Sprintf("==============================Global Node %d Synchronized Before Each==============================", GinkgoParallelNode())))
-	// Ginkgo Globals
-	SetDefaultEventuallyTimeout(CFEventuallyTimeout)
-	SetDefaultConsistentlyDuration(CFConsistentlyTimeout)
-
-	// Setup common environment variables
-	helpers.TurnOffColors()
-
-	ReadOnlyOrg, ReadOnlySpace = helpers.SetupReadOnlyOrgAndSpace()
-	GinkgoWriter.Write([]byte(fmt.Sprintf("==============================End of Global Node %d Synchronized Before Each==============================", GinkgoParallelNode())))
-})
-
-var _ = SynchronizedAfterSuite(func() {
-	GinkgoWriter.Write([]byte(fmt.Sprintf("==============================Global Node %d Synchronized After Each==============================", GinkgoParallelNode())))
-	homeDir = helpers.SetHomeDir()
-	helpers.SetAPI()
-	helpers.LoginCF()
-	helpers.QuickDeleteOrg(ReadOnlyOrg)
-	helpers.DestroyHomeDir(homeDir)
-	GinkgoWriter.Write([]byte(fmt.Sprintf("==============================End of Global Node %d Synchronized After Each==============================", GinkgoParallelNode())))
-}, func() {
-	outputRoot := os.Getenv(helpers.PRBuilderOutputEnvVar)
-	if outputRoot != "" {
-		helpers.WriteFailureSummary(outputRoot, "summary_isi.txt")
-	}
-})
-
-var _ = BeforeEach(func() {
-	GinkgoWriter.Write([]byte("==============================Global Before Each=============================="))
-	homeDir = helpers.SetHomeDir()
-	apiURL, skipSSLValidation = helpers.SetAPI()
-	GinkgoWriter.Write([]byte("==============================End of Global Before Each=============================="))
-})
-
-var _ = AfterEach(func() {
-	GinkgoWriter.Write([]byte("==============================Global After Each==============================\n"))
-	helpers.DestroyHomeDir(homeDir)
-	GinkgoWriter.Write([]byte("==============================End of Global After Each=============================="))
-})
+var _ = commonisolated.CommonGinkgoSetup(
+	"summary_isi.txt",
+	&apiURL,
+	&skipSSLValidation,
+	&ReadOnlyOrg,
+	&ReadOnlySpace,
+	&homeDir,
+)


### PR DESCRIPTION
The culprit was peculiar behaviour of fakeservicebroker helper when
there are left-over un-purged service instances from previous usage
of the reusable broker.

Because we’re creating a new config for reusable broker, we don’t know
what was the service offering name for that existing instance, as we
are generating a new random name here.

The fix is to purge existing service instances not based on the config
of a fake service broker, but based on its catalog instead, which would
always purge real, currently existing service offerings.

Tracker: https://www.pivotaltracker.com/story/show/168383869