### PR TITLE
Detect CF-on-K8s in `cf api`

### DIFF
--- a/actor/v7action/target.go
+++ b/actor/v7action/target.go
@@ -31,6 +31,7 @@ func (actor Actor) SetTarget(settings TargetSettings) (Warnings, error) {
 		Routing:           rootInfo.Routing(),
 		SkipSSLValidation: settings.SkipSSLValidation,
 		UAA:               rootInfo.UAA(),
+		CFOnK8s:           rootInfo.CFOnK8s,
 	})
 
 	actor.Config.SetTokenInformation("", "", "")

--- a/actor/v7action/target_test.go
+++ b/actor/v7action/target_test.go
@@ -25,7 +25,6 @@ var _ = Describe("Targeting", func() {
 
 	BeforeEach(func() {
 		actor, fakeCloudControllerClient, fakeConfig, _, _, _, _ = NewTestActor()
-
 	})
 
 	Describe("SetTarget", func() {
@@ -120,6 +119,7 @@ var _ = Describe("Targeting", func() {
 			Expect(targetInfoArgs.LogCache).To(Equal(expectedLogCache))
 			Expect(targetInfoArgs.Routing).To(Equal(expectedRouting))
 			Expect(targetInfoArgs.SkipSSLValidation).To(Equal(skipSSLValidation))
+			Expect(targetInfoArgs.CFOnK8s).To(BeFalse())
 		})
 
 		It("clears all the token information", func() {
@@ -134,6 +134,18 @@ var _ = Describe("Targeting", func() {
 		It("succeeds and returns all warnings", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(warnings).To(ConsistOf(Warnings{"info-warning"}))
+		})
+
+		When("deployed on Kubernetes", func() {
+			BeforeEach(func() {
+				fakeCloudControllerClient.GetInfoReturns(ccv3.Info{CFOnK8s: true}, nil, nil)
+			})
+
+			It("sets the CFOnK8s target information", func() {
+				Expect(fakeConfig.SetTargetInformationCallCount()).To(Equal(1))
+				targetInfoArgs := fakeConfig.SetTargetInformationArgsForCall(0)
+				Expect(targetInfoArgs.CFOnK8s).To(BeTrue())
+			})
 		})
 	})
 

--- a/api/cloudcontroller/ccv3/info.go
+++ b/api/cloudcontroller/ccv3/info.go
@@ -39,7 +39,8 @@ type InfoLinks struct {
 // controller API.
 type Info struct {
 	// Links is a list of top level Cloud Controller APIs.
-	Links InfoLinks `json:"links"`
+	Links   InfoLinks `json:"links"`
+	CFOnK8s bool      `json:"cf-on-k8s"`
 }
 
 // AppSSHEndpoint returns the HREF for SSHing into an app container.

--- a/api/cloudcontroller/ccv3/info_test.go
+++ b/api/cloudcontroller/ccv3/info_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Info", func() {
 		client          *Client
 		rootRespondWith http.HandlerFunc
 
-		apis       Info
+		info       Info
 		warnings   Warnings
 		executeErr error
 	)
@@ -37,7 +37,7 @@ var _ = Describe("Info", func() {
 			),
 		)
 
-		apis, warnings, executeErr = client.GetInfo()
+		info, warnings, executeErr = client.GetInfo()
 	})
 
 	Describe("when all requests are successful", func() {
@@ -86,17 +86,28 @@ var _ = Describe("Info", func() {
 
 		It("returns the CC Information", func() {
 			Expect(executeErr).NotTo(HaveOccurred())
-			Expect(apis.UAA()).To(Equal("https://uaa.bosh-lite.com"))
-			Expect(apis.Logging()).To(Equal("wss://doppler.bosh-lite.com:443"))
-			Expect(apis.NetworkPolicyV1()).To(Equal(fmt.Sprintf("%s/networking/v1/external", server.URL())))
-			Expect(apis.AppSSHHostKeyFingerprint()).To(Equal("some-fingerprint"))
-			Expect(apis.AppSSHEndpoint()).To(Equal("ssh.bosh-lite.com:2222"))
-			Expect(apis.OAuthClient()).To(Equal("some-client"))
+			Expect(info.UAA()).To(Equal("https://uaa.bosh-lite.com"))
+			Expect(info.Logging()).To(Equal("wss://doppler.bosh-lite.com:443"))
+			Expect(info.NetworkPolicyV1()).To(Equal(fmt.Sprintf("%s/networking/v1/external", server.URL())))
+			Expect(info.AppSSHHostKeyFingerprint()).To(Equal("some-fingerprint"))
+			Expect(info.AppSSHEndpoint()).To(Equal("ssh.bosh-lite.com:2222"))
+			Expect(info.OAuthClient()).To(Equal("some-client"))
+			Expect(info.CFOnK8s).To(BeFalse())
 		})
 
 		It("returns all warnings", func() {
 			Expect(executeErr).NotTo(HaveOccurred())
 			Expect(warnings).To(ConsistOf("warning 1"))
+		})
+
+		When("CF-on-K8s", func() {
+			BeforeEach(func() {
+				rootRespondWith = RespondWith(http.StatusOK, `{ "cf-on-k8s": true }`)
+			})
+
+			It("sets the CFOnK8s", func() {
+				Expect(info.CFOnK8s).To(BeTrue())
+			})
 		})
 	})
 

--- a/util/configv3/json_config.go
+++ b/util/configv3/json_config.go
@@ -12,6 +12,7 @@ type JSONConfig struct {
 	APIVersion               string             `json:"APIVersion"`
 	AsyncTimeout             int                `json:"AsyncTimeout"`
 	AuthorizationEndpoint    string             `json:"AuthorizationEndpoint"`
+	CFOnK8s                  CFOnK8s            `json:"CFOnK8s"`
 	ColorEnabled             string             `json:"ColorEnabled"`
 	ConfigVersion            int                `json:"ConfigVersion"`
 	DopplerEndpoint          string             `json:"DopplerEndPoint"`
@@ -46,6 +47,10 @@ type Space struct {
 	GUID     string `json:"GUID"`
 	Name     string `json:"Name"`
 	AllowSSH bool   `json:"AllowSSH"`
+}
+
+type CFOnK8s struct {
+	Enabled bool `json:"Enabled"`
 }
 
 // User represents the user information provided by the JWT access token.
@@ -192,6 +197,7 @@ type TargetInformationArgs struct {
 	Routing           string
 	SkipSSLValidation bool
 	UAA               string
+	CFOnK8s           bool
 }
 
 // SetTargetInformation sets the currently targeted CC API and related other
@@ -212,6 +218,8 @@ func (config *Config) SetTargetInformation(args TargetInformationArgs) {
 	// NOTE: This gets written to the config file, but I do not believe it is currently
 	// ever read from there.
 	config.ConfigFile.AuthorizationEndpoint = args.Auth
+
+	config.ConfigFile.CFOnK8s.Enabled = args.CFOnK8s
 
 	config.UnsetOrganizationAndSpaceInformation()
 }
@@ -319,7 +327,6 @@ func (config *Config) UnsetUserInformation() {
 	config.SetUAAClientCredentials(DefaultUAAOAuthClient, DefaultUAAOAuthClientSecret)
 
 	config.UnsetOrganizationAndSpaceInformation()
-
 }
 
 // V7SetSpaceInformation sets the currently targeted space.

--- a/util/configv3/json_config_test.go
+++ b/util/configv3/json_config_test.go
@@ -307,6 +307,7 @@ var _ = Describe("JSONConfig", func() {
 				LogCache:          "https://log-cache.foo.com",
 				Routing:           "https://api.foo.com/routing",
 				SkipSSLValidation: true,
+				CFOnK8s:           true,
 			})
 
 			Expect(config.ConfigFile.Target).To(Equal("https://api.foo.com"))
@@ -323,6 +324,8 @@ var _ = Describe("JSONConfig", func() {
 			Expect(config.ConfigFile.TargetedSpace.GUID).To(BeEmpty())
 			Expect(config.ConfigFile.TargetedSpace.Name).To(BeEmpty())
 			Expect(config.ConfigFile.TargetedSpace.AllowSSH).To(BeFalse())
+
+			Expect(config.ConfigFile.CFOnK8s.Enabled).To(BeTrue())
 		})
 	})
 


### PR DESCRIPTION
This makes `cf api` able to detect the `cf-on-k8s` flag in the root endpoint response and persist this information in the config. This will allow us to enable CF-on-K8s-specific behaviour for every following command.

Issue: cloudfoundry/cf-k8s-api#10