### PR TITLE
Correct an issue with the update-service command.

### DIFF
--- a/cf/api/apifakes/fake_service_repository.go
+++ b/cf/api/apifakes/fake_service_repository.go
@@ -227,13 +227,13 @@ type FakeServiceRepository struct {
 	renameServiceReturnsOnCall map[int]struct {
 		result1 error
 	}
-	UpdateServiceInstanceStub        func(string, string, map[string]interface{}, []string) error
+	UpdateServiceInstanceStub        func(string, string, map[string]interface{}, *[]string) error
 	updateServiceInstanceMutex       sync.RWMutex
 	updateServiceInstanceArgsForCall []struct {
 		arg1 string
 		arg2 string
 		arg3 map[string]interface{}
-		arg4 []string
+		arg4 *[]string
 	}
 	updateServiceInstanceReturns struct {
 		result1 error
@@ -1310,21 +1310,16 @@ func (fake *FakeServiceRepository) RenameServiceReturnsOnCall(i int, result1 err
 	}{result1}
 }
 
-func (fake *FakeServiceRepository) UpdateServiceInstance(arg1 string, arg2 string, arg3 map[string]interface{}, arg4 []string) error {
-	var arg4Copy []string
-	if arg4 != nil {
-		arg4Copy = make([]string, len(arg4))
-		copy(arg4Copy, arg4)
-	}
+func (fake *FakeServiceRepository) UpdateServiceInstance(arg1 string, arg2 string, arg3 map[string]interface{}, arg4 *[]string) error {
 	fake.updateServiceInstanceMutex.Lock()
 	ret, specificReturn := fake.updateServiceInstanceReturnsOnCall[len(fake.updateServiceInstanceArgsForCall)]
 	fake.updateServiceInstanceArgsForCall = append(fake.updateServiceInstanceArgsForCall, struct {
 		arg1 string
 		arg2 string
 		arg3 map[string]interface{}
-		arg4 []string
-	}{arg1, arg2, arg3, arg4Copy})
-	fake.recordInvocation("UpdateServiceInstance", []interface{}{arg1, arg2, arg3, arg4Copy})
+		arg4 *[]string
+	}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("UpdateServiceInstance", []interface{}{arg1, arg2, arg3, arg4})
 	fake.updateServiceInstanceMutex.Unlock()
 	if fake.UpdateServiceInstanceStub != nil {
 		return fake.UpdateServiceInstanceStub(arg1, arg2, arg3, arg4)
@@ -1342,13 +1337,13 @@ func (fake *FakeServiceRepository) UpdateServiceInstanceCallCount() int {
 	return len(fake.updateServiceInstanceArgsForCall)
 }
 
-func (fake *FakeServiceRepository) UpdateServiceInstanceCalls(stub func(string, string, map[string]interface{}, []string) error) {
+func (fake *FakeServiceRepository) UpdateServiceInstanceCalls(stub func(string, string, map[string]interface{}, *[]string) error) {
 	fake.updateServiceInstanceMutex.Lock()
 	defer fake.updateServiceInstanceMutex.Unlock()
 	fake.UpdateServiceInstanceStub = stub
 }
 
-func (fake *FakeServiceRepository) UpdateServiceInstanceArgsForCall(i int) (string, string, map[string]interface{}, []string) {
+func (fake *FakeServiceRepository) UpdateServiceInstanceArgsForCall(i int) (string, string, map[string]interface{}, *[]string) {
 	fake.updateServiceInstanceMutex.RLock()
 	defer fake.updateServiceInstanceMutex.RUnlock()
 	argsForCall := fake.updateServiceInstanceArgsForCall[i]

--- a/cf/api/services.go
+++ b/cf/api/services.go
@@ -29,7 +29,7 @@ type ServiceRepository interface {
 	FindInstanceByName(name string) (instance models.ServiceInstance, apiErr error)
 	PurgeServiceInstance(instance models.ServiceInstance) error
 	CreateServiceInstance(name, planGUID string, params map[string]interface{}, tags []string) (apiErr error)
-	UpdateServiceInstance(instanceGUID, planGUID string, params map[string]interface{}, tags []string) (apiErr error)
+	UpdateServiceInstance(instanceGUID, planGUID string, params map[string]interface{}, tags *[]string) (apiErr error)
 	RenameService(instance models.ServiceInstance, newName string) (apiErr error)
 	DeleteService(instance models.ServiceInstance) (apiErr error)
 	FindServicePlanByDescription(planDescription resources.ServicePlanDescription) (planGUID string, apiErr error)
@@ -166,7 +166,7 @@ func (repo CloudControllerServiceRepository) CreateServiceInstance(name, planGUI
 	return
 }
 
-func (repo CloudControllerServiceRepository) UpdateServiceInstance(instanceGUID, planGUID string, params map[string]interface{}, tags []string) (err error) {
+func (repo CloudControllerServiceRepository) UpdateServiceInstance(instanceGUID, planGUID string, params map[string]interface{}, tags *[]string) (err error) {
 	path := fmt.Sprintf("/v2/service_instances/%s?accepts_incomplete=true", instanceGUID)
 	request := models.ServiceInstanceUpdateRequest{
 		PlanGUID: planGUID,

--- a/cf/api/services_test.go
+++ b/cf/api/services_test.go
@@ -376,7 +376,7 @@ var _ = Describe("Services Repo", func() {
 			setupTestServer(apifakes.NewCloudControllerTestRequest(testnet.TestRequest{
 				Method:   "PUT",
 				Path:     "/v2/service_instances/instance-guid?accepts_incomplete=true",
-				Matcher:  testnet.RequestBodyMatcher(`{"service_plan_guid":"plan-guid", "tags": null}`),
+				Matcher:  testnet.RequestBodyMatcher(`{"service_plan_guid":"plan-guid"}`),
 				Response: testnet.TestResponse{Status: http.StatusOK},
 			}))
 
@@ -390,11 +390,12 @@ var _ = Describe("Services Repo", func() {
 				setupTestServer(apifakes.NewCloudControllerTestRequest(testnet.TestRequest{
 					Method:   "PUT",
 					Path:     "/v2/service_instances/instance-guid?accepts_incomplete=true",
-					Matcher:  testnet.RequestBodyMatcher(`{"service_plan_guid":"plan-guid", "tags": null}`),
+					Matcher:  testnet.RequestBodyMatcher(`{"service_plan_guid":"plan-guid"}`),
 					Response: testnet.TestResponse{Status: http.StatusNotFound},
 				}))
 
 				err := repo.UpdateServiceInstance("instance-guid", "plan-guid", nil, nil)
+
 				Expect(testHandler).To(HaveAllRequestsCalled())
 				Expect(err).To(HaveOccurred())
 			})
@@ -405,7 +406,7 @@ var _ = Describe("Services Repo", func() {
 				setupTestServer(apifakes.NewCloudControllerTestRequest(testnet.TestRequest{
 					Method:   "PUT",
 					Path:     "/v2/service_instances/instance-guid?accepts_incomplete=true",
-					Matcher:  testnet.RequestBodyMatcher(`{"parameters": {"foo": "bar"}, "tags": null}`),
+					Matcher:  testnet.RequestBodyMatcher(`{"parameters": {"foo": "bar"}}`),
 					Response: testnet.TestResponse{Status: http.StatusOK},
 				}))
 
@@ -436,7 +437,7 @@ var _ = Describe("Services Repo", func() {
 					Response: testnet.TestResponse{Status: http.StatusOK},
 				}))
 
-				tags := []string{"foo", "bar"}
+				tags := &[]string{"foo", "bar"}
 
 				err := repo.UpdateServiceInstance("instance-guid", "", nil, tags)
 				Expect(testHandler).To(HaveAllRequestsCalled())
@@ -451,7 +452,7 @@ var _ = Describe("Services Repo", func() {
 					Response: testnet.TestResponse{Status: http.StatusOK},
 				}))
 
-				tags := []string{}
+				tags := &[]string{}
 
 				err := repo.UpdateServiceInstance("instance-guid", "", nil, tags)
 				Expect(testHandler).To(HaveAllRequestsCalled())

--- a/cf/commands/service/update_service.go
+++ b/cf/commands/service/update_service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"code.cloudfoundry.org/cli/cf/uihelpers"
 	"errors"
 	"fmt"
 	"strings"
@@ -14,7 +15,6 @@ import (
 	"code.cloudfoundry.org/cli/cf/models"
 	"code.cloudfoundry.org/cli/cf/requirements"
 	"code.cloudfoundry.org/cli/cf/terminal"
-	"code.cloudfoundry.org/cli/cf/uihelpers"
 	"code.cloudfoundry.org/cli/cf/util/json"
 )
 
@@ -115,8 +115,12 @@ func (cmd *UpdateService) Execute(c flags.FlagContext) error {
 	if err != nil {
 		return errors.New(T("Invalid configuration provided for -c flag. Please provide a valid JSON object or path to a file containing a valid JSON object."))
 	}
+	var tags *[]string
 
-	tags := uihelpers.ParseTags(tagsList)
+	if tagsSet {
+		parsedTags := uihelpers.ParseTags(tagsList)
+		tags = &parsedTags
+	}
 
 	var plan models.ServicePlanFields
 	if planName != "" {

--- a/cf/commands/service/update_service_test.go
+++ b/cf/commands/service/update_service_test.go
@@ -291,7 +291,7 @@ var _ = Describe("update-service command", func() {
 				[]string{"OK"},
 			))
 			_, _, _, tags := serviceRepo.UpdateServiceInstanceArgsForCall(0)
-			Expect(tags).To(ConsistOf("tag1", "tag2", "tag3", "tag4"))
+			Expect(*tags).To(ConsistOf("tag1", "tag2", "tag3", "tag4"))
 		})
 
 		It("successfully updates a service and passes the tags as json", func() {
@@ -302,7 +302,7 @@ var _ = Describe("update-service command", func() {
 				[]string{"OK"},
 			))
 			_, _, _, tags := serviceRepo.UpdateServiceInstanceArgsForCall(0)
-			Expect(tags).To(ConsistOf("tag1"))
+			Expect(*tags).To(ConsistOf("tag1"))
 		})
 
 		Context("and the tags string is passed with an empty string", func() {
@@ -314,7 +314,7 @@ var _ = Describe("update-service command", func() {
 					[]string{"OK"},
 				))
 				_, _, _, tags := serviceRepo.UpdateServiceInstanceArgsForCall(0)
-				Expect(tags).To(Equal([]string{}))
+				Expect(tags).To(Equal(&[]string{}))
 			})
 		})
 	})

--- a/cf/models/service_instance.go
+++ b/cf/models/service_instance.go
@@ -19,7 +19,7 @@ type ServiceInstanceCreateRequest struct {
 type ServiceInstanceUpdateRequest struct {
 	PlanGUID string                 `json:"service_plan_guid,omitempty"`
 	Params   map[string]interface{} `json:"parameters,omitempty"`
-	Tags     []string               `json:"tags"`
+	Tags     *[]string              `json:"tags,omitempty"`
 }
 
 type ServiceInstanceFields struct {


### PR DESCRIPTION
## Does this PR modify CLI v6 or v7?

V6

## Description of the Change

The update-service command was removing the tags on service when no tags were provided. Correct this issue and allow the users to keep the tags without providing them on every invocation.


## Why Is This PR Valuable?

This corrects a bug. 

## Why Should This Be In Core?

This is a bug in the core

## Applicable Issues

#1913 

## How Urgent Is The Change?

Not urgent

## Other Relevant Parties

N/A
