### PR TITLE
Fix stack being over-ridden everytime in v7 push

### DIFF
--- a/actor/v7pushaction/handle_stack_override.go
+++ b/actor/v7pushaction/handle_stack_override.go
@@ -10,8 +10,8 @@ func HandleStackOverride(manifest manifestparser.Manifest, overrides FlagOverrid
 		if manifest.ContainsMultipleApps() {
 			return manifest, translatableerror.CommandLineArgsWithMultipleAppsError{}
 		}
+		manifest.Applications[0].Stack = overrides.Stack
 	}
-	manifest.Applications[0].Stack = overrides.Stack
 
 	return manifest, nil
 }

--- a/actor/v7pushaction/handle_stack_override_test.go
+++ b/actor/v7pushaction/handle_stack_override_test.go
@@ -27,6 +27,23 @@ var _ = Describe("HandleStackOverride", func() {
 		transformedManifest, executeErr = HandleStackOverride(originalManifest, overrides)
 	})
 
+	When("stack is not set", func() {
+		When("there is a single app in the manifest with the stack specified", func() {
+			BeforeEach(func() {
+				originalManifest.Applications = []manifestparser.Application{
+					{
+						Stack: "og_cflinuxfs",
+					},
+				}
+			})
+
+			It("will retain the origional stack value", func() {
+				Expect(executeErr).To(Not(HaveOccurred()))
+				Expect(transformedManifest.Applications[0].Stack).To(Equal("og_cflinuxfs"))
+			})
+		})
+	})
+
 	When("stack flag is set", func() {
 		When("there is a single app in the manifest with a stack specified", func() {
 			BeforeEach(func() {


### PR DESCRIPTION

## Does this PR modify CLI v6 or v7? 
v7

## Description of the Change

When v7 push is called with a manifest that has a stack field set, the cf CLI would override that field to an empty string. This PR makes it so that we only override the stack field in the manifest when a user provides a stack with the -s flag. 

## Why Is This PR Valuable?

When users set the stack field in their manifest, they would like to use it. 

## Why Should This Be In Core?

Bug fix.

## Applicable Issues

https://github.com/cloudfoundry/cloud_controller_ng/issues/1819

## How Urgent Is The Change?

We would like this shipped in the next minor v7 release 

## Other Relevant Parties

@amhuber who reported this issue 
