### PR TITLE
v8(services): fetch bindings in batches for services 

### DIFF
--- a/integration/v7/isolated/services_command_test.go
+++ b/integration/v7/isolated/services_command_test.go
@@ -12,9 +12,7 @@ import (
 )
 
 var _ = Describe("services command", func() {
-	var (
-		userName string
-	)
+	var userName string
 
 	BeforeEach(func() {
 		userName, _ = helpers.GetCredentials()

--- a/util/batcher/batcher.go
+++ b/util/batcher/batcher.go
@@ -1,0 +1,29 @@
+package batcher
+
+import "code.cloudfoundry.org/cli/api/cloudcontroller/ccv3"
+
+const BatchSize = 50
+
+type callback func(guids []string) (ccv3.Warnings, error)
+
+func RequestByGUID(guids []string, cb callback) (ccv3.Warnings, error) {
+	var allWarnings ccv3.Warnings
+
+	for len(guids) > 0 {
+		remaining := len(guids)
+		if remaining > BatchSize {
+			remaining = BatchSize
+		}
+
+		batch := guids[:remaining]
+		guids = guids[remaining:]
+
+		warnings, err := cb(batch)
+		allWarnings = append(allWarnings, warnings...)
+		if err != nil {
+			return allWarnings, err
+		}
+	}
+
+	return allWarnings, nil
+}

--- a/util/batcher/batcher_suite_test.go
+++ b/util/batcher/batcher_suite_test.go
@@ -1,0 +1,13 @@
+package batcher_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestBatcher(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Batcher Suite")
+}

--- a/util/batcher/batcher_test.go
+++ b/util/batcher/batcher_test.go
@@ -1,0 +1,114 @@
+package batcher_test
+
+import (
+	"fmt"
+
+	"code.cloudfoundry.org/cli/cf/errors"
+
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3"
+	"code.cloudfoundry.org/cli/util/batcher"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Batcher", func() {
+	var (
+		calls            [][]string
+		warningsToReturn []ccv3.Warnings
+		errorsToReturn   []error
+	)
+
+	fakeCallback := func(guids []string) (ccv3.Warnings, error) {
+		index := len(calls)
+		calls = append(calls, guids)
+
+		var (
+			warnings ccv3.Warnings
+			err      error
+		)
+
+		if len(warningsToReturn) > index {
+			warnings = warningsToReturn[index]
+		}
+
+		if len(errorsToReturn) > index {
+			err = errorsToReturn[index]
+		}
+
+		return warnings, err
+	}
+
+	spreadGuids := func(start, end int) (result []string) {
+		for i := start; i < end; i++ {
+			result = append(result, fmt.Sprintf("fake-guid-%d", i))
+		}
+		return
+	}
+
+	BeforeEach(func() {
+		calls = nil
+		warningsToReturn = nil
+		errorsToReturn = nil
+	})
+
+	It("calls the callback", func() {
+		batcher.RequestByGUID([]string{"one", "two", "three"}, fakeCallback)
+
+		Expect(calls).To(HaveLen(1))
+		Expect(calls[0]).To(Equal([]string{"one", "two", "three"}))
+	})
+
+	When("the guids list exceeds the batch size", func() {
+		It("calls the callback multiple times", func() {
+			batcher.RequestByGUID(spreadGuids(0, 120), fakeCallback)
+
+			Expect(calls).To(HaveLen(3))
+			Expect(calls[0]).To(Equal(spreadGuids(0, 50)))
+			Expect(calls[1]).To(Equal(spreadGuids(50, 100)))
+			Expect(calls[2]).To(Equal(spreadGuids(100, 120)))
+		})
+	})
+
+	When("the callback returns warnings", func() {
+		BeforeEach(func() {
+			warningsToReturn = []ccv3.Warnings{
+				{"one", "two"},
+				{"three", "four"},
+				{},
+				{"five"},
+			}
+		})
+
+		It("returns all the accumulated warnings", func() {
+			warnings, _ := batcher.RequestByGUID(spreadGuids(0, 160), fakeCallback)
+
+			Expect(warnings).To(ConsistOf("one", "two", "three", "four", "five"))
+		})
+	})
+
+	When("the callback returns an error", func() {
+		BeforeEach(func() {
+			warningsToReturn = []ccv3.Warnings{
+				{"one", "two"},
+				{"three", "four"},
+				{"five"},
+				{"six", "seven"},
+			}
+
+			errorsToReturn = []error{
+				nil,
+				nil,
+				errors.New("bang"),
+				nil,
+			}
+		})
+
+		It("returns the error and accumulated warnings", func() {
+			warnings, err := batcher.RequestByGUID(spreadGuids(0, 160), fakeCallback)
+
+			Expect(calls).To(HaveLen(3))
+			Expect(warnings).To(ConsistOf("one", "two", "three", "four", "five"))
+			Expect(err).To(MatchError("bang"))
+		})
+	})
+})


### PR DESCRIPTION
When there are a lot of service instances (more than 200), the URL used
to fetch service credential bindings becomes too long. So we now fetch
the bindings in in batches of up to 50.

[#175230712](https://www.pivotaltracker.com/story/show/175230712)