### PR TITLE
v8(services): v3-service cmd to show bound apps

### DIFF
--- a/actor/v7action/cloud_controller_client.go
+++ b/actor/v7action/cloud_controller_client.go
@@ -107,7 +107,7 @@ type CloudControllerClient interface {
 	GetRunningSecurityGroups(spaceGUID string, queries ...ccv3.Query) ([]resources.SecurityGroup, ccv3.Warnings, error)
 	GetSecurityGroups(query ...ccv3.Query) ([]resources.SecurityGroup, ccv3.Warnings, error)
 	GetServiceBrokers(query ...ccv3.Query) ([]resources.ServiceBroker, ccv3.Warnings, error)
-	GetServiceCredentialBindings(query ...ccv3.Query) ([]resources.ServiceCredentialBinding, ccv3.IncludedResources, ccv3.Warnings, error)
+	GetServiceCredentialBindings(query ...ccv3.Query) ([]resources.ServiceCredentialBinding, ccv3.Warnings, error)
 	GetServiceInstanceByNameAndSpace(name, spaceGUID string, query ...ccv3.Query) (resources.ServiceInstance, ccv3.IncludedResources, ccv3.Warnings, error)
 	GetServiceInstanceParameters(serviceInstanceGUID string) (types.OptionalObject, ccv3.Warnings, error)
 	GetServiceInstanceSharedSpaces(serviceInstanceGUID string) ([]resources.Space, ccv3.Warnings, error)

--- a/actor/v7action/service_instance_details.go
+++ b/actor/v7action/service_instance_details.go
@@ -70,7 +70,9 @@ func (actor Actor) GetServiceInstanceDetails(serviceInstanceName string, spaceGU
 			return
 		},
 		func() (warnings ccv3.Warnings, err error) {
-			serviceInstanceDetails.BoundApps, warnings, err = actor.getServiceInstanceBoundApps(serviceInstanceDetails.GUID, omitApps)
+			if !omitApps {
+				serviceInstanceDetails.BoundApps, warnings, err = actor.getServiceInstanceBoundApps(serviceInstanceDetails.GUID)
+			}
 			return
 		},
 	)
@@ -220,17 +222,12 @@ func (actor Actor) getServiceInstanceUpgradeStatus(serviceInstanceDetails Servic
 	}
 }
 
-func (actor Actor) getServiceInstanceBoundApps(serviceInstanceGUID string, omitApps bool) (boundApps []resources.ServiceCredentialBinding, warnings ccv3.Warnings, err error) {
-	switch omitApps {
-	case true:
-		return
-	default:
-		return actor.CloudControllerClient.GetServiceCredentialBindings(
-			ccv3.Query{Key: ccv3.Include, Values: []string{"app"}},
-			ccv3.Query{Key: ccv3.ServiceInstanceGUIDFilter, Values: []string{serviceInstanceGUID}},
-			ccv3.Query{Key: ccv3.TypeFilter, Values: []string{"app"}},
-		)
-	}
+func (actor Actor) getServiceInstanceBoundApps(serviceInstanceGUID string) ([]resources.ServiceCredentialBinding, ccv3.Warnings, error) {
+	return actor.CloudControllerClient.GetServiceCredentialBindings(
+		ccv3.Query{Key: ccv3.Include, Values: []string{"app"}},
+		ccv3.Query{Key: ccv3.ServiceInstanceGUIDFilter, Values: []string{serviceInstanceGUID}},
+		ccv3.Query{Key: ccv3.TypeFilter, Values: []string{"app"}},
+	)
 }
 
 func extractServicePlan(included ccv3.IncludedResources) resources.ServicePlan {

--- a/actor/v7action/service_instance_details_test.go
+++ b/actor/v7action/service_instance_details_test.go
@@ -45,9 +45,40 @@ var _ = Describe("Service Instance Details Action", func() {
 			serviceInstance ServiceInstanceDetails
 			warnings        Warnings
 			executionError  error
+			omitApps        bool
 		)
 
 		BeforeEach(func() {
+			fakeCloudControllerClient.GetServiceInstanceByNameAndSpaceReturns(
+				resources.ServiceInstance{
+					Type:      resources.ManagedServiceInstance,
+					Name:      serviceInstanceName,
+					GUID:      serviceInstanceGUID,
+					SpaceGUID: spaceGUID,
+				},
+				ccv3.IncludedResources{
+					ServicePlans: []resources.ServicePlan{{Name: servicePlanName}},
+					ServiceOfferings: []resources.ServiceOffering{{
+						Name:             serviceOfferingName,
+						GUID:             serviceOfferingGUID,
+						Description:      serviceOfferingDescription,
+						DocumentationURL: serviceOfferingDocumentation,
+						Tags:             types.NewOptionalStringSlice("foo", "bar"),
+					}},
+					ServiceBrokers: []resources.ServiceBroker{{Name: serviceBrokerName}},
+					Spaces:         []resources.Space{{Name: spaceName}},
+					Organizations:  []resources.Organization{{Name: orgName}},
+				},
+				ccv3.Warnings{"some-service-instance-warning"},
+				nil,
+			)
+
+			fakeCloudControllerClient.GetServiceInstanceParametersReturns(
+				types.NewOptionalObject(map[string]interface{}{"foo": "bar"}),
+				ccv3.Warnings{"some-parameters-warning"},
+				nil,
+			)
+
 			fakeCloudControllerClient.GetFeatureFlagReturns(
 				resources.FeatureFlag{Name: "service_instance_sharing", Enabled: true},
 				ccv3.Warnings{},
@@ -59,81 +90,101 @@ var _ = Describe("Service Instance Details Action", func() {
 				ccv3.Warnings{},
 				nil,
 			)
+
+			fakeCloudControllerClient.GetServiceCredentialBindingsReturns(
+				[]resources.ServiceCredentialBinding{
+					{
+						Type:    resources.AppBinding,
+						Name:    "binding-1",
+						AppName: "app-1",
+						LastOperation: resources.LastOperation{
+							Type:        resources.CreateOperation,
+							State:       resources.OperationSucceeded,
+							Description: "all ok",
+						},
+					},
+					{
+						Type:    resources.AppBinding,
+						Name:    "binding-2",
+						AppName: "app-2",
+						LastOperation: resources.LastOperation{
+							Type:        resources.UpdateOperation,
+							State:       resources.OperationInProgress,
+							Description: "please wait",
+						},
+					},
+				},
+				ccv3.Warnings{"some-bindings-warning"},
+				nil,
+			)
+
+			omitApps = false
 		})
 
 		JustBeforeEach(func() {
-			serviceInstance, warnings, executionError = actor.GetServiceInstanceDetails(serviceInstanceName, spaceGUID)
+			serviceInstance, warnings, executionError = actor.GetServiceInstanceDetails(serviceInstanceName, spaceGUID, omitApps)
 		})
 
-		When("the cloud controller request is successful", func() {
-			BeforeEach(func() {
-				fakeCloudControllerClient.GetServiceInstanceByNameAndSpaceReturns(
-					resources.ServiceInstance{
+		It("returns warnings and no errors", func() {
+			Expect(executionError).NotTo(HaveOccurred())
+			Expect(warnings).To(ConsistOf(
+				"some-service-instance-warning",
+				"some-parameters-warning",
+				"some-bindings-warning",
+			))
+		})
+
+		It("returns the correct service instance details object", func() {
+			Expect(serviceInstance).To(Equal(
+				ServiceInstanceDetails{
+					ServiceInstance: resources.ServiceInstance{
 						Type:      resources.ManagedServiceInstance,
 						Name:      serviceInstanceName,
 						GUID:      serviceInstanceGUID,
 						SpaceGUID: spaceGUID,
 					},
-					ccv3.IncludedResources{
-						ServicePlans: []resources.ServicePlan{{Name: servicePlanName}},
-						ServiceOfferings: []resources.ServiceOffering{{
-							Name:             serviceOfferingName,
-							GUID:             serviceOfferingGUID,
-							Description:      serviceOfferingDescription,
-							DocumentationURL: serviceOfferingDocumentation,
-							Tags:             types.NewOptionalStringSlice("foo", "bar"),
-						}},
-						ServiceBrokers: []resources.ServiceBroker{{Name: serviceBrokerName}},
-						Spaces:         []resources.Space{{Name: spaceName}},
-						Organizations:  []resources.Organization{{Name: orgName}},
+					SpaceName:        spaceName,
+					OrganizationName: orgName,
+					ServiceOffering: resources.ServiceOffering{
+						Name:             serviceOfferingName,
+						GUID:             serviceOfferingGUID,
+						Description:      serviceOfferingDescription,
+						DocumentationURL: serviceOfferingDocumentation,
+						Tags:             types.NewOptionalStringSlice("foo", "bar"),
 					},
-					ccv3.Warnings{"some-service-instance-warning"},
-					nil,
-				)
-
-				fakeCloudControllerClient.GetServiceInstanceParametersReturns(
-					types.NewOptionalObject(map[string]interface{}{"foo": "bar"}),
-					ccv3.Warnings{"some-parameters-warning"},
-					nil,
-				)
-			})
-
-			It("returns warnings and no errors", func() {
-				Expect(executionError).NotTo(HaveOccurred())
-				Expect(warnings).To(ConsistOf(
-					"some-service-instance-warning",
-					"some-parameters-warning",
-				))
-			})
-
-			It("returns the correct service instance details object", func() {
-				Expect(serviceInstance).To(Equal(
-					ServiceInstanceDetails{
-						ServiceInstance: resources.ServiceInstance{
-							Type:      resources.ManagedServiceInstance,
-							Name:      serviceInstanceName,
-							GUID:      serviceInstanceGUID,
-							SpaceGUID: spaceGUID,
+					ServicePlan:       resources.ServicePlan{Name: servicePlanName},
+					ServiceBrokerName: serviceBrokerName,
+					SharedStatus:      SharedStatus{},
+					Parameters: ServiceInstanceParameters{
+						Value: types.NewOptionalObject(map[string]interface{}{"foo": "bar"}),
+					},
+					BoundApps: []resources.ServiceCredentialBinding{
+						{
+							Type:    resources.AppBinding,
+							Name:    "binding-1",
+							AppName: "app-1",
+							LastOperation: resources.LastOperation{
+								Type:        resources.CreateOperation,
+								State:       resources.OperationSucceeded,
+								Description: "all ok",
+							},
 						},
-						SpaceName:        spaceName,
-						OrganizationName: orgName,
-						ServiceOffering: resources.ServiceOffering{
-							Name:             serviceOfferingName,
-							GUID:             serviceOfferingGUID,
-							Description:      serviceOfferingDescription,
-							DocumentationURL: serviceOfferingDocumentation,
-							Tags:             types.NewOptionalStringSlice("foo", "bar"),
-						},
-						ServicePlan:       resources.ServicePlan{Name: servicePlanName},
-						ServiceBrokerName: serviceBrokerName,
-						SharedStatus:      SharedStatus{},
-						Parameters: ServiceInstanceParameters{
-							Value: types.NewOptionalObject(map[string]interface{}{"foo": "bar"}),
+						{
+							Type:    resources.AppBinding,
+							Name:    "binding-2",
+							AppName: "app-2",
+							LastOperation: resources.LastOperation{
+								Type:        resources.UpdateOperation,
+								State:       resources.OperationInProgress,
+								Description: "please wait",
+							},
 						},
 					},
-				))
-			})
+				},
+			))
+		})
 
+		Describe("getting the service instance", func() {
 			It("makes the correct call to get the service instance", func() {
 				Expect(fakeCloudControllerClient.GetServiceInstanceByNameAndSpaceCallCount()).To(Equal(1))
 				actualName, actualSpaceGUID, actualQuery := fakeCloudControllerClient.GetServiceInstanceByNameAndSpaceArgsForCall(0)
@@ -163,441 +214,494 @@ var _ = Describe("Service Instance Details Action", func() {
 				))
 			})
 
+			When("the service instance cannot be found", func() {
+				BeforeEach(func() {
+					fakeCloudControllerClient.GetServiceInstanceByNameAndSpaceReturns(
+						resources.ServiceInstance{},
+						ccv3.IncludedResources{},
+						ccv3.Warnings{},
+						ccerror.ServiceInstanceNotFoundError{},
+					)
+				})
+
+				It("returns an error and warnings", func() {
+					Expect(executionError).To(MatchError(actionerror.ServiceInstanceNotFoundError{Name: serviceInstanceName}))
+				})
+
+				It("does not attempt any other requests", func() {
+					Expect(fakeCloudControllerClient.GetServiceInstanceParametersCallCount()).To(Equal(0))
+					Expect(fakeCloudControllerClient.GetFeatureFlagCallCount()).To(Equal(0))
+					Expect(fakeCloudControllerClient.GetServiceOfferingByGUIDCallCount()).To(Equal(0))
+					Expect(fakeCloudControllerClient.GetServiceInstanceSharedSpacesCallCount()).To(Equal(0))
+					Expect(fakeCloudControllerClient.GetServicePlanByGUIDCallCount()).To(Equal(0))
+					Expect(fakeCloudControllerClient.GetServiceCredentialBindingsCallCount()).To(Equal(0))
+				})
+			})
+
+			When("getting the service instance returns an error", func() {
+				BeforeEach(func() {
+					fakeCloudControllerClient.GetServiceInstanceByNameAndSpaceReturns(
+						resources.ServiceInstance{},
+						ccv3.IncludedResources{},
+						ccv3.Warnings{"some-service-instance-warning"},
+						errors.New("no service instance"))
+				})
+
+				It("returns an error and warnings", func() {
+					Expect(executionError).To(MatchError("no service instance"))
+					Expect(warnings).To(ConsistOf("some-service-instance-warning"))
+				})
+
+				It("does not attempt any other requests", func() {
+					Expect(fakeCloudControllerClient.GetServiceInstanceParametersCallCount()).To(Equal(0))
+					Expect(fakeCloudControllerClient.GetFeatureFlagCallCount()).To(Equal(0))
+					Expect(fakeCloudControllerClient.GetServiceOfferingByGUIDCallCount()).To(Equal(0))
+					Expect(fakeCloudControllerClient.GetServiceInstanceSharedSpacesCallCount()).To(Equal(0))
+					Expect(fakeCloudControllerClient.GetServicePlanByGUIDCallCount()).To(Equal(0))
+					Expect(fakeCloudControllerClient.GetServiceCredentialBindingsCallCount()).To(Equal(0))
+				})
+			})
+		})
+
+		Describe("getting the parameters", func() {
 			It("makes the correct call to get the parameters", func() {
 				Expect(fakeCloudControllerClient.GetServiceInstanceParametersCallCount()).To(Equal(1))
 				Expect(fakeCloudControllerClient.GetServiceInstanceParametersArgsForCall(0)).To(Equal(serviceInstanceGUID))
 			})
 
-			Describe("sharing", func() {
-				When("targeting originating service instance space", func() {
-					When("the service instance has shared spaces", func() {
-						BeforeEach(func() {
-							fakeCloudControllerClient.GetServiceInstanceSharedSpacesReturns(
-								[]resources.Space{{GUID: "some-other-space-guid"}},
-								ccv3.Warnings{},
-								nil,
-							)
-						})
-						It("returns a service with a SharedStatus of IsSharedToOtherSpaces: true", func() {
-							Expect(serviceInstance.SharedStatus.IsSharedToOtherSpaces).To(BeTrue())
-						})
+			When("getting the parameters fails with an expected error", func() {
+				BeforeEach(func() {
+					fakeCloudControllerClient.GetServiceInstanceParametersReturns(
+						types.OptionalObject{},
+						ccv3.Warnings{"some-parameters-warning"},
+						ccerror.V3UnexpectedResponseError{
+							V3ErrorResponse: ccerror.V3ErrorResponse{
+								Errors: []ccerror.V3Error{{
+									Code:   1234,
+									Detail: "cannot get parameters reason",
+									Title:  "CF-SomeRandomError",
+								}},
+							},
+						},
+					)
+				})
+
+				It("does not return an error, but returns warnings and the reason", func() {
+					Expect(executionError).NotTo(HaveOccurred())
+					Expect(warnings).To(ContainElement("some-parameters-warning"))
+					Expect(serviceInstance.Parameters.MissingReason).To(Equal("cannot get parameters reason"))
+				})
+			})
+
+			When("getting the parameters fails with an another error", func() {
+				BeforeEach(func() {
+					fakeCloudControllerClient.GetServiceInstanceParametersReturns(
+						types.OptionalObject{},
+						ccv3.Warnings{"some-parameters-warning"},
+						errors.New("not expected"),
+					)
+				})
+
+				It("does not return an error, but returns warnings and the reason", func() {
+					Expect(executionError).NotTo(HaveOccurred())
+					Expect(warnings).To(ContainElement("some-parameters-warning"))
+					Expect(serviceInstance.Parameters.MissingReason).To(Equal("not expected"))
+				})
+			})
+		})
+
+		Describe("sharing", func() {
+			When("targeting originating service instance space", func() {
+				When("the service instance has shared spaces", func() {
+					BeforeEach(func() {
+						fakeCloudControllerClient.GetServiceInstanceSharedSpacesReturns(
+							[]resources.Space{{GUID: "some-other-space-guid"}},
+							ccv3.Warnings{},
+							nil,
+						)
 					})
-
-					When("the service instance does not have shared spaces", func() {
-						BeforeEach(func() {
-							fakeCloudControllerClient.GetServiceInstanceSharedSpacesReturns(
-								[]resources.Space{},
-								ccv3.Warnings{},
-								nil,
-							)
-						})
-
-						It("returns a service with a SharedStatus of IsSharedToOtherSpaces: false", func() {
-							Expect(serviceInstance.SharedStatus.FeatureFlagIsDisabled).To(BeFalse())
-						})
-					})
-
-					When("the service sharing feature flag is disabled", func() {
-						BeforeEach(func() {
-							fakeCloudControllerClient.GetFeatureFlagReturns(
-								resources.FeatureFlag{Name: "service_instance_sharing", Enabled: false},
-								ccv3.Warnings{},
-								nil,
-							)
-						})
-
-						It("returns service is not shared and feature flag info", func() {
-							Expect(serviceInstance.SharedStatus.FeatureFlagIsDisabled).To(BeTrue())
-						})
-					})
-
-					When("the service sharing feature flag is enabled", func() {
-						BeforeEach(func() {
-							fakeCloudControllerClient.GetFeatureFlagReturns(
-								resources.FeatureFlag{Name: "service_instance_sharing", Enabled: true},
-								ccv3.Warnings{},
-								nil,
-							)
-						})
-
-						It("returns service is not shared and feature flag info", func() {
-							Expect(serviceInstance.SharedStatus.FeatureFlagIsDisabled).To(BeFalse())
-						})
-					})
-
-					When("the service offering does not allow sharing", func() {
-						BeforeEach(func() {
-							fakeCloudControllerClient.GetServiceOfferingByGUIDReturns(
-								resources.ServiceOffering{Name: serviceOfferingName, AllowsInstanceSharing: false},
-								ccv3.Warnings{},
-								nil,
-							)
-						})
-
-						It("returns service is not shared and feature flag info", func() {
-							Expect(serviceInstance.SharedStatus.OfferingDisablesSharing).To(BeTrue())
-
-							actualOfferingGUID := fakeCloudControllerClient.GetServiceOfferingByGUIDArgsForCall(0)
-							Expect(actualOfferingGUID).To(Equal(serviceOfferingGUID))
-						})
-					})
-
-					When("the service offering allows sharing", func() {
-						BeforeEach(func() {
-							fakeCloudControllerClient.GetServiceOfferingByNameAndBrokerReturns(
-								resources.ServiceOffering{Name: serviceOfferingName, AllowsInstanceSharing: true},
-								ccv3.Warnings{},
-								nil,
-							)
-						})
-
-						It("returns that the service broker does not disable sharing", func() {
-							Expect(serviceInstance.SharedStatus.OfferingDisablesSharing).To(BeFalse())
-
-							actualOfferingGUID := fakeCloudControllerClient.GetServiceOfferingByGUIDArgsForCall(0)
-							Expect(actualOfferingGUID).To(Equal(serviceOfferingGUID))
-						})
-					})
-
-					When("the service offering details can't be found", func() {
-						const warningMessage = "some-offering-warning"
-
-						BeforeEach(func() {
-							fakeCloudControllerClient.GetServiceOfferingByNameAndBrokerReturns(
-								resources.ServiceOffering{},
-								ccv3.Warnings{warningMessage},
-								ccerror.ServiceOfferingNotFoundError{},
-							)
-						})
-
-						Context("because they can't actually share this service", func() {
-							It("just returns that the service broker does not disable sharing and carries on", func() {
-								Expect(serviceInstance.SharedStatus.OfferingDisablesSharing).To(BeFalse())
-								Expect(executionError).NotTo(HaveOccurred())
-							})
-						})
-					})
-
-					When("getting feature flags errors", func() {
-						const warningMessage = "some-feature-flag-warning"
-
-						BeforeEach(func() {
-							fakeCloudControllerClient.GetFeatureFlagReturns(
-								resources.FeatureFlag{},
-								ccv3.Warnings{warningMessage},
-								errors.New("error getting feature flag"),
-							)
-						})
-
-						It("returns an empty service instance, warnings, and the error", func() {
-							Expect(serviceInstance).To(Equal(ServiceInstanceDetails{}))
-							Expect(executionError).To(MatchError("error getting feature flag"))
-							Expect(warnings).To(ConsistOf("some-service-instance-warning", "some-parameters-warning", warningMessage))
-						})
-					})
-
-					When("getting offering errors", func() {
-						const warningMessage = "some-offering-warning"
-
-						BeforeEach(func() {
-							fakeCloudControllerClient.GetServiceOfferingByGUIDReturns(
-								resources.ServiceOffering{},
-								ccv3.Warnings{warningMessage},
-								errors.New("error getting offering"),
-							)
-						})
-
-						It("returns an empty service instance, warnings, and the error", func() {
-							Expect(serviceInstance).To(Equal(ServiceInstanceDetails{}))
-							Expect(executionError).To(MatchError("error getting offering"))
-							Expect(warnings).To(ConsistOf("some-service-instance-warning", "some-parameters-warning", warningMessage))
-						})
-					})
-
-					When("the fetching spaces returns new warnings", func() {
-						const warningMessage = "some-shared-spaces-warning"
-
-						BeforeEach(func() {
-							fakeCloudControllerClient.GetServiceInstanceSharedSpacesReturns(
-								[]resources.Space{},
-								ccv3.Warnings{warningMessage},
-								nil,
-							)
-						})
-						It("forwards those warnings on", func() {
-							Expect(warnings).To(ContainElement(warningMessage))
-						})
-					})
-
-					When("fetching shared spaces throws an error", func() {
-						const warningMessage = "some-shared-spaces-warning"
-
-						BeforeEach(func() {
-							fakeCloudControllerClient.GetServiceInstanceSharedSpacesReturns(
-								nil,
-								ccv3.Warnings{warningMessage},
-								errors.New("no service instance"),
-							)
-						})
-
-						It("returns an empty service instance, warnings, and the error", func() {
-							Expect(serviceInstance).To(Equal(ServiceInstanceDetails{}))
-							Expect(executionError).To(MatchError("no service instance"))
-							Expect(warnings).To(ConsistOf("some-service-instance-warning", "some-parameters-warning", warningMessage))
-						})
+					It("returns a service with a SharedStatus of IsSharedToOtherSpaces: true", func() {
+						Expect(serviceInstance.SharedStatus.IsSharedToOtherSpaces).To(BeTrue())
 					})
 				})
 
-				When("targeting space that service instance has been shared to", func() {
+				When("the service instance does not have shared spaces", func() {
 					BeforeEach(func() {
-						originalSpace := "some-other-space"
-						fakeCloudControllerClient.GetServiceInstanceByNameAndSpaceReturns(
-							resources.ServiceInstance{
-								Type:      resources.ManagedServiceInstance,
-								Name:      serviceInstanceName,
-								GUID:      serviceInstanceGUID,
-								SpaceGUID: originalSpace,
-							},
-							ccv3.IncludedResources{
-								ServicePlans: []resources.ServicePlan{{Name: servicePlanName}},
-								ServiceOfferings: []resources.ServiceOffering{{
-									Name:             serviceOfferingName,
-									GUID:             serviceOfferingGUID,
-									Description:      serviceOfferingDescription,
-									DocumentationURL: serviceOfferingDocumentation,
-									Tags:             types.NewOptionalStringSlice("foo", "bar"),
-								}},
-								ServiceBrokers: []resources.ServiceBroker{{Name: serviceBrokerName}},
-								Spaces:         []resources.Space{{Name: spaceName}},
-								Organizations:  []resources.Organization{{Name: orgName}},
-							},
-							ccv3.Warnings{"some-service-instance-warning"},
+						fakeCloudControllerClient.GetServiceInstanceSharedSpacesReturns(
+							[]resources.Space{},
+							ccv3.Warnings{},
 							nil,
 						)
 					})
 
-					It("returns a service with a SharedStatus of IsSharedFromOriginalSpace: true", func() {
-						Expect(serviceInstance.SharedStatus.IsSharedFromOriginalSpace).To(BeTrue())
+					It("returns a service with a SharedStatus of IsSharedToOtherSpaces: false", func() {
+						Expect(serviceInstance.SharedStatus.FeatureFlagIsDisabled).To(BeFalse())
+					})
+				})
+
+				When("the service sharing feature flag is disabled", func() {
+					BeforeEach(func() {
+						fakeCloudControllerClient.GetFeatureFlagReturns(
+							resources.FeatureFlag{Name: "service_instance_sharing", Enabled: false},
+							ccv3.Warnings{},
+							nil,
+						)
 					})
 
-					It("does not retrieve more sharing information", func() {
-						Expect(serviceInstance.SharedStatus.IsSharedToOtherSpaces).To(BeFalse())
-						Expect(serviceInstance.SharedStatus.OfferingDisablesSharing).To(BeFalse())
-						Expect(serviceInstance.SharedStatus.FeatureFlagIsDisabled).To(BeFalse())
+					It("returns service is not shared and feature flag info", func() {
+						Expect(serviceInstance.SharedStatus.FeatureFlagIsDisabled).To(BeTrue())
+					})
+				})
 
-						Expect(fakeCloudControllerClient.GetFeatureFlagCallCount()).To(BeZero())
-						Expect(fakeCloudControllerClient.GetServiceOfferingByGUIDCallCount()).To(BeZero())
-						Expect(fakeCloudControllerClient.GetServiceInstanceSharedSpacesCallCount()).To(BeZero())
+				When("the service sharing feature flag is enabled", func() {
+					BeforeEach(func() {
+						fakeCloudControllerClient.GetFeatureFlagReturns(
+							resources.FeatureFlag{Name: "service_instance_sharing", Enabled: true},
+							ccv3.Warnings{},
+							nil,
+						)
+					})
+
+					It("returns service is not shared and feature flag info", func() {
+						Expect(serviceInstance.SharedStatus.FeatureFlagIsDisabled).To(BeFalse())
+					})
+				})
+
+				When("the service offering does not allow sharing", func() {
+					BeforeEach(func() {
+						fakeCloudControllerClient.GetServiceOfferingByGUIDReturns(
+							resources.ServiceOffering{Name: serviceOfferingName, AllowsInstanceSharing: false},
+							ccv3.Warnings{},
+							nil,
+						)
+					})
+
+					It("returns service is not shared and feature flag info", func() {
+						Expect(serviceInstance.SharedStatus.OfferingDisablesSharing).To(BeTrue())
+
+						actualOfferingGUID := fakeCloudControllerClient.GetServiceOfferingByGUIDArgsForCall(0)
+						Expect(actualOfferingGUID).To(Equal(serviceOfferingGUID))
+					})
+				})
+
+				When("the service offering allows sharing", func() {
+					BeforeEach(func() {
+						fakeCloudControllerClient.GetServiceOfferingByNameAndBrokerReturns(
+							resources.ServiceOffering{Name: serviceOfferingName, AllowsInstanceSharing: true},
+							ccv3.Warnings{},
+							nil,
+						)
+					})
+
+					It("returns that the service broker does not disable sharing", func() {
+						Expect(serviceInstance.SharedStatus.OfferingDisablesSharing).To(BeFalse())
+
+						actualOfferingGUID := fakeCloudControllerClient.GetServiceOfferingByGUIDArgsForCall(0)
+						Expect(actualOfferingGUID).To(Equal(serviceOfferingGUID))
+					})
+				})
+
+				When("the service offering details can't be found", func() {
+					const warningMessage = "some-offering-warning"
+
+					BeforeEach(func() {
+						fakeCloudControllerClient.GetServiceOfferingByNameAndBrokerReturns(
+							resources.ServiceOffering{},
+							ccv3.Warnings{warningMessage},
+							ccerror.ServiceOfferingNotFoundError{},
+						)
+					})
+
+					Context("because they can't actually share this service", func() {
+						It("just returns that the service broker does not disable sharing and carries on", func() {
+							Expect(serviceInstance.SharedStatus.OfferingDisablesSharing).To(BeFalse())
+							Expect(executionError).NotTo(HaveOccurred())
+						})
+					})
+				})
+
+				When("getting feature flags errors", func() {
+					const warningMessage = "some-feature-flag-warning"
+
+					BeforeEach(func() {
+						fakeCloudControllerClient.GetFeatureFlagReturns(
+							resources.FeatureFlag{},
+							ccv3.Warnings{warningMessage},
+							errors.New("error getting feature flag"),
+						)
+					})
+
+					It("returns an empty service instance, warnings, and the error", func() {
+						Expect(serviceInstance).To(Equal(ServiceInstanceDetails{}))
+						Expect(executionError).To(MatchError("error getting feature flag"))
+						Expect(warnings).To(ConsistOf("some-service-instance-warning", "some-parameters-warning", warningMessage))
+					})
+				})
+
+				When("getting offering errors", func() {
+					const warningMessage = "some-offering-warning"
+
+					BeforeEach(func() {
+						fakeCloudControllerClient.GetServiceOfferingByGUIDReturns(
+							resources.ServiceOffering{},
+							ccv3.Warnings{warningMessage},
+							errors.New("error getting offering"),
+						)
+					})
+
+					It("returns an empty service instance, warnings, and the error", func() {
+						Expect(serviceInstance).To(Equal(ServiceInstanceDetails{}))
+						Expect(executionError).To(MatchError("error getting offering"))
+						Expect(warnings).To(ConsistOf("some-service-instance-warning", "some-parameters-warning", warningMessage))
+					})
+				})
+
+				When("the fetching spaces returns new warnings", func() {
+					const warningMessage = "some-shared-spaces-warning"
+
+					BeforeEach(func() {
+						fakeCloudControllerClient.GetServiceInstanceSharedSpacesReturns(
+							[]resources.Space{},
+							ccv3.Warnings{warningMessage},
+							nil,
+						)
+					})
+					It("forwards those warnings on", func() {
+						Expect(warnings).To(ContainElement(warningMessage))
+					})
+				})
+
+				When("fetching shared spaces throws an error", func() {
+					const warningMessage = "some-shared-spaces-warning"
+
+					BeforeEach(func() {
+						fakeCloudControllerClient.GetServiceInstanceSharedSpacesReturns(
+							nil,
+							ccv3.Warnings{warningMessage},
+							errors.New("no service instance"),
+						)
+					})
+
+					It("returns an empty service instance, warnings, and the error", func() {
+						Expect(serviceInstance).To(Equal(ServiceInstanceDetails{}))
+						Expect(executionError).To(MatchError("no service instance"))
+						Expect(warnings).To(ConsistOf("some-service-instance-warning", "some-parameters-warning", warningMessage))
 					})
 				})
 			})
 
-			Describe("upgrades", func() {
-				When("upgrade is not available and the service does not have maintenance info", func() {
-					It("says that upgrades are not supported", func() {
-						Expect(serviceInstance.UpgradeStatus.State).To(Equal(ServiceInstanceUpgradeNotSupported))
-					})
-
-					It("does not get the service plan", func() {
-						Expect(fakeCloudControllerClient.GetServicePlanByGUIDCallCount()).To(Equal(0))
-					})
+			When("targeting space that service instance has been shared to", func() {
+				BeforeEach(func() {
+					originalSpace := "some-other-space"
+					fakeCloudControllerClient.GetServiceInstanceByNameAndSpaceReturns(
+						resources.ServiceInstance{
+							Type:      resources.ManagedServiceInstance,
+							Name:      serviceInstanceName,
+							GUID:      serviceInstanceGUID,
+							SpaceGUID: originalSpace,
+						},
+						ccv3.IncludedResources{
+							ServicePlans: []resources.ServicePlan{{Name: servicePlanName}},
+							ServiceOfferings: []resources.ServiceOffering{{
+								Name:             serviceOfferingName,
+								GUID:             serviceOfferingGUID,
+								Description:      serviceOfferingDescription,
+								DocumentationURL: serviceOfferingDocumentation,
+								Tags:             types.NewOptionalStringSlice("foo", "bar"),
+							}},
+							ServiceBrokers: []resources.ServiceBroker{{Name: serviceBrokerName}},
+							Spaces:         []resources.Space{{Name: spaceName}},
+							Organizations:  []resources.Organization{{Name: orgName}},
+						},
+						ccv3.Warnings{"some-service-instance-warning"},
+						nil,
+					)
 				})
 
-				When("upgrade is not available but the service instance has maintenance info", func() {
-					BeforeEach(func() {
-						fakeCloudControllerClient.GetServiceInstanceByNameAndSpaceReturns(
-							resources.ServiceInstance{
-								Type:                   resources.ManagedServiceInstance,
-								Name:                   serviceInstanceName,
-								GUID:                   serviceInstanceGUID,
-								MaintenanceInfoVersion: "1.2.3",
-							},
-							ccv3.IncludedResources{
-								ServicePlans: []resources.ServicePlan{{Name: servicePlanName}},
-								ServiceOfferings: []resources.ServiceOffering{{
-									Name:             serviceOfferingName,
-									GUID:             serviceOfferingGUID,
-									Description:      serviceOfferingDescription,
-									DocumentationURL: serviceOfferingDocumentation,
-									Tags:             types.NewOptionalStringSlice("foo", "bar"),
-								}},
-								ServiceBrokers: []resources.ServiceBroker{{Name: serviceBrokerName}},
-							},
-							ccv3.Warnings{"some-service-instance-warning"},
-							nil,
-						)
-					})
-
-					It("says that an upgrade is not available", func() {
-						Expect(serviceInstance.UpgradeStatus.State).To(Equal(ServiceInstanceUpgradeNotAvailable))
-					})
-
-					It("does not get the service plan", func() {
-						Expect(fakeCloudControllerClient.GetServicePlanByGUIDCallCount()).To(Equal(0))
-					})
+				It("returns a service with a SharedStatus of IsSharedFromOriginalSpace: true", func() {
+					Expect(serviceInstance.SharedStatus.IsSharedFromOriginalSpace).To(BeTrue())
 				})
 
-				When("an upgrade is available", func() {
-					BeforeEach(func() {
-						fakeCloudControllerClient.GetServiceInstanceByNameAndSpaceReturns(
-							resources.ServiceInstance{
-								Type:             resources.ManagedServiceInstance,
-								Name:             serviceInstanceName,
-								GUID:             serviceInstanceGUID,
-								ServicePlanGUID:  servicePlanGUID,
-								UpgradeAvailable: types.NewOptionalBoolean(true),
-							},
-							ccv3.IncludedResources{
-								ServicePlans: []resources.ServicePlan{{Name: servicePlanName}},
-								ServiceOfferings: []resources.ServiceOffering{{
-									Name:             serviceOfferingName,
-									GUID:             serviceOfferingGUID,
-									Description:      serviceOfferingDescription,
-									DocumentationURL: serviceOfferingDocumentation,
-									Tags:             types.NewOptionalStringSlice("foo", "bar"),
-								}},
-								ServiceBrokers: []resources.ServiceBroker{{Name: serviceBrokerName}},
-							},
-							ccv3.Warnings{"some-service-instance-warning"},
-							nil,
-						)
+				It("does not retrieve more sharing information", func() {
+					Expect(serviceInstance.SharedStatus.IsSharedToOtherSpaces).To(BeFalse())
+					Expect(serviceInstance.SharedStatus.OfferingDisablesSharing).To(BeFalse())
+					Expect(serviceInstance.SharedStatus.FeatureFlagIsDisabled).To(BeFalse())
 
+					Expect(fakeCloudControllerClient.GetFeatureFlagCallCount()).To(BeZero())
+					Expect(fakeCloudControllerClient.GetServiceOfferingByGUIDCallCount()).To(BeZero())
+					Expect(fakeCloudControllerClient.GetServiceInstanceSharedSpacesCallCount()).To(BeZero())
+				})
+			})
+		})
+
+		Describe("upgrades", func() {
+			When("upgrade is not available and the service does not have maintenance info", func() {
+				It("says that upgrades are not supported", func() {
+					Expect(serviceInstance.UpgradeStatus.State).To(Equal(ServiceInstanceUpgradeNotSupported))
+				})
+
+				It("does not get the service plan", func() {
+					Expect(fakeCloudControllerClient.GetServicePlanByGUIDCallCount()).To(Equal(0))
+				})
+			})
+
+			When("upgrade is not available but the service instance has maintenance info", func() {
+				BeforeEach(func() {
+					fakeCloudControllerClient.GetServiceInstanceByNameAndSpaceReturns(
+						resources.ServiceInstance{
+							Type:                   resources.ManagedServiceInstance,
+							Name:                   serviceInstanceName,
+							GUID:                   serviceInstanceGUID,
+							MaintenanceInfoVersion: "1.2.3",
+						},
+						ccv3.IncludedResources{
+							ServicePlans: []resources.ServicePlan{{Name: servicePlanName}},
+							ServiceOfferings: []resources.ServiceOffering{{
+								Name:             serviceOfferingName,
+								GUID:             serviceOfferingGUID,
+								Description:      serviceOfferingDescription,
+								DocumentationURL: serviceOfferingDocumentation,
+								Tags:             types.NewOptionalStringSlice("foo", "bar"),
+							}},
+							ServiceBrokers: []resources.ServiceBroker{{Name: serviceBrokerName}},
+						},
+						ccv3.Warnings{"some-service-instance-warning"},
+						nil,
+					)
+				})
+
+				It("says that an upgrade is not available", func() {
+					Expect(serviceInstance.UpgradeStatus.State).To(Equal(ServiceInstanceUpgradeNotAvailable))
+				})
+
+				It("does not get the service plan", func() {
+					Expect(fakeCloudControllerClient.GetServicePlanByGUIDCallCount()).To(Equal(0))
+				})
+			})
+
+			When("an upgrade is available", func() {
+				BeforeEach(func() {
+					fakeCloudControllerClient.GetServiceInstanceByNameAndSpaceReturns(
+						resources.ServiceInstance{
+							Type:             resources.ManagedServiceInstance,
+							Name:             serviceInstanceName,
+							GUID:             serviceInstanceGUID,
+							ServicePlanGUID:  servicePlanGUID,
+							UpgradeAvailable: types.NewOptionalBoolean(true),
+						},
+						ccv3.IncludedResources{
+							ServicePlans: []resources.ServicePlan{{Name: servicePlanName}},
+							ServiceOfferings: []resources.ServiceOffering{{
+								Name:             serviceOfferingName,
+								GUID:             serviceOfferingGUID,
+								Description:      serviceOfferingDescription,
+								DocumentationURL: serviceOfferingDocumentation,
+								Tags:             types.NewOptionalStringSlice("foo", "bar"),
+							}},
+							ServiceBrokers: []resources.ServiceBroker{{Name: serviceBrokerName}},
+						},
+						ccv3.Warnings{"some-service-instance-warning"},
+						nil,
+					)
+
+					fakeCloudControllerClient.GetServicePlanByGUIDReturns(
+						resources.ServicePlan{
+							GUID:                       servicePlanGUID,
+							Name:                       servicePlanName,
+							MaintenanceInfoDescription: "requires downtime",
+						},
+						ccv3.Warnings{"service-plan-warning"},
+						nil,
+					)
+				})
+
+				It("gets the service plan", func() {
+					Expect(fakeCloudControllerClient.GetServicePlanByGUIDCallCount()).To(Equal(1))
+					Expect(fakeCloudControllerClient.GetServicePlanByGUIDArgsForCall(0)).To(Equal(servicePlanGUID))
+
+					Expect(warnings).To(ContainElement("service-plan-warning"))
+				})
+
+				It("says that an upgrade is available", func() {
+					Expect(serviceInstance.UpgradeStatus).To(Equal(ServiceInstanceUpgradeStatus{
+						State:       ServiceInstanceUpgradeAvailable,
+						Description: "requires downtime",
+					}))
+				})
+
+				When("the service plan cannot be found", func() {
+					BeforeEach(func() {
 						fakeCloudControllerClient.GetServicePlanByGUIDReturns(
-							resources.ServicePlan{
-								GUID:                       servicePlanGUID,
-								Name:                       servicePlanName,
-								MaintenanceInfoDescription: "requires downtime",
-							},
+							resources.ServicePlan{},
 							ccv3.Warnings{"service-plan-warning"},
-							nil,
+							ccerror.ServicePlanNotFound{},
 						)
 					})
 
-					It("gets the service plan", func() {
-						Expect(fakeCloudControllerClient.GetServicePlanByGUIDCallCount()).To(Equal(1))
-						Expect(fakeCloudControllerClient.GetServicePlanByGUIDArgsForCall(0)).To(Equal(servicePlanGUID))
-
+					It("says that an upgrade is available without details", func() {
 						Expect(warnings).To(ContainElement("service-plan-warning"))
-					})
-
-					It("says that an upgrade is available", func() {
 						Expect(serviceInstance.UpgradeStatus).To(Equal(ServiceInstanceUpgradeStatus{
 							State:       ServiceInstanceUpgradeAvailable,
-							Description: "requires downtime",
+							Description: "No upgrade details where found",
 						}))
 					})
+				})
 
-					When("the service plan cannot be found", func() {
-						BeforeEach(func() {
-							fakeCloudControllerClient.GetServicePlanByGUIDReturns(
-								resources.ServicePlan{},
-								ccv3.Warnings{"service-plan-warning"},
-								ccerror.ServicePlanNotFound{},
-							)
-						})
-
-						It("says that an upgrade is available without details", func() {
-							Expect(warnings).To(ContainElement("service-plan-warning"))
-							Expect(serviceInstance.UpgradeStatus).To(Equal(ServiceInstanceUpgradeStatus{
-								State:       ServiceInstanceUpgradeAvailable,
-								Description: "No upgrade details where found",
-							}))
-						})
+				When("getting the service plan fails", func() {
+					BeforeEach(func() {
+						fakeCloudControllerClient.GetServicePlanByGUIDReturns(
+							resources.ServicePlan{},
+							ccv3.Warnings{"service-plan-warning"},
+							errors.New("boom"),
+						)
 					})
 
-					When("getting the service plan fails", func() {
-						BeforeEach(func() {
-							fakeCloudControllerClient.GetServicePlanByGUIDReturns(
-								resources.ServicePlan{},
-								ccv3.Warnings{"service-plan-warning"},
-								errors.New("boom"),
-							)
-						})
-
-						It("says that an upgrade is available without details", func() {
-							Expect(warnings).To(ContainElement("service-plan-warning"))
-							Expect(executionError).To(MatchError("boom"))
-						})
+					It("says that an upgrade is available without details", func() {
+						Expect(warnings).To(ContainElement("service-plan-warning"))
+						Expect(executionError).To(MatchError("boom"))
 					})
 				})
 			})
 		})
 
-		When("the service instance cannot be found", func() {
-			BeforeEach(func() {
-				fakeCloudControllerClient.GetServiceInstanceByNameAndSpaceReturns(
-					resources.ServiceInstance{},
-					ccv3.IncludedResources{},
-					ccv3.Warnings{},
-					ccerror.ServiceInstanceNotFoundError{},
-				)
+		Describe("bindings", func() {
+			It("makes the correct call to get bindings", func() {
+				Expect(fakeCloudControllerClient.GetServiceCredentialBindingsCallCount()).To(Equal(1))
+
+				Expect(fakeCloudControllerClient.GetServiceCredentialBindingsArgsForCall(0)).To(ConsistOf(
+					ccv3.Query{Key: ccv3.ServiceInstanceGUIDFilter, Values: []string{serviceInstanceGUID}},
+					ccv3.Query{Key: ccv3.TypeFilter, Values: []string{"app"}},
+					ccv3.Query{Key: ccv3.Include, Values: []string{"app"}},
+				))
 			})
 
-			It("returns an error and warnings", func() {
-				Expect(executionError).To(MatchError(actionerror.ServiceInstanceNotFoundError{Name: serviceInstanceName}))
+			When("omitApps is true", func() {
+				BeforeEach(func() {
+					omitApps = true
+				})
+
+				It("does not get the bindings", func() {
+					Expect(fakeCloudControllerClient.GetServiceCredentialBindingsCallCount()).To(BeZero())
+				})
+
+				It("does not include the bindings in the result", func() {
+					Expect(serviceInstance.BoundApps).To(BeEmpty())
+				})
 			})
 
-			It("does not attempt to get the parameters", func() {
-				Expect(fakeCloudControllerClient.GetServiceInstanceParametersCallCount()).To(Equal(0))
-			})
-		})
+			When("there is an error getting the bindings", func() {
+				BeforeEach(func() {
+					fakeCloudControllerClient.GetServiceCredentialBindingsReturns(
+						[]resources.ServiceCredentialBinding{},
+						ccv3.Warnings{"some-bindings-warning"},
+						errors.New("a bindings error"),
+					)
+				})
 
-		When("getting the service instance returns an error", func() {
-			BeforeEach(func() {
-				fakeCloudControllerClient.GetServiceInstanceByNameAndSpaceReturns(
-					resources.ServiceInstance{},
-					ccv3.IncludedResources{},
-					ccv3.Warnings{"some-service-instance-warning"},
-					errors.New("no service instance"))
-			})
-
-			It("returns an error and warnings", func() {
-				Expect(executionError).To(MatchError("no service instance"))
-				Expect(warnings).To(ConsistOf("some-service-instance-warning"))
-			})
-
-			It("does not attempt to get the parameters", func() {
-				Expect(fakeCloudControllerClient.GetServiceInstanceParametersCallCount()).To(Equal(0))
-			})
-		})
-
-		When("getting the parameters fails with an expected error", func() {
-			BeforeEach(func() {
-				fakeCloudControllerClient.GetServiceInstanceParametersReturns(
-					types.OptionalObject{},
-					ccv3.Warnings{"some-parameters-warning"},
-					ccerror.V3UnexpectedResponseError{
-						V3ErrorResponse: ccerror.V3ErrorResponse{
-							Errors: []ccerror.V3Error{{
-								Code:   1234,
-								Detail: "cannot get parameters reason",
-								Title:  "CF-SomeRandomError",
-							}},
-						},
-					},
-				)
-			})
-
-			It("does not return an error, but returns warnings and the reason", func() {
-				Expect(executionError).NotTo(HaveOccurred())
-				Expect(warnings).To(ContainElement("some-parameters-warning"))
-				Expect(serviceInstance.Parameters.MissingReason).To(Equal("cannot get parameters reason"))
-			})
-		})
-
-		When("getting the parameters fails with an another error", func() {
-			BeforeEach(func() {
-				fakeCloudControllerClient.GetServiceInstanceParametersReturns(
-					types.OptionalObject{},
-					ccv3.Warnings{"some-parameters-warning"},
-					errors.New("not expected"),
-				)
-			})
-
-			It("does not return an error, but returns warnings and the reason", func() {
-				Expect(executionError).NotTo(HaveOccurred())
-				Expect(warnings).To(ContainElement("some-parameters-warning"))
-				Expect(serviceInstance.Parameters.MissingReason).To(Equal("not expected"))
+				It("returns the error and warnings", func() {
+					Expect(executionError).To(MatchError("a bindings error"))
+					Expect(warnings).To(ContainElement("some-bindings-warning"))
+				})
 			})
 		})
 	})

--- a/actor/v7action/service_instance_list_test.go
+++ b/actor/v7action/service_instance_list_test.go
@@ -1,13 +1,12 @@
 package v7action_test
 
 import (
-	"errors"
-
 	. "code.cloudfoundry.org/cli/actor/v7action"
 	"code.cloudfoundry.org/cli/actor/v7action/v7actionfakes"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3"
 	"code.cloudfoundry.org/cli/resources"
 	"code.cloudfoundry.org/cli/types"
+	"errors"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -139,25 +138,15 @@ var _ = Describe("Service Instance List Action", func() {
 		)
 		fakeCloudControllerClient.GetServiceCredentialBindingsReturns(
 			[]resources.ServiceCredentialBinding{
-				{Type: "app", ServiceInstanceGUID: "fake-guid-1", AppGUID: "app-1"},
-				{Type: "app", ServiceInstanceGUID: "fake-guid-1", AppGUID: "app-2"},
-				{Type: "app", ServiceInstanceGUID: "fake-guid-2", AppGUID: "app-3"},
-				{Type: "app", ServiceInstanceGUID: "fake-guid-2", AppGUID: "app-4"},
-				{Type: "app", ServiceInstanceGUID: "fake-guid-3", AppGUID: "app-5"},
-				{Type: "app", ServiceInstanceGUID: "fake-guid-4", AppGUID: "app-6"},
-				{Type: "app", ServiceInstanceGUID: "fake-guid-5", AppGUID: "app-6"},
+				{Type: "app", ServiceInstanceGUID: "fake-guid-1", AppGUID: "app-1", AppName: "great-app-1"},
+				{Type: "app", ServiceInstanceGUID: "fake-guid-1", AppGUID: "app-2", AppName: "great-app-2"},
+				{Type: "app", ServiceInstanceGUID: "fake-guid-2", AppGUID: "app-3", AppName: "great-app-3"},
+				{Type: "app", ServiceInstanceGUID: "fake-guid-2", AppGUID: "app-4", AppName: "great-app-4"},
+				{Type: "app", ServiceInstanceGUID: "fake-guid-3", AppGUID: "app-5", AppName: "great-app-5"},
+				{Type: "app", ServiceInstanceGUID: "fake-guid-4", AppGUID: "app-6", AppName: "great-app-6"},
+				{Type: "app", ServiceInstanceGUID: "fake-guid-5", AppGUID: "app-6", AppName: "great-app-6"},
 				{Type: "key", ServiceInstanceGUID: "fake-guid-1"},
 				{Type: "key", ServiceInstanceGUID: "fake-guid-2"},
-			},
-			ccv3.IncludedResources{
-				Apps: []resources.Application{
-					{GUID: "app-1", Name: "great-app-1"},
-					{GUID: "app-2", Name: "great-app-2"},
-					{GUID: "app-3", Name: "great-app-3"},
-					{GUID: "app-4", Name: "great-app-4"},
-					{GUID: "app-5", Name: "great-app-5"},
-					{GUID: "app-6", Name: "great-app-6"},
-				},
 			},
 			ccv3.Warnings{"bindings warning"},
 			nil,
@@ -302,7 +291,6 @@ var _ = Describe("Service Instance List Action", func() {
 			BeforeEach(func() {
 				fakeCloudControllerClient.GetServiceCredentialBindingsReturns(
 					[]resources.ServiceCredentialBinding{},
-					ccv3.IncludedResources{},
 					ccv3.Warnings{"some-service-credential-binding-warning"},
 					errors.New("something really REALLY awful"),
 				)

--- a/actor/v7action/v7actionfakes/fake_cloud_controller_client.go
+++ b/actor/v7action/v7actionfakes/fake_cloud_controller_client.go
@@ -1454,22 +1454,20 @@ type FakeCloudControllerClient struct {
 		result2 ccv3.Warnings
 		result3 error
 	}
-	GetServiceCredentialBindingsStub        func(...ccv3.Query) ([]resources.ServiceCredentialBinding, ccv3.IncludedResources, ccv3.Warnings, error)
+	GetServiceCredentialBindingsStub        func(...ccv3.Query) ([]resources.ServiceCredentialBinding, ccv3.Warnings, error)
 	getServiceCredentialBindingsMutex       sync.RWMutex
 	getServiceCredentialBindingsArgsForCall []struct {
 		arg1 []ccv3.Query
 	}
 	getServiceCredentialBindingsReturns struct {
 		result1 []resources.ServiceCredentialBinding
-		result2 ccv3.IncludedResources
-		result3 ccv3.Warnings
-		result4 error
+		result2 ccv3.Warnings
+		result3 error
 	}
 	getServiceCredentialBindingsReturnsOnCall map[int]struct {
 		result1 []resources.ServiceCredentialBinding
-		result2 ccv3.IncludedResources
-		result3 ccv3.Warnings
-		result4 error
+		result2 ccv3.Warnings
+		result3 error
 	}
 	GetServiceInstanceByNameAndSpaceStub        func(string, string, ...ccv3.Query) (resources.ServiceInstance, ccv3.IncludedResources, ccv3.Warnings, error)
 	getServiceInstanceByNameAndSpaceMutex       sync.RWMutex
@@ -8809,7 +8807,7 @@ func (fake *FakeCloudControllerClient) GetServiceBrokersReturnsOnCall(i int, res
 	}{result1, result2, result3}
 }
 
-func (fake *FakeCloudControllerClient) GetServiceCredentialBindings(arg1 ...ccv3.Query) ([]resources.ServiceCredentialBinding, ccv3.IncludedResources, ccv3.Warnings, error) {
+func (fake *FakeCloudControllerClient) GetServiceCredentialBindings(arg1 ...ccv3.Query) ([]resources.ServiceCredentialBinding, ccv3.Warnings, error) {
 	fake.getServiceCredentialBindingsMutex.Lock()
 	ret, specificReturn := fake.getServiceCredentialBindingsReturnsOnCall[len(fake.getServiceCredentialBindingsArgsForCall)]
 	fake.getServiceCredentialBindingsArgsForCall = append(fake.getServiceCredentialBindingsArgsForCall, struct {
@@ -8821,10 +8819,10 @@ func (fake *FakeCloudControllerClient) GetServiceCredentialBindings(arg1 ...ccv3
 		return fake.GetServiceCredentialBindingsStub(arg1...)
 	}
 	if specificReturn {
-		return ret.result1, ret.result2, ret.result3, ret.result4
+		return ret.result1, ret.result2, ret.result3
 	}
 	fakeReturns := fake.getServiceCredentialBindingsReturns
-	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3, fakeReturns.result4
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
 func (fake *FakeCloudControllerClient) GetServiceCredentialBindingsCallCount() int {
@@ -8833,7 +8831,7 @@ func (fake *FakeCloudControllerClient) GetServiceCredentialBindingsCallCount() i
 	return len(fake.getServiceCredentialBindingsArgsForCall)
 }
 
-func (fake *FakeCloudControllerClient) GetServiceCredentialBindingsCalls(stub func(...ccv3.Query) ([]resources.ServiceCredentialBinding, ccv3.IncludedResources, ccv3.Warnings, error)) {
+func (fake *FakeCloudControllerClient) GetServiceCredentialBindingsCalls(stub func(...ccv3.Query) ([]resources.ServiceCredentialBinding, ccv3.Warnings, error)) {
 	fake.getServiceCredentialBindingsMutex.Lock()
 	defer fake.getServiceCredentialBindingsMutex.Unlock()
 	fake.GetServiceCredentialBindingsStub = stub
@@ -8846,36 +8844,33 @@ func (fake *FakeCloudControllerClient) GetServiceCredentialBindingsArgsForCall(i
 	return argsForCall.arg1
 }
 
-func (fake *FakeCloudControllerClient) GetServiceCredentialBindingsReturns(result1 []resources.ServiceCredentialBinding, result2 ccv3.IncludedResources, result3 ccv3.Warnings, result4 error) {
+func (fake *FakeCloudControllerClient) GetServiceCredentialBindingsReturns(result1 []resources.ServiceCredentialBinding, result2 ccv3.Warnings, result3 error) {
 	fake.getServiceCredentialBindingsMutex.Lock()
 	defer fake.getServiceCredentialBindingsMutex.Unlock()
 	fake.GetServiceCredentialBindingsStub = nil
 	fake.getServiceCredentialBindingsReturns = struct {
 		result1 []resources.ServiceCredentialBinding
-		result2 ccv3.IncludedResources
-		result3 ccv3.Warnings
-		result4 error
-	}{result1, result2, result3, result4}
+		result2 ccv3.Warnings
+		result3 error
+	}{result1, result2, result3}
 }
 
-func (fake *FakeCloudControllerClient) GetServiceCredentialBindingsReturnsOnCall(i int, result1 []resources.ServiceCredentialBinding, result2 ccv3.IncludedResources, result3 ccv3.Warnings, result4 error) {
+func (fake *FakeCloudControllerClient) GetServiceCredentialBindingsReturnsOnCall(i int, result1 []resources.ServiceCredentialBinding, result2 ccv3.Warnings, result3 error) {
 	fake.getServiceCredentialBindingsMutex.Lock()
 	defer fake.getServiceCredentialBindingsMutex.Unlock()
 	fake.GetServiceCredentialBindingsStub = nil
 	if fake.getServiceCredentialBindingsReturnsOnCall == nil {
 		fake.getServiceCredentialBindingsReturnsOnCall = make(map[int]struct {
 			result1 []resources.ServiceCredentialBinding
-			result2 ccv3.IncludedResources
-			result3 ccv3.Warnings
-			result4 error
+			result2 ccv3.Warnings
+			result3 error
 		})
 	}
 	fake.getServiceCredentialBindingsReturnsOnCall[i] = struct {
 		result1 []resources.ServiceCredentialBinding
-		result2 ccv3.IncludedResources
-		result3 ccv3.Warnings
-		result4 error
-	}{result1, result2, result3, result4}
+		result2 ccv3.Warnings
+		result3 error
+	}{result1, result2, result3}
 }
 
 func (fake *FakeCloudControllerClient) GetServiceInstanceByNameAndSpace(arg1 string, arg2 string, arg3 ...ccv3.Query) (resources.ServiceInstance, ccv3.IncludedResources, ccv3.Warnings, error) {

--- a/api/cloudcontroller/ccv3/query.go
+++ b/api/cloudcontroller/ccv3/query.go
@@ -53,6 +53,8 @@ const (
 	RoleTypesFilter QueryKey = "types"
 	// StackFilter is a query parameter for listing objects by stack name
 	StackFilter QueryKey = "stacks"
+	// TypeFiler is a query parameter for selecting binding type
+	TypeFilter QueryKey = "type"
 	// UnmappedFilter is a query parameter specifying unmapped routes
 	UnmappedFilter QueryKey = "unmapped"
 	// UserGUIDFilter is a query parameter when getting a user by GUID

--- a/command/v7/actor.go
+++ b/command/v7/actor.go
@@ -145,7 +145,7 @@ type Actor interface {
 	GetServiceBrokerLabels(serviceBrokerName string) (map[string]types.NullString, v7action.Warnings, error)
 	GetServiceBrokers() ([]resources.ServiceBroker, v7action.Warnings, error)
 	GetServiceInstanceByNameAndSpace(serviceInstanceName, spaceGUID string) (resources.ServiceInstance, v7action.Warnings, error)
-	GetServiceInstanceDetails(serviceInstanceName, spaceGUID string) (v7action.ServiceInstanceDetails, v7action.Warnings, error)
+	GetServiceInstanceDetails(serviceInstanceName, spaceGUID string, omitApps bool) (v7action.ServiceInstanceDetails, v7action.Warnings, error)
 	GetServiceInstancesForSpace(spaceGUID string, omitApps bool) ([]v7action.ServiceInstance, v7action.Warnings, error)
 	GetServiceOfferingLabels(serviceOfferingName, serviceBrokerName string) (map[string]types.NullString, v7action.Warnings, error)
 	GetServicePlanLabels(servicePlanName, serviceOfferingName, serviceBrokerName string) (map[string]types.NullString, v7action.Warnings, error)

--- a/command/v7/v7fakes/fake_actor.go
+++ b/command/v7/v7fakes/fake_actor.go
@@ -1905,11 +1905,12 @@ type FakeActor struct {
 		result2 v7action.Warnings
 		result3 error
 	}
-	GetServiceInstanceDetailsStub        func(string, string) (v7action.ServiceInstanceDetails, v7action.Warnings, error)
+	GetServiceInstanceDetailsStub        func(string, string, bool) (v7action.ServiceInstanceDetails, v7action.Warnings, error)
 	getServiceInstanceDetailsMutex       sync.RWMutex
 	getServiceInstanceDetailsArgsForCall []struct {
 		arg1 string
 		arg2 string
+		arg3 bool
 	}
 	getServiceInstanceDetailsReturns struct {
 		result1 v7action.ServiceInstanceDetails
@@ -11460,17 +11461,18 @@ func (fake *FakeActor) GetServiceInstanceByNameAndSpaceReturnsOnCall(i int, resu
 	}{result1, result2, result3}
 }
 
-func (fake *FakeActor) GetServiceInstanceDetails(arg1 string, arg2 string) (v7action.ServiceInstanceDetails, v7action.Warnings, error) {
+func (fake *FakeActor) GetServiceInstanceDetails(arg1 string, arg2 string, arg3 bool) (v7action.ServiceInstanceDetails, v7action.Warnings, error) {
 	fake.getServiceInstanceDetailsMutex.Lock()
 	ret, specificReturn := fake.getServiceInstanceDetailsReturnsOnCall[len(fake.getServiceInstanceDetailsArgsForCall)]
 	fake.getServiceInstanceDetailsArgsForCall = append(fake.getServiceInstanceDetailsArgsForCall, struct {
 		arg1 string
 		arg2 string
-	}{arg1, arg2})
-	fake.recordInvocation("GetServiceInstanceDetails", []interface{}{arg1, arg2})
+		arg3 bool
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("GetServiceInstanceDetails", []interface{}{arg1, arg2, arg3})
 	fake.getServiceInstanceDetailsMutex.Unlock()
 	if fake.GetServiceInstanceDetailsStub != nil {
-		return fake.GetServiceInstanceDetailsStub(arg1, arg2)
+		return fake.GetServiceInstanceDetailsStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
@@ -11485,17 +11487,17 @@ func (fake *FakeActor) GetServiceInstanceDetailsCallCount() int {
 	return len(fake.getServiceInstanceDetailsArgsForCall)
 }
 
-func (fake *FakeActor) GetServiceInstanceDetailsCalls(stub func(string, string) (v7action.ServiceInstanceDetails, v7action.Warnings, error)) {
+func (fake *FakeActor) GetServiceInstanceDetailsCalls(stub func(string, string, bool) (v7action.ServiceInstanceDetails, v7action.Warnings, error)) {
 	fake.getServiceInstanceDetailsMutex.Lock()
 	defer fake.getServiceInstanceDetailsMutex.Unlock()
 	fake.GetServiceInstanceDetailsStub = stub
 }
 
-func (fake *FakeActor) GetServiceInstanceDetailsArgsForCall(i int) (string, string) {
+func (fake *FakeActor) GetServiceInstanceDetailsArgsForCall(i int) (string, string, bool) {
 	fake.getServiceInstanceDetailsMutex.RLock()
 	defer fake.getServiceInstanceDetailsMutex.RUnlock()
 	argsForCall := fake.getServiceInstanceDetailsArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeActor) GetServiceInstanceDetailsReturns(result1 v7action.ServiceInstanceDetails, result2 v7action.Warnings, result3 error) {

--- a/resources/service_credential_binding_resource.go
+++ b/resources/service_credential_binding_resource.go
@@ -22,6 +22,10 @@ type ServiceCredentialBinding struct {
 	ServiceInstanceGUID string `jsonry:"relationships.service_instance.data.guid,omitempty"`
 	// AppGUID is the application that this binding is attached to
 	AppGUID string `jsonry:"relationships.app.data.guid,omitempty"`
+	// AppName is the application name. It is not part of the API response, and is here as pragmatic convenience.
+	AppName string `jsonry:"-"`
+	// LastOperation is the last operation on the service credential binding
+	LastOperation LastOperation `jsonry:"last_operation"`
 }
 
 func (s ServiceCredentialBinding) MarshalJSON() ([]byte, error) {

--- a/resources/service_credential_binding_resource_test.go
+++ b/resources/service_credential_binding_resource_test.go
@@ -31,9 +31,21 @@ var _ = Describe("service credential binding resource", func() {
 			ServiceCredentialBinding{ServiceInstanceGUID: "fake-instance-guid"},
 			`{ "relationships": { "service_instance": { "data": { "guid": "fake-instance-guid" } } } }`,
 		),
-		Entry("App guid",
+		Entry("app guid",
 			ServiceCredentialBinding{AppGUID: "fake-app-guid"},
 			`{ "relationships": { "app": { "data": { "guid": "fake-app-guid" } } } }`,
+		),
+		Entry(
+			"last operation",
+			ServiceCredentialBinding{
+				LastOperation: LastOperation{Type: CreateOperation, State: OperationInProgress},
+			},
+			`{
+				"last_operation": {
+					"type": "create",
+					"state": "in progress"
+				}
+			}`,
 		),
 		Entry(
 			"everything",


### PR DESCRIPTION
Note: the current CAPI version sometimes returns `null` for the last
opertation of a binding, which would cause this code to fail. There is work in the
pipeline to resolve this, and for now this is being delivered without
integration tests, so that we do not break CI.

[#171843320](https://www.pivotaltracker.com/story/show/171843320)
