### PR TITLE
chore: de-duplicate lookup table building

### DIFF
--- a/actor/cfnetworkingaction/policy.go
+++ b/actor/cfnetworkingaction/policy.go
@@ -6,6 +6,7 @@ import (
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/constant"
 	"code.cloudfoundry.org/cli/resources"
+	"code.cloudfoundry.org/cli/util/lookuptable"
 )
 
 type Policy struct {
@@ -196,10 +197,7 @@ func (actor Actor) orgNamesBySpaceGUID(spaces []resources.Space) (map[string]str
 		return nil, warnings, err
 	}
 
-	orgNamesByGUID := make(map[string]string, len(orgs))
-	for _, org := range orgs {
-		orgNamesByGUID[org.GUID] = org.Name
-	}
+	orgNamesByGUID := lookuptable.NameFromGUID(orgs)
 
 	orgNamesBySpaceGUID := make(map[string]string, len(spaces))
 	for _, space := range spaces {
@@ -249,10 +247,7 @@ func (actor Actor) getPoliciesForApplications(applications []resources.Applicati
 		return []Policy{}, allWarnings, err
 	}
 
-	spaceNamesByGUID := make(map[string]string, len(spaces))
-	for _, destSpace := range spaces {
-		spaceNamesByGUID[destSpace.GUID] = destSpace.Name
-	}
+	spaceNamesByGUID := lookuptable.NameFromGUID(spaces)
 
 	orgNamesBySpaceGUID, warnings, err := actor.orgNamesBySpaceGUID(spaces)
 	allWarnings = append(allWarnings, warnings...)
@@ -260,10 +255,7 @@ func (actor Actor) getPoliciesForApplications(applications []resources.Applicati
 		return []Policy{}, allWarnings, err
 	}
 
-	appByGUID := map[string]resources.Application{}
-	for _, app := range applications {
-		appByGUID[app.GUID] = app
-	}
+	appByGUID := lookuptable.AppFromGUID(applications)
 
 	var policies []Policy
 	for _, v1Policy := range v1Policies {

--- a/actor/v3action/organization.go
+++ b/actor/v3action/organization.go
@@ -4,6 +4,7 @@ import (
 	"code.cloudfoundry.org/cli/actor/actionerror"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3"
 	"code.cloudfoundry.org/cli/resources"
+	"code.cloudfoundry.org/cli/util/lookuptable"
 )
 
 // Organization represents a V3 actor organization.
@@ -36,10 +37,7 @@ func (actor Actor) GetOrganizationsByGUIDs(guids ...string) ([]Organization, War
 		return []Organization{}, Warnings(warnings), err
 	}
 
-	guidToOrg := make(map[string]resources.Organization)
-	for _, org := range orgs {
-		guidToOrg[org.GUID] = org
-	}
+	guidToOrg := lookuptable.OrgFromGUID(orgs)
 
 	filteredOrgs := make([]resources.Organization, 0)
 	for _, guid := range guids {

--- a/actor/v3action/space.go
+++ b/actor/v3action/space.go
@@ -5,6 +5,7 @@ import (
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/constant"
 	"code.cloudfoundry.org/cli/resources"
+	"code.cloudfoundry.org/cli/util/lookuptable"
 )
 
 type Space struct {
@@ -92,10 +93,7 @@ func (actor Actor) GetSpacesByGUIDs(guids ...string) ([]Space, Warnings, error) 
 	}
 
 	var filteredSpaces []resources.Space
-	guidToSpaces := map[string]resources.Space{}
-	for _, space := range spaces {
-		guidToSpaces[space.GUID] = space
-	}
+	guidToSpaces := lookuptable.SpaceFromGUID(spaces)
 
 	for _, guid := range guids {
 		filteredSpaces = append(filteredSpaces, guidToSpaces[guid])

--- a/actor/v7action/security_group.go
+++ b/actor/v7action/security_group.go
@@ -10,6 +10,7 @@ import (
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/constant"
 	"code.cloudfoundry.org/cli/resources"
+	"code.cloudfoundry.org/cli/util/lookuptable"
 )
 
 type SecurityGroupSummary struct {
@@ -336,15 +337,8 @@ func getSecurityGroupSpaces(actor Actor, stagingSpaceGUIDs []string, runningSpac
 			return securityGroupSpaces, warnings, err
 		}
 
-		orgsByGuid := make(map[string]resources.Organization)
-		for _, org := range includes.Organizations {
-			orgsByGuid[org.GUID] = org
-		}
-
-		spacesByGuid := make(map[string]resources.Space)
-		for _, space := range spaces {
-			spacesByGuid[space.GUID] = space
-		}
+		orgsByGuid := lookuptable.OrgFromGUID(includes.Organizations)
+		spacesByGuid := lookuptable.SpaceFromGUID(spaces)
 
 		for _, runningSpaceGUID := range runningSpaceGUIDs {
 			space := spacesByGuid[runningSpaceGUID]

--- a/actor/v7action/service_instance_list.go
+++ b/actor/v7action/service_instance_list.go
@@ -7,6 +7,7 @@ import (
 	"code.cloudfoundry.org/cli/resources"
 	"code.cloudfoundry.org/cli/types"
 	"code.cloudfoundry.org/cli/util/batcher"
+	"code.cloudfoundry.org/cli/util/lookuptable"
 	"code.cloudfoundry.org/cli/util/railway"
 )
 
@@ -98,10 +99,7 @@ func instanceGUIDS(instances []resources.ServiceInstance) []string {
 }
 
 func buildPlanDetailsLookup(included ccv3.IncludedResources) map[string]planDetails {
-	brokerLookup := make(map[string]string)
-	for _, b := range included.ServiceBrokers {
-		brokerLookup[b.GUID] = b.Name
-	}
+	brokerLookup := lookuptable.NameFromGUID(included.ServiceBrokers)
 
 	type twoNames struct{ broker, offering string }
 	offeringLookup := make(map[string]twoNames)

--- a/api/cloudcontroller/ccv3/service_credential_binding.go
+++ b/api/cloudcontroller/ccv3/service_credential_binding.go
@@ -3,6 +3,7 @@ package ccv3
 import (
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/internal"
 	"code.cloudfoundry.org/cli/resources"
+	"code.cloudfoundry.org/cli/util/lookuptable"
 )
 
 // GetServiceCredentialBindings queries the CC API with the specified query
@@ -23,10 +24,7 @@ func (client Client) GetServiceCredentialBindings(query ...Query) ([]resources.S
 	})
 
 	if len(included.Apps) > 0 {
-		appLookup := make(map[string]resources.Application)
-		for _, app := range included.Apps {
-			appLookup[app.GUID] = app
-		}
+		appLookup := lookuptable.AppFromGUID(included.Apps)
 
 		for i := range result {
 			result[i].AppName = appLookup[result[i].AppGUID].Name

--- a/api/cloudcontroller/ccv3/service_instance.go
+++ b/api/cloudcontroller/ccv3/service_instance.go
@@ -6,6 +6,7 @@ import (
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/internal"
 	"code.cloudfoundry.org/cli/resources"
 	"code.cloudfoundry.org/cli/types"
+	"code.cloudfoundry.org/cli/util/lookuptable"
 )
 
 type SpaceWithOrganization struct {
@@ -164,15 +165,11 @@ func (client *Client) GetServiceInstanceUsageSummary(serviceInstanceGUID string)
 func mapRelationshipsToSpaces(sharedToSpaces resources.SharedToSpacesListWrapper) []SpaceWithOrganization {
 	var spacesToReturn []SpaceWithOrganization
 
-	guidToOrgNameMap := make(map[string]string)
-
-	for _, o := range sharedToSpaces.Organizations {
-		guidToOrgNameMap[o.GUID] = o.Name
-	}
+	guidToOrgNameLookup := lookuptable.NameFromGUID(sharedToSpaces.Organizations)
 
 	for _, s := range sharedToSpaces.Spaces {
 		org := s.Relationships[constant.RelationshipTypeOrganization]
-		space := SpaceWithOrganization{SpaceGUID: s.GUID, SpaceName: s.Name, OrganizationName: guidToOrgNameMap[org.GUID]}
+		space := SpaceWithOrganization{SpaceGUID: s.GUID, SpaceName: s.Name, OrganizationName: guidToOrgNameLookup[org.GUID]}
 		spacesToReturn = append(spacesToReturn, space)
 	}
 

--- a/api/cloudcontroller/ccv3/service_offering.go
+++ b/api/cloudcontroller/ccv3/service_offering.go
@@ -4,6 +4,7 @@ import (
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccerror"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/internal"
 	"code.cloudfoundry.org/cli/resources"
+	"code.cloudfoundry.org/cli/util/lookuptable"
 )
 
 // GetServiceOffering lists service offering with optional filters.
@@ -22,10 +23,7 @@ func (client *Client) GetServiceOfferings(query ...Query) ([]resources.ServiceOf
 		},
 	})
 
-	brokerNameLookup := make(map[string]string)
-	for _, b := range included.ServiceBrokers {
-		brokerNameLookup[b.GUID] = b.Name
-	}
+	brokerNameLookup := lookuptable.NameFromGUID(included.ServiceBrokers)
 
 	for i, _ := range result {
 		result[i].ServiceBrokerName = brokerNameLookup[result[i].ServiceBrokerGUID]

--- a/api/cloudcontroller/ccv3/service_plan.go
+++ b/api/cloudcontroller/ccv3/service_plan.go
@@ -5,6 +5,7 @@ import (
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/constant"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/internal"
 	"code.cloudfoundry.org/cli/resources"
+	"code.cloudfoundry.org/cli/util/lookuptable"
 )
 
 func (client *Client) GetServicePlanByGUID(guid string) (resources.ServicePlan, Warnings, error) {
@@ -138,10 +139,7 @@ func (client *Client) GetServicePlansWithOfferings(query ...Query) ([]ServiceOff
 		return i
 	}
 
-	brokerNameLookup := make(map[string]string)
-	for _, b := range included.ServiceBrokers {
-		brokerNameLookup[b.GUID] = b.Name
-	}
+	brokerNameLookup := lookuptable.NameFromGUID(included.ServiceBrokers)
 
 	for _, p := range plans {
 		i := indexOfOffering(p.ServiceOfferingGUID)
@@ -159,10 +157,7 @@ func (client *Client) GetServicePlansWithOfferings(query ...Query) ([]ServiceOff
 }
 
 func computeSpaceDetailsTable(included IncludedResources) map[string]planSpaceDetails {
-	orgNameFromGUID := make(map[string]string)
-	for _, org := range included.Organizations {
-		orgNameFromGUID[org.GUID] = org.Name
-	}
+	orgNameFromGUID := lookuptable.NameFromGUID(included.Organizations)
 
 	spaceDetailsFromGUID := make(map[string]planSpaceDetails)
 	for _, space := range included.Spaces {

--- a/util/lookuptable/lookuptable_suite_test.go
+++ b/util/lookuptable/lookuptable_suite_test.go
@@ -1,0 +1,13 @@
+package lookuptable_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestLookuptable(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Lookuptable Suite")
+}

--- a/util/lookuptable/name_from_guid.go
+++ b/util/lookuptable/name_from_guid.go
@@ -1,0 +1,20 @@
+package lookuptable
+
+import "reflect"
+
+func NameFromGUID(input interface{}) map[string]string {
+	val := reflect.ValueOf(input)
+	if val.Kind() != reflect.Slice || val.Type().Elem().Kind() != reflect.Struct {
+		return nil
+	}
+
+	result := make(map[string]string)
+	for i := 0; i < val.Len(); i++ {
+		element := val.Index(i)
+		guid := element.FieldByName("GUID")
+		name := element.FieldByName("Name")
+		result[guid.String()] = name.String()
+	}
+
+	return result
+}

--- a/util/lookuptable/name_from_guid_test.go
+++ b/util/lookuptable/name_from_guid_test.go
@@ -1,0 +1,43 @@
+package lookuptable_test
+
+import (
+	"code.cloudfoundry.org/cli/util/lookuptable"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("NameFromGuid", func() {
+	It("builds a lookup table", func() {
+		input := []struct{ Name, GUID string }{
+			{Name: "foo-name", GUID: "foo-guid"},
+			{Name: "bar-name", GUID: "bar-guid"},
+			{Name: "baz-name", GUID: "baz-guid"},
+			{Name: "quz-name", GUID: "quz-guid"},
+		}
+
+		Expect(lookuptable.NameFromGUID(input)).To(Equal(map[string]string{
+			"foo-guid": "foo-name",
+			"bar-guid": "bar-name",
+			"baz-guid": "baz-name",
+			"quz-guid": "quz-name",
+		}))
+	})
+
+	When("the input is not a slice", func() {
+		It("returns nil", func() {
+			input := struct{ Name, GUID string }{
+				Name: "foo-name",
+				GUID: "foo-guid",
+			}
+
+			Expect(lookuptable.NameFromGUID(input)).To(BeNil())
+		})
+	})
+
+	When("the elements are not structs", func() {
+		It("returns nil", func() {
+			input := []string{"foo", "bar"}
+			Expect(lookuptable.NameFromGUID(input)).To(BeNil())
+		})
+	})
+})

--- a/util/lookuptable/resource_from_guid.go
+++ b/util/lookuptable/resource_from_guid.go
@@ -1,0 +1,27 @@
+package lookuptable
+
+import "code.cloudfoundry.org/cli/resources"
+
+func OrgFromGUID(orgs []resources.Organization) map[string]resources.Organization {
+	result := make(map[string]resources.Organization)
+	for _, org := range orgs {
+		result[org.GUID] = org
+	}
+	return result
+}
+
+func SpaceFromGUID(spaces []resources.Space) map[string]resources.Space {
+	result := make(map[string]resources.Space)
+	for _, space := range spaces {
+		result[space.GUID] = space
+	}
+	return result
+}
+
+func AppFromGUID(apps []resources.Application) map[string]resources.Application {
+	result := make(map[string]resources.Application)
+	for _, app := range apps {
+		result[app.GUID] = app
+	}
+	return result
+}


### PR DESCRIPTION
We build lots of lookup tables using identical, or nearly identical
code. This change creates a common package for doing that, reducing
duplication.

[#175327708](https://www.pivotaltracker.com/story/show/175327708)
