### PR TITLE
Allow for configuration of quotas in terabytes

### DIFF
--- a/command/flag/megabytes.go
+++ b/command/flag/megabytes.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	AllowedUnits = "mg"
+	AllowedUnits = "mgt"
 )
 
 type Megabytes struct {

--- a/command/flag/megabytes_test.go
+++ b/command/flag/megabytes_test.go
@@ -47,6 +47,22 @@ var _ = Describe("Megabytes", func() {
 			})
 		})
 
+		When("the suffix is T", func() {
+			It("interprets the number as terabytes", func() {
+				err := megabytes.UnmarshalFlag("2T")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(megabytes.Value).To(BeEquivalentTo(2097152))
+			})
+		})
+
+		When("the suffix is TB", func() {
+			It("interprets the number as terabytes", func() {
+				err := megabytes.UnmarshalFlag("3TB")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(megabytes.Value).To(BeEquivalentTo(3145728))
+			})
+		})
+
 		When("the suffix is lowercase", func() {
 			It("is case insensitive", func() {
 				err := megabytes.UnmarshalFlag("7m")


### PR DESCRIPTION
## Does this PR modify CLI v6 or v7?

v7

## Description of the Change

Allows for configuring quotas using memory values in terabytes.

All the code for converting values in TB to megabytes was already there. It was just limiting the valid input units to `m` and `g`. I've added `t` to that list.

I ran the unit tests locally and all the ones that ran passed. I got an error about failing to compile a database which failed the suite. I can't imagine how my change would break funcitonality elsewhere in the codebase.

## Why Is This PR Valuable?

This fixes a regression from v6. Configuring quotas in TB is valuable when configuring org quotas in large foundations.

## Applicable Issues

https://github.com/cloudfoundry/cli/issues/2069
