### PR TITLE
Add buildpack details to cf7 app summary

### DIFF
--- a/command/v7/shared/app_summary_displayer.go
+++ b/command/v7/shared/app_summary_displayer.go
@@ -146,31 +146,39 @@ func (display AppSummaryDisplayer) getCreatedTime(summary v7action.DetailedAppli
 	return ""
 }
 
-func (AppSummaryDisplayer) buildpackInfo(buildpacks []resources.DropletBuildpack) (string, string, string) {
+func (display AppSummaryDisplayer) buildpackInfo(buildpacks []resources.DropletBuildpack) (string, string, string) {
 	var names []string
 	var versions []string
 	var userProvidedNames []string
 
 	for _, buildpack := range buildpacks {
-		if buildpack.DetectOutput != "" {
-			names = append(names, buildpack.DetectOutput)
-			buildpackVersion := []string{buildpack.DetectOutput, buildpack.Version}
-			if buildpack.Version != "" {
-				versions = append(versions, strings.Join(buildpackVersion, " "))
-			} else {
-				versions = append(versions, buildpack.DetectOutput)
-			}
-		} else {
-			names = append(names, buildpack.Name)
-			versions = append(versions, buildpack.Name)
-		}
+		name := display.buildpackName(buildpack)
+		names = append(names, name)
+		versions = append(versions, display.buildpackVersion(name, buildpack.Version))
+
 		userProvidedNames = append(userProvidedNames, buildpack.Name)
 	}
 
 	detectedNamesString := strings.Join(names, ", ")
 	versionsString := strings.TrimSpace(strings.Join(versions, ", "))
-	userProvidedNamesString:= strings.TrimSpace(strings.Join(userProvidedNames, ", "))
+	userProvidedNamesString := strings.TrimSpace(strings.Join(userProvidedNames, ", "))
 	return detectedNamesString, versionsString, userProvidedNamesString
+}
+
+func (AppSummaryDisplayer) buildpackName(buildpack resources.DropletBuildpack) string {
+	if buildpack.BuildpackName != "" {
+		return buildpack.BuildpackName
+	}
+
+	return buildpack.Name
+}
+
+func (AppSummaryDisplayer) buildpackVersion(name, version string) string {
+	if version == "" {
+		return name
+	}
+
+	return strings.Join([]string{name, version}, " ")
 }
 
 func (AppSummaryDisplayer) appInstanceDate(input time.Time) string {

--- a/command/v7/shared/app_summary_displayer_test.go
+++ b/command/v7/shared/app_summary_displayer_test.go
@@ -549,6 +549,12 @@ var _ = Describe("app summary displayer", func() {
 							{
 								Name:         "ruby_buildpack",
 								DetectOutput: "some-detect-output",
+								Version: "0.0.1",
+							},
+							{
+								Name: "go_buildpack_without_version",
+								DetectOutput: "some-other-detect-output",
+								Version: "",
 							},
 							{
 								Name:         "some-buildpack",
@@ -561,7 +567,9 @@ var _ = Describe("app summary displayer", func() {
 
 			It("displays stack and buildpacks", func() {
 				Expect(testUI.Out).To(Say(`stack:\s+cflinuxfs2`))
-				Expect(testUI.Out).To(Say(`buildpacks:\s+some-detect-output, some-buildpack`))
+				Expect(testUI.Out).To(Say(`buildpacks:\s+some-detect-output, some-other-detect-output, some-buildpack`))
+				Expect(testUI.Out).To(Say(`buildpack versions:\s+some-detect-output 0.0.1, some-other-detect-output, some-buildpack`))
+				Expect(testUI.Out).To(Say(`buildpack names:\s+ruby_buildpack, go_buildpack_without_version, some-buildpack`))
 			})
 		})
 	})

--- a/command/v7/shared/app_summary_displayer_test.go
+++ b/command/v7/shared/app_summary_displayer_test.go
@@ -547,14 +547,22 @@ var _ = Describe("app summary displayer", func() {
 						Stack: "cflinuxfs2",
 						Buildpacks: []resources.DropletBuildpack{
 							{
-								Name:         "ruby_buildpack",
-								DetectOutput: "some-detect-output",
-								Version: "0.0.1",
+								Name:          "ruby_buildpack",
+								BuildpackName: "ruby_buildpack_name",
+								DetectOutput:  "some-detect-output",
+								Version:       "0.0.1",
 							},
 							{
-								Name: "go_buildpack_without_version",
-								DetectOutput: "some-other-detect-output",
-								Version: "",
+								Name:          "go_buildpack_without_detect_output",
+								BuildpackName: "go_buildpack_name",
+								DetectOutput:  "",
+								Version:       "0.0.2",
+							},
+							{
+								Name:          "go_buildpack_without_version",
+								BuildpackName: "go_buildpack_name",
+								DetectOutput:  "",
+								Version:       "",
 							},
 							{
 								Name:         "some-buildpack",
@@ -567,9 +575,9 @@ var _ = Describe("app summary displayer", func() {
 
 			It("displays stack and buildpacks", func() {
 				Expect(testUI.Out).To(Say(`stack:\s+cflinuxfs2`))
-				Expect(testUI.Out).To(Say(`buildpacks:\s+some-detect-output, some-other-detect-output, some-buildpack`))
-				Expect(testUI.Out).To(Say(`buildpack versions:\s+some-detect-output 0.0.1, some-other-detect-output, some-buildpack`))
-				Expect(testUI.Out).To(Say(`buildpack names:\s+ruby_buildpack, go_buildpack_without_version, some-buildpack`))
+				Expect(testUI.Out).To(Say(`buildpacks:\s+ruby_buildpack_name, go_buildpack_name, go_buildpack_name, some-buildpack`))
+				Expect(testUI.Out).To(Say(`buildpack versions:\s+ruby_buildpack_name 0.0.1, go_buildpack_name 0.0.2, go_buildpack_name, some-buildpack`))
+				Expect(testUI.Out).To(Say(`buildpack names:\s+ruby_buildpack, go_buildpack_without_detect_output, go_buildpack_without_version, some-buildpack`))
 			})
 		})
 	})

--- a/integration/v7/isolated/app_command_test.go
+++ b/integration/v7/isolated/app_command_test.go
@@ -80,6 +80,8 @@ var _ = Describe("app command", func() {
 					Eventually(session).Should(Say(`last uploaded:\s+\n`))
 					Eventually(session).Should(Say(`stack:\s+\n`))
 					Eventually(session).Should(Say(`buildpacks:\s+\n`))
+					Eventually(session).Should(Say(`buildpack versions:\s+\n`))
+					Eventually(session).Should(Say(`buildpack names:\s+\n`))
 					Eventually(session).Should(Exit(0))
 				})
 			})
@@ -128,6 +130,8 @@ applications:
 						Eventually(session).Should(Say(`last uploaded:\s+%s`, helpers.ReadableDateTimeRegex))
 						Eventually(session).Should(Say(`stack:\s+cflinuxfs`))
 						Eventually(session).Should(Say(`buildpacks:\s+staticfile`))
+						Eventually(session).Should(Say(`buildpack versions:\s+staticfile\s+[\d\.]+`))
+						Eventually(session).Should(Say(`buildpack names:\s+staticfile_buildpack`))
 						Eventually(session).Should(Say(`type:\s+web`))
 						Eventually(session).Should(Say(`instances:\s+\d/2`))
 						Eventually(session).Should(Say(`memory usage:\s+128M`))
@@ -236,7 +240,9 @@ applications:
 
 				It("displays the app buildpacks", func() {
 					session := helpers.CF("app", appName)
-					Eventually(session).Should(Say(`buildpacks:\s+ruby_buildpack,\s+go`))
+					Eventually(session).Should(Say(`buildpacks:\s+ruby,\s+go`))
+					Eventually(session).Should(Say(`buildpack versions:\s+ruby\s+[\d\.]+,\s+go\s+[\d\.]+`))
+					Eventually(session).Should(Say(`buildpack names:\s+ruby_buildpack,\s+go_buildpack`))
 					Eventually(session).Should(Exit(0))
 				})
 			})

--- a/resources/droplet_resource.go
+++ b/resources/droplet_resource.go
@@ -30,6 +30,8 @@ type DropletBuildpack struct {
 	Name string `json:"name"`
 	//DetectOutput is the output during buildpack detect process.
 	DetectOutput string `json:"detect_output"`
+	// Name reported by the buildpack
+	BuildpackName string `json:"buildpack_name"`
 	//Version is the version of the detected buildpack.
 	Version string `json:"version"`
 }

--- a/resources/droplet_resource.go
+++ b/resources/droplet_resource.go
@@ -26,8 +26,10 @@ type Droplet struct {
 // DropletBuildpack is the name and output of a buildpack used to create a
 // droplet.
 type DropletBuildpack struct {
-	// Name is the buildpack name.
+	// Name is the user-provided buildpack name.
 	Name string `json:"name"`
 	//DetectOutput is the output during buildpack detect process.
 	DetectOutput string `json:"detect_output"`
+	//Version is the version of the detected buildpack.
+	Version string `json:"version"`
 }


### PR DESCRIPTION
Co-authored-by: Piyali Banerjee <pbanerjee@pivotal.io>
Co-authored-by: Connor Braa <cbraa@pivotal.io>

Thank you for contributing to the CF CLI! Please read the following:


* If you haven't yet, please review our contributing guidelines: https://github.com/cloudfoundry/cli/blob/master/.github/CONTRIBUTING.md
* We're not allowed to accept any PRs without a signed CLA, no matter how small.
If your contribution falls under a company CLA but your membership is not public, expect delays while we confirm.
* All new code requires tests to protect against regressions.
* Contributions must confirm to our [style guide](https://github.com/cloudfoundry/cli/wiki/CLI-Product-Specific-Style-Guide). Please reach out to us if you have questions.


## Does this PR modify CLI v6 or v7?
 v7 

Please see the contribution doc above or review [Architecture Guide](https://github.com/cloudfoundry/cli/wiki/Architecture-Guide).

## Description of the Change and Value of PR
The app summary command sometimes lists buildpack names hardcoded in the buildpacks themselves (i.e.: "python" for any python buildpack). Since these names may be different from the user-provided names (for Custom Buildpacks), this may be confusing for users. This PR includes some additions to the buildpacks info in the app summary output to include the user-provided buildpack names as well as the buildpack versions if available. We kept the original `buildpacks` field the same in case other scripts rely on that already. 

Slack discussion with CLI team: https://cloudfoundry.slack.com/archives/C032824SM/p1593561984360700

## Why Should This Be In Core?

Explain why this functionality should be in the cf CLI, as opposed to a plugin. 
Having detailed buildpack information in the app summary output is valuable in general for debugging purposes, as well as for ensuring the correct buildpacks were used to build the app. 

## Applicable Issues

List any applicable Github Issues here

## How Urgent Is The Change?

Is the change urgent? If so, explain why it is time-sensitive.
No.
## Other Relevant Parties

Who else is affected by the change? 
