### PR TITLE
Revert "Quote $PATH in Makefile to avoid word splitting"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL := env PATH="$(PATH)" /bin/bash
+SHELL := env PATH=$(PATH) /bin/bash
 CF_DIAL_TIMEOUT ?= 15
 NODES ?= 10
 PACKAGES ?= api actor command types util version integration/helpers


### PR DESCRIPTION
Reverts cloudfoundry/cli#2183
@tjvman this one is incorrect because it is wrapping the whole old PATH into one string

```sh
PATH="/path1 /path2"
```
and breaks our Linux pipeline