### PR TITLE
Version checking

### DIFF
--- a/api/cloudcontroller/ccversion/minimum_version.go
+++ b/api/cloudcontroller/ccversion/minimum_version.go
@@ -2,7 +2,7 @@ package ccversion
 
 const (
 	MinSupportedV2ClientVersion = "2.128.0"
-	MinSupportedV3ClientVersion = "3.63.0"
+	MinSupportedClientVersionV8 = "3.99.0"
 
 	MinVersionUpdateServiceNameWhenPlanNotVisibleV2  = "2.131.0"
 	MinVersionUpdateServiceInstanceMaintenanceInfoV2 = "2.135.0"

--- a/command/v7/shared/version_checker.go
+++ b/command/v7/shared/version_checker.go
@@ -3,10 +3,9 @@ package shared
 import (
 	"fmt"
 
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccversion"
 	"github.com/blang/semver"
 )
-
-const minimumCCAPIVersionForV8 = "3.99.0"
 
 func CheckCCAPIVersion(currentAPIVersion string) (string, error) {
 	currentSemver, err := semver.Make(currentAPIVersion)
@@ -14,13 +13,13 @@ func CheckCCAPIVersion(currentAPIVersion string) (string, error) {
 		return "", err
 	}
 
-	minimumSemver, err := semver.Make(minimumCCAPIVersionForV8)
+	minimumSemver, err := semver.Make(ccversion.MinSupportedClientVersionV8)
 	if err != nil {
 		return "", err
 	}
 
 	if currentSemver.LT(minimumSemver) {
-		return fmt.Sprintf("\nWarning: Your targeted API's version (%s) is less than the minimum supported API version (%s). Some commands may not function correctly.", currentAPIVersion, minimumCCAPIVersionForV8), nil
+		return fmt.Sprintf("\nWarning: Your targeted API's version (%s) is less than the minimum supported API version (%s). Some commands may not function correctly.", currentAPIVersion, ccversion.MinSupportedClientVersionV8), nil
 	}
 
 	return "", nil


### PR DESCRIPTION
## Does this PR modify CLI v6, CLI v7, or CLI v8?

V8

## Description of the Change

    We noticed the constant for minimum v3 versioning was not being used
    anywhere and also did not accurately reflect the minimum CAPI version
    required for the V8 CLI, which the CLI version that supports V3 only
    uses. We replaced it with the accurate minimum version based on a
    version checker that is being used in login and auth and consolidated
    references to only use the minimum version constant.


## Why Is This PR Valuable?

Cleaning up out dated references will hopefully prevent future errors.

## Why Should This Be In Core?

Core V8 CLI supports V3 only functionality. 

## Applicable Issues

This is a follow up to our PR for this [issue](https://github.com/cloudfoundry/cli/issues/2219)

## How Urgent Is The Change?

Not at all.

## Other Relevant Parties

@sweinstein22  @MerricdeLauney 
