### PR TITLE
Add a CAPI version check for HTTP/2 to certain integration tests

### DIFF
--- a/api/cloudcontroller/ccversion/minimum_version.go
+++ b/api/cloudcontroller/ccversion/minimum_version.go
@@ -10,4 +10,6 @@ const (
 
 	MinVersionCreateServiceBrokerV3            = "3.72.0"
 	MinVersionCreateSpaceScopedServiceBrokerV3 = "3.75.0"
+
+	MinVersionHTTP2RoutingV3 = "3.104.0"
 )

--- a/integration/v7/isolated/map_route_command_test.go
+++ b/integration/v7/isolated/map_route_command_test.go
@@ -3,6 +3,7 @@ package isolated
 import (
 	"fmt"
 
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccversion"
 	. "code.cloudfoundry.org/cli/cf/util/testhelpers/matchers"
 	"code.cloudfoundry.org/cli/integration/helpers"
 
@@ -125,15 +126,19 @@ var _ = Describe("map-route command", func() {
 					Eventually(session).Should(Say(`OK`))
 					Eventually(session).Should(Exit(0))
 				})
-			})
 
-			When("destination protocol is provided", func() {
-				It("maps the route to an app", func() {
-					session := helpers.CF("map-route", appName, domainName, "--hostname", route.Host, "--destination-protocol", "http2")
+				When("destination protocol is provided", func() {
+					BeforeEach(func() {
+						helpers.SkipIfVersionLessThan(ccversion.MinVersionHTTP2RoutingV3)
+					})
 
-					Eventually(session).Should(Say(`Mapping route %s.%s to app %s with protocol http2 in org %s / space %s as %s\.\.\.`, hostName, domainName, appName, orgName, spaceName, userName))
-					Eventually(session).Should(Say(`OK`))
-					Eventually(session).Should(Exit(0))
+					It("maps the route to an app", func() {
+						session := helpers.CF("map-route", appName, domainName, "--hostname", route.Host, "--destination-protocol", "http2")
+
+						Eventually(session).Should(Say(`Mapping route %s.%s to app %s with protocol http2 in org %s / space %s as %s\.\.\.`, hostName, domainName, appName, orgName, spaceName, userName))
+						Eventually(session).Should(Say(`OK`))
+						Eventually(session).Should(Exit(0))
+					})
 				})
 			})
 		})
@@ -214,6 +219,21 @@ var _ = Describe("map-route command", func() {
 					Eventually(session).Should(Say(`Mapping route %s.%s%s to app %s in org %s / space %s as %s\.\.\.`, hostName, domainName, path, appName, orgName, spaceName, userName))
 					Eventually(session).Should(Say(`OK`))
 					Eventually(session).Should(Exit(0))
+				})
+
+				When("destination protocol is provided", func() {
+					BeforeEach(func() {
+						helpers.SkipIfVersionLessThan(ccversion.MinVersionHTTP2RoutingV3)
+					})
+
+					It("maps the route to an app", func() {
+						session := helpers.CF("map-route", appName, domainName, "--hostname", hostName, "--destination-protocol", "http2")
+						Eventually(session).Should(Say(`Creating route %s.%s%s for org %s / space %s as %s\.\.\.`, hostName, domainName, path, orgName, spaceName, userName))
+						Eventually(session).Should(Say(`OK`))
+						Eventually(session).Should(Say(`Mapping route %s.%s to app %s with protocol http2 in org %s / space %s as %s\.\.\.`, hostName, domainName, appName, orgName, spaceName, userName))
+						Eventually(session).Should(Say(`OK`))
+						Eventually(session).Should(Exit(0))
+					})
 				})
 			})
 


### PR DESCRIPTION
## Does this PR modify CLI v6 or v7?

v8

## Description of the Change

Adds a new CC version check to an integration test that (probably?) depends on certain CAPI. Paves the way for future HTTP/2 integration tests to be written in CLI that won't break pipelines.

Also adds one new integration test for if the route destination doesn't already exist and the DestinationProtocol flag is set.

## Why Is This PR Valuable?

* (Maybe) fix breaking pipelines
* No pressure to upgrade environments that CLI uses for integration tests to enable HTTP/2
* Easier testing of HTTP/2-specific tests, just point the integration tests at a CAPI of proper version and it'll work!

## Why Should This Be In Core?

Fixes current core functionality.

## Applicable Issues

cloudfoundry/routing-release#200

## How Urgent Is The Change?

Somewhat urgent depending on if the last HTTP/2 PR is breaking pipelines.