### PR TITLE
v(services): missing instance msg quoted name

### DIFF
--- a/command/translatableerror/service_instance_not_found_error.go
+++ b/command/translatableerror/service_instance_not_found_error.go
@@ -9,7 +9,7 @@ func (e ServiceInstanceNotFoundError) Error() string {
 	if e.Name == "" {
 		return "Service instance (GUID: {{.GUID}}) not found"
 	}
-	return "Service instance {{.ServiceInstance}} not found"
+	return "Service instance '{{.ServiceInstance}}' not found"
 }
 
 func (e ServiceInstanceNotFoundError) Translate(translate func(string, ...interface{}) string) string {

--- a/integration/v7/isolated/bind_service_command_test.go
+++ b/integration/v7/isolated/bind_service_command_test.go
@@ -123,7 +123,7 @@ var _ = Describe("bind-service command", func() {
 				It("displays FAILED and service not found", func() {
 					session := helpers.CF("bind-service", appName, "does-not-exist")
 					Eventually(session).Should(Say("FAILED"))
-					Eventually(session.Err).Should(Say("Service instance %s not found", "does-not-exist"))
+					Eventually(session.Err).Should(Say("Service instance '%s' not found", "does-not-exist"))
 					Eventually(session).Should(Exit(1))
 				})
 			})

--- a/integration/v7/isolated/create_service_key_command_test.go
+++ b/integration/v7/isolated/create_service_key_command_test.go
@@ -110,7 +110,7 @@ var _ = Describe("create-service-key command", func() {
 			It("displays FAILED and an informative error, and exits 1", func() {
 				session := helpers.CF("create-service-key", "missing-service-instance", serviceKeyName)
 				Eventually(session.Out).Should(Say("FAILED"))
-				Eventually(session.Err).Should(Say("Service instance missing-service-instance not found"))
+				Eventually(session.Err).Should(Say("Service instance 'missing-service-instance' not found"))
 				Eventually(session).Should(Exit(1))
 			})
 		})

--- a/integration/v7/isolated/rename_service_command_test.go
+++ b/integration/v7/isolated/rename_service_command_test.go
@@ -104,7 +104,7 @@ var _ = Describe("rename-service command", func() {
 				session := helpers.CF("rename-service", currentName, newName)
 
 				Eventually(session).Should(Exit(1))
-				Expect(session.Err).To(Say("Service instance %s not found", currentName))
+				Expect(session.Err).To(Say("Service instance '%s' not found", currentName))
 			})
 		})
 

--- a/integration/v7/isolated/share_service_command_test.go
+++ b/integration/v7/isolated/share_service_command_test.go
@@ -118,7 +118,7 @@ var _ = Describe("share-service command", func() {
 						Say("Sharing service instance %s into org %s / space %s as %s...", serviceInstanceName, orgName, shareToSpaceName, username),
 						Say("FAILED"),
 					))
-					Expect(session.Err).To(Say("Service instance %s not found", serviceInstanceName))
+					Expect(session.Err).To(Say("Service instance '%s' not found", serviceInstanceName))
 				})
 			})
 

--- a/integration/v7/isolated/unbind_service_command_test.go
+++ b/integration/v7/isolated/unbind_service_command_test.go
@@ -100,7 +100,7 @@ var _ = Describe("unbind-service command", func() {
 				It("fails to unbind the service", func() {
 					session := helpers.CF("unbind-service", appName, "does-not-exist")
 					Eventually(session).Should(Say("FAILED"))
-					Eventually(session.Err).Should(Say("Service instance %s not found", "does-not-exist"))
+					Eventually(session.Err).Should(Say("Service instance '%s' not found", "does-not-exist"))
 					Eventually(session).Should(Exit(1))
 				})
 			})
@@ -215,7 +215,7 @@ var _ = Describe("unbind-service command", func() {
 					It("fails to unbind the service", func() {
 						session := helpers.CF("unbind-service", appName, serviceInstance)
 						Eventually(session).Should(Say("FAILED"))
-						Eventually(session.Err).Should(Say("Service instance %s not found", serviceInstance))
+						Eventually(session.Err).Should(Say("Service instance '%s' not found", serviceInstance))
 						Eventually(session).Should(Exit(1))
 					})
 				})

--- a/integration/v7/isolated/unshare_service_command_test.go
+++ b/integration/v7/isolated/unshare_service_command_test.go
@@ -132,7 +132,7 @@ var _ = Describe("unshare-service command", func() {
 						Say("Unsharing service instance %s from org %s / space %s as %s...", serviceInstanceName, orgName, unshareFromSpaceName, username),
 						Say("FAILED"),
 					))
-					Expect(session.Err).To(Say("Service instance %s not found", serviceInstanceName))
+					Expect(session.Err).To(Say("Service instance '%s' not found", serviceInstanceName))
 				})
 			})
 

--- a/integration/v7/isolated/update_service_command_test.go
+++ b/integration/v7/isolated/update_service_command_test.go
@@ -149,7 +149,7 @@ var _ = Describe("update-service command", func() {
 					Say("Updating service instance %s in org %s / space %s as %s...", serviceInstanceName, orgName, spaceName, username),
 					Say("FAILED"),
 				))
-				Expect(session.Err).To(Say("Service instance %s not found\n", serviceInstanceName))
+				Expect(session.Err).To(Say("Service instance '%s' not found\n", serviceInstanceName))
 			})
 		})
 

--- a/integration/v7/isolated/update_user_provided_service_command_test.go
+++ b/integration/v7/isolated/update_user_provided_service_command_test.go
@@ -111,7 +111,7 @@ var _ = Describe("update-user-provided-service command", func() {
 				session := helpers.CF("update-user-provided-service", "non-existent-service", "-l", "syslog://example.com")
 				Eventually(session).Should(Exit(1))
 
-				Expect(session.Err).To(Say("Service instance non-existent-service not found"))
+				Expect(session.Err).To(Say("Service instance 'non-existent-service' not found"))
 				Expect(session.Out).To(Say("FAILED"))
 			})
 		})

--- a/integration/v7/isolated/upgrade_service_command_test.go
+++ b/integration/v7/isolated/upgrade_service_command_test.go
@@ -1,6 +1,8 @@
 package isolated
 
 import (
+	"time"
+
 	"code.cloudfoundry.org/cli/integration/assets/hydrabroker/config"
 	"code.cloudfoundry.org/cli/integration/helpers"
 	"code.cloudfoundry.org/cli/integration/helpers/servicebrokerstub"
@@ -8,7 +10,6 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gbytes"
 	. "github.com/onsi/gomega/gexec"
-	"time"
 )
 
 var _ = Describe("upgrade-service command", func() {
@@ -101,7 +102,7 @@ var _ = Describe("upgrade-service command", func() {
 					))
 
 					Expect(session.Err).To(
-						Say("Service instance %s not found\n", serviceInstanceName),
+						Say("Service instance '%s' not found\n", serviceInstanceName),
 					)
 				})
 			})


### PR DESCRIPTION
The missing service instance message does not quote the service instance
name, whereas most other missing resources messages do. We should make
the message consistent.

[#175020062](https://www.pivotaltracker.com/story/show/175020062)
