### PR TITLE
[Feature] Rename flag to app-protocol in map-route

### DIFF
--- a/command/v7/map_route_command.go
+++ b/command/v7/map_route_command.go
@@ -8,11 +8,11 @@ import (
 type MapRouteCommand struct {
 	BaseCommand
 
-	RequiredArgs        flag.AppDomain   `positional-args:"yes"`
-	Hostname            string           `long:"hostname" short:"n" description:"Hostname for the HTTP route (required for shared domains)"`
-	Path                flag.V7RoutePath `long:"path" description:"Path for the HTTP route"`
-	Port                int              `long:"port" description:"Port for the TCP route (default: random port)"`
-	DestinationProtocol string           `long:"destination-protocol" description:"[Beta flag, subject to change] Protocol for the route destination (default: http1). Only applied to HTTP routes"`
+	RequiredArgs flag.AppDomain   `positional-args:"yes"`
+	Hostname     string           `long:"hostname" short:"n" description:"Hostname for the HTTP route (required for shared domains)"`
+	Path         flag.V7RoutePath `long:"path" description:"Path for the HTTP route"`
+	Port         int              `long:"port" description:"Port for the TCP route (default: random port)"`
+	AppProtocol  string           `long:"app-protocol" description:"[Beta flag, subject to change] Protocol for the route destination (default: http1). Only applied to HTTP routes"`
 
 	relatedCommands interface{} `related_commands:"create-route, routes, unmap-route"`
 }
@@ -20,7 +20,7 @@ type MapRouteCommand struct {
 func (cmd MapRouteCommand) Usage() string {
 	return `
 Map an HTTP route:
-   CF_NAME map-route APP_NAME DOMAIN [--hostname HOSTNAME] [--path PATH] [--destination-protocol PROTOCOL]
+   CF_NAME map-route APP_NAME DOMAIN [--hostname HOSTNAME] [--path PATH] [--app-protocol PROTOCOL]
 
 Map a TCP route:
    CF_NAME map-route APP_NAME DOMAIN [--port PORT]`
@@ -31,7 +31,7 @@ func (cmd MapRouteCommand) Examples() string {
 CF_NAME map-route my-app example.com                                                # example.com
 CF_NAME map-route my-app example.com --hostname myhost                              # myhost.example.com
 CF_NAME map-route my-app example.com --hostname myhost --path foo                   # myhost.example.com/foo
-CF_NAME map-route my-app example.com --hostname myhost --destination-protocol http2 # myhost.example.com
+CF_NAME map-route my-app example.com --hostname myhost --app-protocol http2 # myhost.example.com
 CF_NAME map-route my-app example.com --port 5000                                    # example.com:5000`
 }
 
@@ -88,14 +88,14 @@ func (cmd MapRouteCommand) Execute(args []string) error {
 		cmd.UI.DisplayOK()
 	}
 
-	if cmd.DestinationProtocol != "" {
+	if cmd.AppProtocol != "" {
 		cmd.UI.DisplayTextWithFlavor("Mapping route {{.URL}} to app {{.AppName}} with protocol {{.Protocol}} in org {{.OrgName}} / space {{.SpaceName}} as {{.User}}...", map[string]interface{}{
 			"URL":       route.URL,
 			"AppName":   cmd.RequiredArgs.App,
 			"User":      user.Name,
 			"SpaceName": cmd.Config.TargetedSpace().Name,
 			"OrgName":   cmd.Config.TargetedOrganization().Name,
-			"Protocol":  cmd.DestinationProtocol,
+			"Protocol":  cmd.AppProtocol,
 		})
 
 	} else {
@@ -121,7 +121,7 @@ func (cmd MapRouteCommand) Execute(args []string) error {
 		cmd.UI.DisplayOK()
 		return nil
 	}
-	warnings, err = cmd.Actor.MapRoute(route.GUID, app.GUID, cmd.DestinationProtocol)
+	warnings, err = cmd.Actor.MapRoute(route.GUID, app.GUID, cmd.AppProtocol)
 	cmd.UI.DisplayWarnings(warnings)
 	if err != nil {
 		return err

--- a/command/v7/map_route_command_test.go
+++ b/command/v7/map_route_command_test.go
@@ -53,10 +53,10 @@ var _ = Describe("map-route Command", func() {
 		spaceGUID = "some-space-guid"
 
 		cmd = MapRouteCommand{
-			RequiredArgs:        flag.AppDomain{App: appName, Domain: domain},
-			Hostname:            hostname,
-			Path:                flag.V7RoutePath{Path: path},
-			DestinationProtocol: "http2",
+			RequiredArgs: flag.AppDomain{App: appName, Domain: domain},
+			Hostname:     hostname,
+			Path:         flag.V7RoutePath{Path: path},
+			AppProtocol:  "http2",
 			BaseCommand: BaseCommand{
 				UI:          testUI,
 				Config:      fakeConfig,
@@ -372,10 +372,10 @@ var _ = Describe("map-route Command", func() {
 								Expect(actualPort).To(Equal(cmd.Port))
 
 								Expect(fakeActor.MapRouteCallCount()).To(Equal(1))
-								actualRouteGUID, actualAppGUID, actualDestinationProtocol := fakeActor.MapRouteArgsForCall(0)
+								actualRouteGUID, actualAppGUID, actualAppProtocol := fakeActor.MapRouteArgsForCall(0)
 								Expect(actualRouteGUID).To(Equal("route-guid"))
 								Expect(actualAppGUID).To(Equal("app-guid"))
-								Expect(actualDestinationProtocol).To(Equal("http2"))
+								Expect(actualAppProtocol).To(Equal("http2"))
 							})
 						})
 
@@ -411,10 +411,10 @@ var _ = Describe("map-route Command", func() {
 									Expect(actualPort).To(Equal(cmd.Port))
 
 									Expect(fakeActor.MapRouteCallCount()).To(Equal(1))
-									actualRouteGUID, actualAppGUID, actualDestinationProtocol := fakeActor.MapRouteArgsForCall(0)
+									actualRouteGUID, actualAppGUID, actualAppProtocol := fakeActor.MapRouteArgsForCall(0)
 									Expect(actualRouteGUID).To(Equal("route-guid"))
 									Expect(actualAppGUID).To(Equal("app-guid"))
-									Expect(actualDestinationProtocol).To(Equal("http2"))
+									Expect(actualAppProtocol).To(Equal("http2"))
 								})
 							})
 						})
@@ -534,10 +534,10 @@ var _ = Describe("map-route Command", func() {
 								Expect(actualPort).To(Equal(cmd.Port))
 
 								Expect(fakeActor.MapRouteCallCount()).To(Equal(1))
-								actualRouteGUID, actualAppGUID, actualDestinationProtocol := fakeActor.MapRouteArgsForCall(0)
+								actualRouteGUID, actualAppGUID, actualAppProtocol := fakeActor.MapRouteArgsForCall(0)
 								Expect(actualRouteGUID).To(Equal("route-guid"))
 								Expect(actualAppGUID).To(Equal("app-guid"))
-								Expect(actualDestinationProtocol).To(Equal("http2"))
+								Expect(actualAppProtocol).To(Equal("http2"))
 							})
 						})
 
@@ -573,10 +573,10 @@ var _ = Describe("map-route Command", func() {
 									Expect(actualPort).To(Equal(cmd.Port))
 
 									Expect(fakeActor.MapRouteCallCount()).To(Equal(1))
-									actualRouteGUID, actualAppGUID, actualDestinationProtocol := fakeActor.MapRouteArgsForCall(0)
+									actualRouteGUID, actualAppGUID, actualAppProtocol := fakeActor.MapRouteArgsForCall(0)
 									Expect(actualRouteGUID).To(Equal("route-guid"))
 									Expect(actualAppGUID).To(Equal("app-guid"))
-									Expect(actualDestinationProtocol).To(Equal("http2"))
+									Expect(actualAppProtocol).To(Equal("http2"))
 								})
 							})
 						})

--- a/integration/v7/isolated/map_route_command_test.go
+++ b/integration/v7/isolated/map_route_command_test.go
@@ -29,7 +29,7 @@ var _ = Describe("map-route command", func() {
 
 			Eventually(session).Should(Say(`USAGE:`))
 			Eventually(session).Should(Say(`Map an HTTP route:\n`))
-			Eventually(session).Should(Say(`cf map-route APP_NAME DOMAIN \[--hostname HOSTNAME\] \[--path PATH\] \[--destination-protocol PROTOCOL\]\n`))
+			Eventually(session).Should(Say(`cf map-route APP_NAME DOMAIN \[--hostname HOSTNAME\] \[--path PATH\] \[--app-protocol PROTOCOL\]\n`))
 			Eventually(session).Should(Say(`Map a TCP route:\n`))
 			Eventually(session).Should(Say(`cf map-route APP_NAME DOMAIN \[--port PORT]\n`))
 			Eventually(session).Should(Say(`\n`))
@@ -38,7 +38,7 @@ var _ = Describe("map-route command", func() {
 			Eventually(session).Should(Say(`cf map-route my-app example.com                                                # example.com`))
 			Eventually(session).Should(Say(`cf map-route my-app example.com --hostname myhost                              # myhost.example.com`))
 			Eventually(session).Should(Say(`cf map-route my-app example.com --hostname myhost --path foo                   # myhost.example.com/foo`))
-			Eventually(session).Should(Say(`cf map-route my-app example.com --hostname myhost --destination-protocol http2 # myhost.example.com`))
+			Eventually(session).Should(Say(`cf map-route my-app example.com --hostname myhost --app-protocol http2 # myhost.example.com`))
 			Eventually(session).Should(Say(`cf map-route my-app example.com --port 5000                                    # example.com:5000`))
 			Eventually(session).Should(Say(`\n`))
 
@@ -46,7 +46,7 @@ var _ = Describe("map-route command", func() {
 			Eventually(session).Should(Say(`--hostname, -n\s+Hostname for the HTTP route \(required for shared domains\)`))
 			Eventually(session).Should(Say(`--path\s+Path for the HTTP route`))
 			Eventually(session).Should(Say(`--port\s+Port for the TCP route \(default: random port\)`))
-			Eventually(session).Should(Say(`--destination-protocol\s+\[Beta flag, subject to change\] Protocol for the route destination \(default: http1\). Only applied to HTTP routes`))
+			Eventually(session).Should(Say(`--app-protocol\s+\[Beta flag, subject to change\] Protocol for the route destination \(default: http1\). Only applied to HTTP routes`))
 
 			Eventually(session).Should(Say(`\n`))
 
@@ -133,7 +133,7 @@ var _ = Describe("map-route command", func() {
 					})
 
 					It("maps the route to an app", func() {
-						session := helpers.CF("map-route", appName, domainName, "--hostname", route.Host, "--destination-protocol", "http2")
+						session := helpers.CF("map-route", appName, domainName, "--hostname", route.Host, "--app-protocol", "http2")
 
 						Eventually(session).Should(Say(`Mapping route %s.%s to app %s with protocol http2 in org %s / space %s as %s\.\.\.`, hostName, domainName, appName, orgName, spaceName, userName))
 						Eventually(session).Should(Say(`OK`))
@@ -227,7 +227,7 @@ var _ = Describe("map-route command", func() {
 					})
 
 					It("maps the route to an app", func() {
-						session := helpers.CF("map-route", appName, domainName, "--hostname", hostName, "--destination-protocol", "http2")
+						session := helpers.CF("map-route", appName, domainName, "--hostname", hostName, "--app-protocol", "http2")
 						Eventually(session).Should(Say(`Creating route %s.%s for org %s / space %s as %s\.\.\.`, hostName, domainName, orgName, spaceName, userName))
 						Eventually(session).Should(Say(`OK`))
 						Eventually(session).Should(Say(`Mapping route %s.%s to app %s with protocol http2 in org %s / space %s as %s\.\.\.`, hostName, domainName, appName, orgName, spaceName, userName))


### PR DESCRIPTION
When running the following command `cf map-route my-app example.com --hostname myhost --app-protocol http2` the following output should be generated:

```
$ cf map-route my-app example.com --hostname myhost --app-protocol http2

Mapping route route my-app.example.com for org my-org / space my-space as admin...
OK
```