### PR TITLE
Quote $PATH in Makefile to avoid word splitting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL := env PATH=$(PATH) /bin/bash
+SHELL := env PATH="$(PATH)" /bin/bash
 CF_DIAL_TIMEOUT ?= 15
 NODES ?= 10
 PACKAGES ?= api actor command types util version integration/helpers


### PR DESCRIPTION
If the `$PATH` contains a path with a space, `make` can fail due to the `$PATH` being split into multiple words.

Thank you for contributing to the CF CLI! Please read the following:


* Please make sure you have implemented changes in line with the [contributing guidelines](https://github.com/cloudfoundry/cli/blob/master/.github/CONTRIBUTING.md)
* We're not allowed to accept any PRs without a signed CLA, no matter how small.
If your contribution falls under a company CLA but your membership is not public, expect delays while we confirm.
* All new code requires tests to protect against regressions.
* Contributions must be made against the appropriate branch. See the [contributing guidelines](https://github.com/cloudfoundry/cli/blob/master/.github/CONTRIBUTING.md)
* Contributions must conform to our [style guide](https://github.com/cloudfoundry/cli/wiki/CLI-Product-Specific-Style-Guide). Please reach out to us if you have questions.


## Does this PR modify CLI v6 or v7?

Does not modify the Golang source code.

## Description of the Change

Fixes a small quoting bug in the Makefile

## Why Is This PR Valuable?

Users affected by this bug can't run any `make` targets locally.

## Why Should This Be In Core?

N/A

## Applicable Issues

N/A

## How Urgent Is The Change?

Not urgent, but also very simple.

## Other Relevant Parties

None.