### PR TITLE
Add inactive column to cf m output when looking at a particular offering

### DIFF
--- a/api/cloudcontroller/ccv3/service_plan.go
+++ b/api/cloudcontroller/ccv3/service_plan.go
@@ -15,6 +15,8 @@ type ServicePlan struct {
 	Name string `json:"name"`
 	// Description of the Service Plan.
 	Description string `json:"description"`
+	// Whether the Service Plan is available
+	Available bool `json:"available"`
 	// VisibilityType can be "public", "admin", "organization" or "space"
 	VisibilityType VisibilityType `json:"visibility_type"`
 	// Free shows whether or not the Service Plan is free of charge.

--- a/api/cloudcontroller/ccv3/service_plan_test.go
+++ b/api/cloudcontroller/ccv3/service_plan_test.go
@@ -46,6 +46,7 @@ var _ = Describe("Service Plan", func() {
 								"guid": "service-plan-1-guid",
 								"name": "service-plan-1-name",
 								"description": "service-plan-1-description",
+                                "available": true,
 								"free": true,
 								"visibility_type": "public",
 								"relationships": {
@@ -59,6 +60,7 @@ var _ = Describe("Service Plan", func() {
 							{
 								"guid": "service-plan-2-guid",
 								"name": "service-plan-2-name",
+								"available": false,
 								"visibility_type": "admin",
 								"description": "service-plan-2-description",
 								"free": false,
@@ -87,6 +89,7 @@ var _ = Describe("Service Plan", func() {
 								"name": "service-plan-3-name",
 								"visibility_type": "organization",
 								"description": "service-plan-3-description",
+                                "available": true,
 								"free": true,
 								"relationships": {
 									"service_offering": {
@@ -134,6 +137,7 @@ var _ = Describe("Service Plan", func() {
 						GUID:                "service-plan-1-guid",
 						Name:                "service-plan-1-name",
 						Description:         "service-plan-1-description",
+						Available:           true,
 						Free:                true,
 						VisibilityType:      "public",
 						ServiceOfferingGUID: "79d428b9-75b4-44db-addf-19c85c7f0f1e",
@@ -142,6 +146,7 @@ var _ = Describe("Service Plan", func() {
 						GUID:                "service-plan-2-guid",
 						Name:                "service-plan-2-name",
 						Description:         "service-plan-2-description",
+						Available:           false,
 						Free:                false,
 						VisibilityType:      "admin",
 						ServiceOfferingGUID: "69d428b9-75b4-44db-addf-19c85c7f0f1e",
@@ -150,6 +155,7 @@ var _ = Describe("Service Plan", func() {
 						GUID:                "service-plan-3-guid",
 						Name:                "service-plan-3-name",
 						Description:         "service-plan-3-description",
+						Available:           true,
 						Free:                true,
 						VisibilityType:      "organization",
 						ServiceOfferingGUID: "59d428b9-75b4-44db-addf-19c85c7f0f1e",
@@ -437,6 +443,7 @@ var _ = Describe("Service Plan", func() {
 								"guid": "service-plan-1-guid",
 								"name": "service-plan-1-name",
 								"description": "service-plan-1-description",
+								"available": true,
 								"free": true,
 								"relationships": {
 									"service_offering": {
@@ -450,6 +457,7 @@ var _ = Describe("Service Plan", func() {
 								"guid": "service-plan-2-guid",
 								"name": "service-plan-2-name",
 								"description": "service-plan-2-description",
+								"available": false,
 								"free": false,
 								"costs": [
 									{
@@ -538,6 +546,7 @@ var _ = Describe("Service Plan", func() {
 								"guid": "service-plan-3-guid",
 								"name": "service-plan-3-name",
 								"description": "service-plan-3-description",
+								"available": true,
 								"free": true,
 								"relationships": {
 									"service_offering": {
@@ -609,6 +618,7 @@ var _ = Describe("Service Plan", func() {
 								GUID:                "service-plan-1-guid",
 								Name:                "service-plan-1-name",
 								Description:         "service-plan-1-description",
+								Available:           true,
 								Free:                true,
 								ServiceOfferingGUID: "79d428b9-75b4-44db-addf-19c85c7f0f1e",
 							},
@@ -616,6 +626,7 @@ var _ = Describe("Service Plan", func() {
 								GUID:                "service-plan-3-guid",
 								Name:                "service-plan-3-name",
 								Description:         "service-plan-3-description",
+								Available:           true,
 								Free:                true,
 								ServiceOfferingGUID: "79d428b9-75b4-44db-addf-19c85c7f0f1e",
 							},
@@ -630,6 +641,7 @@ var _ = Describe("Service Plan", func() {
 							{
 								GUID:        "service-plan-2-guid",
 								Name:        "service-plan-2-name",
+								Available:   false,
 								Description: "service-plan-2-description",
 								Free:        false,
 								Costs: []Cost{

--- a/command/v7/marketplace_command.go
+++ b/command/v7/marketplace_command.go
@@ -119,9 +119,9 @@ func (cmd MarketplaceCommand) displayMessage(username string) {
 
 func (cmd MarketplaceCommand) displayPlansTable(offerings []v7action.ServiceOfferingWithPlans) error {
 	for _, o := range offerings {
-		data := [][]string{{"plan", "description", "free or paid", "costs"}}
+		data := [][]string{{"plan", "description", "free or paid", "costs", "available"}}
 		for _, p := range o.Plans {
-			data = append(data, []string{p.Name, p.Description, freeOrPaid(p.Free), costsList(p.Costs)})
+			data = append(data, []string{p.Name, p.Description, freeOrPaid(p.Free), costsList(p.Costs), available(p.Available)})
 		}
 
 		cmd.UI.DisplayNewline()
@@ -179,6 +179,13 @@ func freeOrPaid(free bool) string {
 		return "free"
 	}
 	return "paid"
+}
+
+func available(available bool) string {
+	if available {
+		return "yes"
+	}
+	return "no"
 }
 
 func costsList(costs []ccv3.Cost) string {

--- a/command/v7/marketplace_command_test.go
+++ b/command/v7/marketplace_command_test.go
@@ -449,6 +449,7 @@ var _ = Describe("marketplace command", func() {
 									GUID:        "plan-guid-1",
 									Name:        "plan-1",
 									Description: "best available plan",
+									Available:   true,
 									Free:        true,
 								},
 							},
@@ -463,6 +464,7 @@ var _ = Describe("marketplace command", func() {
 									GUID:        "plan-guid-2",
 									Name:        "plan-2",
 									Description: "just another plan",
+									Available:   true,
 									Free:        false,
 									Costs: []ccv3.Cost{
 										{
@@ -478,14 +480,16 @@ var _ = Describe("marketplace command", func() {
 									},
 								},
 								{
-									GUID: "plan-guid-3",
-									Name: "plan-3",
-									Free: true,
+									GUID:      "plan-guid-3",
+									Name:      "plan-3",
+									Free:      true,
+									Available: false,
 								},
 								{
-									GUID: "plan-guid-4",
-									Name: "plan-4",
-									Free: false,
+									GUID:      "plan-guid-4",
+									Name:      "plan-4",
+									Free:      false,
+									Available: true,
 								},
 							},
 						},
@@ -500,14 +504,14 @@ var _ = Describe("marketplace command", func() {
 
 				Expect(testUI.Out).To(Say(`\n\n`))
 				Expect(testUI.Out).To(Say(`broker: service-broker-1`))
-				Expect(testUI.Out).To(Say(`plan\s+description\s+free or paid\s+cost`))
-				Expect(testUI.Out).To(Say(`plan-1\s+best available plan\s+free`))
+				Expect(testUI.Out).To(Say(`plan\s+description\s+free or paid\s+costs\s+available`))
+				Expect(testUI.Out).To(Say(`plan-1\s+best available plan\s+free\s+yes`))
 				Expect(testUI.Out).To(Say(`\n\n`))
 				Expect(testUI.Out).To(Say(`broker: service-broker-2`))
-				Expect(testUI.Out).To(Say(`plan\s+description\s+free or paid\s+cost`))
-				Expect(testUI.Out).To(Say(`plan-2\s+just another plan\s+paid\s+USD 100.00/Monthly, USD 1.00/1GB of messages over 20GB`))
-				Expect(testUI.Out).To(Say(`plan-3\s+free`))
-				Expect(testUI.Out).To(Say(`plan-4\s+paid`))
+				Expect(testUI.Out).To(Say(`plan\s+description\s+free or paid\s+costs\s+available`))
+				Expect(testUI.Out).To(Say(`plan-2\s+just another plan\s+paid\s+USD 100.00/Monthly, USD 1.00/1GB of messages over 20GB\s+yes`))
+				Expect(testUI.Out).To(Say(`plan-3\s+free\s+no`))
+				Expect(testUI.Out).To(Say(`plan-4\s+paid\s+yes`))
 
 				Expect(testUI.Err).To(Say("warning 1"))
 				Expect(testUI.Err).To(Say("warning 2"))

--- a/integration/v7/isolated/marketplace_command_test.go
+++ b/integration/v7/isolated/marketplace_command_test.go
@@ -240,8 +240,8 @@ var _ = Describe("marketplace command", func() {
 					Expect(session).To(Say(`Getting service plan information for service offering %s from service broker %s\.\.\.`, broker2.Services[0].Name, broker2.Name))
 					Expect(session).To(Say(`\n\n`))
 					Expect(session).To(Say(`broker: %s`, broker2.Name))
-					Expect(session).To(Say(`plan\s+description\s+free or paid\s+cost`))
-					Expect(session).To(Say(`%s\s+%s\s+%s`, broker2.Services[0].Plans[2].Name, broker2.Services[0].Plans[2].Description, "free"))
+					Expect(session).To(Say(`plan\s+description+\s+free or paid\s+costs\s+available`))
+					Expect(session).To(Say(`%s\s+%s\s+%s\s+%s`, broker2.Services[0].Plans[2].Name, broker2.Services[0].Plans[2].Description, "free", "yes"))
 
 					Expect(string(session.Out.Contents())).NotTo(SatisfyAny(
 						ContainSubstring(broker1.Name),
@@ -274,8 +274,8 @@ var _ = Describe("marketplace command", func() {
 					Expect(session).To(Say(`Getting service plan information for service offering %s from service broker %s in org %s / space %s as %s\.\.\.`, broker2.Services[0].Name, broker2.Name, org1, space1, username))
 					Expect(session).To(Say(`\n\n`))
 					Expect(session).To(Say(`broker: %s`, broker2.Name))
-					Expect(session).To(Say(`plan\s+description\s+free or paid\s+cost`))
-					Expect(session).To(Say(`%s\s+%s\s+%s`, broker2.Services[0].Plans[2].Name, broker2.Services[0].Plans[2].Description, "free"))
+					Expect(session).To(Say(`plan\s+description\s+free or paid\s+costs\s+available`))
+					Expect(session).To(Say(`%s\s+%s\s+%s\s+%s`, broker2.Services[0].Plans[2].Name, broker2.Services[0].Plans[2].Description, "free", "yes"))
 
 					Expect(string(session.Out.Contents())).NotTo(SatisfyAny(
 						ContainSubstring(broker1.Name),
@@ -290,14 +290,14 @@ var _ = Describe("marketplace command", func() {
 func expectMarketplaceServiceOfferingOutput(session *Session, broker2, broker3 *servicebrokerstub.ServiceBrokerStub) {
 	Expect(session).To(Say(`\n\n`))
 	Expect(session).To(Say(`broker: %s`, broker2.Name))
-	Expect(session).To(Say(`plan\s+description\s+free or paid\s+cost`))
-	Expect(session).To(Say(`%s\s+%s\s+%s`, broker2.Services[0].Plans[2].Name, broker2.Services[0].Plans[2].Description, "free"))
+	Expect(session).To(Say(`plan\s+description\s+free or paid\s+costs\s+available`))
+	Expect(session).To(Say(`%s\s+%s\s+%s\s+%s`, broker2.Services[0].Plans[2].Name, broker2.Services[0].Plans[2].Description, "free", "yes"))
 
 	Expect(session).To(Say(`\n\n`))
 	Expect(session).To(Say(`broker: %s`, broker3.Name))
-	Expect(session).To(Say(`plan\s+description\s+free or paid\s+cost`))
-	Expect(session).To(Say(`%s\s+%s\s+%s\s+%s`, broker3.Services[0].Plans[0].Name, broker3.Services[0].Plans[0].Description, "paid", "GBP 600.00/MONTHLY, USD 649.00/MONTHLY, USD 1.00/1GB of messages over 20GB"))
-	Expect(session).To(Say(`%s\s+%s\s+%s`, broker3.Services[0].Plans[1].Name, broker3.Services[0].Plans[1].Description, "paid"))
+	Expect(session).To(Say(`plan\s+description\s+free or paid\s+costs\s+available`))
+	Expect(session).To(Say(`%s\s+%s\s+%s\s+%s\s+%s`, broker3.Services[0].Plans[0].Name, broker3.Services[0].Plans[0].Description, "paid", "GBP 600.00/MONTHLY, USD 649.00/MONTHLY, USD 1.00/1GB of messages over 20GB", "yes"))
+	Expect(session).To(Say(`%s\s+%s\s+%s\s+%s`, broker3.Services[0].Plans[1].Name, broker3.Services[0].Plans[1].Description, "paid", "yes"))
 }
 
 func planNamesOf(broker *servicebrokerstub.ServiceBrokerStub) string {


### PR DESCRIPTION
[#153290488](https://www.pivotaltracker.com/story/show/153290488)

When doing cf m -e overview-service, one extra `available` column is display with a yes/no flag 