### PR TITLE
Internals: JSONry should maintain field name case

### DIFF
--- a/api/cloudcontroller/ccv3/service_broker.go
+++ b/api/cloudcontroller/ccv3/service_broker.go
@@ -13,13 +13,13 @@ import (
 // ServiceBroker represents Service Broker data
 type ServiceBroker struct {
 	// GUID is a unique service broker identifier.
-	GUID string
+	GUID string `json:"guid"`
 	// Name is the name of the service broker.
-	Name string
+	Name string `json:"name"`
 	// URL is the url of the service broker.
-	URL string
+	URL string `json:"url"`
 
-	Metadata *resources.Metadata
+	Metadata *resources.Metadata `json:"metadata"`
 }
 
 func (s *ServiceBroker) UnmarshalJSON(data []byte) error {

--- a/api/cloudcontroller/ccv3/service_offering.go
+++ b/api/cloudcontroller/ccv3/service_offering.go
@@ -10,17 +10,17 @@ import (
 // ServiceOffering represents a Cloud Controller V3 Service Offering.
 type ServiceOffering struct {
 	// GUID is a unique service offering identifier.
-	GUID string
+	GUID string `json:"guid"`
 	// Name is the name of the service offering.
-	Name string
+	Name string `json:"name"`
 	// ServiceBrokerName is the name of the service broker
 	ServiceBrokerName string
 	// ServiceBrokerGUID is the guid of the service broker
 	ServiceBrokerGUID string `jsonry:"relationships.service_broker.data.guid"`
 	// Description of the service offering
-	Description string
+	Description string `json:"description"`
 
-	Metadata *resources.Metadata
+	Metadata *resources.Metadata `json:"metadata"`
 }
 
 func (so *ServiceOffering) UnmarshalJSON(data []byte) error {

--- a/api/cloudcontroller/ccv3/service_plan.go
+++ b/api/cloudcontroller/ccv3/service_plan.go
@@ -11,15 +11,15 @@ import (
 // ServicePlan represents a Cloud Controller V3 Service Plan.
 type ServicePlan struct {
 	// GUID is a unique service plan identifier.
-	GUID string
+	GUID string `json:"guid"`
 	// Name is the name of the service plan.
-	Name string
+	Name string `json:"name"`
 	// Description of the Service Plan.
-	Description string
+	Description string `json:"description"`
 	// VisibilityType can be "public", "admin", "organization" or "space"
 	VisibilityType VisibilityType `json:"visibility_type"`
 	// Free shows whether or not the Service Plan is free of charge.
-	Free bool
+	Free bool `json:"free"`
 	// Cost shows the cost of a paid service plan
 	Costs []Cost `json:"costs"`
 	// ServicePlanGUID is the GUID of the service offering
@@ -27,7 +27,7 @@ type ServicePlan struct {
 	// SpaceGUID is the space that a plan from a space-scoped broker relates to
 	SpaceGUID string `jsonry:"relationships.space.data.guid"`
 
-	Metadata *resources.Metadata
+	Metadata *resources.Metadata `json:"metadata"`
 }
 
 func (sp *ServicePlan) UnmarshalJSON(data []byte) error {

--- a/api/cloudcontroller/jsonry/jsonry.go
+++ b/api/cloudcontroller/jsonry/jsonry.go
@@ -40,7 +40,7 @@ func computePath(field reflect.StructField) jsonryPath {
 
 		jsonry := parts[0]
 		if len(jsonry) == 0 {
-			jsonry = strings.ToLower(field.Name)
+			jsonry = field.Name
 		}
 
 		var elements []pathElement
@@ -63,5 +63,5 @@ func computePath(field reflect.StructField) jsonryPath {
 		}
 	}
 
-	return jsonryPath{elements: []pathElement{{name: strings.ToLower(field.Name)}}}
+	return jsonryPath{elements: []pathElement{{name: field.Name}}}
 }

--- a/api/cloudcontroller/jsonry/marshal_test.go
+++ b/api/cloudcontroller/jsonry/marshal_test.go
@@ -13,7 +13,7 @@ var _ = Describe("Marshal", func() {
 
 		json, err := jsonry.Marshal(s)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(json).To(MatchJSON(`{"foo": "works"}`))
+		Expect(json).To(MatchJSON(`{"Foo": "works"}`))
 	})
 
 	It("reads `json` and `jsonry` tags", func() {
@@ -29,7 +29,7 @@ var _ = Describe("Marshal", func() {
 
 		json, err := jsonry.Marshal(s)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(json).To(MatchJSON(`{"foo": "JSON", "bar": "JSONry", "c": "inference"}`))
+		Expect(json).To(MatchJSON(`{"foo": "JSON", "bar": "JSONry", "C": "inference"}`))
 	})
 
 	It("marshals from a struct pointer", func() {
@@ -37,7 +37,7 @@ var _ = Describe("Marshal", func() {
 
 		json, err := jsonry.Marshal(&s)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(json).To(MatchJSON(`{"foo": "struct pointer works"}`))
+		Expect(json).To(MatchJSON(`{"Foo": "struct pointer works"}`))
 	})
 
 	It("marshals from a pointer field", func() {
@@ -46,7 +46,7 @@ var _ = Describe("Marshal", func() {
 
 		json, err := jsonry.Marshal(s)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(json).To(MatchJSON(`{"a": "pointer works", "b": null}`))
+		Expect(json).To(MatchJSON(`{"A": "pointer works", "B": null}`))
 	})
 
 	It("marshals lists", func() {
@@ -62,7 +62,7 @@ var _ = Describe("Marshal", func() {
 
 		json, err := jsonry.Marshal(s)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(json).To(MatchJSON(`{"a": ["q", "w", "e"], "b": ["r", "t", "y"], "c": [1, 2, 3]}`))
+		Expect(json).To(MatchJSON(`{"A": ["q", "w", "e"], "B": ["r", "t", "y"], "C": [1, 2, 3]}`))
 	})
 
 	It("marshals into nested JSON", func() {
@@ -115,7 +115,7 @@ var _ = Describe("Marshal", func() {
 			Baz: &s{Foo: "pointer recursion works"},
 		}
 
-		e := `{"bar": {"foo": "recursion works"}, "baz": {"foo": "pointer recursion works"}}`
+		e := `{"Bar": {"Foo": "recursion works"}, "Baz": {"Foo": "pointer recursion works"}}`
 
 		json, err := jsonry.Marshal(t)
 		Expect(err).NotTo(HaveOccurred())
@@ -140,7 +140,7 @@ var _ = Describe("Marshal", func() {
 		t.C = &c
 		json, err = jsonry.Marshal(t)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(json).To(MatchJSON(`{"a": "AA", "bee": "BB", "c": "foo"}`))
+		Expect(json).To(MatchJSON(`{"A": "AA", "bee": "BB", "c": "foo"}`))
 	})
 
 	It("marshals a realistic object", func() {
@@ -175,7 +175,7 @@ var _ = Describe("Marshal", func() {
 
 		e := `
 	   {
-			"name": "foo",
+			"Name": "foo",
 			"guid": "long-guid",
 			"url": "https://foo.com",
 			"authentication": {
@@ -208,19 +208,19 @@ var _ = Describe("Marshal", func() {
 	When("there is a type mismatch", func() {
 		It("fails for simple types", func() {
 			var s struct{ S int }
-			err := jsonry.Unmarshal([]byte(`{"s": "hello"}`), &s)
+			err := jsonry.Unmarshal([]byte(`{"S": "hello"}`), &s)
 			Expect(err).To(MatchError("could not convert value 'hello' type 'string' to 'int' for field 'S'"))
 		})
 
 		It("fails when the field expects a list", func() {
 			var s struct{ S []string }
-			err := jsonry.Unmarshal([]byte(`{"s": "hello"}`), &s)
+			err := jsonry.Unmarshal([]byte(`{"S": "hello"}`), &s)
 			Expect(err).To(MatchError(`could not convert value 'hello' type 'string' to '[]string' for field 'S' because it is not a list type`))
 		})
 
 		It("fails for elements in a list", func() {
 			var s struct{ S []int }
-			err := jsonry.Unmarshal([]byte(`{"s": [4, "hello"]}`), &s)
+			err := jsonry.Unmarshal([]byte(`{"S": [4, "hello"]}`), &s)
 			Expect(err).To(MatchError(`could not convert value 'hello' type 'string' to 'int' for field 'S' index 1`))
 		})
 	})
@@ -228,14 +228,14 @@ var _ = Describe("Marshal", func() {
 	Context("numbers", func() {
 		It("can unmarshal an int", func() {
 			var s struct{ I int }
-			err := jsonry.Unmarshal([]byte(`{"i": 42}`), &s)
+			err := jsonry.Unmarshal([]byte(`{"I": 42}`), &s)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(s.I).To(Equal(42))
 		})
 
 		It("fails when the JSON value is not an int", func() {
 			var s struct{ I int }
-			err := jsonry.Unmarshal([]byte(`{"i": "stuffs"}`), &s)
+			err := jsonry.Unmarshal([]byte(`{"I": "stuffs"}`), &s)
 			Expect(err).To(MatchError("could not convert value 'stuffs' type 'string' to 'int' for field 'I'"))
 		})
 	})
@@ -243,7 +243,7 @@ var _ = Describe("Marshal", func() {
 	Context("the special map[string]types.NullString", func() {
 		It("can unmarshal a map", func() {
 			var s struct{ M map[string]types.NullString }
-			err := jsonry.Unmarshal([]byte(`{"m": {"foo": "bar", "baz": null}}`), &s)
+			err := jsonry.Unmarshal([]byte(`{"M": {"foo": "bar", "baz": null}}`), &s)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(s.M).To(Equal(map[string]types.NullString{
 				"foo": types.NewNullString("bar"),
@@ -253,7 +253,7 @@ var _ = Describe("Marshal", func() {
 
 		It("can unmarshal a pointer to a map", func() {
 			var s struct{ M *map[string]types.NullString }
-			err := jsonry.Unmarshal([]byte(`{"m": {"foo": "bar", "baz": null}}`), &s)
+			err := jsonry.Unmarshal([]byte(`{"M": {"foo": "bar", "baz": null}}`), &s)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(s.M).To(Equal(&map[string]types.NullString{
 				"foo": types.NewNullString("bar"),

--- a/api/cloudcontroller/jsonry/unmarshal_test.go
+++ b/api/cloudcontroller/jsonry/unmarshal_test.go
@@ -12,7 +12,7 @@ var _ = Describe("Unmarshal", func() {
 	It("unmarshals a field", func() {
 		var s struct{ Foo string }
 
-		err := jsonry.Unmarshal([]byte(`{"foo": "works"}`), &s)
+		err := jsonry.Unmarshal([]byte(`{"Foo": "works"}`), &s)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(s.Foo).To(Equal("works"))
 	})
@@ -24,7 +24,7 @@ var _ = Describe("Unmarshal", func() {
 			C string
 		}
 
-		data := `{"foo": "JSON", "bar": "JSONry", "c": "inference"}`
+		data := `{"foo": "JSON", "bar": "JSONry", "C": "inference"}`
 
 		err := jsonry.Unmarshal([]byte(data), &s)
 		Expect(err).NotTo(HaveOccurred())
@@ -36,7 +36,7 @@ var _ = Describe("Unmarshal", func() {
 	It("unmarshals into a pointer", func() {
 		var s struct{ A *string }
 
-		err := jsonry.Unmarshal([]byte(`{"a": "pointer works"}`), &s)
+		err := jsonry.Unmarshal([]byte(`{"A": "pointer works"}`), &s)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(s.A).To(PointTo(Equal("pointer works")))
 	})
@@ -48,7 +48,7 @@ var _ = Describe("Unmarshal", func() {
 			C []int
 		}
 
-		data := `{"a": ["q", "w", "e"], "b": ["r", "t", "y"], "c": [1, 2, 3]}`
+		data := `{"A": ["q", "w", "e"], "B": ["r", "t", "y"], "C": [1, 2, 3]}`
 		err := jsonry.Unmarshal([]byte(data), &s)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(s.A).To(Equal([]string{"q", "w", "e"}))
@@ -67,7 +67,7 @@ var _ = Describe("Unmarshal", func() {
 			A []T
 		}
 
-		data := `{"p":"baz", "a": [ {"d": "foo", "e": 123}, {"d": "bar", "e": 1} ]}`
+		data := `{"P":"baz", "A": [ {"d": "foo", "e": 123}, {"d": "bar", "e": 1} ]}`
 
 		err := jsonry.Unmarshal([]byte(data), &s)
 
@@ -111,7 +111,7 @@ var _ = Describe("Unmarshal", func() {
 			Baz *s
 		}
 
-		data := `{"bar": {"foo": "recursion works"}, "baz": {"foo": "pointer recursion works"}}`
+		data := `{"Bar": {"Foo": "recursion works"}, "Baz": {"Foo": "pointer recursion works"}}`
 
 		err := jsonry.Unmarshal([]byte(data), &t)
 		Expect(err).NotTo(HaveOccurred())
@@ -126,7 +126,7 @@ var _ = Describe("Unmarshal", func() {
 			B *rope
 		}
 
-		err := jsonry.Unmarshal([]byte(`{"a": "foo", "b": "bar"}`), &s)
+		err := jsonry.Unmarshal([]byte(`{"A": "foo", "B": "bar"}`), &s)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(s.A).To(Equal(rope("foo")))
 		Expect(s.B).To(PointTo(Equal(rope("bar"))))
@@ -151,7 +151,7 @@ var _ = Describe("Unmarshal", func() {
 
 		data := `
         {
-			"name": "foo",
+			"Name": "foo",
 			"guid": "long-guid",
 			"url": "https://foo.com",
 			"authentication": {
@@ -199,26 +199,26 @@ var _ = Describe("Unmarshal", func() {
 	When("there is a type mismatch", func() {
 		It("fails for simple types", func() {
 			var s struct{ S int }
-			err := jsonry.Unmarshal([]byte(`{"s": "hello"}`), &s)
+			err := jsonry.Unmarshal([]byte(`{"S": "hello"}`), &s)
 			Expect(err).To(MatchError("could not convert value 'hello' type 'string' to 'int' for field 'S'"))
 		})
 
 		It("fails when the field expects a list", func() {
 			var s struct{ S []string }
-			err := jsonry.Unmarshal([]byte(`{"s": "hello"}`), &s)
+			err := jsonry.Unmarshal([]byte(`{"S": "hello"}`), &s)
 			Expect(err).To(MatchError(`could not convert value 'hello' type 'string' to '[]string' for field 'S' because it is not a list type`))
 		})
 
 		It("fails for elements in a list", func() {
 			var s struct{ S []int }
-			err := jsonry.Unmarshal([]byte(`{"s": [4, "hello"]}`), &s)
+			err := jsonry.Unmarshal([]byte(`{"S": [4, "hello"]}`), &s)
 			Expect(err).To(MatchError(`could not convert value 'hello' type 'string' to 'int' for field 'S' index 1`))
 		})
 
 		When("in a list of structs", func() {
 			It("fails when its not a struct", func() {
 				var s struct{ S []struct{ A string } }
-				err := jsonry.Unmarshal([]byte(`{"s": ["123"]}`), &s)
+				err := jsonry.Unmarshal([]byte(`{"S": ["123"]}`), &s)
 				Expect(err).To(MatchError(`could not convert value '123' type 'string' to 'struct { A string }' for field 'S' index 0`))
 			})
 
@@ -228,7 +228,7 @@ var _ = Describe("Unmarshal", func() {
 						A bool
 					}
 				}
-				err := jsonry.Unmarshal([]byte(`{"s": [{"b": "123"}]}`), &s)
+				err := jsonry.Unmarshal([]byte(`{"S": [{"b": "123"}]}`), &s)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(s.S[0].A).To(BeFalse())
 			})
@@ -238,7 +238,7 @@ var _ = Describe("Unmarshal", func() {
 	Context("numbers", func() {
 		It("can unmarshal an int", func() {
 			var s struct{ I int }
-			err := jsonry.Unmarshal([]byte(`{"i": 42}`), &s)
+			err := jsonry.Unmarshal([]byte(`{"I": 42}`), &s)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(s.I).To(Equal(42))
 		})
@@ -246,7 +246,7 @@ var _ = Describe("Unmarshal", func() {
 		It("can unmarshal a float", func() {
 			var s struct{ F float64 }
 
-			err := jsonry.Unmarshal([]byte(`{"f": 42.02}`), &s)
+			err := jsonry.Unmarshal([]byte(`{"F": 42.02}`), &s)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(s.F).To(Equal(42.02))
@@ -254,7 +254,7 @@ var _ = Describe("Unmarshal", func() {
 
 		It("fails when the JSON value is not an int", func() {
 			var s struct{ I int }
-			err := jsonry.Unmarshal([]byte(`{"i": "stuffs"}`), &s)
+			err := jsonry.Unmarshal([]byte(`{"I": "stuffs"}`), &s)
 			Expect(err).To(MatchError("could not convert value 'stuffs' type 'string' to 'int' for field 'I'"))
 		})
 	})
@@ -262,7 +262,7 @@ var _ = Describe("Unmarshal", func() {
 	Context("the special map[string]types.NullString", func() {
 		It("can unmarshal a map", func() {
 			var s struct{ M map[string]types.NullString }
-			err := jsonry.Unmarshal([]byte(`{"m": {"foo": "bar", "baz": null}}`), &s)
+			err := jsonry.Unmarshal([]byte(`{"M": {"foo": "bar", "baz": null}}`), &s)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(s.M).To(Equal(map[string]types.NullString{
 				"foo": types.NewNullString("bar"),
@@ -272,7 +272,7 @@ var _ = Describe("Unmarshal", func() {
 
 		It("can unmarshal a pointer to a map", func() {
 			var s struct{ M *map[string]types.NullString }
-			err := jsonry.Unmarshal([]byte(`{"m": {"foo": "bar", "baz": null}}`), &s)
+			err := jsonry.Unmarshal([]byte(`{"M": {"foo": "bar", "baz": null}}`), &s)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(s.M).To(Equal(&map[string]types.NullString{
 				"foo": types.NewNullString("bar"),


### PR DESCRIPTION
- When the Go json parser infers a JSON key from a field name it
maintains the case
- When the JSONry parser infers a JSON key from a field name it converts
it to lower case
- It makes sense for the parsers to work in a consistent way, and the Go
parser sets the precedent, which it makes sense to follow