### PR TITLE
Add space supporter to space users command

### DIFF
--- a/api/cloudcontroller/ccversion/minimum_version.go
+++ b/api/cloudcontroller/ccversion/minimum_version.go
@@ -11,5 +11,6 @@ const (
 	MinVersionCreateServiceBrokerV3            = "3.72.0"
 	MinVersionCreateSpaceScopedServiceBrokerV3 = "3.75.0"
 
-	MinVersionHTTP2RoutingV3 = "3.104.0"
+	MinVersionHTTP2RoutingV3   = "3.104.0"
+	MinVersionSpaceSupporterV3 = "3.104.0"
 )

--- a/command/v7/space_users_command.go
+++ b/command/v7/space_users_command.go
@@ -58,6 +58,7 @@ func (cmd *SpaceUsersCommand) Execute(args []string) error {
 func (cmd SpaceUsersCommand) displaySpaceUsers(orgUsersByRoleType map[constant.RoleType][]resources.User) {
 	cmd.displayRoleGroup(orgUsersByRoleType[constant.SpaceManagerRole], "SPACE MANAGER")
 	cmd.displayRoleGroup(orgUsersByRoleType[constant.SpaceDeveloperRole], "SPACE DEVELOPER")
+	cmd.displayRoleGroup(orgUsersByRoleType[constant.SpaceSupporterRole], "SPACE SUPPORTER")
 	cmd.displayRoleGroup(orgUsersByRoleType[constant.SpaceAuditorRole], "SPACE AUDITOR")
 }
 

--- a/command/v7/space_users_command_test.go
+++ b/command/v7/space_users_command_test.go
@@ -167,6 +167,11 @@ var _ = Describe("space-users Command", func() {
 								PresentationName: "billing-manager",
 								GUID:             "spaceDeveloper-guid",
 							}
+							spaceSupporter := resources.User{
+								Origin:           "uaa",
+								PresentationName: "fred",
+								GUID:             "spaceSupporter-guid",
+							}
 							spaceAuditor := resources.User{
 								Origin:           "uaa",
 								PresentationName: "org-auditor",
@@ -176,6 +181,7 @@ var _ = Describe("space-users Command", func() {
 							spaceUsersByRole := map[constant.RoleType][]resources.User{
 								constant.SpaceManagerRole:   {uaaAdmin, ldapAdmin, abbyUser, client},
 								constant.SpaceDeveloperRole: {spaceDeveloper},
+								constant.SpaceSupporterRole: {spaceSupporter},
 								constant.SpaceAuditorRole:   {spaceAuditor},
 							}
 
@@ -198,6 +204,9 @@ var _ = Describe("space-users Command", func() {
 							Expect(testUI.Out).To(Say(`\n`))
 							Expect(testUI.Out).To(Say(`\nSPACE DEVELOPER`))
 							Expect(testUI.Out).To(Say(`\n  billing-manager \(uaa\)`))
+							Expect(testUI.Out).To(Say(`\n`))
+							Expect(testUI.Out).To(Say(`\nSPACE SUPPORTER`))
+							Expect(testUI.Out).To(Say(`\n  fred \(uaa\)`))
 							Expect(testUI.Out).To(Say(`\n`))
 							Expect(testUI.Out).To(Say(`\nSPACE AUDITOR`))
 							Expect(testUI.Out).To(Say(`\n  org-auditor \(uaa\)`))


### PR DESCRIPTION
## Does this PR modify CLI v6, CLI v7, or CLI v8?
V8 only

## Description of the Change
Adds space supporter to space users command

Space supporter is only available on certain versions of CAPI. To ensure
space user command behavior is always being tested at the integration
level, we created a new test that only would be run on newer versions of
CAPI where the space supporter is able to be created and retrieved by
this command.

## Why Is This PR Valuable?
Allows users to access new capi feature

## Applicable Issues
#2219

## How Urgent Is The Change?
not time sensitive