### PR TITLE
v8(services): services cmd - remove experimental formats

### DIFF
--- a/actor/v7action/service_instance_list.go
+++ b/actor/v7action/service_instance_list.go
@@ -13,14 +13,14 @@ import (
 )
 
 type ServiceInstance struct {
-	Type                resources.ServiceInstanceType `json:"type,omitempty"`
-	Name                string                        `json:"name"`
-	ServicePlanName     string                        `json:"plan,omitempty"`
-	ServiceOfferingName string                        `json:"offering,omitempty"`
-	ServiceBrokerName   string                        `json:"broker,omitempty"`
-	BoundApps           []string                      `json:"bound_apps,omitempty"`
-	LastOperation       string                        `json:"last_operation,omitempty"`
-	UpgradeAvailable    types.OptionalBoolean         `json:"upgrade_available"`
+	Type                resources.ServiceInstanceType
+	Name                string
+	ServicePlanName     string
+	ServiceOfferingName string
+	ServiceBrokerName   string
+	BoundApps           []string
+	LastOperation       string
+	UpgradeAvailable    types.OptionalBoolean
 }
 
 type planDetails struct {

--- a/integration/v7/isolated/services_command_test.go
+++ b/integration/v7/isolated/services_command_test.go
@@ -228,6 +228,8 @@ var _ = Describe("services command V3", func() {
 			Say(`cf services\n`),
 			Say(`ALIAS:\n`),
 			Say(`s\n`),
+			Say(`OPTIONS:\n`),
+			Say(`--no-apps\s+Do not retrieve bound apps information\.\n`),
 			Say(`SEE ALSO:\n`),
 			Say(`create-service, marketplace\n`),
 		)


### PR DESCRIPTION
We experimented with some different formatting options and in the end
decided to keep the existing format

[#176843213](https://www.pivotaltracker.com/story/show/176843213)