### PR TITLE
Use`UI.DisplayJSON` for all services JSON output

### DIFF
--- a/actor/v7action/service_instance_details.go
+++ b/actor/v7action/service_instance_details.go
@@ -5,7 +5,6 @@ import (
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccerror"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3"
 	"code.cloudfoundry.org/cli/resources"
-	"code.cloudfoundry.org/cli/types"
 	"code.cloudfoundry.org/cli/util/extract"
 	"code.cloudfoundry.org/cli/util/railway"
 )
@@ -32,7 +31,7 @@ type SharedStatus struct {
 	UsageSummary              []UsageSummaryWithSpaceAndOrg
 }
 
-type ServiceInstanceParameters types.JSONObject
+type ServiceInstanceParameters map[string]interface{}
 
 type ServiceInstanceUpgradeState int
 

--- a/actor/v7action/service_instance_details_test.go
+++ b/actor/v7action/service_instance_details_test.go
@@ -735,7 +735,7 @@ var _ = Describe("Service Instance Details Action", func() {
 			)
 
 			fakeCloudControllerClient.GetServiceInstanceParametersReturns(
-				types.JSONObject{"foo": "bar"},
+				map[string]interface{}{"foo": "bar"},
 				ccv3.Warnings{"some-parameters-warning"},
 				nil,
 			)
@@ -812,13 +812,13 @@ var _ = Describe("Service Instance Details Action", func() {
 
 			It("returns parameters", func() {
 				Expect(serviceInstanceParams).To(Equal(
-					ServiceInstanceParameters(types.JSONObject{"foo": "bar"})))
+					ServiceInstanceParameters(map[string]interface{}{"foo": "bar"})))
 			})
 
 			When("getting the parameters fails with a ServiceInstanceParametersFetchNotSupportedError", func() {
 				BeforeEach(func() {
 					fakeCloudControllerClient.GetServiceInstanceParametersReturns(
-						types.JSONObject{},
+						map[string]interface{}{},
 						ccv3.Warnings{"some-parameters-warning"},
 						ccerror.ServiceInstanceParametersFetchNotSupportedError{
 							Message: "This service does not support fetching service instance parameters.",
@@ -835,7 +835,7 @@ var _ = Describe("Service Instance Details Action", func() {
 			When("getting the parameters fails with a ResourceNotFoundError", func() {
 				BeforeEach(func() {
 					fakeCloudControllerClient.GetServiceInstanceParametersReturns(
-						types.JSONObject{},
+						map[string]interface{}{},
 						ccv3.Warnings{"some-parameters-warning"},
 						ccerror.ResourceNotFoundError{
 							Message: "Service instance not found",
@@ -852,7 +852,7 @@ var _ = Describe("Service Instance Details Action", func() {
 			When("getting the parameters fails with an another error", func() {
 				BeforeEach(func() {
 					fakeCloudControllerClient.GetServiceInstanceParametersReturns(
-						types.JSONObject{},
+						map[string]interface{}{},
 						ccv3.Warnings{"some-parameters-warning"},
 						errors.New("not expected"),
 					)

--- a/actor/v7action/service_key_test.go
+++ b/actor/v7action/service_key_test.go
@@ -477,7 +477,7 @@ var _ = Describe("Service Key Action", func() {
 
 			fakeCloudControllerClient.GetServiceCredentialBindingDetailsReturns(
 				resources.ServiceCredentialBindingDetails{
-					Credentials: types.JSONObject{"foo": "bar"},
+					Credentials: map[string]interface{}{"foo": "bar"},
 				},
 				ccv3.Warnings{"get details warning"},
 				nil,

--- a/command/v7/service_command.go
+++ b/command/v7/service_command.go
@@ -1,7 +1,6 @@
 package v7
 
 import (
-	"encoding/json"
 	"fmt"
 	"strconv"
 
@@ -60,8 +59,10 @@ func (cmd ServiceCommand) fetchAndDisplayParams() error {
 		return err
 	}
 
-	data, _ := json.MarshalIndent(params, "", "  ")
-	cmd.UI.DisplayText(string(data))
+	err = cmd.UI.DisplayJSON("", params)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/command/v7/service_command_test.go
+++ b/command/v7/service_command_test.go
@@ -744,7 +744,7 @@ var _ = Describe("service command", func() {
 		When("parameters are set", func() {
 			BeforeEach(func() {
 				fakeActor.GetServiceInstanceParametersReturns(
-					v7action.ServiceInstanceParameters(types.JSONObject{"foo": "bar"}),
+					map[string]interface{}{"foo": "bar"},
 					v7action.Warnings{"warning one", "warning two"},
 					nil,
 				)

--- a/command/v7/service_key_command.go
+++ b/command/v7/service_key_command.go
@@ -1,8 +1,6 @@
 package v7
 
 import (
-	"encoding/json"
-
 	"code.cloudfoundry.org/cli/command/flag"
 )
 
@@ -72,13 +70,12 @@ func (cmd ServiceKeyCommand) details() error {
 		return err
 	}
 
-	serialized, err := json.MarshalIndent(details.Credentials, "", "  ")
+	cmd.UI.DisplayNewline()
+
+	err = cmd.UI.DisplayJSON("", details)
 	if err != nil {
 		return err
 	}
-
-	cmd.UI.DisplayNewline()
-	cmd.UI.DisplayText(string(serialized))
 
 	return nil
 }

--- a/command/v7/service_key_command_test.go
+++ b/command/v7/service_key_command_test.go
@@ -3,8 +3,6 @@ package v7_test
 import (
 	"errors"
 
-	"code.cloudfoundry.org/cli/types"
-
 	"code.cloudfoundry.org/cli/actor/v7action"
 	"code.cloudfoundry.org/cli/command/commandfakes"
 	v7 "code.cloudfoundry.org/cli/command/v7"
@@ -74,7 +72,7 @@ var _ = Describe("service-key Command", func() {
 
 			fakeActor.GetServiceKeyDetailsByServiceInstanceAndNameReturns(
 				resources.ServiceCredentialBindingDetails{
-					Credentials: types.JSONObject{"foo": "bar"},
+					Credentials: map[string]interface{}{"foo": "bar", "pass": "<3test"},
 				},
 				v7action.Warnings{"a warning"},
 				nil,
@@ -96,7 +94,8 @@ var _ = Describe("service-key Command", func() {
 				Say(`Getting key %s for service instance %s as %s\.\.\.\n`, fakeServiceKeyName, fakeServiceInstanceName, fakeUserName),
 				Say(`\n`),
 				Say(`\{\n`),
-				Say(`  "foo": "bar"\n`),
+				Say(`  "foo": "bar",\n`),
+				Say(`  "pass": "<3test"\n`),
 				Say(`\}\n`),
 			))
 		})

--- a/resources/service_credential_binding_details_resource.go
+++ b/resources/service_credential_binding_details_resource.go
@@ -1,9 +1,5 @@
 package resources
 
-import (
-	"code.cloudfoundry.org/cli/types"
-)
-
 type ServiceCredentialBindingDetails struct {
-	Credentials types.JSONObject `json:"credentials"`
+	Credentials map[string]interface{} `json:"credentials"`
 }


### PR DESCRIPTION
Service instance param and service key details now use UI.DisplayJSON - which does not escape special chars

[#171951689](https://www.pivotaltracker.com/story/show/171951689)
