### PR TITLE
v8(services): test: fix hydrabroker fetch binding response

### DIFF
--- a/integration/assets/hydrabroker/app/helpers.go
+++ b/integration/assets/hydrabroker/app/helpers.go
@@ -3,11 +3,10 @@ package app
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
+	"log"
 	"net/http"
 
 	"code.cloudfoundry.org/cli/integration/assets/hydrabroker/store"
-
 	"github.com/gorilla/mux"
 	uuid "github.com/nu7hatch/gouuid"
 )
@@ -18,7 +17,7 @@ func respondWithJSON(w http.ResponseWriter, data interface{}) error {
 		return err
 	}
 
-	fmt.Printf(`responding with JSON: %s\n`, string(bytes))
+	log.Printf("responding with JSON: %s", string(bytes))
 	w.Header().Set("Content-Type", "application/json")
 	_, err = w.Write(bytes)
 	return err

--- a/integration/assets/hydrabroker/integrationtest/integrationtest_test.go
+++ b/integration/assets/hydrabroker/integrationtest/integrationtest_test.go
@@ -225,6 +225,17 @@ var _ = Describe("Integration Test For Hydrabroker", func() {
 				var r resources.BindingDetails
 				fromJSON(response.Body, &r)
 				Expect(r).To(Equal(details))
+
+				By("making sure that empty parameters is {} rather than null")
+				newBindingGUID := randomString()
+				response = httpRequest(cfg, "PUT", server.URL+"/broker/"+guid+"/v2/service_instances/"+instanceGUID+"/service_bindings/"+newBindingGUID, toJSON(resources.BindingDetails{}))
+				expectStatusCode(response, http.StatusCreated)
+
+				response = httpRequest(cfg, "GET", server.URL+"/broker/"+guid+"/v2/service_instances/"+instanceGUID+"/service_bindings/"+newBindingGUID, nil)
+				expectStatusCode(response, http.StatusOK)
+				var s interface{}
+				fromJSON(response.Body, &s)
+				Expect(s).To(Equal(map[string]interface{}{"parameters": map[string]interface{}{}}))
 			})
 
 			It("allows a binding to be deleted", func() {

--- a/integration/assets/hydrabroker/main.go
+++ b/integration/assets/hydrabroker/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 
@@ -10,7 +11,7 @@ import (
 
 func main() {
 	port := port()
-	fmt.Printf("Listening on port: %s\n", port)
+	log.Printf("Listening on port: %s", port)
 	http.Handle("/", app.App())
 	http.ListenAndServe(port, nil)
 }


### PR DESCRIPTION
When no parameters are provided, it's responding {"parameters":null}
which is invalid, it should respond {"parameters":{}}

[#175141198](https://www.pivotaltracker.com/story/show/175141198)
