### PR TITLE
v7(services): do not poll empty jobs

### DIFF
--- a/api/cloudcontroller/ccv3/job.go
+++ b/api/cloudcontroller/ccv3/job.go
@@ -90,6 +90,10 @@ func (client *Client) GetJob(jobURL JobURL) (Job, Warnings, error) {
 // error is encountered, or config.OverallPollingTimeout is reached. In the
 // last case, a JobTimeoutError is returned.
 func (client *Client) PollJob(jobURL JobURL) (Warnings, error) {
+	if jobURL == "" {
+		return nil, nil
+	}
+
 	var (
 		err         error
 		warnings    Warnings

--- a/api/cloudcontroller/ccv3/job_test.go
+++ b/api/cloudcontroller/ccv3/job_test.go
@@ -178,6 +178,17 @@ var _ = Describe("Job", func() {
 			warnings, executeErr = client.PollJob(jobLocation)
 		})
 
+		When("the job URL is an empty", func() {
+			BeforeEach(func() {
+				jobLocation = ""
+			})
+
+			It("returns no warnings or errors", func() {
+				Expect(executeErr).ToNot(HaveOccurred())
+				Expect(warnings).To(BeEmpty())
+			})
+		})
+
 		When("the job starts queued and then finishes successfully", func() {
 			BeforeEach(func() {
 				server.AppendHandlers(


### PR DESCRIPTION
We tried to change the PATCH /v3/service_broker endpoint to return HTTP
200 with no job when only the service broker name was being changed.
However the CLI attempted to poll a non-existent job resulting in an
error. When `PollJob()` is passed an empty job, it should simply return
and not fail.

[#169090128](https://www.pivotaltracker.com/story/show/169090128)