### PR TITLE
Add support for Korifi to the `cf auth` command

### DIFF
--- a/command/v7/auth_command.go
+++ b/command/v7/auth_command.go
@@ -1,6 +1,7 @@
 package v7
 
 import (
+	"errors"
 	"fmt"
 
 	"code.cloudfoundry.org/cli/api/uaa/constant"
@@ -77,6 +78,29 @@ func (cmd AuthCommand) Execute(args []string) error {
 		grantType = constant.GrantTypeClientCredentials
 		credentials["client_id"] = username
 		credentials["client_secret"] = password
+	} else if cmd.Config.IsCFOnK8s() {
+		prompts, err := cmd.Actor.GetLoginPrompts()
+		if err != nil {
+			return err
+		}
+		prompt, ok := prompts["k8s-auth-info"]
+		if !ok {
+			return errors.New("kubernetes login context is missing")
+		}
+
+		userFound := false
+		for _, val := range prompt.Entries {
+			if val == username {
+				userFound = true
+				break
+			}
+		}
+		if !userFound {
+			return errors.New("kubernetes user not found in configuration: " + username)
+		}
+		credentials = map[string]string{
+			"k8s-auth-info": username,
+		}
 	} else {
 		credentials = map[string]string{
 			"username": username,
@@ -118,7 +142,7 @@ func (cmd AuthCommand) getUsernamePassword() (string, string, error) {
 	if password == "" {
 		if envPassword := cmd.Config.CFPassword(); envPassword != "" {
 			password = envPassword
-		} else {
+		} else if !cmd.Config.IsCFOnK8s() {
 			passwordMissing = true
 		}
 	}


### PR DESCRIPTION
## Does this PR modify CLI v6, CLI v7, or CLI v8?

v8

## Description of the Change

- Prior to this change, login to Korifi was only possible through `cf login`. This change adds support for `cf auth`.
- `cf auth` normally requires a password. This change make the password optional when the CF API is Korifi, since we pull credentials from the user's KUBECONFIG in this case.
- We also check the provided username against the available users from the k8s config to ensure that we will be able to use it.
- Note that error messages for this command are not localized. My rationale was that other similar errors (like a missing/empty KUBECONFIG) also produce unlocalized errors. Maybe this reasoning is incorrect? If so, we can amend the PR.

I've only made a PR for the `v8` branch, based on the instructions in the contributing guidelines. Please let me know if you'd also like a separate PR for `main`.

## Why Is This PR Valuable?

This is useful to us for the same reasons that `cf auth` is useful in CF on VMs: It's much easier to interact with from automation scripts since it doesn't require us to pipe answers into the CLI from `<STDIN>`. This will be helpful for us as developers, but likely also for customers that interact with CF through CI pipelines.

## Why Should This Be In Core?

The `cf login` changes are already in core (see #2233), so it would be odd to put `cf auth` into a plugin. (Also maybe not possible? I am not really sure)

## Applicable Issues

Related to #2233 and #2267

## How Urgent Is The Change?

Not urgent, just useful.

## Other Relevant Parties

CC @tcdowney @emalm @gcapizzi   
