### PR TITLE
Add status to service broker struct and output table (V7)

### DIFF
--- a/actor/v7action/service_broker_test.go
+++ b/actor/v7action/service_broker_test.go
@@ -38,14 +38,16 @@ var _ = Describe("Service Broker Actions", func() {
 				BeforeEach(func() {
 					fakeCloudControllerClient.GetServiceBrokersReturns([]ccv3.ServiceBroker{
 						{
-							GUID: "service-broker-guid-1",
-							Name: "service-broker-1",
-							URL:  "service-broker-url-1",
+							GUID:   "service-broker-guid-1",
+							Name:   "service-broker-1",
+							URL:    "service-broker-url-1",
+							Status: "synchronization in progress",
 						},
 						{
-							GUID: "service-broker-guid-2",
-							Name: "service-broker-2",
-							URL:  "service-broker-url-2",
+							GUID:   "service-broker-guid-2",
+							Name:   "service-broker-2",
+							URL:    "service-broker-url-2",
+							Status: "available",
 						},
 					}, ccv3.Warnings{"some-service-broker-warning"}, nil)
 				})
@@ -54,8 +56,8 @@ var _ = Describe("Service Broker Actions", func() {
 					Expect(executionError).NotTo(HaveOccurred())
 
 					Expect(serviceBrokers).To(ConsistOf(
-						ServiceBroker{Name: "service-broker-1", GUID: "service-broker-guid-1", URL: "service-broker-url-1"},
-						ServiceBroker{Name: "service-broker-2", GUID: "service-broker-guid-2", URL: "service-broker-url-2"},
+						ServiceBroker{Name: "service-broker-1", GUID: "service-broker-guid-1", URL: "service-broker-url-1", Status: "synchronization in progress"},
+						ServiceBroker{Name: "service-broker-2", GUID: "service-broker-guid-2", URL: "service-broker-url-2", Status: "available"},
 					))
 					Expect(warnings).To(ConsistOf("some-service-broker-warning"))
 					Expect(fakeCloudControllerClient.GetServiceBrokersCallCount()).To(Equal(1))

--- a/api/cloudcontroller/ccv3/service_broker_test.go
+++ b/api/cloudcontroller/ccv3/service_broker_test.go
@@ -32,42 +32,45 @@ var _ = Describe("ServiceBroker", func() {
 		When("service brokers exist", func() {
 			BeforeEach(func() {
 				response1 := fmt.Sprintf(`
-{
-	"pagination": {
-		"next": {
-			"href": "%s/v3/service_brokers?page=2&per_page=2"
-		}
-	},
-	"resources": [
-		{
-			"name": "service-broker-name-1",
-			"guid": "service-broker-guid-1",
-			"url": "service-broker-url-1",
-			"relationships": {}
-		},
-		{
-			"name": "service-broker-name-2",
-			"guid": "service-broker-guid-2",
-			"url": "service-broker-url-2",
-			"relationships": {}
-		}
-	]
-}`, server.URL())
+					{
+						"pagination": {
+							"next": {
+								"href": "%s/v3/service_brokers?page=2&per_page=2"
+							}
+						},
+						"resources": [
+							{
+								"name": "service-broker-name-1",
+								"guid": "service-broker-guid-1",
+								"url": "service-broker-url-1",
+							    "status": "synchronization in progress",
+								"relationships": {}
+							},
+							{
+								"name": "service-broker-name-2",
+								"guid": "service-broker-guid-2",
+								"url": "service-broker-url-2",
+								"status": "synchronization failed",
+								"relationships": {}
+							}
+						]
+					}`, server.URL())
 
 				response2 := `
-{
-	"pagination": {
-		"next": null
-	},
-	"resources": [
-		{
-			"name": "service-broker-name-3",
-			"guid": "service-broker-guid-3",
-			"url": "service-broker-url-3",
-			"relationships": {}
-		}
-	]
-}`
+					{
+						"pagination": {
+							"next": null
+						},
+						"resources": [
+							{
+								"name": "service-broker-name-3",
+								"guid": "service-broker-guid-3",
+								"url": "service-broker-url-3",
+								"status": "available",
+								"relationships": {}
+							}
+						]
+					}`
 
 				server.AppendHandlers(
 					CombineHandlers(
@@ -87,9 +90,9 @@ var _ = Describe("ServiceBroker", func() {
 				Expect(executeErr).NotTo(HaveOccurred())
 
 				Expect(serviceBrokers).To(ConsistOf(
-					ServiceBroker{Name: "service-broker-name-1", GUID: "service-broker-guid-1", URL: "service-broker-url-1"},
-					ServiceBroker{Name: "service-broker-name-2", GUID: "service-broker-guid-2", URL: "service-broker-url-2"},
-					ServiceBroker{Name: "service-broker-name-3", GUID: "service-broker-guid-3", URL: "service-broker-url-3"},
+					ServiceBroker{Name: "service-broker-name-1", GUID: "service-broker-guid-1", URL: "service-broker-url-1", Status: "synchronization in progress"},
+					ServiceBroker{Name: "service-broker-name-2", GUID: "service-broker-guid-2", URL: "service-broker-url-2", Status: "synchronization failed"},
+					ServiceBroker{Name: "service-broker-name-3", GUID: "service-broker-guid-3", URL: "service-broker-url-3", Status: "available"},
 				))
 				Expect(warnings).To(ConsistOf("this is a warning", "this is another warning"))
 			})

--- a/command/v7/service_brokers_command.go
+++ b/command/v7/service_brokers_command.go
@@ -76,11 +76,12 @@ func (cmd *ServiceBrokersCommand) displayServiceBrokersTable(serviceBrokers []v7
 		{
 			cmd.UI.TranslateText("name"),
 			cmd.UI.TranslateText("url"),
+			cmd.UI.TranslateText("status"),
 		},
 	}
 
 	for _, serviceBroker := range serviceBrokers {
-		table = append(table, []string{serviceBroker.Name, serviceBroker.URL})
+		table = append(table, []string{serviceBroker.Name, serviceBroker.URL, serviceBroker.Status})
 	}
 
 	cmd.UI.DisplayTableWithHeader("", table, ui.DefaultTableSpacePadding)

--- a/command/v7/service_brokers_command_test.go
+++ b/command/v7/service_brokers_command_test.go
@@ -116,14 +116,14 @@ var _ = Describe("service-brokers Command", func() {
 		When("there is one service broker", func() {
 			BeforeEach(func() {
 				serviceBrokers := []v7action.ServiceBroker{
-					{Name: "foo", URL: "http://foo.url", GUID: "guid-foo"},
+					{Name: "foo", URL: "http://foo.url", GUID: "guid-foo", Status: "available"},
 				}
 				fakeActor.GetServiceBrokersReturns(serviceBrokers, v7action.Warnings{"service-broker-warnings"}, nil)
 			})
 
 			It("prints a table header and the broker details", func() {
-				Expect(testUI.Out).To(Say("name\\s+url"))
-				Expect(testUI.Out).To(Say("foo\\s+http://foo.url"))
+				Expect(testUI.Out).To(Say("name\\s+url\\s+status"))
+				Expect(testUI.Out).To(Say("foo\\s+http://foo.url\\s+available"))
 				Expect(testUI.Err).To(Say("service-broker-warnings"))
 				Expect(executeErr).NotTo(HaveOccurred())
 			})
@@ -132,16 +132,16 @@ var _ = Describe("service-brokers Command", func() {
 		When("there are many service brokers", func() {
 			BeforeEach(func() {
 				serviceBrokers := []v7action.ServiceBroker{
-					{Name: "foo", URL: "http://foo.url", GUID: "guid-foo"},
-					{Name: "bar", URL: "https://bar.com", GUID: "guid-bar"},
+					{Name: "foo", URL: "http://foo.url", GUID: "guid-foo", Status: "available"},
+					{Name: "bar", URL: "https://bar.com", GUID: "guid-bar", Status: "available"},
 				}
 				fakeActor.GetServiceBrokersReturns(serviceBrokers, v7action.Warnings{"service-broker-warnings"}, nil)
 			})
 
 			It("prints a table header and the broker details", func() {
-				Expect(testUI.Out).To(Say("name\\s+url"))
-				Expect(testUI.Out).To(Say("foo\\s+http://foo.url"))
-				Expect(testUI.Out).To(Say("bar\\s+https://bar.com"))
+				Expect(testUI.Out).To(Say("name\\s+url\\s+status"))
+				Expect(testUI.Out).To(Say("foo\\s+http://foo.url\\s+available"))
+				Expect(testUI.Out).To(Say("bar\\s+https://bar.com\\s+available"))
 				Expect(testUI.Err).To(Say("service-broker-warnings"))
 				Expect(executeErr).NotTo(HaveOccurred())
 			})

--- a/integration/v6/isolated/service_brokers_command_test.go
+++ b/integration/v6/isolated/service_brokers_command_test.go
@@ -25,13 +25,6 @@ var _ = Describe("service-brokers command", func() {
 		})
 	})
 
-	When("environment is not set up", func() {
-		It("displays an error and exits 1", func() {
-			Skip("Unrefactored command is writing login errors to STDOUT; remove skip when refactored")
-			helpers.CheckEnvironmentTargetedCorrectly(false, false, ReadOnlyOrg, "service-brokers")
-		})
-	})
-
 	When("the environment is set up correctly", func() {
 		var (
 			username string
@@ -57,7 +50,7 @@ var _ = Describe("service-brokers command", func() {
 				orgName = helpers.NewOrgName()
 				spaceName = helpers.NewSpaceName()
 				helpers.SetupCF(orgName, spaceName)
-				broker = fakeservicebroker.New().EnsureBrokerIsAvailable()
+				broker = fakeservicebroker.New().Register()
 			})
 
 			AfterEach(func() {

--- a/integration/v6/isolated/service_brokers_command_test.go
+++ b/integration/v6/isolated/service_brokers_command_test.go
@@ -50,7 +50,7 @@ var _ = Describe("service-brokers command", func() {
 				orgName = helpers.NewOrgName()
 				spaceName = helpers.NewSpaceName()
 				helpers.SetupCF(orgName, spaceName)
-				broker = fakeservicebroker.New().Register()
+				broker = fakeservicebroker.New().EnsureBrokerIsAvailable()
 			})
 
 			AfterEach(func() {

--- a/integration/v7/isolated/service_brokers_command_test.go
+++ b/integration/v7/isolated/service_brokers_command_test.go
@@ -1,0 +1,98 @@
+package isolated
+
+import (
+	"code.cloudfoundry.org/cli/integration/helpers"
+	"code.cloudfoundry.org/cli/integration/helpers/fakeservicebroker"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+	. "github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("service-brokers command", func() {
+	Describe("help", func() {
+		When("--help flag is set", func() {
+			It("Displays command usage to output", func() {
+				session := helpers.CF("service-brokers", "--help")
+				Eventually(session).Should(Say("NAME:"))
+				Eventually(session).Should(Say("service-brokers - List service brokers"))
+				Eventually(session).Should(Say("USAGE:"))
+				Eventually(session).Should(Say("cf service-brokers"))
+				Eventually(session).Should(Say("SEE ALSO:"))
+				Eventually(session).Should(Say("delete-service-broker, disable-service-access, enable-service-access"))
+				Eventually(session).Should(Exit(0))
+			})
+		})
+	})
+
+	When("environment is not set up", func() {
+		It("displays an error and exits 1", func() {
+			helpers.CheckEnvironmentTargetedCorrectly(false, false, ReadOnlyOrg, "service-brokers")
+		})
+	})
+
+	When("the environment is set up correctly", func() {
+		var (
+			username string
+			session  *Session
+		)
+
+		BeforeEach(func() {
+			username = helpers.LoginCF()
+		})
+
+		JustBeforeEach(func() {
+			session = helpers.CF("service-brokers")
+		})
+
+		When("there is a broker", func() {
+			var (
+				orgName   string
+				spaceName string
+				broker    *fakeservicebroker.FakeServiceBroker
+			)
+
+			BeforeEach(func() {
+				orgName = helpers.NewOrgName()
+				spaceName = helpers.NewSpaceName()
+				helpers.SetupCF(orgName, spaceName)
+				broker = fakeservicebroker.New().EnsureBrokerIsAvailable()
+			})
+
+			AfterEach(func() {
+				broker.Destroy()
+				helpers.QuickDeleteOrg(orgName)
+			})
+
+			It("prints a table of service brokers", func() {
+				Eventually(session).Should(Say("Getting service brokers as %s...", username))
+				Eventually(session).Should(Say(`name\s+url\s+status`))
+				Eventually(session).Should(Say(`%s\s+%s\s+%s`, broker.Name(), broker.URL(), "available"))
+				Eventually(session).Should(Exit(0))
+			})
+
+			When("user is not authorized to see the brokers", func() {
+				var unprivilegedUsername string
+
+				BeforeEach(func() {
+					var password string
+					unprivilegedUsername, password = helpers.CreateUser()
+					helpers.LogoutCF()
+					helpers.LoginAs(unprivilegedUsername, password)
+				})
+
+				AfterEach(func() {
+					helpers.LoginCF()
+					helpers.TargetOrgAndSpace(orgName, spaceName)
+					helpers.DeleteUser(unprivilegedUsername)
+				})
+
+				It("says that no service brokers were found", func() {
+					Eventually(session).Should(Say("Getting service brokers as"))
+					Eventually(session).Should(Say("No service brokers found"))
+					Eventually(session).Should(Exit(0))
+				})
+			})
+		})
+	})
+})


### PR DESCRIPTION
* Split internal representation struct (at client level) into two:
  request and response.

[#168219805](https://www.pivotaltracker.com/story/show/168219805)
