### PR TITLE
Fix destination protocol flake in map-route test

### DIFF
--- a/api/cloudcontroller/ccv3/route_test.go
+++ b/api/cloudcontroller/ccv3/route_test.go
@@ -539,7 +539,7 @@ var _ = Describe("Route", func() {
 		var (
 			routeGUID           = "route-guid"
 			appGUID             = "app-guid"
-			destinationProtocol = "http2"
+			destinationProtocol string
 			expectedBody        string
 			warnings            Warnings
 			executeErr          error
@@ -559,6 +559,7 @@ var _ = Describe("Route", func() {
 
 		When("the request is successful", func() {
 			BeforeEach(func() {
+				destinationProtocol = "http2"
 				expectedBody = fmt.Sprintf(`
 					{
 						"destinations": [


### PR DESCRIPTION
destination protocol variable is changing in context and that causes a test pollution when tests run in parallel.
