### PR TITLE
v8(services): handle "operation in progress" error

### DIFF
--- a/api/cloudcontroller/ccerror/service_instance_operation_in_progress_error.go
+++ b/api/cloudcontroller/ccerror/service_instance_operation_in_progress_error.go
@@ -1,0 +1,11 @@
+package ccerror
+
+// ServiceInstanceOperationInProgressError is returned when an operation
+// cannot proceed because an operation is already in progress
+type ServiceInstanceOperationInProgressError struct {
+	Message string
+}
+
+func (e ServiceInstanceOperationInProgressError) Error() string {
+	return e.Message
+}

--- a/api/cloudcontroller/ccv3/errors_test.go
+++ b/api/cloudcontroller/ccv3/errors_test.go
@@ -275,6 +275,33 @@ var _ = Describe("Error Wrapper", func() {
 					})
 				})
 
+				Context("(409) Conflict", func() {
+					BeforeEach(func() {
+						serverResponseCode = http.StatusConflict
+					})
+
+					When("a service instance operation is in progress", func() {
+						BeforeEach(func() {
+							serverResponse = `
+{
+  "errors": [
+    {
+      "code": 60016,
+      "detail": "An operation for service instance foo is in progress.",
+      "title": "CF-AsyncServiceInstanceOperationInProgress"
+    }
+  ]
+}`
+						})
+
+						It("returns a ServiceInstanceOperationInProgressError", func() {
+							Expect(makeError).To(MatchError(ccerror.ServiceInstanceOperationInProgressError{
+								Message: "An operation for service instance foo is in progress.",
+							}))
+						})
+					})
+				})
+
 				Context("(422) Unprocessable Entity", func() {
 					BeforeEach(func() {
 						serverResponseCode = http.StatusUnprocessableEntity


### PR DESCRIPTION
- reports the message from the cloud controller
- no longer reports as an unexpected error

[#176379736](https://www.pivotaltracker.com/story/show/176379736)