### PR TITLE
Refresh token in logs is disabled for Korifi

### DIFF
--- a/command/v7/logs_command_test.go
+++ b/command/v7/logs_command_test.go
@@ -248,6 +248,16 @@ var _ = Describe("logs command", func() {
 					})
 				})
 
+				When("isCFOnK8s is true", func() {
+					BeforeEach(func() {
+						fakeConfig.IsCFOnK8sReturns(true)
+					})
+
+					It("does not call ScheduleTokenRefresh", func() {
+						Expect(fakeActor.ScheduleTokenRefreshCallCount()).To(Equal(0))
+					})
+				})
+
 				It("displays the error and all warnings", func() {
 					Expect(executeErr).NotTo(HaveOccurred())
 					Expect(testUI.Err).To(Say("steve for all I care"))


### PR DESCRIPTION
## Does this PR modify CLI v6, CLI v7, or CLI v8?
CLI v8

## Description of the Change
Disables refresh token call for the `cf logs` command when targeting Korifi (CF on K8s). We are not using UAA for AuthN/Z, so this call was resulting in errors.

## Why Is This PR Valuable?

This will allow users of Korifi to use the `cf logs` command without causing an error on the refresh token call.

## Why Should This Be In Core?

This change extends previous core functionality to allow targeting of Korifi (CF on K8s) clusters.

## Applicable Issues

[[Feature]: CF CLI user can skip oauth/token requests on Korifi](https://github.com/cloudfoundry/korifi/issues/1299)

## How Urgent Is The Change?

Medium/high urgency - we would like to pair it with a beta release. This functionality will be needed for standard user flows.

## Other Relevant Parties

Korifi users. 
