### PR TITLE
[Feature] support HTTP/2 - Rename protocol to app-protocol to cf route command

### DIFF
--- a/command/v7/route_command.go
+++ b/command/v7/route_command.go
@@ -116,7 +116,7 @@ func (cmd RouteCommand) displayDestinations(route resources.Route, appMap map[st
 				cmd.UI.TranslateText("app"),
 				cmd.UI.TranslateText("process"),
 				cmd.UI.TranslateText("port"),
-				cmd.UI.TranslateText("protocol"),
+				cmd.UI.TranslateText("app-protocol"),
 			},
 		}
 

--- a/command/v7/route_command_test.go
+++ b/command/v7/route_command_test.go
@@ -220,7 +220,7 @@ var _ = Describe("route Command", func() {
 			Expect(testUI.Out).To(Say(`protocol:\s+http`))
 			Expect(testUI.Out).To(Say(`\n`))
 			Expect(testUI.Out).To(Say(`Destinations:`))
-			Expect(testUI.Out).To(Say(`\s+app\s+process\s+port\s+protocol`))
+			Expect(testUI.Out).To(Say(`\s+app\s+process\s+port\s+app-protocol`))
 			Expect(testUI.Out).To(Say(`\s+app-name\s+web\s+8080\s+http1`))
 			Expect(testUI.Out).To(Say(`\s+other-app-name\s+web\s+1337\s+http2`))
 

--- a/integration/v7/isolated/route_command_test.go
+++ b/integration/v7/isolated/route_command_test.go
@@ -119,7 +119,7 @@ var _ = Describe("route command", func() {
 						Eventually(session).Should(Say(`protocol:\s+http`))
 						Eventually(session).Should(Say(`\n`))
 						Eventually(session).Should(Say(`Destinations:`))
-						Eventually(session).Should(Say(`\s+app\s+process\s+port\s+protocol`))
+						Eventually(session).Should(Say(`\s+app\s+process\s+port\s+app-protocol`))
 						Eventually(session).Should(Exit(0))
 					})
 
@@ -167,7 +167,7 @@ var _ = Describe("route command", func() {
 						Eventually(session).Should(Say(`protocol:\s+tcp`))
 						Eventually(session).Should(Say(`\n`))
 						Eventually(session).Should(Say(`Destinations:`))
-						Eventually(session).Should(Say(`\s+app\s+process\s+port\s+protocol`))
+						Eventually(session).Should(Say(`\s+app\s+process\s+port\s+app-protocol`))
 						Eventually(session).Should(Exit(0))
 					})
 


### PR DESCRIPTION
I want to see the `app-protocol`  instead of `protocol` in the header of the  `cf route` command output.

When running the `cf route` command must be  able to see the app-protocol column in the output
```
$ cf route mydomain.cli.fun --hostname pora
domain:     mydomain.cli.fun
host:       pora
port:
path:
protocol:   http

app    process   port   app-protocol
pora   web       8080   http2
```