### PR TITLE
[Bugfix] [v8] Idempotency when trying to create a service twice

### DIFF
--- a/api/cloudcontroller/ccv3/errors.go
+++ b/api/cloudcontroller/ccv3/errors.go
@@ -171,6 +171,9 @@ func handleUnprocessableEntity(errorResponse ccerror.V3Error) error {
 	case strings.Contains(errorString,
 		"Assign a droplet before starting this app."):
 		return ccerror.InvalidStartError{}
+	case strings.Contains(errorString,
+		"The service instance name is taken"):
+		return ccerror.ServiceInstanceNameTakenError{Message: err.Message}
 	case orgNameTakenRegexp.MatchString(errorString):
 		return ccerror.OrganizationNameTakenError{UnprocessableEntityError: err}
 	case roleExistsRegexp.MatchString(errorString):

--- a/api/cloudcontroller/ccv3/errors_test.go
+++ b/api/cloudcontroller/ccv3/errors_test.go
@@ -486,6 +486,27 @@ var _ = Describe("Error Wrapper", func() {
 						})
 					})
 
+					When("the service instance name is taken", func() {
+						BeforeEach(func() {
+							serverResponse = `
+{
+  "errors": [
+    {
+      "code": 10008,
+      "detail": "The service instance name is taken",
+      "title": "CF-UnprocessableEntity"
+    }
+  ]
+}`
+						})
+
+						It("returns an ServiceInstanceNameTakenError", func() {
+							Expect(makeError).To(MatchError(ccerror.ServiceInstanceNameTakenError{
+								Message: "The service instance name is taken",
+							}))
+						})
+					})
+
 					When("the buildpack is invalid", func() {
 						BeforeEach(func() {
 							serverResponse = `


### PR DESCRIPTION
Thank you for contributing to the CF CLI! Please read the following:


* Please make sure you have implemented changes in line with the [contributing guidelines](https://github.com/cloudfoundry/cli/blob/master/.github/CONTRIBUTING.md)
* We're not allowed to accept any PRs without a signed CLA, no matter how small.
If your contribution falls under a company CLA but your membership is not public, expect delays while we confirm.
* All new code requires tests to protect against regressions.
* Contributions must be made against the appropriate branch. See the [contributing guidelines](https://github.com/cloudfoundry/cli/blob/master/.github/CONTRIBUTING.md)
* Contributions must conform to our [style guide](https://github.com/cloudfoundry/cli/wiki/CLI-Product-Specific-Style-Guide). Please reach out to us if you have questions.


## Does this PR modify CLI v6, CLI v7, or CLI v8?

It modifies CLI V8

## Description of the Change

For the _**cf cs**_ command, before V8 it was able to work in a idempotent way. The expected behavior was to be able to fulfill with an OK status the command even if the service name was already taken. Now, V8 fails in this scenario.
By looking into the code, this pattern was implemented but left the error handler when CAPI V3 answered with a 422 status code with the message
"the service instance name is taken".

Adding the message into the error handling function and everything works as expected.


## Why Is This PR Valuable?

Enabling an expected behavior to the create-service command.

## Why Should This Be In Core?

Bugifx.

## Applicable Issues


## How Urgent Is The Change?

Is the change urgent? If so, explain why it is time-sensitive.

## Other Relevant Parties

Who else is affected by the change? 
