### PR TITLE
v8(services): bind-route-service: get correct route

### DIFF
--- a/actor/v7action/route_binding.go
+++ b/actor/v7action/route_binding.go
@@ -70,15 +70,11 @@ func (actor Actor) createRouteBinding(serviceInstanceGUID, routeGUID string, par
 }
 
 func (actor Actor) getRouteForBinding(params CreateRouteBindingParams, domain resources.Domain) (resources.Route, ccv3.Warnings, error) {
-	query := []ccv3.Query{{Key: ccv3.DomainGUIDFilter, Values: []string{domain.GUID}}}
-	if params.Hostname != "" {
-		query = append(query, ccv3.Query{Key: ccv3.HostsFilter, Values: []string{params.Hostname}})
-	}
-	if params.Path != "" {
-		query = append(query, ccv3.Query{Key: ccv3.PathsFilter, Values: []string{params.Path}})
-	}
-
-	routes, warnings, err := actor.CloudControllerClient.GetRoutes(query...)
+	routes, warnings, err := actor.CloudControllerClient.GetRoutes(
+		ccv3.Query{Key: ccv3.DomainGUIDFilter, Values: []string{domain.GUID}},
+		ccv3.Query{Key: ccv3.HostsFilter, Values: []string{params.Hostname}},
+		ccv3.Query{Key: ccv3.PathsFilter, Values: []string{params.Path}},
+	)
 	switch {
 	case err != nil:
 		return resources.Route{}, warnings, err

--- a/actor/v7action/route_binding_test.go
+++ b/actor/v7action/route_binding_test.go
@@ -93,6 +93,8 @@ var _ = Describe("Route Binding Action", func() {
 				SpaceGUID:           spaceGUID,
 				ServiceInstanceName: serviceInstanceName,
 				DomainName:          domainName,
+				Hostname:            hostname,
+				Path:                path,
 				Parameters: types.NewOptionalObject(map[string]interface{}{
 					"foo": "bar",
 				}),
@@ -206,51 +208,9 @@ var _ = Describe("Route Binding Action", func() {
 				Expect(fakeCloudControllerClient.GetRoutesCallCount()).To(Equal(1))
 				Expect(fakeCloudControllerClient.GetRoutesArgsForCall(0)).To(ConsistOf(
 					ccv3.Query{Key: ccv3.DomainGUIDFilter, Values: []string{domainGUID}},
+					ccv3.Query{Key: ccv3.HostsFilter, Values: []string{hostname}},
+					ccv3.Query{Key: ccv3.PathsFilter, Values: []string{path}},
 				))
-			})
-
-			When("hostname specified", func() {
-				BeforeEach(func() {
-					params.Hostname = hostname
-				})
-
-				It("makes the correct call", func() {
-					Expect(fakeCloudControllerClient.GetRoutesCallCount()).To(Equal(1))
-					Expect(fakeCloudControllerClient.GetRoutesArgsForCall(0)).To(ConsistOf(
-						ccv3.Query{Key: ccv3.DomainGUIDFilter, Values: []string{domainGUID}},
-						ccv3.Query{Key: ccv3.HostsFilter, Values: []string{hostname}},
-					))
-				})
-			})
-
-			When("path specified", func() {
-				BeforeEach(func() {
-					params.Path = path
-				})
-
-				It("makes the correct call", func() {
-					Expect(fakeCloudControllerClient.GetRoutesCallCount()).To(Equal(1))
-					Expect(fakeCloudControllerClient.GetRoutesArgsForCall(0)).To(ConsistOf(
-						ccv3.Query{Key: ccv3.DomainGUIDFilter, Values: []string{domainGUID}},
-						ccv3.Query{Key: ccv3.PathsFilter, Values: []string{path}},
-					))
-				})
-			})
-
-			When("hostname and path specified", func() {
-				BeforeEach(func() {
-					params.Hostname = hostname
-					params.Path = path
-				})
-
-				It("makes the correct call", func() {
-					Expect(fakeCloudControllerClient.GetRoutesCallCount()).To(Equal(1))
-					Expect(fakeCloudControllerClient.GetRoutesArgsForCall(0)).To(ConsistOf(
-						ccv3.Query{Key: ccv3.DomainGUIDFilter, Values: []string{domainGUID}},
-						ccv3.Query{Key: ccv3.HostsFilter, Values: []string{hostname}},
-						ccv3.Query{Key: ccv3.PathsFilter, Values: []string{path}},
-					))
-				})
 			})
 
 			When("not found", func() {


### PR DESCRIPTION
Sometimes a domain may have many routes. If the --hostname and --path
flag was not specified, the command was just choosing the first route,
and not the one with empty hostname and path.

[#175142930](https://www.pivotaltracker.com/story/show/175142930)

