### PR TITLE
v8(services): get large pages for services and marketplace

### DIFF
--- a/actor/v7action/marketplace.go
+++ b/actor/v7action/marketplace.go
@@ -12,7 +12,7 @@ type MarketplaceFilter struct {
 }
 
 func (actor Actor) Marketplace(filter MarketplaceFilter) ([]ServiceOfferingWithPlans, Warnings, error) {
-	var query []ccv3.Query
+	query := []ccv3.Query{{Key: ccv3.PerPage, Values: []string{ccv3.MaxPerPage}}}
 
 	if filter.SpaceGUID != "" {
 		query = append(query, ccv3.Query{

--- a/actor/v7action/marketplace_test.go
+++ b/actor/v7action/marketplace_test.go
@@ -65,10 +65,10 @@ var _ = Describe("marketplace", func() {
 
 			Expect(fakeCloudControllerClient.GetServicePlansWithOfferingsCallCount()).To(Equal(1))
 			queries := fakeCloudControllerClient.GetServicePlansWithOfferingsArgsForCall(0)
-			Expect(queries).To(ConsistOf(ccv3.Query{
-				Key:    ccv3.AvailableFilter,
-				Values: []string{"true"},
-			}))
+			Expect(queries).To(ConsistOf(
+				ccv3.Query{Key: ccv3.AvailableFilter, Values: []string{"true"}},
+				ccv3.Query{Key: ccv3.PerPage, Values: []string{ccv3.MaxPerPage}},
+			))
 		})
 
 		It("returns a list of service offerings and plans", func() {
@@ -162,6 +162,7 @@ var _ = Describe("marketplace", func() {
 					ccv3.Query{Key: ccv3.SpaceGUIDFilter, Values: []string{"space-guid"}},
 					ccv3.Query{Key: ccv3.ServiceOfferingNamesFilter, Values: []string{"my-service-offering"}},
 					ccv3.Query{Key: ccv3.AvailableFilter, Values: []string{"true"}},
+					ccv3.Query{Key: ccv3.PerPage, Values: []string{ccv3.MaxPerPage}},
 				))
 			})
 		})

--- a/actor/v7action/service_instance_list.go
+++ b/actor/v7action/service_instance_list.go
@@ -41,7 +41,8 @@ func (actor Actor) GetServiceInstancesForSpace(spaceGUID string, omitApps bool) 
 				ccv3.Query{Key: ccv3.FieldsServicePlan, Values: []string{"guid", "name", "relationships.service_offering"}},
 				ccv3.Query{Key: ccv3.FieldsServicePlanServiceOffering, Values: []string{"guid", "name", "relationships.service_broker"}},
 				ccv3.Query{Key: ccv3.FieldsServicePlanServiceOfferingServiceBroker, Values: []string{"guid", "name"}},
-				ccv3.Query{Key: ccv3.OrderBy, Values: []string{"name"}},
+				ccv3.Query{Key: ccv3.OrderBy, Values: []string{ccv3.NameOrder}},
+				ccv3.Query{Key: ccv3.PerPage, Values: []string{ccv3.MaxPerPage}},
 			)
 			return
 		},

--- a/actor/v7action/service_instance_list_test.go
+++ b/actor/v7action/service_instance_list_test.go
@@ -180,7 +180,8 @@ var _ = Describe("Service Instance List Action", func() {
 				ccv3.Query{Key: ccv3.FieldsServicePlan, Values: []string{"guid", "name", "relationships.service_offering"}},
 				ccv3.Query{Key: ccv3.FieldsServicePlanServiceOffering, Values: []string{"guid", "name", "relationships.service_broker"}},
 				ccv3.Query{Key: ccv3.FieldsServicePlanServiceOfferingServiceBroker, Values: []string{"guid", "name"}},
-				ccv3.Query{Key: ccv3.OrderBy, Values: []string{"name"}},
+				ccv3.Query{Key: ccv3.OrderBy, Values: []string{ccv3.NameOrder}},
+				ccv3.Query{Key: ccv3.PerPage, Values: []string{ccv3.MaxPerPage}},
 			))
 		})
 

--- a/api/cloudcontroller/ccv3/query.go
+++ b/api/cloudcontroller/ccv3/query.go
@@ -122,6 +122,9 @@ const (
 
 	// Purge is a query parameter used on a Delete request to indicate that dependent resources should also be deleted
 	Purge = "purge"
+
+	// MaxPerPage is the largest value of "per_page" that should be used
+	MaxPerPage = "5000"
 )
 
 // Query is additional settings that can be passed to some requests that can


### PR DESCRIPTION
These commands can potentially get a lot of data, and they are much
faster if they get 5000 results per page, instead of the default of 50
per page.

[#175715881](https://www.pivotaltracker.com/story/show/175715881)