### PR TITLE
V3: default to large page size for list requests

### DIFF
--- a/api/cloudcontroller/ccv3/buildpack_test.go
+++ b/api/cloudcontroller/ccv3/buildpack_test.go
@@ -101,7 +101,7 @@ var _ = Describe("Buildpacks", func() {
 
 				server.AppendHandlers(
 					CombineHandlers(
-						VerifyRequest(http.MethodGet, "/v3/buildpacks", "names=some-buildpack-name"),
+						VerifyRequest(http.MethodGet, "/v3/buildpacks", "names=some-buildpack-name&per_page=5000"),
 						RespondWith(http.StatusOK, response1, http.Header{"X-Cf-Warnings": {"this is a warning"}}),
 					),
 				)

--- a/api/cloudcontroller/ccv3/domain_test.go
+++ b/api/cloudcontroller/ccv3/domain_test.go
@@ -782,7 +782,7 @@ var _ = Describe("Domain", func() {
 
 				server.AppendHandlers(
 					CombineHandlers(
-						VerifyRequest(http.MethodGet, "/v3/organizations/some-org-guid/domains", "organization_guids=some-org-guid"),
+						VerifyRequest(http.MethodGet, "/v3/organizations/some-org-guid/domains", "organization_guids=some-org-guid&per_page=5000"),
 						RespondWith(http.StatusOK, response1, http.Header{"X-Cf-Warnings": {"this is a warning"}}),
 					),
 				)

--- a/api/cloudcontroller/ccv3/errors_test.go
+++ b/api/cloudcontroller/ccv3/errors_test.go
@@ -168,7 +168,7 @@ var _ = Describe("Error Wrapper", func() {
 						})
 
 						It("returns a APINotFoundError", func() {
-							Expect(makeError).To(MatchError(ccerror.APINotFoundError{URL: server.URL() + "/v3/apps"}))
+							Expect(makeError).To(MatchError(ccerror.APINotFoundError{URL: server.URL() + "/v3/apps?per_page=5000"}))
 						})
 					})
 

--- a/api/cloudcontroller/ccv3/isolation_segment_test.go
+++ b/api/cloudcontroller/ccv3/isolation_segment_test.go
@@ -160,7 +160,7 @@ var _ = Describe("Isolation Segments", func() {
 				}`
 				server.AppendHandlers(
 					CombineHandlers(
-						VerifyRequest(http.MethodGet, "/v3/isolation_segments", "organization_guids=some-org-guid&names=iso1,iso2,iso3"),
+						VerifyRequest(http.MethodGet, "/v3/isolation_segments", "organization_guids=some-org-guid&names=iso1,iso2,iso3&per_page=5000"),
 						RespondWith(http.StatusOK, response1, http.Header{"X-Cf-Warnings": {"this is a warning"}}),
 					),
 				)

--- a/api/cloudcontroller/ccv3/organization_quota_test.go
+++ b/api/cloudcontroller/ccv3/organization_quota_test.go
@@ -239,7 +239,7 @@ var _ = Describe("Organization Quotas", func() {
 
 				server.AppendHandlers(
 					CombineHandlers(
-						VerifyRequest(http.MethodGet, "/v3/organization_quotas", "names=sancho-panza"),
+						VerifyRequest(http.MethodGet, "/v3/organization_quotas", "names=sancho-panza&per_page=5000"),
 						RespondWith(http.StatusOK, response, http.Header{"X-Cf-Warnings": {"page1 warning"}}),
 					),
 				)

--- a/api/cloudcontroller/ccv3/organization_test.go
+++ b/api/cloudcontroller/ccv3/organization_test.go
@@ -361,7 +361,7 @@ var _ = Describe("Organizations", func() {
 }`
 				server.AppendHandlers(
 					CombineHandlers(
-						VerifyRequest(http.MethodGet, "/v3/organizations", "names=some-org-name"),
+						VerifyRequest(http.MethodGet, "/v3/organizations", "names=some-org-name&per_page=5000"),
 						RespondWith(http.StatusOK, response1, http.Header{"X-Cf-Warnings": {"this is a warning"}}),
 					),
 				)

--- a/api/cloudcontroller/ccv3/package_test.go
+++ b/api/cloudcontroller/ccv3/package_test.go
@@ -354,7 +354,7 @@ var _ = Describe("Package", func() {
 				}`
 				server.AppendHandlers(
 					CombineHandlers(
-						VerifyRequest(http.MethodGet, "/v3/packages", "app_guids=some-app-guid"),
+						VerifyRequest(http.MethodGet, "/v3/packages", "app_guids=some-app-guid&per_page=5000"),
 						RespondWith(http.StatusOK, response, http.Header{"X-Cf-Warnings": {"this is a warning"}}),
 					),
 				)
@@ -405,7 +405,7 @@ var _ = Describe("Package", func() {
 				}`
 				server.AppendHandlers(
 					CombineHandlers(
-						VerifyRequest(http.MethodGet, "/v3/packages", "app_guids=some-app-guid"),
+						VerifyRequest(http.MethodGet, "/v3/packages", "app_guids=some-app-guid&per_page=5000"),
 						RespondWith(http.StatusTeapot, response, http.Header{"X-Cf-Warnings": {"this is a warning"}}),
 					),
 				)

--- a/api/cloudcontroller/ccv3/requester.go
+++ b/api/cloudcontroller/ccv3/requester.go
@@ -6,10 +6,13 @@ import (
 	"fmt"
 	"io"
 	"runtime"
+	"strconv"
 
 	"code.cloudfoundry.org/cli/api/cloudcontroller"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/internal"
 )
+
+const DefaultPerPage = 5000
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . Requester
 
@@ -83,6 +86,7 @@ func (requester *RealRequester) InitializeRouter(resources map[string]string) {
 }
 
 func (requester *RealRequester) MakeListRequest(requestParams RequestParams) (IncludedResources, Warnings, error) {
+	requestParams.Query = adjustPerPage(requestParams.Query)
 	request, err := requester.buildRequest(requestParams)
 	if err != nil {
 		return IncludedResources{}, nil, err
@@ -271,4 +275,14 @@ func (requester *RealRequester) uploadAsynchronously(request *cloudcontroller.Re
 	}
 
 	return response.ResourceLocationURL, response.Warnings, firstError
+}
+
+func adjustPerPage(query []Query) []Query {
+	for _, q := range query {
+		if q.Key == PerPage {
+			return query
+		}
+	}
+
+	return append(query, Query{Key: PerPage, Values: []string{strconv.Itoa(DefaultPerPage)}})
 }

--- a/api/cloudcontroller/ccv3/requester_test.go
+++ b/api/cloudcontroller/ccv3/requester_test.go
@@ -513,7 +513,7 @@ var _ = Describe("shared request helpers", func() {
 
 					server.AppendHandlers(
 						CombineHandlers(
-							VerifyRequest(http.MethodGet, "/v3/roles", "organization_guids=some-org-name&include=users"),
+							VerifyRequest(http.MethodGet, "/v3/roles", "organization_guids=some-org-name&include=users&per_page=5000"),
 							RespondWith(http.StatusOK, response1, http.Header{"X-Cf-Warnings": {"warning-1"}}),
 						),
 					)
@@ -620,7 +620,7 @@ var _ = Describe("shared request helpers", func() {
 
 					server.AppendHandlers(
 						CombineHandlers(
-							VerifyRequest(http.MethodGet, "/v3/roles", "organization_guids=some-org-name&include=users"),
+							VerifyRequest(http.MethodGet, "/v3/roles", "organization_guids=some-org-name&include=users&per_page=5000"),
 							RespondWith(http.StatusOK, response1, http.Header{"X-Cf-Warnings": {"warning-1"}}),
 						),
 					)
@@ -771,6 +771,62 @@ var _ = Describe("shared request helpers", func() {
 						},
 					}))
 					Expect(warnings).To(ConsistOf("this is a warning"))
+				})
+			})
+
+			When("`per_page` is specified`", func() {
+				BeforeEach(func() {
+					requestParams.Query = append(requestParams.Query, Query{Key: PerPage, Values: []string{"42"}})
+
+					response1 := fmt.Sprintf(`{
+	"pagination": {
+		"next": {
+			"href": "%s/v3/roles?organization_guids=some-org-name&page=2&per_page=1&include=users"
+		}
+	},
+  "resources": [
+    {
+      "guid": "role-guid-1",
+      "type": "organization_user"
+    }
+  ]
+}`, server.URL())
+					response2 := `{
+							"pagination": {
+								"next": null
+							},
+						 "resources": [
+						   {
+						     "guid": "role-guid-2",
+						     "type": "organization_manager"
+						   }
+						 ]
+						}`
+
+					server.AppendHandlers(
+						CombineHandlers(
+							VerifyRequest(http.MethodGet, "/v3/roles", "organization_guids=some-org-name&include=users&per_page=42"),
+							RespondWith(http.StatusOK, response1, http.Header{"X-Cf-Warnings": {"warning-1"}}),
+						),
+					)
+					server.AppendHandlers(
+						CombineHandlers(
+							VerifyRequest(http.MethodGet, "/v3/roles", "organization_guids=some-org-name&page=2&per_page=1&include=users"),
+							RespondWith(http.StatusOK, response2, http.Header{"X-Cf-Warnings": {"warning-2"}}),
+						),
+					)
+				})
+
+				It("overrides the default `per_page` value", func() {
+					Expect(executeErr).ToNot(HaveOccurred())
+					Expect(warnings).To(ConsistOf("warning-1", "warning-2"))
+					Expect(resourceList).To(Equal([]resources.Role{{
+						GUID: "role-guid-1",
+						Type: constant.OrgUserRole,
+					}, {
+						GUID: "role-guid-2",
+						Type: constant.OrgManagerRole,
+					}}))
 				})
 			})
 		})

--- a/api/cloudcontroller/ccv3/role_test.go
+++ b/api/cloudcontroller/ccv3/role_test.go
@@ -434,7 +434,7 @@ var _ = Describe("Role", func() {
 
 					server.AppendHandlers(
 						CombineHandlers(
-							VerifyRequest(http.MethodGet, "/v3/roles", "organization_guids=some-org-name&include=users"),
+							VerifyRequest(http.MethodGet, "/v3/roles", "organization_guids=some-org-name&include=users&per_page=5000"),
 							RespondWith(http.StatusOK, response1, http.Header{"X-Cf-Warnings": {"warning-1"}}),
 						),
 					)
@@ -517,7 +517,7 @@ var _ = Describe("Role", func() {
 
 					server.AppendHandlers(
 						CombineHandlers(
-							VerifyRequest(http.MethodGet, "/v3/roles", "organization_guids=some-org-name&include=users"),
+							VerifyRequest(http.MethodGet, "/v3/roles", "organization_guids=some-org-name&include=users&per_page=5000"),
 							RespondWith(http.StatusOK, response1, http.Header{"X-Cf-Warnings": {"warning-1"}}),
 						),
 					)

--- a/api/cloudcontroller/ccv3/route_test.go
+++ b/api/cloudcontroller/ccv3/route_test.go
@@ -415,13 +415,13 @@ var _ = Describe("Route", func() {
 
 					server.AppendHandlers(
 						CombineHandlers(
-							VerifyRequest(http.MethodGet, "/v3/routes", "space_guids=guid1,guid2"),
+							VerifyRequest(http.MethodGet, "/v3/routes", "space_guids=guid1,guid2&per_page=5000"),
 							RespondWith(http.StatusOK, response1, http.Header{"X-Cf-Warnings": {"warning-1"}}),
 						),
 					)
 					server.AppendHandlers(
 						CombineHandlers(
-							VerifyRequest(http.MethodGet, "/v3/routes", "page=2", "space_guids=guid1,guid2"),
+							VerifyRequest(http.MethodGet, "/v3/routes", "page=2", "space_guids=guid1,guid2&per_page=5000"),
 							RespondWith(http.StatusOK, response2, http.Header{"X-Cf-Warnings": {"warning-2"}}),
 						),
 					)

--- a/api/cloudcontroller/ccv3/service_broker_test.go
+++ b/api/cloudcontroller/ccv3/service_broker_test.go
@@ -230,7 +230,7 @@ var _ = Describe("ServiceBroker", func() {
 
 				server.AppendHandlers(
 					CombineHandlers(
-						VerifyRequest(http.MethodGet, "/v3/service_brokers", "names=special-unicorn-broker"),
+						VerifyRequest(http.MethodGet, "/v3/service_brokers", "names=special-unicorn-broker&per_page=5000"),
 						RespondWith(http.StatusOK, response, http.Header{"X-Cf-Warnings": {"this is another warning"}}),
 					),
 				)

--- a/api/cloudcontroller/ccv3/service_instance_test.go
+++ b/api/cloudcontroller/ccv3/service_instance_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Service Instance", func() {
 
 				server.AppendHandlers(
 					CombineHandlers(
-						VerifyRequest(http.MethodGet, "/v3/service_instances", "names=some-service-instance-name"),
+						VerifyRequest(http.MethodGet, "/v3/service_instances", "names=some-service-instance-name&per_page=5000"),
 						RespondWith(http.StatusOK, response1, http.Header{"X-Cf-Warnings": {"warning-1"}}),
 					),
 					CombineHandlers(

--- a/api/cloudcontroller/ccv3/service_offering_test.go
+++ b/api/cloudcontroller/ccv3/service_offering_test.go
@@ -111,7 +111,7 @@ var _ = Describe("Service Offering", func() {
 
 				server.AppendHandlers(
 					CombineHandlers(
-						VerifyRequest(http.MethodGet, "/v3/service_offerings", "names=myServiceOffering&service_broker_names=myServiceBroker&fields[service_broker]=name,guid"),
+						VerifyRequest(http.MethodGet, "/v3/service_offerings", "names=myServiceOffering&service_broker_names=myServiceBroker&fields[service_broker]=name,guid&per_page=5000"),
 						RespondWith(http.StatusOK, response1, http.Header{"X-Cf-Warnings": {"warning-1"}}),
 					),
 					CombineHandlers(

--- a/api/cloudcontroller/ccv3/service_plan_test.go
+++ b/api/cloudcontroller/ccv3/service_plan_test.go
@@ -106,7 +106,7 @@ var _ = Describe("Service Plan", func() {
 
 				server.AppendHandlers(
 					CombineHandlers(
-						VerifyRequest(http.MethodGet, "/v3/service_plans", "names=myServicePlan&service_broker_names=myServiceBroker&service_offering_names=someOffering"),
+						VerifyRequest(http.MethodGet, "/v3/service_plans", "names=myServicePlan&service_broker_names=myServiceBroker&service_offering_names=someOffering&per_page=5000"),
 						RespondWith(http.StatusOK, response1, http.Header{"X-Cf-Warnings": {"warning-1"}}),
 					),
 					CombineHandlers(
@@ -327,7 +327,7 @@ var _ = Describe("Service Plan", func() {
 
 				server.AppendHandlers(
 					CombineHandlers(
-						VerifyRequest(http.MethodGet, "/v3/service_plans", "include=space.organization&service_offering_names=someOffering"),
+						VerifyRequest(http.MethodGet, "/v3/service_plans", "include=space.organization&service_offering_names=someOffering&per_page=5000"),
 						RespondWith(http.StatusOK, response1, http.Header{"X-Cf-Warnings": {"warning-1"}}),
 					),
 					CombineHandlers(
@@ -392,7 +392,7 @@ var _ = Describe("Service Plan", func() {
 				}`
 				server.AppendHandlers(
 					CombineHandlers(
-						VerifyRequest(http.MethodGet, "/v3/service_plans", "include=space.organization"),
+						VerifyRequest(http.MethodGet, "/v3/service_plans", "include=space.organization&per_page=5000"),
 						RespondWith(http.StatusTeapot, response, http.Header{"X-Cf-Warnings": {"this is a warning"}}),
 					),
 				)
@@ -585,7 +585,7 @@ var _ = Describe("Service Plan", func() {
 
 				server.AppendHandlers(
 					CombineHandlers(
-						VerifyRequest(http.MethodGet, "/v3/service_plans", "include=service_offering&space_guids=some-space-guid&organization_guids=some-org-guid&fields[service_offering.service_broker]=name,guid"),
+						VerifyRequest(http.MethodGet, "/v3/service_plans", "include=service_offering&space_guids=some-space-guid&organization_guids=some-org-guid&fields[service_offering.service_broker]=name,guid&per_page=5000"),
 						RespondWith(http.StatusOK, response1, http.Header{"X-Cf-Warnings": {"warning-1"}}),
 					),
 					CombineHandlers(
@@ -684,7 +684,7 @@ var _ = Describe("Service Plan", func() {
 				}`
 				server.AppendHandlers(
 					CombineHandlers(
-						VerifyRequest(http.MethodGet, "/v3/service_plans", "include=service_offering&fields[service_offering.service_broker]=name,guid"),
+						VerifyRequest(http.MethodGet, "/v3/service_plans", "include=service_offering&fields[service_offering.service_broker]=name,guid&per_page=5000"),
 						RespondWith(http.StatusTeapot, response, http.Header{"X-Cf-Warnings": {"this is a warning"}}),
 					),
 				)

--- a/api/cloudcontroller/ccv3/space_quota_test.go
+++ b/api/cloudcontroller/ccv3/space_quota_test.go
@@ -840,7 +840,7 @@ var _ = Describe("Space Quotas", func() {
 
 				server.AppendHandlers(
 					CombineHandlers(
-						VerifyRequest(http.MethodGet, "/v3/space_quotas", "names=sancho-panza"),
+						VerifyRequest(http.MethodGet, "/v3/space_quotas", "names=sancho-panza&per_page=5000"),
 						RespondWith(http.StatusOK, response, http.Header{"X-Cf-Warnings": {"page1 warning"}}),
 					),
 				)

--- a/api/cloudcontroller/ccv3/space_test.go
+++ b/api/cloudcontroller/ccv3/space_test.go
@@ -178,7 +178,7 @@ var _ = Describe("Spaces", func() {
 
 				server.AppendHandlers(
 					CombineHandlers(
-						VerifyRequest(http.MethodGet, "/v3/spaces", "names=some-space-name"),
+						VerifyRequest(http.MethodGet, "/v3/spaces", "names=some-space-name&per_page=5000"),
 						RespondWith(http.StatusOK, response1, http.Header{"X-Cf-Warnings": {"this is a warning"}}),
 					),
 				)
@@ -277,7 +277,7 @@ var _ = Describe("Spaces", func() {
 
 				server.AppendHandlers(
 					CombineHandlers(
-						VerifyRequest(http.MethodGet, "/v3/spaces", "names=some-space-name&include=organizations"),
+						VerifyRequest(http.MethodGet, "/v3/spaces", "names=some-space-name&include=organizations&per_page=5000"),
 						RespondWith(http.StatusOK, response1, http.Header{"X-Cf-Warnings": {"warning-1"}}),
 					),
 				)

--- a/api/cloudcontroller/ccv3/stack_test.go
+++ b/api/cloudcontroller/ccv3/stack_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Stacks", func() {
 
 				server.AppendHandlers(
 					CombineHandlers(
-						VerifyRequest(http.MethodGet, "/v3/stacks", "names=some-stack-name"),
+						VerifyRequest(http.MethodGet, "/v3/stacks", "names=some-stack-name&per_page=5000"),
 						RespondWith(http.StatusOK, response1, http.Header{"X-Cf-Warnings": {"this is a warning"}}),
 					),
 				)

--- a/api/cloudcontroller/ccv3/user_test.go
+++ b/api/cloudcontroller/ccv3/user_test.go
@@ -227,7 +227,7 @@ var _ = Describe("User", func() {
 
 					server.AppendHandlers(
 						CombineHandlers(
-							VerifyRequest(http.MethodGet, "/v3/users", "usernames=some-user-name&origins=uaa"),
+							VerifyRequest(http.MethodGet, "/v3/users", "usernames=some-user-name&origins=uaa&per_page=5000"),
 							RespondWith(http.StatusOK, response1, http.Header{"X-Cf-Warnings": {"warning-1"}}),
 						),
 					)


### PR DESCRIPTION
When getting a large number of resources for a list endpoint, we
currently get 50 resources per page. The V3 maximum is 5000, so we could
make 100 times fewer HTTP requests which significantly improves
performance. This change means that we will request 5000 resources per
page except for situations where the code specifically requests a
different number.

[#175715881](https://www.pivotaltracker.com/story/show/175715881)