### PR TITLE
v8(services): v3-update-service validations

### DIFF
--- a/command/v7/update_service_command.go
+++ b/command/v7/update_service_command.go
@@ -5,9 +5,7 @@ import (
 
 	"code.cloudfoundry.org/cli/actor/v7action"
 
-	"code.cloudfoundry.org/cli/actor/actionerror"
 	"code.cloudfoundry.org/cli/command/flag"
-	"code.cloudfoundry.org/cli/command/translatableerror"
 	"code.cloudfoundry.org/cli/types"
 )
 
@@ -46,17 +44,12 @@ func (cmd UpdateServiceCommand) Execute(args []string) error {
 		},
 	)
 	cmd.UI.DisplayWarnings(warnings)
-	switch err.(type) {
-	case nil:
-		cmd.UI.DisplayOK()
-		return nil
-	case actionerror.ServiceInstanceNotFoundError:
-		return translatableerror.ServiceInstanceNotFoundError{Name: cmd.RequiredArgs.ServiceInstance}
-	case actionerror.ServicePlanNotFoundError:
-		return translatableerror.ServicePlanNotFoundError{PlanName: cmd.Plan.Value}
-	default:
+	if err != nil {
 		return err
 	}
+
+	cmd.UI.DisplayOK()
+	return nil
 }
 
 func (cmd UpdateServiceCommand) Usage() string {

--- a/command/v7/update_service_command_test.go
+++ b/command/v7/update_service_command_test.go
@@ -157,14 +157,16 @@ var _ = Describe("update-service command", func() {
 				setFlag(&cmd, "-p", flag.OptionalString{IsSet: true, Value: invalidPlan})
 				fakeActor.UpdateManagedServiceInstanceReturns(
 					v7action.Warnings{"actor warning"},
-					actionerror.ServicePlanNotFoundError{PlanName: invalidPlan},
+					actionerror.ServicePlanNotFoundError{PlanName: invalidPlan, ServiceBrokerName: "the-broker", OfferingName: "the-offering"},
 				)
 			})
 
 			It("prints warnings and returns a translatable error", func() {
 				Expect(testUI.Err).To(Say("actor warning"))
-				Expect(executeErr).To(MatchError(translatableerror.ServicePlanNotFoundError{
-					PlanName: invalidPlan,
+				Expect(executeErr).To(MatchError(actionerror.ServicePlanNotFoundError{
+					PlanName:          invalidPlan,
+					OfferingName:      "the-offering",
+					ServiceBrokerName: "the-broker",
 				}))
 			})
 		})

--- a/integration/v7/isolated/update_service_command_test.go
+++ b/integration/v7/isolated/update_service_command_test.go
@@ -293,7 +293,7 @@ var _ = Describe("update-service command", func() {
 			Say(`\s+%s - Update a service instance\n`, command),
 			Say(`\n`),
 			Say(`USAGE:\n`),
-			Say(`\s+cf update-service SERVICE_INSTANCE \[-p NEW_PLAN\] \[-c PARAMETERS_AS_JSON\] \[-t TAGS\] \[--upgrade\]\n`),
+			Say(`\s+cf update-service SERVICE_INSTANCE \[-p NEW_PLAN\] \[-c PARAMETERS_AS_JSON\] \[-t TAGS\]\n`),
 			Say(`\n`),
 			Say(`\s+Optionally provide service-specific configuration parameters in a valid JSON object in-line:\n`),
 			Say(`\s+cf update-service SERVICE_INSTANCE -c '{\"name\":\"value\",\"name\":\"value\"}'\n`),
@@ -313,14 +313,10 @@ var _ = Describe("update-service command", func() {
 			Say(`\s+cf update-service mydb -c '{\"ram_gb\":4}'\n`),
 			Say(`\s+cf update-service mydb -c ~/workspace/tmp/instance_config.json\n`),
 			Say(`\s+cf update-service mydb -t "list, of, tags"\n`),
-			Say(`\s+cf update-service mydb --upgrade\n`),
-			Say(`\s+cf update-service mydb --upgrade --force\n`),
 			Say(`OPTIONS:\n`),
 			Say(`\s+-c\s+Valid JSON object containing service-specific configuration parameters, provided either in-line or in a file\. For a list of supported configuration parameters, see documentation for the particular service offering\.\n`),
 			Say(`\s+-p\s+Change service plan for a service instance\n`),
 			Say(`\s+-t\s+User provided tags\n`),
-			Say(`\s+--upgrade, -u\s+Upgrade the service instance to the latest version of the service plan available. It cannot be combined with flags: -c, -p, -t.\n`),
-			Say(`\s+--force, -f\s+Force the upgrade to the latest available version of the service plan. It can only be used with: -u, --upgrade.\n`),
 			Say(`SEE ALSO:\n`),
 			Say(`\s+rename-service, services, update-user-provided-service\n`),
 		)
@@ -517,6 +513,20 @@ var _ = Describe("update-service command", func() {
 					Eventually(session).Should(Exit(1))
 
 					Expect(session.Err).To(Say("Incorrect Usage: Invalid configuration provided for -c flag. Please provide a valid JSON object or path to a file containing a valid JSON object.\n"))
+				})
+			})
+
+			Describe("updating plan", func() {
+				const (
+					invalidPlan = "invalid-plan"
+				)
+
+				When("plan does not exist", func() {
+					It("displays an error and exits 1", func() {
+						session := helpers.CF(command, serviceInstanceName, "-p", invalidPlan)
+						Eventually(session).Should(Exit(1))
+						Expect(session.Err).To(Say("Service plan '%s' not found.", invalidPlan))
+					})
 				})
 			})
 		})

--- a/integration/v7/isolated/update_service_command_test.go
+++ b/integration/v7/isolated/update_service_command_test.go
@@ -432,7 +432,7 @@ var _ = Describe("update-service command", func() {
 			var broker *servicebrokerstub.ServiceBrokerStub
 
 			BeforeEach(func() {
-				broker = servicebrokerstub.New().WithAsyncDelay(time.Microsecond).EnableServiceAccess()
+				broker = servicebrokerstub.New().WithPlans(2).WithAsyncDelay(time.Microsecond).EnableServiceAccess()
 				helpers.CreateManagedServiceInstance(
 					broker.FirstServiceOfferingName(),
 					broker.FirstServicePlanName(),
@@ -517,15 +517,18 @@ var _ = Describe("update-service command", func() {
 			})
 
 			Describe("updating plan", func() {
-				const (
-					invalidPlan = "invalid-plan"
-				)
+				It("exits 0", func() {
+					session := helpers.CF(command, serviceInstanceName, "-p", broker.Services[0].Plans[1].Name)
+					Eventually(session).Should(Exit(0))
+				})
 
 				When("plan does not exist", func() {
+					const invalidPlan = "invalid-plan"
+
 					It("displays an error and exits 1", func() {
 						session := helpers.CF(command, serviceInstanceName, "-p", invalidPlan)
 						Eventually(session).Should(Exit(1))
-						Expect(session.Err).To(Say("Service plan '%s' not found.", invalidPlan))
+						Expect(session.Err).To(Say("The plan '%s' could not be found for service offering '%s' and broker '%s'.", invalidPlan, broker.Services[0].Name, broker.Name))
 					})
 				})
 			})


### PR DESCRIPTION
[#173416529](https://www.pivotaltracker.com/story/show/173416529)

A few notes:

1. Removed upgrade related flags as upgrade will be implemented as a separate command
2. At the actor, chose to not include the plan lookup as part of the railway function as it returns a different type of warnings and it is only executed if the `plan` was specified
