### PR TITLE
Add --wait, -w flag to run-task

### DIFF
--- a/actor/actionerror/task_failed_error.go
+++ b/actor/actionerror/task_failed_error.go
@@ -1,0 +1,7 @@
+package actionerror
+
+type TaskFailedError struct{}
+
+func (TaskFailedError) Error() string {
+	return "Task failed to complete successfully"
+}

--- a/actor/v7action/cloud_controller_client.go
+++ b/actor/v7action/cloud_controller_client.go
@@ -123,6 +123,7 @@ type CloudControllerClient interface {
 	GetAppFeature(appGUID string, featureName string) (resources.ApplicationFeature, ccv3.Warnings, error)
 	GetStacks(query ...ccv3.Query) ([]resources.Stack, ccv3.Warnings, error)
 	GetStagingSecurityGroups(spaceGUID string, queries ...ccv3.Query) ([]resources.SecurityGroup, ccv3.Warnings, error)
+	GetTask(guid string) (resources.Task, ccv3.Warnings, error)
 	GetUser(userGUID string) (resources.User, ccv3.Warnings, error)
 	GetUsers(query ...ccv3.Query) ([]resources.User, ccv3.Warnings, error)
 	MapRoute(routeGUID string, appGUID string) (ccv3.Warnings, error)

--- a/actor/v7action/task.go
+++ b/actor/v7action/task.go
@@ -2,13 +2,16 @@ package v7action
 
 import (
 	"strconv"
+	"time"
 
 	"sort"
 
 	"code.cloudfoundry.org/cli/actor/actionerror"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccerror"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3"
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/constant"
 	"code.cloudfoundry.org/cli/resources"
+	log "github.com/sirupsen/logrus"
 )
 
 // Run resources.Task runs the provided command in the application environment associated
@@ -66,4 +69,33 @@ func (actor Actor) GetTaskBySequenceIDAndApplication(sequenceID int, appGUID str
 func (actor Actor) TerminateTask(taskGUID string) (resources.Task, Warnings, error) {
 	task, warnings, err := actor.CloudControllerClient.UpdateTaskCancel(taskGUID)
 	return resources.Task(task), Warnings(warnings), err
+}
+
+func (actor Actor) PollTask(task resources.Task) (resources.Task, Warnings, error) {
+	var allWarnings Warnings
+
+	for task.State != constant.TaskSucceeded && task.State != constant.TaskFailed {
+
+		time.Sleep(actor.Config.PollingInterval())
+
+		ccTask, warnings, err := actor.CloudControllerClient.GetTask(task.GUID)
+		log.WithFields(log.Fields{
+			"task_guid": task.GUID,
+			"state":     task.State,
+		}).Debug("polling task state")
+
+		allWarnings = append(allWarnings, warnings...)
+
+		if err != nil {
+			return resources.Task{}, allWarnings, err
+		}
+
+		task = resources.Task(ccTask)
+	}
+
+	if task.State == constant.TaskFailed {
+		return task, allWarnings, actionerror.TaskFailedError{}
+	}
+
+	return task, allWarnings, nil
 }

--- a/actor/v7action/v7actionfakes/fake_cloud_controller_client.go
+++ b/actor/v7action/v7actionfakes/fake_cloud_controller_client.go
@@ -1697,6 +1697,21 @@ type FakeCloudControllerClient struct {
 		result2 ccv3.Warnings
 		result3 error
 	}
+	GetTaskStub        func(string) (resources.Task, ccv3.Warnings, error)
+	getTaskMutex       sync.RWMutex
+	getTaskArgsForCall []struct {
+		arg1 string
+	}
+	getTaskReturns struct {
+		result1 resources.Task
+		result2 ccv3.Warnings
+		result3 error
+	}
+	getTaskReturnsOnCall map[int]struct {
+		result1 resources.Task
+		result2 ccv3.Warnings
+		result3 error
+	}
 	GetUserStub        func(string) (resources.User, ccv3.Warnings, error)
 	getUserMutex       sync.RWMutex
 	getUserArgsForCall []struct {
@@ -9757,6 +9772,72 @@ func (fake *FakeCloudControllerClient) GetStagingSecurityGroupsReturnsOnCall(i i
 	}{result1, result2, result3}
 }
 
+func (fake *FakeCloudControllerClient) GetTask(arg1 string) (resources.Task, ccv3.Warnings, error) {
+	fake.getTaskMutex.Lock()
+	ret, specificReturn := fake.getTaskReturnsOnCall[len(fake.getTaskArgsForCall)]
+	fake.getTaskArgsForCall = append(fake.getTaskArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("GetTask", []interface{}{arg1})
+	fake.getTaskMutex.Unlock()
+	if fake.GetTaskStub != nil {
+		return fake.GetTaskStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	fakeReturns := fake.getTaskReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeCloudControllerClient) GetTaskCallCount() int {
+	fake.getTaskMutex.RLock()
+	defer fake.getTaskMutex.RUnlock()
+	return len(fake.getTaskArgsForCall)
+}
+
+func (fake *FakeCloudControllerClient) GetTaskCalls(stub func(string) (resources.Task, ccv3.Warnings, error)) {
+	fake.getTaskMutex.Lock()
+	defer fake.getTaskMutex.Unlock()
+	fake.GetTaskStub = stub
+}
+
+func (fake *FakeCloudControllerClient) GetTaskArgsForCall(i int) string {
+	fake.getTaskMutex.RLock()
+	defer fake.getTaskMutex.RUnlock()
+	argsForCall := fake.getTaskArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeCloudControllerClient) GetTaskReturns(result1 resources.Task, result2 ccv3.Warnings, result3 error) {
+	fake.getTaskMutex.Lock()
+	defer fake.getTaskMutex.Unlock()
+	fake.GetTaskStub = nil
+	fake.getTaskReturns = struct {
+		result1 resources.Task
+		result2 ccv3.Warnings
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeCloudControllerClient) GetTaskReturnsOnCall(i int, result1 resources.Task, result2 ccv3.Warnings, result3 error) {
+	fake.getTaskMutex.Lock()
+	defer fake.getTaskMutex.Unlock()
+	fake.GetTaskStub = nil
+	if fake.getTaskReturnsOnCall == nil {
+		fake.getTaskReturnsOnCall = make(map[int]struct {
+			result1 resources.Task
+			result2 ccv3.Warnings
+			result3 error
+		})
+	}
+	fake.getTaskReturnsOnCall[i] = struct {
+		result1 resources.Task
+		result2 ccv3.Warnings
+		result3 error
+	}{result1, result2, result3}
+}
+
 func (fake *FakeCloudControllerClient) GetUser(arg1 string) (resources.User, ccv3.Warnings, error) {
 	fake.getUserMutex.Lock()
 	ret, specificReturn := fake.getUserReturnsOnCall[len(fake.getUserArgsForCall)]
@@ -13043,6 +13124,8 @@ func (fake *FakeCloudControllerClient) Invocations() map[string][][]interface{} 
 	defer fake.getStacksMutex.RUnlock()
 	fake.getStagingSecurityGroupsMutex.RLock()
 	defer fake.getStagingSecurityGroupsMutex.RUnlock()
+	fake.getTaskMutex.RLock()
+	defer fake.getTaskMutex.RUnlock()
 	fake.getUserMutex.RLock()
 	defer fake.getUserMutex.RUnlock()
 	fake.getUsersMutex.RLock()

--- a/api/cloudcontroller/ccv3/internal/api_routes.go
+++ b/api/cloudcontroller/ccv3/internal/api_routes.go
@@ -92,6 +92,7 @@ const (
 	GetSpaceStagingSecurityGroupsRequest                        = "GetSpaceStagingSecurityGroups"
 	GetSSHEnabled                                               = "GetSSHEnabled"
 	GetStacksRequest                                            = "GetStacks"
+	GetTaskRequest                                              = "GetTask"
 	GetUserRequest                                              = "GetUser"
 	GetUsersRequest                                             = "GetUsers"
 	MapRouteRequest                                             = "MapRoute"
@@ -303,6 +304,7 @@ var APIRoutes = []Route{
 	{Resource: StacksResource, Path: "/", Method: http.MethodGet, Name: GetStacksRequest},
 	{Resource: StacksResource, Path: "/:stack_guid", Method: http.MethodPatch, Name: PatchStackRequest},
 	{Resource: TasksResource, Path: "/:task_guid/cancel", Method: http.MethodPut, Name: PutTaskCancelRequest},
+	{Resource: TasksResource, Path: "/:task_guid", Method: http.MethodGet, Name: GetTaskRequest},
 	{Resource: UsersResource, Path: "/", Method: http.MethodGet, Name: GetUsersRequest},
 	{Resource: UsersResource, Path: "/:user_guid", Method: http.MethodGet, Name: GetUserRequest},
 	{Resource: UsersResource, Path: "/", Method: http.MethodPost, Name: PostUserRequest},

--- a/api/cloudcontroller/ccv3/task.go
+++ b/api/cloudcontroller/ccv3/task.go
@@ -53,3 +53,17 @@ func (client *Client) UpdateTaskCancel(taskGUID string) (resources.Task, Warning
 
 	return responseBody, warnings, err
 }
+
+func (client *Client) GetTask(guid string) (resources.Task, Warnings, error) {
+	var responseBody resources.Task
+
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName: internal.GetTaskRequest,
+		URIParams: internal.Params{
+			"task_guid": guid,
+		},
+		ResponseBody: &responseBody,
+	})
+
+	return responseBody, warnings, err
+}

--- a/command/v7/actor.go
+++ b/command/v7/actor.go
@@ -164,6 +164,7 @@ type Actor interface {
 	PollPackage(pkg resources.Package) (resources.Package, v7action.Warnings, error)
 	PollStart(app resources.Application, noWait bool, handleProcessStats func(string)) (v7action.Warnings, error)
 	PollStartForRolling(app resources.Application, deploymentGUID string, noWait bool, handleProcessStats func(string)) (v7action.Warnings, error)
+	PollTask(task resources.Task) (resources.Task, v7action.Warnings, error)
 	PollUploadBuildpackJob(jobURL ccv3.JobURL) (v7action.Warnings, error)
 	PrepareBuildpackBits(inputPath string, tmpDirPath string, downloader v7action.Downloader) (string, error)
 	PurgeServiceOfferingByNameAndBroker(serviceOfferingName, serviceBrokerName string) (v7action.Warnings, error)

--- a/command/v7/run_task_command.go
+++ b/command/v7/run_task_command.go
@@ -16,6 +16,7 @@ type RunTaskCommand struct {
 	Memory          flag.Megabytes     `short:"m" description:"Memory limit (e.g. 256M, 1024M, 1G)"`
 	Name            string             `long:"name" description:"Name to give the task (generated if omitted)"`
 	Process         string             `long:"process" description:"Process type to use as a template for command, memory, and disk for the created task."`
+	Wait            bool               `long:"wait" short:"w" description:"Wait for the task to complete before exiting"`
 	usage           interface{}        `usage:"CF_NAME run-task APP_NAME [--command COMMAND] [-k DISK] [-m MEMORY] [--name TASK_NAME] [--process PROCESS_TYPE]\n\nTIP:\n   Use 'cf logs' to display the logs of the app and all its tasks. If your task name is unique, grep this command's output for the task name to view task-specific logs.\n\nEXAMPLES:\n   CF_NAME run-task my-app --command \"bundle exec rake db:migrate\" --name migrate\n\n   CF_NAME run-task my-app --process batch_job\n\n   CF_NAME run-task my-app"`
 	relatedCommands interface{}        `related_commands:"logs, tasks, terminate-task"`
 }
@@ -89,6 +90,22 @@ func (cmd RunTaskCommand) Execute(args []string) error {
 		{cmd.UI.TranslateText("task name:"), task.Name},
 		{cmd.UI.TranslateText("task id:"), fmt.Sprint(task.SequenceID)},
 	}, 3)
+
+	if cmd.Wait {
+		cmd.UI.DisplayNewline()
+		cmd.UI.DisplayText("Waiting for task to complete execution...")
+
+		_, pollWarnings, err := cmd.Actor.PollTask(task)
+		cmd.UI.DisplayWarnings(pollWarnings)
+		if err != nil {
+			return err
+		}
+
+		cmd.UI.DisplayNewline()
+		cmd.UI.DisplayText("Task has completed successfully.")
+	}
+
+	cmd.UI.DisplayOK()
 
 	return nil
 }

--- a/command/v7/run_task_command_test.go
+++ b/command/v7/run_task_command_test.go
@@ -145,6 +145,7 @@ var _ = Describe("run-task Command", func() {
 
 						Expect(testUI.Out).To(Say(`task name:\s+31337ddd`))
 						Expect(testUI.Out).To(Say(`task id:\s+3`))
+						Expect(testUI.Out).To(Say("OK"))
 
 						Expect(testUI.Err).To(Say("get-application-warning-1"))
 						Expect(testUI.Err).To(Say("get-application-warning-2"))
@@ -190,6 +191,7 @@ var _ = Describe("run-task Command", func() {
 
 						Expect(testUI.Out).To(Say(`task name:\s+some-task-name`))
 						Expect(testUI.Out).To(Say(`task id:\s+3`))
+						Expect(testUI.Out).To(Say("OK"))
 
 						Expect(testUI.Err).To(Say("get-application-warning-1"))
 						Expect(testUI.Err).To(Say("get-application-warning-2"))
@@ -237,6 +239,7 @@ var _ = Describe("run-task Command", func() {
 
 						Expect(testUI.Out).To(Say(`task name:\s+some-task-name`))
 						Expect(testUI.Out).To(Say(`task id:\s+3`))
+						Expect(testUI.Out).To(Say("OK"))
 
 						Expect(testUI.Err).To(Say("get-application-warning-1"))
 						Expect(testUI.Err).To(Say("get-application-warning-2"))
@@ -288,11 +291,55 @@ var _ = Describe("run-task Command", func() {
 
 						Expect(testUI.Out).To(Say(`task name:\s+some-task-name`))
 						Expect(testUI.Out).To(Say(`task id:\s+3`))
+						Expect(testUI.Out).To(Say("OK"))
 
 						Expect(testUI.Err).To(Say("get-application-warning-1"))
 						Expect(testUI.Err).To(Say("get-application-warning-2"))
 						Expect(testUI.Err).To(Say("get-process-warning"))
 						Expect(testUI.Err).To(Say("get-application-warning-3"))
+					})
+				})
+
+				When("wait is provided", func() {
+					BeforeEach(func() {
+						cmd.Name = "some-task-name"
+						cmd.Command = "echo hello"
+						cmd.Wait = true
+						fakeActor.RunTaskReturns(
+							resources.Task{
+								Name:       "some-task-name",
+								SequenceID: 3,
+							},
+							v7action.Warnings{"get-application-warning-3"},
+							nil)
+						fakeActor.PollTaskReturns(
+							resources.Task{
+								Name:       "some-task-name",
+								SequenceID: 3,
+							},
+							v7action.Warnings{"poll-warnings"},
+							nil)
+					})
+
+					It("waits for the task to complete before exiting", func() {
+						Expect(executeErr).ToNot(HaveOccurred())
+
+						Expect(testUI.Out).To(Say("Creating task for app some-app-name in org some-org / space some-space as some-user..."))
+
+						Expect(testUI.Out).To(Say("Task has been submitted successfully for execution."))
+						Expect(testUI.Out).To(Say(`task name:\s+some-task-name`))
+						Expect(testUI.Out).To(Say(`task id:\s+3`))
+
+						Expect(testUI.Out).To(Say(`Waiting for task to complete execution...`))
+
+						Expect(testUI.Out).To(Say(`Task has completed successfully.`))
+						Expect(testUI.Out).To(Say("OK"))
+
+						Expect(testUI.Err).To(Say("get-application-warning-1"))
+						Expect(testUI.Err).To(Say("get-application-warning-2"))
+						Expect(testUI.Err).To(Say("get-application-warning-3"))
+						Expect(testUI.Err).To(Say("poll-warnings"))
+
 					})
 				})
 			})
@@ -329,6 +376,31 @@ var _ = Describe("run-task Command", func() {
 								nil,
 								nil)
 							fakeActor.RunTaskReturns(
+								resources.Task{},
+								nil,
+								returnedErr)
+						})
+
+						It("returns a translatable error", func() {
+							Expect(executeErr).To(MatchError(returnedErr))
+						})
+					})
+
+					When("polling the task returns the error", func() {
+						var returnedErr error
+
+						BeforeEach(func() {
+							cmd.Wait = true
+							returnedErr = ccerror.UnverifiedServerError{URL: "some-url"}
+							fakeActor.GetApplicationByNameAndSpaceReturns(
+								resources.Application{GUID: "some-app-guid"},
+								nil,
+								nil)
+							fakeActor.RunTaskReturns(
+								resources.Task{},
+								nil,
+								nil)
+							fakeActor.PollTaskReturns(
 								resources.Task{},
 								nil,
 								returnedErr)

--- a/command/v7/v7fakes/fake_actor.go
+++ b/command/v7/v7fakes/fake_actor.go
@@ -2211,6 +2211,21 @@ type FakeActor struct {
 		result1 v7action.Warnings
 		result2 error
 	}
+	PollTaskStub        func(resources.Task) (resources.Task, v7action.Warnings, error)
+	pollTaskMutex       sync.RWMutex
+	pollTaskArgsForCall []struct {
+		arg1 resources.Task
+	}
+	pollTaskReturns struct {
+		result1 resources.Task
+		result2 v7action.Warnings
+		result3 error
+	}
+	pollTaskReturnsOnCall map[int]struct {
+		result1 resources.Task
+		result2 v7action.Warnings
+		result3 error
+	}
 	PollUploadBuildpackJobStub        func(ccv3.JobURL) (v7action.Warnings, error)
 	pollUploadBuildpackJobMutex       sync.RWMutex
 	pollUploadBuildpackJobArgsForCall []struct {
@@ -12539,6 +12554,72 @@ func (fake *FakeActor) PollStartForRollingReturnsOnCall(i int, result1 v7action.
 	}{result1, result2}
 }
 
+func (fake *FakeActor) PollTask(arg1 resources.Task) (resources.Task, v7action.Warnings, error) {
+	fake.pollTaskMutex.Lock()
+	ret, specificReturn := fake.pollTaskReturnsOnCall[len(fake.pollTaskArgsForCall)]
+	fake.pollTaskArgsForCall = append(fake.pollTaskArgsForCall, struct {
+		arg1 resources.Task
+	}{arg1})
+	fake.recordInvocation("PollTask", []interface{}{arg1})
+	fake.pollTaskMutex.Unlock()
+	if fake.PollTaskStub != nil {
+		return fake.PollTaskStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	fakeReturns := fake.pollTaskReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeActor) PollTaskCallCount() int {
+	fake.pollTaskMutex.RLock()
+	defer fake.pollTaskMutex.RUnlock()
+	return len(fake.pollTaskArgsForCall)
+}
+
+func (fake *FakeActor) PollTaskCalls(stub func(resources.Task) (resources.Task, v7action.Warnings, error)) {
+	fake.pollTaskMutex.Lock()
+	defer fake.pollTaskMutex.Unlock()
+	fake.PollTaskStub = stub
+}
+
+func (fake *FakeActor) PollTaskArgsForCall(i int) resources.Task {
+	fake.pollTaskMutex.RLock()
+	defer fake.pollTaskMutex.RUnlock()
+	argsForCall := fake.pollTaskArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeActor) PollTaskReturns(result1 resources.Task, result2 v7action.Warnings, result3 error) {
+	fake.pollTaskMutex.Lock()
+	defer fake.pollTaskMutex.Unlock()
+	fake.PollTaskStub = nil
+	fake.pollTaskReturns = struct {
+		result1 resources.Task
+		result2 v7action.Warnings
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeActor) PollTaskReturnsOnCall(i int, result1 resources.Task, result2 v7action.Warnings, result3 error) {
+	fake.pollTaskMutex.Lock()
+	defer fake.pollTaskMutex.Unlock()
+	fake.PollTaskStub = nil
+	if fake.pollTaskReturnsOnCall == nil {
+		fake.pollTaskReturnsOnCall = make(map[int]struct {
+			result1 resources.Task
+			result2 v7action.Warnings
+			result3 error
+		})
+	}
+	fake.pollTaskReturnsOnCall[i] = struct {
+		result1 resources.Task
+		result2 v7action.Warnings
+		result3 error
+	}{result1, result2, result3}
+}
+
 func (fake *FakeActor) PollUploadBuildpackJob(arg1 ccv3.JobURL) (v7action.Warnings, error) {
 	fake.pollUploadBuildpackJobMutex.Lock()
 	ret, specificReturn := fake.pollUploadBuildpackJobReturnsOnCall[len(fake.pollUploadBuildpackJobArgsForCall)]
@@ -16726,6 +16807,8 @@ func (fake *FakeActor) Invocations() map[string][][]interface{} {
 	defer fake.pollStartMutex.RUnlock()
 	fake.pollStartForRollingMutex.RLock()
 	defer fake.pollStartForRollingMutex.RUnlock()
+	fake.pollTaskMutex.RLock()
+	defer fake.pollTaskMutex.RUnlock()
 	fake.pollUploadBuildpackJobMutex.RLock()
 	defer fake.pollUploadBuildpackJobMutex.RUnlock()
 	fake.prepareBuildpackBitsMutex.RLock()

--- a/util/randomword/generator.go
+++ b/util/randomword/generator.go
@@ -214,8 +214,8 @@ func (Generator) RandomNoun() string {
 
 func (Generator) RandomTwoLetters() string {
 	var asciiLetterA = 97
-	letterOne := string(rand.Intn(26) + asciiLetterA)
-	letterTwo := string(rand.Intn(26) + asciiLetterA)
+	letterOne := string(rune(rand.Intn(26) + asciiLetterA))
+	letterTwo := string(rune(rand.Intn(26) + asciiLetterA))
 	return letterOne + letterTwo
 }
 


### PR DESCRIPTION
When the wait flag is supplied to run-task, the cli will
not exit until the task enters a terminal state; SUCCEEDED or FAILED.

The cli exits 0 when the task succeeds and exits 1 when the task fails.

This improves the scriptability of tasks. They can be run
serially in a script.

Addresses Issue #1104

---

This affects v7 only.

Does not address the --log request in the associated issue.



