### PR TITLE
v8(services): delete service better confirmation message

### DIFF
--- a/command/v7/delete_service_command.go
+++ b/command/v7/delete_service_command.go
@@ -95,7 +95,7 @@ func (cmd DeleteServiceCommand) displayEvent() error {
 func (cmd DeleteServiceCommand) displayPrompt() (bool, error) {
 	delete, err := cmd.UI.DisplayBoolPrompt(
 		false,
-		"Really delete the service instance {{.ServiceInstanceName}}?",
+		"Really delete the service instance {{.ServiceInstanceName}}, including app bindings, route bindings, and service keys?",
 		cmd.serviceInstanceName(),
 	)
 	if err != nil {

--- a/command/v7/delete_service_command_test.go
+++ b/command/v7/delete_service_command_test.go
@@ -279,8 +279,9 @@ var _ = Describe("delete-service command", func() {
 	})
 
 	It("prompts the user", func() {
-		Expect(testUI.Out).To(SatisfyAll(
-			Say(`Really delete the service instance %s\? \[yN\]:`, serviceInstanceName),
+		Expect(testUI.Out).To(Say(
+			`Really delete the service instance %s, including app bindings, route bindings, and service keys\? \[yN\]:`,
+			serviceInstanceName,
 		))
 	})
 


### PR DESCRIPTION
In common with other V3 endpoints, the intention is for deleting a
service to be recursive. The confirmation message in the CLI should
reflect this.

[#175741832](https://www.pivotaltracker.com/story/show/175741832)