### PR TITLE
Add --task flag to push for custom push flow

### DIFF
--- a/actor/v7pushaction/actor.go
+++ b/actor/v7pushaction/actor.go
@@ -56,6 +56,7 @@ func NewActor(v3Actor V7Actor, sharedActor SharedActor) *Actor {
 		HandleDiskOverride,
 		HandleNoRouteOverride,
 		HandleRandomRouteOverride,
+		HandleTaskOverride,
 
 		// this must come after all routing related transforms
 		HandleDefaultRouteOverride,
@@ -76,6 +77,7 @@ func NewActor(v3Actor V7Actor, sharedActor SharedActor) *Actor {
 		SetupDeploymentStrategyForPushPlan,
 		SetupNoStartForPushPlan,
 		SetupNoWaitForPushPlan,
+		SetupTaskAppForPushPlan,
 	}
 
 	actor.ChangeApplicationSequence = func(plan PushPlan) []ChangeApplicationFunc {

--- a/actor/v7pushaction/actor_test.go
+++ b/actor/v7pushaction/actor_test.go
@@ -25,6 +25,7 @@ var _ = Describe("Actor", func() {
 				SetupDeploymentStrategyForPushPlan,
 				SetupNoStartForPushPlan,
 				SetupNoWaitForPushPlan,
+				SetupTaskAppForPushPlan,
 			))
 		})
 	})

--- a/actor/v7pushaction/handle_task_override.go
+++ b/actor/v7pushaction/handle_task_override.go
@@ -5,8 +5,8 @@ import (
 	"code.cloudfoundry.org/cli/util/pushmanifestparser"
 )
 
-func HandleNoRouteOverride(manifest pushmanifestparser.Manifest, overrides FlagOverrides) (pushmanifestparser.Manifest, error) {
-	if overrides.NoRoute {
+func HandleTaskOverride(manifest pushmanifestparser.Manifest, overrides FlagOverrides) (pushmanifestparser.Manifest, error) {
+	if overrides.Task {
 		if manifest.ContainsMultipleApps() {
 			return manifest, translatableerror.CommandLineArgsWithMultipleAppsError{}
 		}

--- a/actor/v7pushaction/handle_task_override_test.go
+++ b/actor/v7pushaction/handle_task_override_test.go
@@ -1,0 +1,61 @@
+package v7pushaction_test
+
+import (
+	"code.cloudfoundry.org/cli/command/translatableerror"
+	"code.cloudfoundry.org/cli/util/pushmanifestparser"
+
+	. "code.cloudfoundry.org/cli/actor/v7pushaction"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("HandleTaskOverride", func() {
+	var (
+		originalManifest    pushmanifestparser.Manifest
+		transformedManifest pushmanifestparser.Manifest
+		overrides           FlagOverrides
+		executeErr          error
+	)
+
+	BeforeEach(func() {
+		originalManifest = pushmanifestparser.Manifest{
+			Applications: []pushmanifestparser.Application{{}},
+		}
+		overrides = FlagOverrides{}
+	})
+
+	JustBeforeEach(func() {
+		transformedManifest, executeErr = HandleTaskOverride(originalManifest, overrides)
+	})
+
+	When("task is set on the flag overrides", func() {
+		BeforeEach(func() {
+			overrides.Task = true
+		})
+
+		It("changes the no-route of the only app in the manifest", func() {
+			Expect(executeErr).ToNot(HaveOccurred())
+			Expect(transformedManifest.Applications).To(ConsistOf(
+				pushmanifestparser.Application{
+					NoRoute: true,
+				},
+			))
+		})
+	})
+
+	When("task flag is set and there are multiple apps in the manifest", func() {
+		BeforeEach(func() {
+			overrides.Task = true
+
+			originalManifest.Applications = []pushmanifestparser.Application{
+				{},
+				{},
+			}
+		})
+
+		It("returns an error", func() {
+			Expect(executeErr).To(MatchError(translatableerror.CommandLineArgsWithMultipleAppsError{}))
+		})
+	})
+})

--- a/actor/v7pushaction/push_plan.go
+++ b/actor/v7pushaction/push_plan.go
@@ -16,9 +16,10 @@ type PushPlan struct {
 
 	Application v7action.Application
 
-	NoStart  bool
-	NoWait   bool
-	Strategy constant.DeploymentStrategy
+	NoStart             bool
+	NoWait              bool
+	Strategy            constant.DeploymentStrategy
+	TaskTypeApplication bool
 
 	DockerImageCredentials v7action.DockerImageCredentials
 
@@ -56,6 +57,7 @@ type FlagOverrides struct {
 	PathsToVarsFiles    []string
 	Vars                []template.VarKV
 	NoManifest          bool
+	Task                bool
 }
 
 func (state PushPlan) String() string {

--- a/actor/v7pushaction/sequence.go
+++ b/actor/v7pushaction/sequence.go
@@ -50,6 +50,15 @@ func (actor Actor) GetPrepareApplicationSourceSequence(plan PushPlan) []ChangeAp
 }
 
 func (actor Actor) GetRuntimeSequence(plan PushPlan) []ChangeApplicationFunc {
+
+	if plan.TaskTypeApplication {
+		return actor.getTaskAppRuntimeSequence(plan)
+	} else {
+		return actor.getDefaultRuntimeSequence(plan)
+	}
+}
+
+func (actor Actor) getDefaultRuntimeSequence(plan PushPlan) []ChangeApplicationFunc {
 	var runtimeSequence []ChangeApplicationFunc
 
 	if ShouldStagePackage(plan) {
@@ -71,6 +80,16 @@ func (actor Actor) GetRuntimeSequence(plan PushPlan) []ChangeApplicationFunc {
 			runtimeSequence = append(runtimeSequence, actor.RestartApplication)
 		}
 	}
+
+	return runtimeSequence
+}
+
+func (actor Actor) getTaskAppRuntimeSequence(plan PushPlan) []ChangeApplicationFunc {
+	var runtimeSequence []ChangeApplicationFunc
+
+	runtimeSequence = append(runtimeSequence, actor.StagePackageForApplication)
+	runtimeSequence = append(runtimeSequence, actor.StopApplication)
+	runtimeSequence = append(runtimeSequence, actor.SetDropletForApplication)
 
 	return runtimeSequence
 }

--- a/actor/v7pushaction/sequence_test.go
+++ b/actor/v7pushaction/sequence_test.go
@@ -111,5 +111,17 @@ var _ = Describe("Actor", func() {
 				Expect(sequence).To(matchers.MatchFuncsByName(actor.StagePackageForApplication, actor.CreateDeploymentForApplication))
 			})
 		})
+
+		When("the plan has task application type", func() {
+			BeforeEach(func() {
+				plan = PushPlan{
+					TaskTypeApplication: true,
+				}
+			})
+
+			It("returns a sequence that stages, sets droplet, and stops the app", func() {
+				Expect(sequence).To(matchers.MatchFuncsByName(actor.StagePackageForApplication, actor.StopApplication, actor.SetDropletForApplication))
+			})
+		})
 	})
 })

--- a/actor/v7pushaction/setup_task_app_for_push_plan.go
+++ b/actor/v7pushaction/setup_task_app_for_push_plan.go
@@ -1,0 +1,7 @@
+package v7pushaction
+
+func SetupTaskAppForPushPlan(pushPlan PushPlan, overrides FlagOverrides) (PushPlan, error) {
+	pushPlan.TaskTypeApplication = overrides.Task
+
+	return pushPlan, nil
+}

--- a/actor/v7pushaction/setup_task_app_for_push_plan_test.go
+++ b/actor/v7pushaction/setup_task_app_for_push_plan_test.go
@@ -1,0 +1,38 @@
+package v7pushaction_test
+
+import (
+	. "code.cloudfoundry.org/cli/actor/v7pushaction"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("SetupTaskAppForPushPlan", func() {
+	var (
+		pushPlan  PushPlan
+		overrides FlagOverrides
+
+		expectedPushPlan PushPlan
+		executeErr       error
+	)
+
+	BeforeEach(func() {
+		pushPlan = PushPlan{}
+		overrides = FlagOverrides{}
+	})
+
+	JustBeforeEach(func() {
+		expectedPushPlan, executeErr = SetupTaskAppForPushPlan(pushPlan, overrides)
+	})
+
+	When("flag overrides specifies task type app", func() {
+		BeforeEach(func() {
+			overrides.Task = true
+		})
+
+		It("sets task app type on the push plan", func() {
+			Expect(executeErr).ToNot(HaveOccurred())
+			Expect(expectedPushPlan.TaskTypeApplication).To(BeTrue())
+		})
+	})
+})

--- a/command/v7/push_command.go
+++ b/command/v7/push_command.go
@@ -87,6 +87,7 @@ type PushCommand struct {
 	Stack                   string                              `long:"stack" short:"s" description:"Stack to use (a stack is a pre-built file system, including an operating system, that can run apps)"`
 	StartCommand            flag.Command                        `long:"start-command" short:"c" description:"Startup command, set to null to reset to default start command"`
 	Strategy                flag.DeploymentStrategy             `long:"strategy" description:"Deployment strategy, either rolling or null."`
+	Task                    bool                                `long:"task" description:"Push an app that is used only to execute tasks. The app will be staged, but not started and will have no route assigned."`
 	Vars                    []template.VarKV                    `long:"var" description:"Variable key value pair for variable substitution, (e.g., name=app1); can specify multiple times"`
 	PathsToVarsFiles        []flag.PathWithExistenceCheck       `long:"vars-file" description:"Path to a variable substitution file for manifest; can specify multiple times"`
 	dockerPassword          interface{}                         `environmentName:"CF_DOCKER_PASSWORD" environmentDescription:"Password used for private docker repository"`
@@ -315,6 +316,7 @@ func (cmd PushCommand) GetFlagOverrides() (v7pushaction.FlagOverrides, error) {
 		PathsToVarsFiles:    pathsToVarsFiles,
 		Vars:                cmd.Vars,
 		NoManifest:          cmd.NoManifest,
+		Task:                cmd.Task,
 	}, nil
 }
 
@@ -394,6 +396,14 @@ func (cmd PushCommand) ValidateFlags() error {
 		return translatableerror.ArgumentCombinationError{
 			Args: []string{
 				"--no-start",
+				"--strategy=rolling",
+			},
+		}
+
+	case cmd.Task && cmd.Strategy == flag.DeploymentStrategy{Name: constant.DeploymentStrategyRolling}:
+		return translatableerror.ArgumentCombinationError{
+			Args: []string{
+				"--task",
 				"--strategy=rolling",
 			},
 		}

--- a/command/v7/push_command_test.go
+++ b/command/v7/push_command_test.go
@@ -976,6 +976,7 @@ var _ = Describe("push Command", func() {
 			cmd.PathToManifest = "/manifest/path"
 			cmd.PathsToVarsFiles = []flag.PathWithExistenceCheck{"/vars1", "/vars2"}
 			cmd.Vars = []template.VarKV{{Name: "key", Value: "val"}}
+			cmd.Task = true
 		})
 
 		JustBeforeEach(func() {
@@ -1003,6 +1004,7 @@ var _ = Describe("push Command", func() {
 			Expect(overrides.ManifestPath).To(Equal("/manifest/path"))
 			Expect(overrides.PathsToVarsFiles).To(Equal([]string{"/vars1", "/vars2"}))
 			Expect(overrides.Vars).To(Equal([]template.VarKV{{Name: "key", Value: "val"}}))
+			Expect(overrides.Task).To(BeTrue())
 		})
 
 		When("a docker image is provided", func() {
@@ -1152,5 +1154,16 @@ var _ = Describe("push Command", func() {
 				cmd.Buildpacks = []string{"some-docker-username", "null"}
 			},
 			translatableerror.InvalidBuildpacksError{}),
+
+		Entry("task and strategy flags are passed",
+			func() {
+				cmd.Task = true
+				cmd.Strategy = flag.DeploymentStrategy{Name: constant.DeploymentStrategyRolling}
+			},
+			translatableerror.ArgumentCombinationError{
+				Args: []string{
+					"--task", "--strategy=rolling",
+				},
+			}),
 	)
 })


### PR DESCRIPTION
A custom push flow for applications that are used for executing one-off
tasks, and are never intended to run a long running process.

The flow is
- application staged
- application kept in a stopped state
- no route applied to the application

Addresses the push updates for #1641
