### PR TITLE
Skipping SSL validation tests for macOS

### DIFF
--- a/.github/workflows/units.yml
+++ b/.github/workflows/units.yml
@@ -70,8 +70,8 @@ jobs:
 
     - name: Set up Test
       run: |
-        go get -u github.com/onsi/ginkgo/ginkgo
-        go get github.com/onsi/gomega/matchers@v1.10.5
+        go install github.com/onsi/ginkgo/ginkgo@v1.16.4
+        go install github.com/onsi/gomega/matchers
 
     - name: Run Linux Units
       run: make units
@@ -103,8 +103,8 @@ jobs:
 
     - name: Set up Test
       run: |
-        go get -u github.com/onsi/ginkgo/ginkgo
-        go get github.com/onsi/gomega/matchers@v1.10.5
+        go install github.com/onsi/ginkgo/ginkgo@v1.16.4
+        go install github.com/onsi/gomega/matchers
 
     - name: Get build-time dependencies
       run: |

--- a/api/cloudcontroller/cloud_controller_connection_test.go
+++ b/api/cloudcontroller/cloud_controller_connection_test.go
@@ -253,6 +253,9 @@ var _ = Describe("Cloud Controller Connection", func() {
 			When("the server does not have a verified certificate", func() {
 				Context("skipSSLValidation is false", func() {
 					BeforeEach(func() {
+						if runtime.GOOS == "darwin" {
+							Skip("ssl verification is different on darwin")
+						}
 						server.AppendHandlers(
 							CombineHandlers(
 								VerifyRequest(http.MethodGet, "/v2/foo"),
@@ -277,8 +280,8 @@ var _ = Describe("Cloud Controller Connection", func() {
 			When("the server's certificate does not match the hostname", func() {
 				Context("skipSSLValidation is false", func() {
 					BeforeEach(func() {
-						if runtime.GOOS == "windows" {
-							Skip("ssl validation has a different order on windows, will not be returned properly")
+						if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+							Skip("ssl validation has a different order on windows/darwin, will not be returned properly")
 						}
 						server.AppendHandlers(
 							CombineHandlers(

--- a/api/plugin/plugin_connection_test.go
+++ b/api/plugin/plugin_connection_test.go
@@ -155,6 +155,9 @@ var _ = Describe("Plugin Connection", func() {
 			When("the server does not have a verified certificate", func() {
 				Context("skipSSLValidation is false", func() {
 					BeforeEach(func() {
+						if runtime.GOOS == "darwin" {
+							Skip("ssl verification is different on darwin")
+						}
 						server.AppendHandlers(
 							CombineHandlers(
 								VerifyRequest(http.MethodGet, "/list"),
@@ -178,8 +181,8 @@ var _ = Describe("Plugin Connection", func() {
 			When("the server's certificate does not match the hostname", func() {
 				Context("skipSSLValidation is false", func() {
 					BeforeEach(func() {
-						if runtime.GOOS == "windows" {
-							Skip("ssl validation has a different order on windows, will not be returned properly")
+						if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+							Skip("ssl validation has a different order on windows/darwin, will not be returned properly")
 						}
 						server.AppendHandlers(
 							CombineHandlers(

--- a/api/uaa/uaa_connection_test.go
+++ b/api/uaa/uaa_connection_test.go
@@ -3,6 +3,7 @@ package uaa_test
 import (
 	"fmt"
 	"net/http"
+	"runtime"
 
 	. "code.cloudfoundry.org/cli/api/uaa"
 	. "github.com/onsi/ginkgo"
@@ -120,6 +121,9 @@ var _ = Describe("UAA Connection", func() {
 			When("the server does not have a verified certificate", func() {
 				Context("skipSSLValidation is false", func() {
 					BeforeEach(func() {
+						if runtime.GOOS == "darwin" {
+							Skip("ssl verification is different on darwin")
+						}
 						server.AppendHandlers(
 							CombineHandlers(
 								VerifyRequest(http.MethodGet, "/v2/foo"),

--- a/cf/net/gateway_test.go
+++ b/cf/net/gateway_test.go
@@ -528,7 +528,13 @@ var _ = Describe("Gateway", func() {
 		})
 
 		Context("when SSL validation is enabled", func() {
+			BeforeEach(func() {
+				if runtime.GOOS == "darwin" {
+					Skip("ssl verification is different on darwin")
+				}
+			})
 			It("returns an invalid cert error if the server's CA is unknown (e.g. cert is self-signed)", func() {
+
 				apiServer.TLS.Certificates = []tls.Certificate{testnet.MakeSelfSignedTLSCert()}
 
 				_, apiErr := ccGateway.PerformRequest(request)

--- a/cf/util/testhelpers/net/make_tls_cert.go
+++ b/cf/util/testhelpers/net/make_tls_cert.go
@@ -30,7 +30,7 @@ func MakeUnauthorizedTLSCert() tls.Certificate {
 }
 
 func generateCert(hosts []string, notAfter time.Time, isAuthorizedToSign bool) tls.Certificate {
-	priv, err := rsa.GenerateKey(rand.Reader, 1024)
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Starting golang 1.18 system APIs are used for certificate verification
on macOS instead of built-in go verifier. Which makes behavior similar
to Windows. Since we are skipping this test for Windows due to
difficulties with execution order we believe it's fair to skip it in
macOS too and rely on Linux test.

References:
- [Changes to x509 in Go 1.18 conversation](https://groups.google.com/g/golang-nuts/c/RGghq2gTWss/m/7GsudTfCAgAJ)
- https://cs.opensource.google/go/go/+/master:src/crypto/x509/root_darwin.go;l=52
- https://cs.opensource.google/go/go/+/master:src/crypto/x509/verify.go;l=766

Co-authored-by: Alexander Berezovsky <aberezovsky@vmware.com>