### PR TITLE
remove redundant reference to version switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,6 @@ Please read the [contributors' guide](.github/CONTRIBUTING.md)
 
 If you'd like to submit updated translations, please see the [i18n README](https://github.com/cloudfoundry/cli/blob/master/cf/i18n/README-i18n.md) for instructions on how to submit an update.
 
-**Need to switch back and forth between CLI versions?**
-See the [Version Switching](#version-switching) section for instructions.
-
 ![Example](.github/cf_example.gif)
 
 Check out our [community contributed CLI plugins](https://plugins.cloudfoundry.org) to further enhance your CLI experience.


### PR DESCRIPTION
It was broken also because it was an inline reference that we should have removed when we moved the version switching guide to it's own page.

Thank you for contributing to the CF CLI! Please read the following:


* Please make sure you have implemented changes in line with the [contributing guidelines](https://github.com/cloudfoundry/cli/blob/master/.github/CONTRIBUTING.md)
* We're not allowed to accept any PRs without a signed CLA, no matter how small.
If your contribution falls under a company CLA but your membership is not public, expect delays while we confirm.
* All new code requires tests to protect against regressions.
* Contributions must be made against the appropriate branch. See the [contributing guidelines](https://github.com/cloudfoundry/cli/blob/master/.github/CONTRIBUTING.md)
* Contributions must conform to our [style guide](https://github.com/cloudfoundry/cli/wiki/CLI-Product-Specific-Style-Guide). Please reach out to us if you have questions.


## Does this PR modify CLI v6 or v7?

Please see the contribution doc above or review [Architecture Guide](https://github.com/cloudfoundry/cli/wiki/Architecture-Guide).

## Description of the Change


We must be able to understand the design of your change from this description.
Keep in mind that the maintainer reviewing this PR may not be familiar with or
have worked with the code here recently, so please walk us through the concepts.


## Why Is This PR Valuable?

What benefits will be realized by the code change? What users would want this change? What user need is this change addressing? 

## Why Should This Be In Core?

Explain why this functionality should be in the cf CLI, as opposed to a plugin. 

## Applicable Issues

List any applicable Github Issues here

## How Urgent Is The Change?

Is the change urgent? If so, explain why it is time-sensitive.

## Other Relevant Parties

Who else is affected by the change? 
