### PR TITLE
[Feature] Add app-protocol to cf routes command output

### DIFF
--- a/actor/v7action/route.go
+++ b/actor/v7action/route.go
@@ -20,6 +20,7 @@ import (
 type RouteSummary struct {
 	resources.Route
 	AppNames            []string
+	AppProtocols        []string
 	DomainName          string
 	SpaceName           string
 	ServiceInstanceName string
@@ -275,13 +276,24 @@ func (actor Actor) GetRouteSummaries(routes []resources.Route) ([]RouteSummary, 
 	for _, route := range routes {
 		var appNames []string
 
+		protocolSet := map[string]bool{}
 		for _, destination := range route.Destinations {
 			appNames = append(appNames, appNamesByGUID[destination.App.GUID])
+			protocolSet[destination.Protocol] = true
+		}
+
+		var appProtocols []string
+		if len(protocolSet) > 0 {
+			appProtocols = make([]string, 0, len(protocolSet))
+			for key := range protocolSet {
+				appProtocols = append(appProtocols, key)
+			}
 		}
 
 		routeSummaries = append(routeSummaries, RouteSummary{
 			Route:               route,
 			AppNames:            appNames,
+			AppProtocols:        appProtocols,
 			SpaceName:           spaceNamesByGUID[route.SpaceGUID],
 			DomainName:          getDomainName(route.URL, route.Host, route.Path, route.Port),
 			ServiceInstanceName: serviceInstanceNameByRouteGUID[route.GUID],

--- a/actor/v7action/route.go
+++ b/actor/v7action/route.go
@@ -288,6 +288,7 @@ func (actor Actor) GetRouteSummaries(routes []resources.Route) ([]RouteSummary, 
 			for key := range protocolSet {
 				appProtocols = append(appProtocols, key)
 			}
+			sort.Strings(appProtocols)
 		}
 
 		routeSummaries = append(routeSummaries, RouteSummary{

--- a/actor/v7action/route_test.go
+++ b/actor/v7action/route_test.go
@@ -677,6 +677,7 @@ var _ = Describe("Route Actions", func() {
 							App: resources.RouteDestinationApp{
 								GUID: "app-guid-1",
 							},
+							Protocol: "http1",
 						},
 					},
 					SpaceGUID: "fake-space-1-guid",
@@ -692,11 +693,13 @@ var _ = Describe("Route Actions", func() {
 							App: resources.RouteDestinationApp{
 								GUID: "app-guid-1",
 							},
+							Protocol: "http2",
 						},
 						{
 							App: resources.RouteDestinationApp{
 								GUID: "app-guid-2",
 							},
+							Protocol: "http1",
 						},
 					},
 					SpaceGUID: "fake-space-1-guid",
@@ -797,7 +800,8 @@ var _ = Describe("Route Actions", func() {
 						GUID: "route-guid-1",
 						Destinations: []resources.RouteDestination{
 							{
-								App: resources.RouteDestinationApp{GUID: "app-guid-1"},
+								App:      resources.RouteDestinationApp{GUID: "app-guid-1"},
+								Protocol: "http1",
 							},
 						},
 						SpaceGUID: "fake-space-1-guid",
@@ -807,6 +811,7 @@ var _ = Describe("Route Actions", func() {
 						Port:      1,
 					},
 					AppNames:            []string{"app-name-1"},
+					AppProtocols:        []string{"http1"},
 					DomainName:          "fake-url-1/fake-path-1",
 					SpaceName:           "fake-space-1",
 					ServiceInstanceName: "foo",
@@ -816,10 +821,12 @@ var _ = Describe("Route Actions", func() {
 						GUID: "route-guid-2",
 						Destinations: []resources.RouteDestination{
 							{
-								App: resources.RouteDestinationApp{GUID: "app-guid-1"},
+								App:      resources.RouteDestinationApp{GUID: "app-guid-1"},
+								Protocol: "http2",
 							},
 							{
-								App: resources.RouteDestinationApp{GUID: "app-guid-2"},
+								App:      resources.RouteDestinationApp{GUID: "app-guid-2"},
+								Protocol: "http1",
 							},
 						},
 						SpaceGUID: "fake-space-1-guid",
@@ -829,6 +836,7 @@ var _ = Describe("Route Actions", func() {
 						Port:      2,
 					},
 					AppNames:            []string{"app-name-1", "app-name-2"},
+					AppProtocols:        []string{"http2", "http1"},
 					DomainName:          "fake-url-2/fake-path-2",
 					SpaceName:           "fake-space-1",
 					ServiceInstanceName: "bar",
@@ -928,6 +936,10 @@ var _ = Describe("Route Actions", func() {
 
 				for i := 0; i < batcher.BatchSize*batches; i++ {
 					port := i + 1000
+					appProtocol := "http1"
+					if i%2 == 0 {
+						appProtocol = "http2"
+					}
 					route := resources.Route{
 						GUID: fmt.Sprintf("route-guid-%d", i),
 						Destinations: []resources.RouteDestination{
@@ -935,6 +947,7 @@ var _ = Describe("Route Actions", func() {
 								App: resources.RouteDestinationApp{
 									GUID: fmt.Sprintf("fake-app-guid-%d", i),
 								},
+								Protocol: appProtocol,
 							},
 						},
 						SpaceGUID: fmt.Sprintf("fake-space-guid-%d", i),
@@ -968,6 +981,7 @@ var _ = Describe("Route Actions", func() {
 
 					manyResults = append(manyResults, RouteSummary{
 						Route:               route,
+						AppProtocols:        []string{appProtocol},
 						AppNames:            []string{fmt.Sprintf("fake-app-name-%d", i)},
 						DomainName:          fmt.Sprintf("fake-url-%d/fake-path-%d", i, i),
 						SpaceName:           fmt.Sprintf("fake-space-name-%d", i),

--- a/actor/v7action/route_test.go
+++ b/actor/v7action/route_test.go
@@ -836,7 +836,7 @@ var _ = Describe("Route Actions", func() {
 						Port:      2,
 					},
 					AppNames:            []string{"app-name-1", "app-name-2"},
-					AppProtocols:        []string{"http2", "http1"},
+					AppProtocols:        []string{"http1", "http2"},
 					DomainName:          "fake-url-2/fake-path-2",
 					SpaceName:           "fake-space-1",
 					ServiceInstanceName: "bar",

--- a/command/v7/routes_command.go
+++ b/command/v7/routes_command.go
@@ -82,6 +82,7 @@ func (cmd RoutesCommand) displayRoutesTable(routeSummaries []v7action.RouteSumma
 			cmd.UI.TranslateText("port"),
 			cmd.UI.TranslateText("path"),
 			cmd.UI.TranslateText("protocol"),
+			cmd.UI.TranslateText("app-protocol"),
 			cmd.UI.TranslateText("apps"),
 			cmd.UI.TranslateText("service instance"),
 		},
@@ -99,6 +100,7 @@ func (cmd RoutesCommand) displayRoutesTable(routeSummaries []v7action.RouteSumma
 			port,
 			routeSummary.Path,
 			routeSummary.Protocol,
+			strings.Join(routeSummary.AppProtocols, ", "),
 			strings.Join(routeSummary.AppNames, ", "),
 			routeSummary.ServiceInstanceName,
 		})

--- a/command/v7/routes_command_test.go
+++ b/command/v7/routes_command_test.go
@@ -29,7 +29,7 @@ var _ = Describe("routes Command", func() {
 		binaryName      string
 	)
 
-	const tableHeaders = `space\s+host\s+domain\s+port\s+path\s+protocol\s+apps\s+service instance`
+	const tableHeaders = `space\s+host\s+domain\s+port\s+path\s+protocol\s+app-protocol\s+apps\s+service instance`
 
 	BeforeEach(func() {
 		testUI = ui.NewTestUI(nil, NewBuffer(), NewBuffer())
@@ -144,10 +144,16 @@ var _ = Describe("routes Command", func() {
 							Route:      resources.Route{GUID: "route-guid-2", Host: "host-3", Path: "/path/2"},
 						},
 						{
-							DomainName:          "domain3",
-							SpaceName:           "space-3",
-							Route:               resources.Route{GUID: "route-guid-3", Host: "host-1"},
+							DomainName: "domain3",
+							SpaceName:  "space-3",
+							Route: resources.Route{GUID: "route-guid-3", Host: "host-1",
+								Destinations: []resources.RouteDestination{
+									{GUID: "app1-guid", Protocol: "http1"},
+									{GUID: "app2-guid", Protocol: "http2"},
+								},
+							},
 							AppNames:            []string{"app1", "app2"},
+							AppProtocols:        []string{"http1", "http2"},
 							ServiceInstanceName: "si-3",
 						},
 						{
@@ -155,6 +161,18 @@ var _ = Describe("routes Command", func() {
 							SpaceName:  "space-3",
 							Route:      resources.Route{GUID: "route-guid-3", Port: 1024},
 							AppNames:   []string{"app1", "app2"},
+						},
+						{
+							DomainName: "domain4",
+							SpaceName:  "space-3",
+							Route: resources.Route{GUID: "route-guid-3", Port: 1024,
+								Destinations: []resources.RouteDestination{
+									{GUID: "app1-guid", Protocol: "http1"},
+									{GUID: "app2-guid", Protocol: "http1"},
+								},
+							},
+							AppNames:     []string{"app1", "app2"},
+							AppProtocols: []string{"http1"},
 						},
 					}
 
@@ -174,8 +192,9 @@ var _ = Describe("routes Command", func() {
 					Expect(testUI.Out).To(Say(tableHeaders))
 					Expect(testUI.Out).To(Say(`space-1\s+domain1\s+si-1\s+`))
 					Expect(testUI.Out).To(Say(`space-2\s+host-3\s+domain2\s+\/path\/2`))
-					Expect(testUI.Out).To(Say(`space-3\s+host-1\s+domain3\s+app1, app2\s+si-3`))
+					Expect(testUI.Out).To(Say(`space-3\s+host-1\s+domain3\s+http1, http2\s+app1, app2\s+si-3`))
 					Expect(testUI.Out).To(Say(`space-3\s+tcp\.domain\s+1024\s+app1, app2`))
+					Expect(testUI.Out).To(Say(`space-3\s+domain4\s+1024\s+http1\s+app1, app2`))
 				})
 			})
 

--- a/integration/helpers/version.go
+++ b/integration/helpers/version.go
@@ -87,11 +87,11 @@ func SkipIfUAAVersionAtLeast(version string) {
 }
 
 func matchMajorAPIVersion(minVersion string) string {
-	version := GetAPIVersionV2()
 	if strings.HasPrefix(minVersion, "3") {
-		version = getAPIVersionV3()
+		return getAPIVersionV3()
+	} else {
+		return GetAPIVersionV2()
 	}
-	return version
 }
 
 // GetAPIVersionV2 returns the V2 api version of the targeted API

--- a/integration/v7/isolated/routes_command_test.go
+++ b/integration/v7/isolated/routes_command_test.go
@@ -1,6 +1,9 @@
 package isolated
 
 import (
+	"fmt"
+
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccversion"
 	. "code.cloudfoundry.org/cli/cf/util/testhelpers/matchers"
 
 	"code.cloudfoundry.org/cli/integration/helpers"
@@ -11,6 +14,13 @@ import (
 )
 
 var _ = Describe("routes command", func() {
+
+	const tableHeaders = `space\s+host\s+domain\s+port\s+path\s+protocol\s+app-protocol\s+apps\s+service instance`
+	appProtocolValue := "http1"
+	if !helpers.IsVersionMet(ccversion.MinVersionHTTP2RoutingV3) {
+		appProtocolValue = ""
+	}
+
 	Context("Help", func() {
 		It("appears in cf help -a", func() {
 			session := helpers.CF("help", "-a")
@@ -110,35 +120,74 @@ var _ = Describe("routes command", func() {
 			It("lists all the routes", func() {
 				session := helpers.CF("routes")
 				Eventually(session).Should(Exit(0))
-
 				Expect(session).To(Say(`Getting routes for org %s / space %s as %s\.\.\.`, orgName, spaceName, userName))
-				Expect(session).To(Say(`space\s+host\s+domain\s+port\s+path\s+protocol\s+apps\s+service instance\n`))
-				Expect(session).To(Say(`%s\s+route1\s+%s\s+http\s+%s\s+%s\n`, spaceName, domainName, appName1, serviceInstanceName))
-				Expect(session).To(Say(`%s\s+route1a\s+%s\s+http\s+%s\s+\n`, spaceName, domainName, appName1))
-				Expect(session).To(Say(`%s\s+route1b\s+%s\s+http\s+%s\s+\n`, spaceName, domainName, appName1))
-				Expect(session).ToNot(Say(`%s\s+route2\s+%s\s+http\s+%s\s+\n`, spaceName, domainName, appName2))
+				Expect(session).To(Say(tableHeaders))
+				Expect(session).To(Say(`%s\s+route1\s+%s\s+http\s+%s\s+%s\s+%s\n`, spaceName, domainName, appProtocolValue, appName1, serviceInstanceName))
+				Expect(session).To(Say(`%s\s+route1a\s+%s\s+http\s+%s\s+%s\s+\n`, spaceName, domainName, appProtocolValue, appName1))
+				Expect(session).To(Say(`%s\s+route1b\s+%s\s+http\s+%s\s+%s\s+\n`, spaceName, domainName, appProtocolValue, appName1))
+				Expect(session).ToNot(Say(`%s\s+route2\s+%s\s+http\s+%s\s+%s\s+\n`, spaceName, domainName, appProtocolValue, appName2))
 			})
 
 			It("lists all the routes by label", func() {
 				session := helpers.CF("routes", "--labels", "env in (prod)")
 				Eventually(session).Should(Exit(0))
 				Expect(session).To(Say(`Getting routes for org %s / space %s as %s\.\.\.`, orgName, spaceName, userName))
-				Expect(session).To(Say(`space\s+host\s+domain\s+port\s+path\s+protocol\s+apps\s+service instance\n`))
-				Expect(session).ToNot(Say(`%s\s+route1\s+%s\s+http\s+%s\s+%s\n`, spaceName, domainName, appName1, serviceInstanceName))
-				Expect(session).ToNot(Say(`%s\s+route1a\s+%s\s+http\s+%s\s+\n`, spaceName, domainName, appName1))
-				Expect(session).To(Say(`%s\s+route1b\s+%s\s+http\s+%s\s+\n`, spaceName, domainName, appName1))
-				Expect(session).ToNot(Say(`%s\s+route2\s+%s\s+http\s+%s\s+\n`, spaceName, domainName, appName2))
+				Expect(session).To(Say(tableHeaders))
+				Expect(session).ToNot(Say(`%s\s+route1\s+%s\s+http\s+%s\s+%s\s+%s\n`, spaceName, domainName, appProtocolValue, appName1, serviceInstanceName))
+				Expect(session).ToNot(Say(`%s\s+route1a\s+%s\s+http\s+%s\s+%s\s+\n`, spaceName, domainName, appProtocolValue, appName1))
+				Expect(session).To(Say(`%s\s+route1b\s+%s\s+http\s+%s\s+%s\s+\n`, spaceName, domainName, appProtocolValue, appName1))
+				Expect(session).ToNot(Say(`%s\s+route2\s+%s\s+http\s+%s\s+%s\s+\n`, spaceName, domainName, appProtocolValue, appName2))
 			})
 
 			When("fetching routes by org", func() {
 				It("lists all the routes in the org", func() {
 					session := helpers.CF("routes", "--org-level")
-					Eventually(session).Should(Say(`Getting routes for org %s as %s\.\.\.`, orgName, userName))
-					Eventually(session).Should(Say(`space\s+host\s+domain\s+port\s+path\s+protocol\s+apps\s+service instance\n`))
-					Eventually(session).Should(Say(`%s\s+route1\s+%s\s+http\s+%s\s+%s\n`, spaceName, domainName, appName1, serviceInstanceName))
-					Eventually(session).Should(Say(`%s\s+route2\s+%s\s+\/dodo\s+http\s+%s\s+\n`, otherSpaceName, domainName, appName2))
 					Eventually(session).Should(Exit(0))
+					Expect(session).To(Say(`Getting routes for org %s as %s\.\.\.`, orgName, userName))
+					Expect(session).To(Say(tableHeaders))
+					Expect(session).To(Say(`%s\s+route1\s+%s\s+http\s+%s\s+%s\s+%s\n`, spaceName, domainName, appProtocolValue, appName1, serviceInstanceName))
+					Expect(session).To(Say(`%s\s+route2\s+%s\s+\/dodo\s+http\s+%s\s+%s\s+\n`, otherSpaceName, domainName, appProtocolValue, appName2))
 				})
+			})
+		})
+
+		When("http1 and http2 routes exist", func() {
+			var (
+				domainName string
+				domain     helpers.Domain
+			)
+
+			BeforeEach(func() {
+				helpers.SkipIfVersionLessThan(ccversion.MinVersionHTTP2RoutingV3)
+				domainName = helpers.NewDomainName()
+
+				domain = helpers.NewDomain(orgName, domainName)
+
+				appName1 = helpers.NewAppName()
+				Eventually(helpers.CF("create-app", appName1)).Should(Exit(0))
+				appName2 = helpers.NewAppName()
+				Eventually(helpers.CF("create-app", appName2)).Should(Exit(0))
+
+				domain.CreatePrivate()
+
+				Eventually(helpers.CF("map-route", appName1, domainName, "--hostname", "route1")).Should(Exit(0))
+				Eventually(helpers.CF("map-route", appName2, domainName, "--hostname", "route2")).Should(Exit(0))
+				Eventually(helpers.CF("map-route", appName2, domainName, "--hostname", "route1", "--app-protocol", "http2")).Should(Exit(0))
+
+				helpers.SetupCF(orgName, spaceName)
+			})
+
+			AfterEach(func() {
+				domain.Delete()
+			})
+
+			It("lists all the routes", func() {
+				session := helpers.CF("routes")
+				Eventually(session).Should(Exit(0))
+				Expect(session).To(Say(`Getting routes for org %s / space %s as %s\.\.\.`, orgName, spaceName, userName))
+				Expect(session).To(Say(tableHeaders))
+				Expect(session).To(Say(`%s\s+route1\s+%s\s+http\s+http1, http2\s+%s\s+\n`, spaceName, domainName, fmt.Sprintf("%s, %s", appName1, appName2)))
+				Expect(session).To(Say(`%s\s+route2\s+%s\s+http\s+http1\s+%s\s+\n`, spaceName, domainName, appName2))
 			})
 		})
 
@@ -174,7 +223,7 @@ var _ = Describe("routes command", func() {
 				Eventually(session).Should(Exit(0))
 
 				Expect(session).To(Say(`Getting routes for org %s / space %s as %s\.\.\.`, orgName, spaceName, userName))
-				Expect(session).To(Say(`space\s+host\s+domain\s+port\s+path\s+protocol\s+apps`))
+				Expect(session).To(Say(tableHeaders))
 				Expect(session).To(Say(`%s\s+%s[^:]\s+%d\s+tcp`, spaceName, domainName, 1028))
 			})
 		})
@@ -182,9 +231,9 @@ var _ = Describe("routes command", func() {
 		When("no routes exist", func() {
 			It("outputs a message about no routes existing", func() {
 				session := helpers.CF("routes")
-				Eventually(session).Should(Say(`Getting routes for org %s / space %s as %s\.\.\.`, orgName, spaceName, userName))
-				Eventually(session).Should(Say("No routes found"))
 				Eventually(session).Should(Exit(0))
+				Expect(session).To(Say(`Getting routes for org %s / space %s as %s\.\.\.`, orgName, spaceName, userName))
+				Expect(session).To(Say("No routes found"))
 			})
 		})
 	})

--- a/integration/v7/isolated/routes_command_test.go
+++ b/integration/v7/isolated/routes_command_test.go
@@ -15,12 +15,8 @@ import (
 
 var _ = Describe("routes command", func() {
 
-	const tableHeaders = `space\s+host\s+domain\s+port\s+path\s+protocol\s+app-protocol\s+apps\s+service instance`
 	appProtocolValue := "http1"
-	if !helpers.IsVersionMet(ccversion.MinVersionHTTP2RoutingV3) {
-		appProtocolValue = ""
-	}
-
+	const tableHeaders = `space\s+host\s+domain\s+port\s+path\s+protocol\s+app-protocol\s+apps\s+service instance`
 	Context("Help", func() {
 		It("appears in cf help -a", func() {
 			session := helpers.CF("help", "-a")
@@ -70,6 +66,10 @@ var _ = Describe("routes command", func() {
 
 			helpers.SetupCF(orgName, spaceName)
 			userName, _ = helpers.GetCredentials()
+			if !helpers.IsVersionMet(ccversion.MinVersionHTTP2RoutingV3) {
+				appProtocolValue = ""
+			}
+
 		})
 
 		AfterEach(func() {


### PR DESCRIPTION
Currently we do not show the app-protocol in the output of the cf routes command, so a new column must be added to the output.
Also, the apps mapped to the route should be displayed in the apps column and must be separated with commas.

When running the `cf routes` command I'm able to see the app-protocol column in the output and the value for it should be a comma separated list that contains http1 and/or http2. This is in the case that the route is an HTTP route. 

```
$ cf routes
space         host                     domain         port   path   protocol   app-protocol     apps                     service instance
MySpace       myHost                   domain.cli.fun               http       http1,http2      app1, app
```