### PR TITLE
[Bugfix] CF security-groups returns 414 error

### DIFF
--- a/actor/v7action/security_group.go
+++ b/actor/v7action/security_group.go
@@ -10,6 +10,7 @@ import (
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/constant"
 	"code.cloudfoundry.org/cli/resources"
+	"code.cloudfoundry.org/cli/util/batcher"
 	"code.cloudfoundry.org/cli/util/lookuptable"
 )
 
@@ -323,16 +324,23 @@ func getSecurityGroupSpaces(actor Actor, stagingSpaceGUIDs []string, runningSpac
 	associatedSpaceGuids = append(associatedSpaceGuids, stagingSpaceGUIDs...)
 
 	var securityGroupSpaces []SecurityGroupSpace
-	if len(associatedSpaceGuids) > 0 {
-		spaces, includes, newWarnings, err := actor.CloudControllerClient.GetSpaces(ccv3.Query{
-			Key:    ccv3.GUIDFilter,
-			Values: associatedSpaceGuids,
-		}, ccv3.Query{
-			Key:    ccv3.Include,
-			Values: []string{"organization"},
-		})
+	var spaces []resources.Space
+	var includes ccv3.IncludedResources
 
-		warnings = newWarnings
+	if len(associatedSpaceGuids) > 0 {
+		ccv3Warnings, err := batcher.RequestByGUID(associatedSpaceGuids, func(guids []string) (ccv3.Warnings, error) {
+			batchSpaces, batchIncludes, newWarnings, err := actor.CloudControllerClient.GetSpaces(ccv3.Query{
+				Key:    ccv3.GUIDFilter,
+				Values: guids,
+			}, ccv3.Query{
+				Key:    ccv3.Include,
+				Values: []string{"organization"},
+			})
+			spaces = append(spaces, batchSpaces...)
+			includes.Organizations = append(includes.Organizations, batchIncludes.Organizations...)
+			return newWarnings, err
+		})
+		warnings = ccv3Warnings
 		if err != nil {
 			return securityGroupSpaces, warnings, err
 		}

--- a/actor/v7action/security_group_test.go
+++ b/actor/v7action/security_group_test.go
@@ -599,7 +599,7 @@ var _ = Describe("Security Group Actions", func() {
 			})
 		})
 
-		FWhen("the request errors", func() {
+		When("the request errors", func() {
 			var expectedError error
 			JustBeforeEach(func() {
 				securityGroupSummaries, warnings, executeErr = actor.GetSecurityGroups()


### PR DESCRIPTION
As described in #2159 the `cf security-groups` command was not able to respond properly when there were too many spaces in the foundation. 
In order to fix this behavior, as done in other commands, we refactored the `getSecurityGroupSpaces` to use the batcher.
