### PR TITLE
Submit adr for v8 code de-version

### DIFF
--- a/doc/adr/0012-de-version-v8-code-base.md
+++ b/doc/adr/0012-de-version-v8-code-base.md
@@ -1,0 +1,37 @@
+# 1. De-version the V8 Code Base
+
+
+## Status
+
+PR Submitted
+
+## Context
+
+### What do you mean by de-version?
+
+De-version in this context means to remove the concept of a version from most of the CLI's codepaths and directory structure outside of the actual version command.
+
+In the v7 code base, and in the current (as of 8/19/2021) version of v8, there are many places in the code which reference either the CLI version, or the CAPI version (command/v6, command/v7, v3action, v7action, v2v3action, etc). This makes it harder to develop in especially for folks without the historical context on the versioning schemes of both the CLI.
+
+After [PR #2180](https://github.com/cloudfoundry/cli/pull/2180) we should be in a state where most of the v6 cruft should be gone, but we will still be left with several places in the code base where there is still mention of v7 in the v8 code base, below you can find a list of all of the places I can find along with suggestions for changing them.
+
+* command/common/command_list_v7* => refactor to command list
+* command/v7 => command/ (just maybe putting all the commands in the root command folder)
+* actor/v7action => actor/ (putting all the actor files in the root actor path)
+* actor/v7pushaction => actor/pushaction
+* integration/v7 => integration/tests
+* Makefile ivi (integration versioned isolated) command => change to ii (integration isolated)
+* Makefile integration versioned global (ivg) => see above
+* cf/ legacy directory => maybe rename it to something like legacy-cf, and put a README descring 
+
+## Decision
+
+PR Submitted
+
+## Consequences
+
+If I am a relatively new contributor to the CLI and I want to make a change to a command I can much easier figure out the code relevant code path. I don't need to know what v6 or v7 are to make changes to v8.
+
+V7 and V8 diverge, meaning that future bugfixes that occur on both the v7 and v8 branch could be more challenging to cherry-pick between branches, as the file paths will be different.
+
+Will update with other consequences the CLI team suggests.


### PR DESCRIPTION
Submitting ADR 12 for discussion with the cf cli team and CF community members.

To clarify what I mean by de-version here, in the CLI code base there are a lot of directories/packages labeled as v6, v7, v2action, v3action, v7action, all with reference to some version of the cf CLI or CAPI.   I think this experience would be improved by trying as much as possible to remove the concept of version, and just having one version of a command per branch, check the markdown file in the PR for more info.

After reading that please feel free to leave feedback, emoji reactions, suggestions for changes, or any concerns on this PR.