### PR TITLE
Fix version switching debian commands in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,10 +287,10 @@ Below you'll find instructions for each of the package managers we support.
 We're working on a robust soluiton that will faciliate more seamless switching via these package managers, but for now you must uninstall one version of the CLI and install the other version of the CLI to switch between them.
 - Currently on v6, want to switch to v7:
   - yum: `sudo yum remove cf-cli && sudo yum install cf7-cli && cf version`
-  - apt: `sudo apt-get remove cf-cli && sudo apt-get cf7-cli && cf version`
+  - apt: `sudo apt-get remove cf-cli && sudo apt-get install cf7-cli && cf version`
 - Currently on v7, want to switch to v6:
   - yum: `sudo yum remove cf7-cli && sudo yum install cf-cli && cf version`
-  - apt: `sudo apt-get remove cf7-cli && sudo apt-get cf-cli && cf version`
+  - apt: `sudo apt-get remove cf7-cli && sudo apt-get install cf-cli && cf version`
 
 #### Switching CLI Versions Pulled via GitHub or CLAW
 The following is a simple approach:


### PR DESCRIPTION

## Does this PR modify CLI v6 or v7?

only readme


## Description of the Change

Fix README.md

Was previously failing with output

```
$ sudo apt-get remove cf-cli && sudo apt-get cf7-cli && cf version
[...]
E: Invalid operation cf7-cli
```

## Why Is This PR Valuable?

ubuntu users fail to run switching commands

