### PR TITLE
Special chars are not HTML encoded when outputting JSON

### DIFF
--- a/command/commandfakes/fake_ui.go
+++ b/command/commandfakes/fake_ui.go
@@ -66,6 +66,18 @@ type FakeUI struct {
 	displayInstancesTableForAppArgsForCall []struct {
 		arg1 [][]string
 	}
+	DisplayJSONStub        func(string, interface{}) error
+	displayJSONMutex       sync.RWMutex
+	displayJSONArgsForCall []struct {
+		arg1 string
+		arg2 interface{}
+	}
+	displayJSONReturns struct {
+		result1 error
+	}
+	displayJSONReturnsOnCall map[int]struct {
+		result1 error
+	}
 	DisplayKeyValueTableStub        func(string, [][]string, int)
 	displayKeyValueTableMutex       sync.RWMutex
 	displayKeyValueTableArgsForCall []struct {
@@ -585,6 +597,67 @@ func (fake *FakeUI) DisplayInstancesTableForAppArgsForCall(i int) [][]string {
 	defer fake.displayInstancesTableForAppMutex.RUnlock()
 	argsForCall := fake.displayInstancesTableForAppArgsForCall[i]
 	return argsForCall.arg1
+}
+
+func (fake *FakeUI) DisplayJSON(arg1 string, arg2 interface{}) error {
+	fake.displayJSONMutex.Lock()
+	ret, specificReturn := fake.displayJSONReturnsOnCall[len(fake.displayJSONArgsForCall)]
+	fake.displayJSONArgsForCall = append(fake.displayJSONArgsForCall, struct {
+		arg1 string
+		arg2 interface{}
+	}{arg1, arg2})
+	fake.recordInvocation("DisplayJSON", []interface{}{arg1, arg2})
+	fake.displayJSONMutex.Unlock()
+	if fake.DisplayJSONStub != nil {
+		return fake.DisplayJSONStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.displayJSONReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeUI) DisplayJSONCallCount() int {
+	fake.displayJSONMutex.RLock()
+	defer fake.displayJSONMutex.RUnlock()
+	return len(fake.displayJSONArgsForCall)
+}
+
+func (fake *FakeUI) DisplayJSONCalls(stub func(string, interface{}) error) {
+	fake.displayJSONMutex.Lock()
+	defer fake.displayJSONMutex.Unlock()
+	fake.DisplayJSONStub = stub
+}
+
+func (fake *FakeUI) DisplayJSONArgsForCall(i int) (string, interface{}) {
+	fake.displayJSONMutex.RLock()
+	defer fake.displayJSONMutex.RUnlock()
+	argsForCall := fake.displayJSONArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeUI) DisplayJSONReturns(result1 error) {
+	fake.displayJSONMutex.Lock()
+	defer fake.displayJSONMutex.Unlock()
+	fake.DisplayJSONStub = nil
+	fake.displayJSONReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeUI) DisplayJSONReturnsOnCall(i int, result1 error) {
+	fake.displayJSONMutex.Lock()
+	defer fake.displayJSONMutex.Unlock()
+	fake.DisplayJSONStub = nil
+	if fake.displayJSONReturnsOnCall == nil {
+		fake.displayJSONReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.displayJSONReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeUI) DisplayKeyValueTable(arg1 string, arg2 [][]string, arg3 int) {
@@ -1707,6 +1780,8 @@ func (fake *FakeUI) Invocations() map[string][][]interface{} {
 	defer fake.displayHeaderMutex.RUnlock()
 	fake.displayInstancesTableForAppMutex.RLock()
 	defer fake.displayInstancesTableForAppMutex.RUnlock()
+	fake.displayJSONMutex.RLock()
+	defer fake.displayJSONMutex.RUnlock()
 	fake.displayKeyValueTableMutex.RLock()
 	defer fake.displayKeyValueTableMutex.RUnlock()
 	fake.displayKeyValueTableForAppMutex.RLock()

--- a/command/ui.go
+++ b/command/ui.go
@@ -18,6 +18,7 @@ type UI interface {
 	DisplayFileDeprecationWarning()
 	DisplayHeader(text string)
 	DisplayInstancesTableForApp(table [][]string)
+	DisplayJSON(name string, jsonData interface{}) error
 	DisplayKeyValueTable(prefix string, table [][]string, padding int)
 	DisplayKeyValueTableForApp(table [][]string)
 	DisplayLogMessage(message ui.LogMessage, displayHeader bool)

--- a/command/v7/env_command.go
+++ b/command/v7/env_command.go
@@ -1,7 +1,6 @@
 package v7
 
 import (
-	"encoding/json"
 	"fmt"
 	"sort"
 
@@ -109,11 +108,10 @@ func sortKeys(group map[string]interface{}) []string {
 
 func (cmd EnvCommand) displaySystem(group map[string]interface{}) error {
 	for key, val := range group {
-		jsonVal, err := json.MarshalIndent(val, "", " ")
+		err := cmd.UI.DisplayJSON(key, val)
 		if err != nil {
 			return err
 		}
-		cmd.UI.DisplayText(fmt.Sprintf("%s: %s", key, jsonVal))
 	}
 	return nil
 }

--- a/command/v7/env_command_test.go
+++ b/command/v7/env_command_test.go
@@ -92,7 +92,7 @@ var _ = Describe("env Command", func() {
 			When("getting the environment returns env vars for all groups", func() {
 				BeforeEach(func() {
 					envGroups := v7action.EnvironmentVariableGroups{
-						System:               map[string]interface{}{"system-name": map[string]interface{}{"mysql": []string{"system-value"}}},
+						System:               map[string]interface{}{"system-name": map[string]interface{}{"mysql": []string{"system-value"}, "password": "test<3"}},
 						Application:          map[string]interface{}{"application-name": "application-value"},
 						EnvironmentVariables: map[string]interface{}{"user-name": "user-value"},
 						Running:              map[string]interface{}{"running-name": "running-value"},
@@ -109,7 +109,8 @@ var _ = Describe("env Command", func() {
 					Expect(testUI.Out).To(Say("system-name: {"))
 					Expect(testUI.Out).To(Say(`"mysql": \[`))
 					Expect(testUI.Out).To(Say(`"system-value"`))
-					Expect(testUI.Out).To(Say(`\]`))
+					Expect(testUI.Out).To(Say(`\],`))
+					Expect(testUI.Out).To(Say(`"password": "test<3"`))
 					Expect(testUI.Out).To(Say("}"))
 					Expect(testUI.Out).To(Say(`application-name: "application-value"`))
 

--- a/command/v7/security_group_command.go
+++ b/command/v7/security_group_command.go
@@ -1,8 +1,6 @@
 package v7
 
 import (
-	"encoding/json"
-
 	"code.cloudfoundry.org/cli/command/flag"
 	"code.cloudfoundry.org/cli/util/ui"
 )
@@ -43,12 +41,10 @@ func (cmd SecurityGroupCommand) Execute(args []string) error {
 		{cmd.UI.TranslateText("rules:"), ""},
 	}, 3)
 
-	jsonRules, err := json.MarshalIndent(securityGroupSummary.Rules, "\t", "\t")
+	err = cmd.UI.DisplayJSON("", securityGroupSummary.Rules)
 	if err != nil {
 		return err
 	}
-
-	cmd.UI.DisplayText("\t" + string(jsonRules))
 
 	cmd.UI.DisplayNewline()
 

--- a/util/ui/ui.go
+++ b/util/ui/ui.go
@@ -279,6 +279,9 @@ func (ui *UI) DisplayTextWithFlavor(template string, templateValues ...map[strin
 // DisplayJSON encodes and indents the input
 // and outputs the result to ui.Out.
 func (ui *UI) DisplayJSON(name string, jsonData interface{}) error {
+	ui.terminalLock.Lock()
+	defer ui.terminalLock.Unlock()
+
 	buff := new(bytes.Buffer)
 	encoder := json.NewEncoder(buff)
 	encoder.SetEscapeHTML(false)
@@ -290,10 +293,11 @@ func (ui *UI) DisplayJSON(name string, jsonData interface{}) error {
 	}
 
 	if name != "" {
-		ui.DisplayText(fmt.Sprintf("%s: %s", name, buff))
+		fmt.Fprintf(ui.Out, "%s\n", fmt.Sprintf("%s: %s", name, buff))
 	} else {
-		ui.DisplayText(fmt.Sprint(buff))
+		fmt.Fprintf(ui.Out, "%s\n", buff)
 	}
+
 	return nil
 }
 

--- a/util/ui/ui.go
+++ b/util/ui/ui.go
@@ -6,6 +6,8 @@
 package ui
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -272,6 +274,27 @@ func (ui *UI) DisplayTextWithFlavor(template string, templateValues ...map[strin
 		firstTemplateValues[key] = ui.modifyColor(fmt.Sprint(value), color.New(color.FgCyan, color.Bold))
 	}
 	fmt.Fprintf(ui.Out, "%s\n", ui.TranslateText(template, firstTemplateValues))
+}
+
+// DisplayJSON encodes and indents the input
+// and outputs the result to ui.Out.
+func (ui *UI) DisplayJSON(name string, jsonData interface{}) error {
+	buff := new(bytes.Buffer)
+	encoder := json.NewEncoder(buff)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", " ")
+
+	err := encoder.Encode(jsonData)
+	if err != nil {
+		return err
+	}
+
+	if name != "" {
+		ui.DisplayText(fmt.Sprintf("%s: %s", name, buff))
+	} else {
+		ui.DisplayText(fmt.Sprint(buff))
+	}
+	return nil
 }
 
 // FlushDeferred displays text previously deferred (using DeferText) to the UI's

--- a/util/ui/ui_test.go
+++ b/util/ui/ui_test.go
@@ -186,6 +186,38 @@ var _ = Describe("UI", func() {
 		})
 	})
 
+	Describe("Display JSON", func() {
+		It("displays the indented JSON object", func() {
+			obj := map[string]interface{}{
+				"str":  "hello",
+				"bool": true,
+				"int":  42,
+				"pass": "abc>&gd!f",
+				"map":  map[string]interface{}{"float": 123.03},
+				"arr":  []string{"a", "b"},
+			}
+
+			ui.DisplayJSON("named_json", obj)
+
+			Expect(out).To(SatisfyAll(
+				Say("named_json: {\n"),
+				Say(" \"arr\": \\[\n"),
+				Say("  \"a\","),
+				Say("  \"b\"\n"),
+				Say(" \\],\n"),
+				Say(" \"bool\": true,\n"),
+				Say(" \"int\": 42,\n"),
+				Say(" \"map\": {\n"),
+				Say("  \"float\": 123.03\n"),
+				Say(" },\n"),
+				Say(" \"pass\": \"abc>&gd!f\",\n"),
+				Say(" \"str\": \"hello\"\n"),
+				Say("}\n"),
+				Say("\n"),
+			))
+		})
+	})
+
 	Describe("DeferText", func() {
 		It("defers the template with map values substituted in to ui.Out with a newline", func() {
 			ui.DeferText(


### PR DESCRIPTION
The previous method `json.MarshalIndent`  has HTML skipping enabled by default. This causes issues, especially when outputting passwords with special chars.

resolves #1917
[#171951689](https://www.pivotaltracker.com/story/show/171951689)

