### PR TITLE
Fix selfcontained tests failing due to /whoami

### DIFF
--- a/integration/v7/selfcontained/kubernetes_auth_test.go
+++ b/integration/v7/selfcontained/kubernetes_auth_test.go
@@ -4,14 +4,15 @@ import (
 	"net/http"
 	"path/filepath"
 
-	"code.cloudfoundry.org/cli/integration/helpers"
-	"code.cloudfoundry.org/cli/integration/v7/selfcontained/fake"
-	"code.cloudfoundry.org/cli/resources"
-	"code.cloudfoundry.org/cli/util/configv3"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 	apiv1 "k8s.io/client-go/tools/clientcmd/api/v1"
+
+	"code.cloudfoundry.org/cli/integration/helpers"
+	"code.cloudfoundry.org/cli/integration/v7/selfcontained/fake"
+	"code.cloudfoundry.org/cli/resources"
+	"code.cloudfoundry.org/cli/util/configv3"
 )
 
 var _ = Describe("auth-provider", func() {
@@ -29,13 +30,19 @@ var _ = Describe("auth-provider", func() {
 						"resources":  []resources.Application{},
 					},
 				},
+				"GET /whoami": {
+					Code: http.StatusOK, Body: map[string]interface{}{
+						"name": "my-user",
+						"kind": "User",
+					},
+				},
 			},
 		}
 		apiServer.SetConfiguration(apiConfig)
 		helpers.SetConfig(func(config *configv3.Config) {
 			config.ConfigFile.Target = apiServer.URL()
 			config.ConfigFile.CFOnK8s.Enabled = true
-			config.ConfigFile.CFOnK8s.AuthInfo = "one"
+			config.ConfigFile.CFOnK8s.AuthInfo = "my-user"
 			config.ConfigFile.TargetedOrganization = configv3.Organization{
 				GUID: "my-org",
 				Name: "My Org",
@@ -52,7 +59,8 @@ var _ = Describe("auth-provider", func() {
 			APIVersion: "v1",
 			AuthInfos: []apiv1.NamedAuthInfo{
 				{
-					Name: "one", AuthInfo: apiv1.AuthInfo{
+					Name: "my-user",
+					AuthInfo: apiv1.AuthInfo{
 						AuthProvider: &apiv1.AuthProviderConfig{
 							Name: "oidc",
 							Config: map[string]string{

--- a/integration/v7/selfcontained/login_command_test.go
+++ b/integration/v7/selfcontained/login_command_test.go
@@ -6,16 +6,17 @@ import (
 	"os"
 	"path/filepath"
 
-	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3"
-	"code.cloudfoundry.org/cli/integration/helpers"
-	"code.cloudfoundry.org/cli/integration/v7/selfcontained/fake"
-	"code.cloudfoundry.org/cli/resources"
-	"code.cloudfoundry.org/cli/util/configv3"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
 	apiv1 "k8s.io/client-go/tools/clientcmd/api/v1"
+
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3"
+	"code.cloudfoundry.org/cli/integration/helpers"
+	"code.cloudfoundry.org/cli/integration/v7/selfcontained/fake"
+	"code.cloudfoundry.org/cli/resources"
+	"code.cloudfoundry.org/cli/util/configv3"
 )
 
 var _ = Describe("LoginCommand", func() {
@@ -43,6 +44,12 @@ var _ = Describe("LoginCommand", func() {
 						Code: http.StatusOK, Body: map[string]interface{}{
 							"pagination": map[string]interface{}{},
 							"resources":  []resources.Organization{},
+						},
+					},
+					"GET /whoami": {
+						Code: http.StatusOK, Body: map[string]interface{}{
+							"name": "two",
+							"kind": "User",
 						},
 					},
 				},

--- a/integration/v7/selfcontained/logout_command_test.go
+++ b/integration/v7/selfcontained/logout_command_test.go
@@ -1,23 +1,86 @@
 package selfcontained_test
 
 import (
-	"code.cloudfoundry.org/cli/integration/helpers"
-	"code.cloudfoundry.org/cli/util/configv3"
+	"net/http"
+	"path/filepath"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
+	apiv1 "k8s.io/client-go/tools/clientcmd/api/v1"
+
+	"code.cloudfoundry.org/cli/integration/helpers"
+	"code.cloudfoundry.org/cli/integration/v7/selfcontained/fake"
+	"code.cloudfoundry.org/cli/util/configv3"
 )
 
 var _ = Describe("cf logout", func() {
 	BeforeEach(func() {
 		helpers.SetConfig(func(config *configv3.Config) {
 			config.ConfigFile.CFOnK8s.Enabled = true
-			config.ConfigFile.CFOnK8s.AuthInfo = "something"
+			config.ConfigFile.CFOnK8s.AuthInfo = "my-user"
 		})
+
+		apiServer.SetConfiguration(fake.CFAPIConfig{Routes: map[string]fake.Response{
+			"GET /whoami": {
+				Code: http.StatusOK, Body: map[string]interface{}{
+					"name": "my-user",
+					"kind": "User",
+				},
+			},
+		}})
+
+		kubeConfig := apiv1.Config{
+			Kind:       "Config",
+			APIVersion: "v1",
+			AuthInfos: []apiv1.NamedAuthInfo{
+				{
+					Name: "my-user",
+					AuthInfo: apiv1.AuthInfo{
+						AuthProvider: &apiv1.AuthProviderConfig{
+							Name: "oidc",
+							Config: map[string]string{
+								"id-token":       string(token),
+								"idp-issuer-url": "-",
+								"client-id":      "-",
+							},
+						},
+					},
+				},
+			},
+			Clusters: []apiv1.NamedCluster{
+				{
+					Name: "my-cluster",
+					Cluster: apiv1.Cluster{
+						Server: "https://example.org",
+					},
+				},
+			},
+			Contexts: []apiv1.NamedContext{
+				{
+					Name: "my-context",
+					Context: apiv1.Context{
+						Cluster:   "my-cluster",
+						AuthInfo:  "my-auth-info",
+						Namespace: "my-namespace",
+					},
+				},
+			},
+			CurrentContext: "my-context",
+		}
+
+		kubeConfigPath := filepath.Join(homeDir, ".kube", "config")
+		storeKubeConfig(kubeConfig, kubeConfigPath)
+
+		env = helpers.CFEnv{
+			EnvVars: map[string]string{
+				"KUBECONFIG": kubeConfigPath,
+			},
+		}
 	})
 
 	JustBeforeEach(func() {
-		Eventually(helpers.CF("logout")).Should(gexec.Exit(0))
+		Eventually(helpers.CustomCF(env, "logout")).Should(gexec.Exit(0))
 	})
 
 	It("clears the auth-info", func() {


### PR DESCRIPTION
## Does this PR modify CLI v6, CLI v7, or CLI v8?

This modifies CLI v8. The same changes may be necessary for v9 as well.

## Description of the Change
The tests under integration/v7/selfcontained were failing due to a missing stub for the GET /whoami endpoint. This commit adds that stub so that the existing tests will pass.

## Why Is This PR Valuable?
See above

## Why Should This Be In Core?

See above

## Applicable Issues

N/A

## How Urgent Is The Change?

Not urgent, but if you intend to run the selfcontained tests in your pipeline then this will be necessary to make them green.

## Other Relevant Parties

Who else is affected by the change? 
@gcapizzi @kieron-dev