### PR TITLE
Rename variable to "p"

### DIFF
--- a/cf/flags/README.md
+++ b/cf/flags/README.md
@@ -27,8 +27,8 @@ func main(){
   fc := flags.New()
   fc.NewStringFlag("password", "p", "flag for password")  //name, short_name and usage of the string flag
   fc.Parse(os.Args...)  //parse the OS arguments
-  println("Flag 'password' is set: ", fc.IsSet("s"))
-  println("Flag 'password' value: ", fc.String("s"))
+  println("Flag 'password' is set: ", fc.IsSet("p"))
+  println("Flag 'password' value: ", fc.String("p"))
 }
 ```
 Running the above code


### PR DESCRIPTION
## Description of the Change

In the example the variable is called `p`, but the check is done on a non-existing field called `s`