### PR TITLE
Feat: create and update org quotas with log volume

### DIFF
--- a/actor/v7action/organization_quota.go
+++ b/actor/v7action/organization_quota.go
@@ -15,6 +15,7 @@ type QuotaLimits struct {
 	TotalServiceInstances *types.NullInt
 	TotalRoutes           *types.NullInt
 	TotalReservedPorts    *types.NullInt
+	TotalLogVolume        *types.NullInt
 }
 
 func (actor Actor) ApplyOrganizationQuotaByName(quotaName string, orgGUID string) (Warnings, error) {
@@ -119,6 +120,7 @@ func createQuotaStruct(name string, limits QuotaLimits) resources.OrganizationQu
 		TotalMemory:       limits.TotalMemoryInMB,
 		InstanceMemory:    limits.PerProcessMemoryInMB,
 		TotalAppInstances: limits.TotalInstances,
+		TotalLogVolume:    limits.TotalLogVolume,
 	}
 	ServiceLimit := resources.ServiceLimit{
 		TotalServiceInstances: limits.TotalServiceInstances,
@@ -164,6 +166,7 @@ func convertUnlimitedToNil(apps *resources.AppLimit, routes *resources.RouteLimi
 		apps.TotalMemory,
 		apps.InstanceMemory,
 		apps.TotalAppInstances,
+		apps.TotalLogVolume,
 		services.TotalServiceInstances,
 		routes.TotalRoutes,
 		routes.TotalReservedPorts,

--- a/actor/v7action/organization_quota_test.go
+++ b/actor/v7action/organization_quota_test.go
@@ -582,6 +582,7 @@ var _ = Describe("Organization Quota Actions", func() {
 				PaidServicesAllowed:   &trueValue,
 				TotalRoutes:           &types.NullInt{Value: 6, IsSet: true},
 				TotalReservedPorts:    &types.NullInt{Value: 5, IsSet: true},
+				TotalLogVolume:        &types.NullInt{Value: 64, IsSet: true},
 			}
 
 			fakeCloudControllerClient.GetOrganizationQuotasReturns(
@@ -627,6 +628,7 @@ var _ = Describe("Organization Quota Actions", func() {
 							TotalMemory:       nil,
 							InstanceMemory:    nil,
 							TotalAppInstances: nil,
+							TotalLogVolume:    nil,
 						},
 						Services: resources.ServiceLimit{
 							TotalServiceInstances: nil,
@@ -674,6 +676,7 @@ var _ = Describe("Organization Quota Actions", func() {
 					TotalServiceInstances: &types.NullInt{Value: -1, IsSet: true},
 					TotalRoutes:           &types.NullInt{Value: -1, IsSet: true},
 					TotalReservedPorts:    &types.NullInt{Value: -1, IsSet: true},
+					TotalLogVolume:        &types.NullInt{Value: -1, IsSet: true},
 				}
 				ccv3Quota = resources.OrganizationQuota{
 					Quota: resources.Quota{
@@ -682,6 +685,7 @@ var _ = Describe("Organization Quota Actions", func() {
 							TotalMemory:       &types.NullInt{Value: 0, IsSet: false},
 							InstanceMemory:    &types.NullInt{Value: 0, IsSet: false},
 							TotalAppInstances: &types.NullInt{Value: 0, IsSet: false},
+							TotalLogVolume:    &types.NullInt{Value: 0, IsSet: false},
 						},
 						Services: resources.ServiceLimit{
 							TotalServiceInstances: &types.NullInt{Value: 0, IsSet: false},
@@ -727,6 +731,7 @@ var _ = Describe("Organization Quota Actions", func() {
 							TotalMemory:       &types.NullInt{Value: 2048, IsSet: true},
 							InstanceMemory:    &types.NullInt{Value: 1024, IsSet: true},
 							TotalAppInstances: &types.NullInt{Value: 0, IsSet: false},
+							TotalLogVolume:    &types.NullInt{Value: 64, IsSet: true},
 						},
 						Services: resources.ServiceLimit{
 							TotalServiceInstances: &types.NullInt{Value: 0, IsSet: true},

--- a/actor/v7action/organization_quota_test.go
+++ b/actor/v7action/organization_quota_test.go
@@ -399,6 +399,7 @@ var _ = Describe("Organization Quota Actions", func() {
 				PaidServicesAllowed:   &trueValue,
 				TotalRoutes:           &types.NullInt{Value: 6, IsSet: true},
 				TotalReservedPorts:    &types.NullInt{Value: 5, IsSet: true},
+				TotalLogVolume:        &types.NullInt{Value: 512, IsSet: true},
 			}
 		})
 
@@ -438,6 +439,7 @@ var _ = Describe("Organization Quota Actions", func() {
 							TotalMemory:       &types.NullInt{Value: 0, IsSet: true},
 							InstanceMemory:    nil,
 							TotalAppInstances: nil,
+							TotalLogVolume:    nil,
 						},
 						Services: resources.ServiceLimit{
 							TotalServiceInstances: &types.NullInt{Value: 0, IsSet: true},
@@ -480,6 +482,7 @@ var _ = Describe("Organization Quota Actions", func() {
 					TotalServiceInstances: &types.NullInt{Value: -1, IsSet: true},
 					TotalRoutes:           &types.NullInt{Value: -1, IsSet: true},
 					TotalReservedPorts:    &types.NullInt{Value: -1, IsSet: true},
+					TotalLogVolume:        &types.NullInt{Value: -1, IsSet: true},
 				}
 				ccv3Quota = resources.OrganizationQuota{
 					Quota: resources.Quota{
@@ -488,6 +491,7 @@ var _ = Describe("Organization Quota Actions", func() {
 							TotalMemory:       &types.NullInt{Value: 0, IsSet: false},
 							InstanceMemory:    &types.NullInt{Value: 0, IsSet: false},
 							TotalAppInstances: &types.NullInt{Value: 0, IsSet: false},
+							TotalLogVolume:    &types.NullInt{Value: 0, IsSet: false},
 						},
 						Services: resources.ServiceLimit{
 							TotalServiceInstances: &types.NullInt{Value: 0, IsSet: false},
@@ -506,7 +510,7 @@ var _ = Describe("Organization Quota Actions", func() {
 				)
 			})
 
-			It("call the create endpoint with the respective values and returns warnings", func() {
+			It("calls the create endpoint with the respective values and returns warnings", func() {
 				Expect(fakeCloudControllerClient.CreateOrganizationQuotaCallCount()).To(Equal(1))
 
 				Expect(warnings).To(ConsistOf("some-quota-warning"))
@@ -516,7 +520,7 @@ var _ = Describe("Organization Quota Actions", func() {
 			})
 		})
 
-		When("The create org quota endpoint succeeds", func() {
+		When("the create org quota endpoint succeeds", func() {
 			var (
 				ccv3Quota resources.OrganizationQuota
 			)
@@ -528,6 +532,7 @@ var _ = Describe("Organization Quota Actions", func() {
 							TotalMemory:       &types.NullInt{Value: 2048, IsSet: true},
 							InstanceMemory:    &types.NullInt{Value: 1024, IsSet: true},
 							TotalAppInstances: &types.NullInt{Value: 0, IsSet: false},
+							TotalLogVolume:    &types.NullInt{Value: 512, IsSet: true},
 						},
 						Services: resources.ServiceLimit{
 							TotalServiceInstances: &types.NullInt{Value: 0, IsSet: true},
@@ -546,7 +551,7 @@ var _ = Describe("Organization Quota Actions", func() {
 				)
 			})
 
-			It("call the create endpoint with the respective values and returns warnings", func() {
+			It("calls the create endpoint with the respective values and returns warnings", func() {
 				Expect(fakeCloudControllerClient.CreateOrganizationQuotaCallCount()).To(Equal(1))
 
 				Expect(warnings).To(ConsistOf("some-quota-warning"))

--- a/api/cloudcontroller/ccversion/minimum_version.go
+++ b/api/cloudcontroller/ccversion/minimum_version.go
@@ -13,4 +13,6 @@ const (
 
 	MinVersionHTTP2RoutingV3   = "3.104.0"
 	MinVersionSpaceSupporterV3 = "3.104.0"
+
+	MinVersionLogRateLimitingV3 = "3.124.0" // TODO: update this when we have a CAPI release
 )

--- a/command/flag/bytes_with_unlimited.go
+++ b/command/flag/bytes_with_unlimited.go
@@ -1,0 +1,49 @@
+package flag
+
+import (
+	"strings"
+
+	"code.cloudfoundry.org/bytefmt"
+	"code.cloudfoundry.org/cli/types"
+	flags "github.com/jessevdk/go-flags"
+)
+
+type BytesWithUnlimited types.NullInt
+
+func (m *BytesWithUnlimited) UnmarshalFlag(val string) error {
+	if val == "" {
+		return nil
+	}
+
+	if val == "-1" {
+		m.Value = -1
+		m.IsSet = true
+		return nil
+	}
+
+	size, err := ConvertToBytes(val)
+	if err != nil {
+		return err
+	}
+
+	m.Value = int(size)
+	m.IsSet = true
+
+	return nil
+}
+
+func (m *BytesWithUnlimited) IsValidValue(val string) error {
+	return m.UnmarshalFlag(val)
+}
+
+func ConvertToBytes(val string) (uint64, error) {
+	size, err := bytefmt.ToBytes(val)
+
+	if err != nil || strings.Contains(strings.ToLower(val), ".") {
+		return size, &flags.Error{
+			Type:    flags.ErrRequired,
+			Message: `Byte quantity must be an integer with a unit of measurement like B, K, KB, M, MB, G, or GB`,
+		}
+	}
+	return size, nil
+}

--- a/command/flag/bytes_with_unlimited_test.go
+++ b/command/flag/bytes_with_unlimited_test.go
@@ -1,0 +1,128 @@
+package flag_test
+
+import (
+	. "code.cloudfoundry.org/cli/command/flag"
+	flags "github.com/jessevdk/go-flags"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("BytesWithUnlimited", func() {
+	var bytesWithUnlimited BytesWithUnlimited
+
+	Describe("UnmarshalFlag", func() {
+		BeforeEach(func() {
+			bytesWithUnlimited = BytesWithUnlimited{}
+		})
+
+		When("the suffix is B", func() {
+			It("interprets the number as bytes", func() {
+				err := bytesWithUnlimited.UnmarshalFlag("17B")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bytesWithUnlimited.Value).To(BeEquivalentTo(17))
+			})
+		})
+
+		When("the suffix is K", func() {
+			It("interprets the number as kilobytes", func() {
+				err := bytesWithUnlimited.UnmarshalFlag("64K")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bytesWithUnlimited.Value).To(BeEquivalentTo(64 * 1024))
+			})
+		})
+
+		When("the suffix is KB", func() {
+			It("interprets the number as kilobytes", func() {
+				err := bytesWithUnlimited.UnmarshalFlag("64KB")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bytesWithUnlimited.Value).To(BeEquivalentTo(64 * 1024))
+			})
+		})
+
+		When("the suffix is M", func() {
+			It("interprets the number as megabytes", func() {
+				err := bytesWithUnlimited.UnmarshalFlag("17M")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bytesWithUnlimited.Value).To(BeEquivalentTo(17 * 1024 * 1024))
+			})
+		})
+
+		When("the suffix is MB", func() {
+			It("interprets the number as megabytes", func() {
+				err := bytesWithUnlimited.UnmarshalFlag("19MB")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bytesWithUnlimited.Value).To(BeEquivalentTo(19 * 1024 * 1024))
+			})
+		})
+
+		When("the suffix is G", func() {
+			It("interprets the number as gigabytes", func() {
+				err := bytesWithUnlimited.UnmarshalFlag("2G")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bytesWithUnlimited.Value).To(BeEquivalentTo(2 * 1024 * 1024 * 1024))
+			})
+		})
+
+		When("the suffix is GB", func() {
+			It("interprets the number as gigabytes", func() {
+				err := bytesWithUnlimited.UnmarshalFlag("3GB")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bytesWithUnlimited.Value).To(BeEquivalentTo(3 * 1024 * 1024 * 1024))
+			})
+		})
+
+		When("the value is -1 (unlimited)", func() {
+			It("interprets the number as -1 (unlimited)", func() {
+				err := bytesWithUnlimited.UnmarshalFlag("-1")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bytesWithUnlimited.Value).To(BeEquivalentTo(-1))
+			})
+		})
+
+		When("the suffix is lowercase", func() {
+			It("is case insensitive", func() {
+				err := bytesWithUnlimited.UnmarshalFlag("7m")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bytesWithUnlimited.Value).To(BeEquivalentTo(7 * 1024 * 1024))
+			})
+		})
+
+		When("the value is invalid", func() {
+			It("returns an error", func() {
+				err := bytesWithUnlimited.UnmarshalFlag("invalid")
+				Expect(err).To(MatchError(&flags.Error{
+					Type:    flags.ErrRequired,
+					Message: `Byte quantity must be an integer with a unit of measurement like B, K, KB, M, MB, G, or GB`,
+				}))
+			})
+		})
+
+		When("a decimal is used", func() {
+			It("returns an error", func() {
+				err := bytesWithUnlimited.UnmarshalFlag("1.2M")
+				Expect(err).To(MatchError(&flags.Error{
+					Type:    flags.ErrRequired,
+					Message: `Byte quantity must be an integer with a unit of measurement like B, K, KB, M, MB, G, or GB`,
+				}))
+			})
+		})
+
+		When("the units are missing", func() {
+			It("returns an error", func() {
+				err := bytesWithUnlimited.UnmarshalFlag("37")
+				Expect(err).To(MatchError(&flags.Error{
+					Type:    flags.ErrRequired,
+					Message: `Byte quantity must be an integer with a unit of measurement like B, K, KB, M, MB, G, or GB`,
+				}))
+			})
+		})
+
+		When("value is empty", func() {
+			It("sets IsSet to false", func() {
+				err := bytesWithUnlimited.UnmarshalFlag("")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(bytesWithUnlimited.IsSet).To(BeFalse())
+			})
+		})
+	})
+})

--- a/command/flag/megabytes_with_unlimited.go
+++ b/command/flag/megabytes_with_unlimited.go
@@ -4,9 +4,9 @@ import (
 	"code.cloudfoundry.org/cli/types"
 )
 
-type MemoryWithUnlimited types.NullInt
+type MegabytesWithUnlimited types.NullInt
 
-func (m *MemoryWithUnlimited) UnmarshalFlag(val string) error {
+func (m *MegabytesWithUnlimited) UnmarshalFlag(val string) error {
 	if val == "" {
 		return nil
 	}
@@ -28,6 +28,6 @@ func (m *MemoryWithUnlimited) UnmarshalFlag(val string) error {
 	return nil
 }
 
-func (m *MemoryWithUnlimited) IsValidValue(val string) error {
+func (m *MegabytesWithUnlimited) IsValidValue(val string) error {
 	return m.UnmarshalFlag(val)
 }

--- a/command/flag/megabytes_with_unlimited_test.go
+++ b/command/flag/megabytes_with_unlimited_test.go
@@ -7,65 +7,65 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("MemoryWithUnlimited", func() {
-	var memoryWithUnlimited MemoryWithUnlimited
+var _ = Describe("MegabytesWithUnlimited", func() {
+	var megabytesWithUnlimited MegabytesWithUnlimited
 
 	Describe("UnmarshalFlag", func() {
 		BeforeEach(func() {
-			memoryWithUnlimited = MemoryWithUnlimited{}
+			megabytesWithUnlimited = MegabytesWithUnlimited{}
 		})
 
 		When("the suffix is M", func() {
-			It("interprets the number as memoryWithUnlimited", func() {
-				err := memoryWithUnlimited.UnmarshalFlag("17M")
+			It("interprets the number as megabytesWithUnlimited", func() {
+				err := megabytesWithUnlimited.UnmarshalFlag("17M")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(memoryWithUnlimited.Value).To(BeEquivalentTo(17))
+				Expect(megabytesWithUnlimited.Value).To(BeEquivalentTo(17))
 			})
 		})
 
 		When("the suffix is MB", func() {
-			It("interprets the number as memoryWithUnlimited", func() {
-				err := memoryWithUnlimited.UnmarshalFlag("19MB")
+			It("interprets the number as megabytesWithUnlimited", func() {
+				err := megabytesWithUnlimited.UnmarshalFlag("19MB")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(memoryWithUnlimited.Value).To(BeEquivalentTo(19))
+				Expect(megabytesWithUnlimited.Value).To(BeEquivalentTo(19))
 			})
 		})
 
 		When("the suffix is G", func() {
 			It("interprets the number as gigabytes", func() {
-				err := memoryWithUnlimited.UnmarshalFlag("2G")
+				err := megabytesWithUnlimited.UnmarshalFlag("2G")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(memoryWithUnlimited.Value).To(BeEquivalentTo(2048))
+				Expect(megabytesWithUnlimited.Value).To(BeEquivalentTo(2048))
 			})
 		})
 
 		When("the suffix is GB", func() {
 			It("interprets the number as gigabytes", func() {
-				err := memoryWithUnlimited.UnmarshalFlag("3GB")
+				err := megabytesWithUnlimited.UnmarshalFlag("3GB")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(memoryWithUnlimited.Value).To(BeEquivalentTo(3072))
+				Expect(megabytesWithUnlimited.Value).To(BeEquivalentTo(3072))
 			})
 		})
 
 		When("the value is -1 (unlimited)", func() {
-			It("interprets the number as memoryWithUnlimited", func() {
-				err := memoryWithUnlimited.UnmarshalFlag("-1")
+			It("interprets the number as megabytesWithUnlimited", func() {
+				err := megabytesWithUnlimited.UnmarshalFlag("-1")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(memoryWithUnlimited.Value).To(BeEquivalentTo(-1))
+				Expect(megabytesWithUnlimited.Value).To(BeEquivalentTo(-1))
 			})
 		})
 
 		When("the suffix is lowercase", func() {
 			It("is case insensitive", func() {
-				err := memoryWithUnlimited.UnmarshalFlag("7m")
+				err := megabytesWithUnlimited.UnmarshalFlag("7m")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(memoryWithUnlimited.Value).To(BeEquivalentTo(7))
+				Expect(megabytesWithUnlimited.Value).To(BeEquivalentTo(7))
 			})
 		})
 
-		When("the memoryWithUnlimited are invalid", func() {
+		When("the megabytesWithUnlimited are invalid", func() {
 			It("returns an error", func() {
-				err := memoryWithUnlimited.UnmarshalFlag("invalid")
+				err := megabytesWithUnlimited.UnmarshalFlag("invalid")
 				Expect(err).To(MatchError(&flags.Error{
 					Type:    flags.ErrRequired,
 					Message: `Byte quantity must be an integer with a unit of measurement like M, MB, G, or GB`,
@@ -75,7 +75,7 @@ var _ = Describe("MemoryWithUnlimited", func() {
 
 		When("a decimal is used", func() {
 			It("returns an error", func() {
-				err := memoryWithUnlimited.UnmarshalFlag("1.2M")
+				err := megabytesWithUnlimited.UnmarshalFlag("1.2M")
 				Expect(err).To(MatchError(&flags.Error{
 					Type:    flags.ErrRequired,
 					Message: `Byte quantity must be an integer with a unit of measurement like M, MB, G, or GB`,
@@ -85,7 +85,7 @@ var _ = Describe("MemoryWithUnlimited", func() {
 
 		When("the units are missing", func() {
 			It("returns an error", func() {
-				err := memoryWithUnlimited.UnmarshalFlag("37")
+				err := megabytesWithUnlimited.UnmarshalFlag("37")
 				Expect(err).To(MatchError(&flags.Error{
 					Type:    flags.ErrRequired,
 					Message: `Byte quantity must be an integer with a unit of measurement like M, MB, G, or GB`,
@@ -95,7 +95,7 @@ var _ = Describe("MemoryWithUnlimited", func() {
 
 		When("the suffix is B", func() {
 			It("returns an error", func() {
-				err := memoryWithUnlimited.UnmarshalFlag("10B")
+				err := megabytesWithUnlimited.UnmarshalFlag("10B")
 				Expect(err).To(MatchError(&flags.Error{
 					Type:    flags.ErrRequired,
 					Message: `Byte quantity must be an integer with a unit of measurement like M, MB, G, or GB`,
@@ -105,9 +105,9 @@ var _ = Describe("MemoryWithUnlimited", func() {
 
 		When("value is empty", func() {
 			It("sets IsSet to false", func() {
-				err := memoryWithUnlimited.UnmarshalFlag("")
+				err := megabytesWithUnlimited.UnmarshalFlag("")
 				Expect(err).NotTo(HaveOccurred())
-				Expect(memoryWithUnlimited.IsSet).To(BeFalse())
+				Expect(megabytesWithUnlimited.IsSet).To(BeFalse())
 			})
 		})
 	})

--- a/command/v7/create_org_quota_command.go
+++ b/command/v7/create_org_quota_command.go
@@ -10,16 +10,16 @@ import (
 type CreateOrgQuotaCommand struct {
 	BaseCommand
 
-	RequiredArgs          flag.OrganizationQuota   `positional-args:"yes"`
-	NumAppInstances       flag.IntegerLimit        `short:"a" description:"Total number of application instances. (Default: unlimited)."`
-	PaidServicePlans      bool                     `long:"allow-paid-service-plans" description:"Allow provisioning instances of paid service plans. (Default: disallowed)."`
-	PerProcessMemory      flag.MemoryWithUnlimited `short:"i" description:"Maximum amount of memory a process can have (e.g. 1024M, 1G, 10G). (Default: unlimited)."`
-	TotalMemory           flag.MemoryWithUnlimited `short:"m" description:"Total amount of memory all processes can have (e.g. 1024M, 1G, 10G).  -1 represents an unlimited amount. (Default: 0)."`
-	TotalRoutes           flag.IntegerLimit        `short:"r" description:"Total number of routes. -1 represents an unlimited amount. (Default: 0)."`
-	TotalReservedPorts    flag.IntegerLimit        `long:"reserved-route-ports" description:"Maximum number of routes that may be created with ports. -1 represents an unlimited amount. (Default: 0)."`
-	TotalServiceInstances flag.IntegerLimit        `short:"s" description:"Total number of service instances. -1 represents an unlimited amount. (Default: 0)."`
-	usage                 interface{}              `usage:"CF_NAME create-org-quota ORG_QUOTA [-m TOTAL_MEMORY] [-i INSTANCE_MEMORY] [-r ROUTES] [-s SERVICE_INSTANCES] [-a APP_INSTANCES] [--allow-paid-service-plans] [--reserved-route-ports RESERVED_ROUTE_PORTS]"`
-	relatedCommands       interface{}              `related_commands:"create-org, org-quotas, set-org-quota"`
+	RequiredArgs          flag.OrganizationQuota      `positional-args:"yes"`
+	NumAppInstances       flag.IntegerLimit           `short:"a" description:"Total number of application instances. (Default: unlimited)."`
+	PaidServicePlans      bool                        `long:"allow-paid-service-plans" description:"Allow provisioning instances of paid service plans. (Default: disallowed)."`
+	PerProcessMemory      flag.MegabytesWithUnlimited `short:"i" description:"Maximum amount of memory a process can have (e.g. 1024M, 1G, 10G). (Default: unlimited)."`
+	TotalMemory           flag.MegabytesWithUnlimited `short:"m" description:"Total amount of memory all processes can have (e.g. 1024M, 1G, 10G).  -1 represents an unlimited amount. (Default: 0)."`
+	TotalRoutes           flag.IntegerLimit           `short:"r" description:"Total number of routes. -1 represents an unlimited amount. (Default: 0)."`
+	TotalReservedPorts    flag.IntegerLimit           `long:"reserved-route-ports" description:"Maximum number of routes that may be created with ports. -1 represents an unlimited amount. (Default: 0)."`
+	TotalServiceInstances flag.IntegerLimit           `short:"s" description:"Total number of service instances. -1 represents an unlimited amount. (Default: 0)."`
+	usage                 interface{}                 `usage:"CF_NAME create-org-quota ORG_QUOTA [-m TOTAL_MEMORY] [-i INSTANCE_MEMORY] [-r ROUTES] [-s SERVICE_INSTANCES] [-a APP_INSTANCES] [--allow-paid-service-plans] [--reserved-route-ports RESERVED_ROUTE_PORTS]"`
+	relatedCommands       interface{}                 `related_commands:"create-org, org-quotas, set-org-quota"`
 }
 
 func (cmd CreateOrgQuotaCommand) Execute(args []string) error {
@@ -66,7 +66,7 @@ func (cmd CreateOrgQuotaCommand) Execute(args []string) error {
 	return nil
 }
 
-func convertMegabytesFlagToNullInt(flag flag.MemoryWithUnlimited) *types.NullInt {
+func convertMegabytesFlagToNullInt(flag flag.MegabytesWithUnlimited) *types.NullInt {
 	if !flag.IsSet {
 		return nil
 	}

--- a/command/v7/create_org_quota_command.go
+++ b/command/v7/create_org_quota_command.go
@@ -18,8 +18,10 @@ type CreateOrgQuotaCommand struct {
 	TotalRoutes           flag.IntegerLimit           `short:"r" description:"Total number of routes. -1 represents an unlimited amount. (Default: 0)."`
 	TotalReservedPorts    flag.IntegerLimit           `long:"reserved-route-ports" description:"Maximum number of routes that may be created with ports. -1 represents an unlimited amount. (Default: 0)."`
 	TotalServiceInstances flag.IntegerLimit           `short:"s" description:"Total number of service instances. -1 represents an unlimited amount. (Default: 0)."`
-	usage                 interface{}                 `usage:"CF_NAME create-org-quota ORG_QUOTA [-m TOTAL_MEMORY] [-i INSTANCE_MEMORY] [-r ROUTES] [-s SERVICE_INSTANCES] [-a APP_INSTANCES] [--allow-paid-service-plans] [--reserved-route-ports RESERVED_ROUTE_PORTS]"`
-	relatedCommands       interface{}                 `related_commands:"create-org, org-quotas, set-org-quota"`
+	TotalLogVolume        flag.BytesWithUnlimited     `short:"l" description:"Total log volume per second all processes can have (e.g. 128B, 4K, 1M). -1 represents an unlimited amount. (Default: -1)."`
+
+	usage           interface{} `usage:"CF_NAME create-org-quota ORG_QUOTA [-m TOTAL_MEMORY] [-i INSTANCE_MEMORY] [-r ROUTES] [-s SERVICE_INSTANCES] [-a APP_INSTANCES] [--allow-paid-service-plans] [--reserved-route-ports RESERVED_ROUTE_PORTS] [-l LOG_VOLUME]"`
+	relatedCommands interface{} `related_commands:"create-org, org-quotas, set-org-quota"`
 }
 
 func (cmd CreateOrgQuotaCommand) Execute(args []string) error {
@@ -49,6 +51,7 @@ func (cmd CreateOrgQuotaCommand) Execute(args []string) error {
 		TotalServiceInstances: convertIntegerLimitFlagToNullInt(cmd.TotalServiceInstances),
 		TotalRoutes:           convertIntegerLimitFlagToNullInt(cmd.TotalRoutes),
 		TotalReservedPorts:    convertIntegerLimitFlagToNullInt(cmd.TotalReservedPorts),
+		TotalLogVolume:        convertBytesFlagToNullInt(cmd.TotalLogVolume),
 	})
 	cmd.UI.DisplayWarnings(warnings)
 
@@ -64,6 +67,14 @@ func (cmd CreateOrgQuotaCommand) Execute(args []string) error {
 	cmd.UI.DisplayOK()
 
 	return nil
+}
+
+func convertBytesFlagToNullInt(flag flag.BytesWithUnlimited) *types.NullInt {
+	if !flag.IsSet {
+		return nil
+	}
+
+	return &types.NullInt{IsSet: true, Value: flag.Value}
 }
 
 func convertMegabytesFlagToNullInt(flag flag.MegabytesWithUnlimited) *types.NullInt {

--- a/command/v7/create_org_quota_command.go
+++ b/command/v7/create_org_quota_command.go
@@ -18,7 +18,7 @@ type CreateOrgQuotaCommand struct {
 	TotalRoutes           flag.IntegerLimit           `short:"r" description:"Total number of routes. -1 represents an unlimited amount. (Default: 0)."`
 	TotalReservedPorts    flag.IntegerLimit           `long:"reserved-route-ports" description:"Maximum number of routes that may be created with ports. -1 represents an unlimited amount. (Default: 0)."`
 	TotalServiceInstances flag.IntegerLimit           `short:"s" description:"Total number of service instances. -1 represents an unlimited amount. (Default: 0)."`
-	TotalLogVolume        flag.BytesWithUnlimited     `short:"l" description:"Total log volume per second all processes can have (e.g. 128B, 4K, 1M). -1 represents an unlimited amount. (Default: -1)."`
+	TotalLogVolume        flag.BytesWithUnlimited     `short:"l" description:"Total log volume per second all processes can have, in bytes (e.g. 128B, 4K, 1M). -1 represents an unlimited amount. (Default: -1)."`
 
 	usage           interface{} `usage:"CF_NAME create-org-quota ORG_QUOTA [-m TOTAL_MEMORY] [-i INSTANCE_MEMORY] [-r ROUTES] [-s SERVICE_INSTANCES] [-a APP_INSTANCES] [--allow-paid-service-plans] [--reserved-route-ports RESERVED_ROUTE_PORTS] [-l LOG_VOLUME]"`
 	relatedCommands interface{} `related_commands:"create-org, org-quotas, set-org-quota"`

--- a/command/v7/create_org_quota_command_test.go
+++ b/command/v7/create_org_quota_command_test.go
@@ -105,8 +105,8 @@ var _ = Describe("create-org-quota Command", func() {
 			BeforeEach(func() {
 				cmd.PaidServicePlans = true
 				cmd.NumAppInstances = flag.IntegerLimit{IsSet: true, Value: 10}
-				cmd.PerProcessMemory = flag.MemoryWithUnlimited{IsSet: true, Value: 9}
-				cmd.TotalMemory = flag.MemoryWithUnlimited{IsSet: true, Value: 2048}
+				cmd.PerProcessMemory = flag.MegabytesWithUnlimited{IsSet: true, Value: 9}
+				cmd.TotalMemory = flag.MegabytesWithUnlimited{IsSet: true, Value: 2048}
 				cmd.TotalRoutes = flag.IntegerLimit{IsSet: true, Value: 7}
 				cmd.TotalReservedPorts = flag.IntegerLimit{IsSet: true, Value: 1}
 				cmd.TotalServiceInstances = flag.IntegerLimit{IsSet: true, Value: 2}

--- a/command/v7/create_org_quota_command_test.go
+++ b/command/v7/create_org_quota_command_test.go
@@ -52,7 +52,6 @@ var _ = Describe("create-org-quota Command", func() {
 	})
 
 	JustBeforeEach(func() {
-
 		executeErr = cmd.Execute(nil)
 	})
 
@@ -110,6 +109,7 @@ var _ = Describe("create-org-quota Command", func() {
 				cmd.TotalRoutes = flag.IntegerLimit{IsSet: true, Value: 7}
 				cmd.TotalReservedPorts = flag.IntegerLimit{IsSet: true, Value: 1}
 				cmd.TotalServiceInstances = flag.IntegerLimit{IsSet: true, Value: 2}
+				cmd.TotalLogVolume = flag.BytesWithUnlimited{IsSet: true, Value: 8}
 				fakeActor.CreateOrganizationQuotaReturns(
 					v7action.Warnings{"warning"},
 					nil)
@@ -141,6 +141,9 @@ var _ = Describe("create-org-quota Command", func() {
 
 				Expect(quotaLimits.TotalServiceInstances.IsSet).To(Equal(true))
 				Expect(quotaLimits.TotalServiceInstances.Value).To(Equal(2))
+
+				Expect(quotaLimits.TotalLogVolume.IsSet).To(Equal(true))
+				Expect(quotaLimits.TotalLogVolume.Value).To(Equal(8))
 
 				Expect(testUI.Out).To(Say("Creating org quota %s as bob...", orgQuotaName))
 				Expect(testUI.Out).To(Say("OK"))

--- a/command/v7/create_space_quota_command.go
+++ b/command/v7/create_space_quota_command.go
@@ -9,16 +9,16 @@ import (
 type CreateSpaceQuotaCommand struct {
 	BaseCommand
 
-	RequiredArgs          flag.SpaceQuota          `positional-args:"yes"`
-	NumAppInstances       flag.IntegerLimit        `short:"a" description:"Total number of application instances. (Default: unlimited)."`
-	PaidServicePlans      bool                     `long:"allow-paid-service-plans" description:"Allow provisioning instances of paid service plans. (Default: disallowed)."`
-	PerProcessMemory      flag.MemoryWithUnlimited `short:"i" description:"Maximum amount of memory a process can have (e.g. 1024M, 1G, 10G). (Default: unlimited)."`
-	TotalMemory           flag.MemoryWithUnlimited `short:"m" description:"Total amount of memory all processes can have (e.g. 1024M, 1G, 10G). -1 represents an unlimited amount. (Default: 0)."`
-	TotalRoutes           flag.IntegerLimit        `short:"r" description:"Total number of routes. -1 represents an unlimited amount. (Default: 0)."`
-	TotalReservedPorts    flag.IntegerLimit        `long:"reserved-route-ports" description:"Maximum number of routes that may be created with ports. -1 represents an unlimited amount. (Default: 0)."`
-	TotalServiceInstances flag.IntegerLimit        `short:"s" description:"Total number of service instances. -1 represents an unlimited amount. (Default: 0)."`
-	usage                 interface{}              `usage:"CF_NAME create-space-quota QUOTA [-m TOTAL_MEMORY] [-i INSTANCE_MEMORY] [-r ROUTES] [-s SERVICE_INSTANCES] [-a APP_INSTANCES] [--allow-paid-service-plans] [--reserved-route-ports RESERVED_ROUTE_PORTS]"`
-	relatedCommands       interface{}              `related_commands:"create-space, space-quotas, set-space-quota"`
+	RequiredArgs          flag.SpaceQuota             `positional-args:"yes"`
+	NumAppInstances       flag.IntegerLimit           `short:"a" description:"Total number of application instances. (Default: unlimited)."`
+	PaidServicePlans      bool                        `long:"allow-paid-service-plans" description:"Allow provisioning instances of paid service plans. (Default: disallowed)."`
+	PerProcessMemory      flag.MegabytesWithUnlimited `short:"i" description:"Maximum amount of memory a process can have (e.g. 1024M, 1G, 10G). (Default: unlimited)."`
+	TotalMemory           flag.MegabytesWithUnlimited `short:"m" description:"Total amount of memory all processes can have (e.g. 1024M, 1G, 10G). -1 represents an unlimited amount. (Default: 0)."`
+	TotalRoutes           flag.IntegerLimit           `short:"r" description:"Total number of routes. -1 represents an unlimited amount. (Default: 0)."`
+	TotalReservedPorts    flag.IntegerLimit           `long:"reserved-route-ports" description:"Maximum number of routes that may be created with ports. -1 represents an unlimited amount. (Default: 0)."`
+	TotalServiceInstances flag.IntegerLimit           `short:"s" description:"Total number of service instances. -1 represents an unlimited amount. (Default: 0)."`
+	usage                 interface{}                 `usage:"CF_NAME create-space-quota QUOTA [-m TOTAL_MEMORY] [-i INSTANCE_MEMORY] [-r ROUTES] [-s SERVICE_INSTANCES] [-a APP_INSTANCES] [--allow-paid-service-plans] [--reserved-route-ports RESERVED_ROUTE_PORTS]"`
+	relatedCommands       interface{}                 `related_commands:"create-space, space-quotas, set-space-quota"`
 }
 
 func (cmd CreateSpaceQuotaCommand) Execute([]string) error {

--- a/command/v7/create_space_quota_command_test.go
+++ b/command/v7/create_space_quota_command_test.go
@@ -135,8 +135,8 @@ var _ = Describe("create-space-quota Command", func() {
 
 		When("all flag limits are given", func() {
 			BeforeEach(func() {
-				cmd.TotalMemory = flag.MemoryWithUnlimited{IsSet: true, Value: 47}
-				cmd.PerProcessMemory = flag.MemoryWithUnlimited{IsSet: true, Value: 23}
+				cmd.TotalMemory = flag.MegabytesWithUnlimited{IsSet: true, Value: 47}
+				cmd.PerProcessMemory = flag.MegabytesWithUnlimited{IsSet: true, Value: 23}
 				cmd.NumAppInstances = flag.IntegerLimit{IsSet: true, Value: 4}
 				cmd.PaidServicePlans = true
 				cmd.TotalServiceInstances = flag.IntegerLimit{IsSet: true, Value: 9}

--- a/command/v7/update_org_quota_command.go
+++ b/command/v7/update_org_quota_command.go
@@ -19,8 +19,10 @@ type UpdateOrgQuotaCommand struct {
 	TotalRoutes           flag.IntegerLimit           `short:"r" description:"Total number of routes. -1 represents an unlimited amount."`
 	TotalReservedPorts    flag.IntegerLimit           `long:"reserved-route-ports" description:"Maximum number of routes that may be created with ports. -1 represents an unlimited amount."`
 	TotalServiceInstances flag.IntegerLimit           `short:"s" description:"Total number of service instances. -1 represents an unlimited amount."`
-	usage                 interface{}                 `usage:"CF_NAME update-org-quota QUOTA [-m TOTAL_MEMORY] [-i INSTANCE_MEMORY] [-n NEW_NAME] [-r ROUTES] [-s SERVICE_INSTANCES] [-a APP_INSTANCES] [--allow-paid-service-plans | --disallow-paid-service-plans] [--reserved-route-ports RESERVED_ROUTE_PORTS]"`
-	relatedCommands       interface{}                 `related_commands:"org, org-quota"`
+	TotalLogVolume        flag.BytesWithUnlimited     `short:"l" description:"Total log volume per second all processes can have (e.g. 128B, 4K, 1M). -1 represents an unlimited amount."`
+
+	usage           interface{} `usage:"CF_NAME update-org-quota QUOTA [-m TOTAL_MEMORY] [-i INSTANCE_MEMORY] [-n NEW_NAME] [-r ROUTES] [-s SERVICE_INSTANCES] [-a APP_INSTANCES] [--allow-paid-service-plans | --disallow-paid-service-plans] [--reserved-route-ports RESERVED_ROUTE_PORTS] [-l LOG_VOLUME]"`
+	relatedCommands interface{} `related_commands:"org, org-quota"`
 }
 
 func (cmd UpdateOrgQuotaCommand) Execute(args []string) error {
@@ -61,6 +63,7 @@ func (cmd UpdateOrgQuotaCommand) Execute(args []string) error {
 		TotalServiceInstances: convertIntegerLimitFlagToNullInt(cmd.TotalServiceInstances),
 		TotalRoutes:           convertIntegerLimitFlagToNullInt(cmd.TotalRoutes),
 		TotalReservedPorts:    convertIntegerLimitFlagToNullInt(cmd.TotalReservedPorts),
+		TotalLogVolume:        convertBytesFlagToNullInt(cmd.TotalLogVolume),
 	}
 
 	warnings, err := cmd.Actor.UpdateOrganizationQuota(oldQuotaName, cmd.NewName, updatedQuotaLimits)

--- a/command/v7/update_org_quota_command.go
+++ b/command/v7/update_org_quota_command.go
@@ -19,7 +19,7 @@ type UpdateOrgQuotaCommand struct {
 	TotalRoutes           flag.IntegerLimit           `short:"r" description:"Total number of routes. -1 represents an unlimited amount."`
 	TotalReservedPorts    flag.IntegerLimit           `long:"reserved-route-ports" description:"Maximum number of routes that may be created with ports. -1 represents an unlimited amount."`
 	TotalServiceInstances flag.IntegerLimit           `short:"s" description:"Total number of service instances. -1 represents an unlimited amount."`
-	TotalLogVolume        flag.BytesWithUnlimited     `short:"l" description:"Total log volume per second all processes can have (e.g. 128B, 4K, 1M). -1 represents an unlimited amount."`
+	TotalLogVolume        flag.BytesWithUnlimited     `short:"l" description:"Total log volume per second all processes can have, in bytes (e.g. 128B, 4K, 1M). -1 represents an unlimited amount."`
 
 	usage           interface{} `usage:"CF_NAME update-org-quota QUOTA [-m TOTAL_MEMORY] [-i INSTANCE_MEMORY] [-n NEW_NAME] [-r ROUTES] [-s SERVICE_INSTANCES] [-a APP_INSTANCES] [--allow-paid-service-plans | --disallow-paid-service-plans] [--reserved-route-ports RESERVED_ROUTE_PORTS] [-l LOG_VOLUME]"`
 	relatedCommands interface{} `related_commands:"org, org-quota"`

--- a/command/v7/update_org_quota_command.go
+++ b/command/v7/update_org_quota_command.go
@@ -9,18 +9,18 @@ import (
 type UpdateOrgQuotaCommand struct {
 	BaseCommand
 
-	RequiredArgs          flag.OrganizationQuota   `positional-args:"Yes"`
-	NumAppInstances       flag.IntegerLimit        `short:"a" description:"Total number of application instances. -1 represents an unlimited amount."`
-	PaidServicePlans      bool                     `long:"allow-paid-service-plans" description:"Allow provisioning instances of paid service plans."`
-	NoPaidServicePlans    bool                     `long:"disallow-paid-service-plans" description:"Disallow provisioning instances of paid service plans."`
-	PerProcessMemory      flag.MemoryWithUnlimited `short:"i" description:"Maximum amount of memory a process can have (e.g. 1024M, 1G, 10G). -1 represents an unlimited amount."`
-	TotalMemory           flag.MemoryWithUnlimited `short:"m" description:"Total amount of memory all processes can have (e.g. 1024M, 1G, 10G).  -1 represents an unlimited amount."`
-	NewName               string                   `short:"n" description:"New name"`
-	TotalRoutes           flag.IntegerLimit        `short:"r" description:"Total number of routes. -1 represents an unlimited amount."`
-	TotalReservedPorts    flag.IntegerLimit        `long:"reserved-route-ports" description:"Maximum number of routes that may be created with ports. -1 represents an unlimited amount."`
-	TotalServiceInstances flag.IntegerLimit        `short:"s" description:"Total number of service instances. -1 represents an unlimited amount."`
-	usage                 interface{}              `usage:"CF_NAME update-org-quota QUOTA [-m TOTAL_MEMORY] [-i INSTANCE_MEMORY] [-n NEW_NAME] [-r ROUTES] [-s SERVICE_INSTANCES] [-a APP_INSTANCES] [--allow-paid-service-plans | --disallow-paid-service-plans] [--reserved-route-ports RESERVED_ROUTE_PORTS]"`
-	relatedCommands       interface{}              `related_commands:"org, org-quota"`
+	RequiredArgs          flag.OrganizationQuota      `positional-args:"Yes"`
+	NumAppInstances       flag.IntegerLimit           `short:"a" description:"Total number of application instances. -1 represents an unlimited amount."`
+	PaidServicePlans      bool                        `long:"allow-paid-service-plans" description:"Allow provisioning instances of paid service plans."`
+	NoPaidServicePlans    bool                        `long:"disallow-paid-service-plans" description:"Disallow provisioning instances of paid service plans."`
+	PerProcessMemory      flag.MegabytesWithUnlimited `short:"i" description:"Maximum amount of memory a process can have (e.g. 1024M, 1G, 10G). -1 represents an unlimited amount."`
+	TotalMemory           flag.MegabytesWithUnlimited `short:"m" description:"Total amount of memory all processes can have (e.g. 1024M, 1G, 10G).  -1 represents an unlimited amount."`
+	NewName               string                      `short:"n" description:"New name"`
+	TotalRoutes           flag.IntegerLimit           `short:"r" description:"Total number of routes. -1 represents an unlimited amount."`
+	TotalReservedPorts    flag.IntegerLimit           `long:"reserved-route-ports" description:"Maximum number of routes that may be created with ports. -1 represents an unlimited amount."`
+	TotalServiceInstances flag.IntegerLimit           `short:"s" description:"Total number of service instances. -1 represents an unlimited amount."`
+	usage                 interface{}                 `usage:"CF_NAME update-org-quota QUOTA [-m TOTAL_MEMORY] [-i INSTANCE_MEMORY] [-n NEW_NAME] [-r ROUTES] [-s SERVICE_INSTANCES] [-a APP_INSTANCES] [--allow-paid-service-plans | --disallow-paid-service-plans] [--reserved-route-ports RESERVED_ROUTE_PORTS]"`
+	relatedCommands       interface{}                 `related_commands:"org, org-quota"`
 }
 
 func (cmd UpdateOrgQuotaCommand) Execute(args []string) error {

--- a/command/v7/update_org_quota_command_test.go
+++ b/command/v7/update_org_quota_command_test.go
@@ -96,6 +96,7 @@ var _ = Describe("UpdateOrgQuotaCommand", func() {
 				cmd.TotalRoutes = flag.IntegerLimit{IsSet: true, Value: 7}
 				cmd.TotalReservedPorts = flag.IntegerLimit{IsSet: true, Value: 1}
 				cmd.TotalServiceInstances = flag.IntegerLimit{IsSet: true, Value: 2}
+				cmd.TotalLogVolume = flag.BytesWithUnlimited{IsSet: true, Value: 8}
 				fakeActor.UpdateOrganizationQuotaReturns(
 					v7action.Warnings{"warning"},
 					nil)
@@ -129,6 +130,9 @@ var _ = Describe("UpdateOrgQuotaCommand", func() {
 
 				Expect(quotaLimits.TotalServiceInstances.IsSet).To(Equal(true))
 				Expect(quotaLimits.TotalServiceInstances.Value).To(Equal(2))
+
+				Expect(quotaLimits.TotalLogVolume.IsSet).To(Equal(true))
+				Expect(quotaLimits.TotalLogVolume.Value).To(Equal(8))
 
 				Expect(testUI.Out).To(Say("Updating org quota %s as bob...", orgQuotaName))
 				Expect(testUI.Out).To(Say("OK"))
@@ -168,6 +172,8 @@ var _ = Describe("UpdateOrgQuotaCommand", func() {
 				Expect(quotaLimits.TotalRoutes).To(BeNil())
 
 				Expect(quotaLimits.TotalReservedPorts).To(BeNil())
+
+				Expect(quotaLimits.TotalLogVolume).To(BeNil())
 
 				Expect(testUI.Out).To(Say("Updating org quota %s as bob...", orgQuotaName))
 				Expect(testUI.Out).To(Say("OK"))

--- a/command/v7/update_org_quota_command_test.go
+++ b/command/v7/update_org_quota_command_test.go
@@ -91,8 +91,8 @@ var _ = Describe("UpdateOrgQuotaCommand", func() {
 				cmd.NewName = "new-org-quota-name"
 				cmd.PaidServicePlans = true
 				cmd.NumAppInstances = flag.IntegerLimit{IsSet: true, Value: 10}
-				cmd.PerProcessMemory = flag.MemoryWithUnlimited{IsSet: true, Value: 9}
-				cmd.TotalMemory = flag.MemoryWithUnlimited{IsSet: true, Value: 2048}
+				cmd.PerProcessMemory = flag.MegabytesWithUnlimited{IsSet: true, Value: 9}
+				cmd.TotalMemory = flag.MegabytesWithUnlimited{IsSet: true, Value: 2048}
 				cmd.TotalRoutes = flag.IntegerLimit{IsSet: true, Value: 7}
 				cmd.TotalReservedPorts = flag.IntegerLimit{IsSet: true, Value: 1}
 				cmd.TotalServiceInstances = flag.IntegerLimit{IsSet: true, Value: 2}
@@ -137,7 +137,7 @@ var _ = Describe("UpdateOrgQuotaCommand", func() {
 
 		When("only some org quota limits are updated", func() {
 			BeforeEach(func() {
-				cmd.TotalMemory = flag.MemoryWithUnlimited{IsSet: true, Value: 2048}
+				cmd.TotalMemory = flag.MegabytesWithUnlimited{IsSet: true, Value: 2048}
 				cmd.TotalServiceInstances = flag.IntegerLimit{IsSet: true, Value: 2}
 				fakeActor.UpdateOrganizationQuotaReturns(
 					v7action.Warnings{"warning"},

--- a/command/v7/update_space_quota_command.go
+++ b/command/v7/update_space_quota_command.go
@@ -9,18 +9,18 @@ import (
 type UpdateSpaceQuotaCommand struct {
 	BaseCommand
 
-	RequiredArgs          flag.SpaceQuota          `positional-args:"Yes"`
-	NumAppInstances       flag.IntegerLimit        `short:"a" description:"Total number of application instances. -1 represents an unlimited amount."`
-	PaidServicePlans      bool                     `long:"allow-paid-service-plans" description:"Allow provisioning instances of paid service plans."`
-	NoPaidServicePlans    bool                     `long:"disallow-paid-service-plans" description:"Disallow provisioning instances of paid service plans."`
-	PerProcessMemory      flag.MemoryWithUnlimited `short:"i" description:"Maximum amount of memory a process can have (e.g. 1024M, 1G, 10G). -1 represents an unlimited amount."`
-	TotalMemory           flag.MemoryWithUnlimited `short:"m" description:"Total amount of memory all processes can have (e.g. 1024M, 1G, 10G).  -1 represents an unlimited amount."`
-	NewName               string                   `short:"n" description:"New name"`
-	TotalRoutes           flag.IntegerLimit        `short:"r" description:"Total number of routes. -1 represents an unlimited amount."`
-	TotalReservedPorts    flag.IntegerLimit        `long:"reserved-route-ports" description:"Maximum number of routes that may be created with ports. -1 represents an unlimited amount."`
-	TotalServiceInstances flag.IntegerLimit        `short:"s" description:"Total number of service instances. -1 represents an unlimited amount."`
-	usage                 interface{}              `usage:"CF_NAME update-space-quota QUOTA [-m TOTAL_MEMORY] [-i INSTANCE_MEMORY] [-n NEW_NAME] [-r ROUTES] [-s SERVICE_INSTANCES] [-a APP_INSTANCES] [--allow-paid-service-plans | --disallow-paid-service-plans] [--reserved-route-ports RESERVED_ROUTE_PORTS]"`
-	relatedCommands       interface{}              `related_commands:"space, space-quota, space-quotas"`
+	RequiredArgs          flag.SpaceQuota             `positional-args:"Yes"`
+	NumAppInstances       flag.IntegerLimit           `short:"a" description:"Total number of application instances. -1 represents an unlimited amount."`
+	PaidServicePlans      bool                        `long:"allow-paid-service-plans" description:"Allow provisioning instances of paid service plans."`
+	NoPaidServicePlans    bool                        `long:"disallow-paid-service-plans" description:"Disallow provisioning instances of paid service plans."`
+	PerProcessMemory      flag.MegabytesWithUnlimited `short:"i" description:"Maximum amount of memory a process can have (e.g. 1024M, 1G, 10G). -1 represents an unlimited amount."`
+	TotalMemory           flag.MegabytesWithUnlimited `short:"m" description:"Total amount of memory all processes can have (e.g. 1024M, 1G, 10G).  -1 represents an unlimited amount."`
+	NewName               string                      `short:"n" description:"New name"`
+	TotalRoutes           flag.IntegerLimit           `short:"r" description:"Total number of routes. -1 represents an unlimited amount."`
+	TotalReservedPorts    flag.IntegerLimit           `long:"reserved-route-ports" description:"Maximum number of routes that may be created with ports. -1 represents an unlimited amount."`
+	TotalServiceInstances flag.IntegerLimit           `short:"s" description:"Total number of service instances. -1 represents an unlimited amount."`
+	usage                 interface{}                 `usage:"CF_NAME update-space-quota QUOTA [-m TOTAL_MEMORY] [-i INSTANCE_MEMORY] [-n NEW_NAME] [-r ROUTES] [-s SERVICE_INSTANCES] [-a APP_INSTANCES] [--allow-paid-service-plans | --disallow-paid-service-plans] [--reserved-route-ports RESERVED_ROUTE_PORTS]"`
+	relatedCommands       interface{}                 `related_commands:"space, space-quota, space-quotas"`
 }
 
 func (cmd UpdateSpaceQuotaCommand) Execute(args []string) error {

--- a/command/v7/update_space_quota_command_test.go
+++ b/command/v7/update_space_quota_command_test.go
@@ -94,8 +94,8 @@ var _ = Describe("UpdateSpaceQuotaCommand", func() {
 				cmd.NewName = "new-space-quota-name"
 				cmd.PaidServicePlans = true
 				cmd.NumAppInstances = flag.IntegerLimit{IsSet: true, Value: 10}
-				cmd.PerProcessMemory = flag.MemoryWithUnlimited{IsSet: true, Value: 9}
-				cmd.TotalMemory = flag.MemoryWithUnlimited{IsSet: true, Value: 2048}
+				cmd.PerProcessMemory = flag.MegabytesWithUnlimited{IsSet: true, Value: 9}
+				cmd.TotalMemory = flag.MegabytesWithUnlimited{IsSet: true, Value: 2048}
 				cmd.TotalRoutes = flag.IntegerLimit{IsSet: true, Value: 7}
 				cmd.TotalReservedPorts = flag.IntegerLimit{IsSet: true, Value: 1}
 				cmd.TotalServiceInstances = flag.IntegerLimit{IsSet: true, Value: 2}
@@ -141,7 +141,7 @@ var _ = Describe("UpdateSpaceQuotaCommand", func() {
 
 		When("only some org quota limits are updated", func() {
 			BeforeEach(func() {
-				cmd.TotalMemory = flag.MemoryWithUnlimited{IsSet: true, Value: 2048}
+				cmd.TotalMemory = flag.MegabytesWithUnlimited{IsSet: true, Value: 2048}
 				cmd.TotalServiceInstances = flag.IntegerLimit{IsSet: true, Value: 2}
 				fakeActor.UpdateSpaceQuotaReturns(
 					v7action.Warnings{"warning"},

--- a/integration/v7/isolated/create_org_quota_command_test.go
+++ b/integration/v7/isolated/create_org_quota_command_test.go
@@ -32,7 +32,7 @@ var _ = Describe("create-org-quota command", func() {
 				Eventually(session).Should(Say("NAME:"))
 				Eventually(session).Should(Say("create-org-quota - Define a new quota for an organization"))
 				Eventually(session).Should(Say("USAGE:"))
-				Eventually(session).Should(Say(`cf create-org-quota ORG_QUOTA \[-m TOTAL_MEMORY\] \[-i INSTANCE_MEMORY\] \[-r ROUTES\] \[-s SERVICE_INSTANCES\] \[-a APP_INSTANCES\] \[--allow-paid-service-plans\] \[--reserved-route-ports RESERVED_ROUTE_PORTS\]`))
+				Eventually(session).Should(Say(`cf create-org-quota ORG_QUOTA \[-m TOTAL_MEMORY\] \[-i INSTANCE_MEMORY\] \[-r ROUTES\] \[-s SERVICE_INSTANCES\] \[-a APP_INSTANCES\] \[--allow-paid-service-plans\] \[--reserved-route-ports RESERVED_ROUTE_PORTS\] \[-l LOG_VOLUME\]`))
 				Eventually(session).Should(Say("ALIAS:"))
 				Eventually(session).Should(Say("create-quota"))
 				Eventually(session).Should(Say("OPTIONS:"))
@@ -43,6 +43,7 @@ var _ = Describe("create-org-quota command", func() {
 				Eventually(session).Should(Say(`-r\s+Total number of routes. -1 represents an unlimited amount. \(Default: 0\)`))
 				Eventually(session).Should(Say(`--reserved-route-ports\s+Maximum number of routes that may be created with ports. -1 represents an unlimited amount. \(Default: 0\)`))
 				Eventually(session).Should(Say(`-s\s+Total number of service instances. -1 represents an unlimited amount. \(Default: 0\)`))
+				Eventually(session).Should(Say(`-l\s+Total log volume per second all processes can have \(e.g. 128B, 4K, 1M\). -1 represents an unlimited amount. \(Default: -1\)`))
 				Eventually(session).Should(Say("SEE ALSO:"))
 				Eventually(session).Should(Say("create-org, org-quotas, set-org-quota"))
 				Eventually(session).Should(Exit(0))
@@ -119,7 +120,9 @@ var _ = Describe("create-org-quota command", func() {
 						"-m", "4M",
 						"-r", "6",
 						"--reserved-route-ports", "5",
-						"-s", "7")
+						"-s", "7",
+						"-l", "32K",
+					)
 					Eventually(session).Should(Say("Creating org quota %s as %s...", orgQuotaName, userName))
 					Eventually(session).Should(Say("OK"))
 					Eventually(session).Should(Exit(0))
@@ -133,6 +136,7 @@ var _ = Describe("create-org-quota command", func() {
 					Eventually(session).Should(Say(`paid service plans:\s+allowed`))
 					Eventually(session).Should(Say(`app instances:\s+2`))
 					Eventually(session).Should(Say(`route ports:\s+5`))
+					//TODO: add an assertion for log quota information
 					Eventually(session).Should(Exit(0))
 				})
 			})
@@ -146,7 +150,9 @@ var _ = Describe("create-org-quota command", func() {
 						"-m", "-1",
 						"-r", "-1",
 						"-s", "-1",
-						"--reserved-route-ports", "-1")
+						"--reserved-route-ports", "-1",
+						"-l", "-1",
+					)
 					Eventually(session).Should(Say("Creating org quota %s as %s...", orgQuotaName, userName))
 					Eventually(session).Should(Say("OK"))
 					Eventually(session).Should(Exit(0))
@@ -158,6 +164,7 @@ var _ = Describe("create-org-quota command", func() {
 					Eventually(session).Should(Say(`service instances:\s+unlimited`))
 					Eventually(session).Should(Say(`app instances:\s+unlimited`))
 					Eventually(session).Should(Say(`route ports:\s+unlimited`))
+					//TODO: add an assertion for log quota information
 					Eventually(session).Should(Exit(0))
 				})
 			})

--- a/integration/v7/isolated/create_org_quota_command_test.go
+++ b/integration/v7/isolated/create_org_quota_command_test.go
@@ -44,7 +44,7 @@ var _ = Describe("create-org-quota command", func() {
 				Eventually(session).Should(Say(`-r\s+Total number of routes. -1 represents an unlimited amount. \(Default: 0\)`))
 				Eventually(session).Should(Say(`--reserved-route-ports\s+Maximum number of routes that may be created with ports. -1 represents an unlimited amount. \(Default: 0\)`))
 				Eventually(session).Should(Say(`-s\s+Total number of service instances. -1 represents an unlimited amount. \(Default: 0\)`))
-				Eventually(session).Should(Say(`-l\s+Total log volume per second all processes can have \(e.g. 128B, 4K, 1M\). -1 represents an unlimited amount. \(Default: -1\)`))
+				Eventually(session).Should(Say(`-l\s+Total log volume per second all processes can have, in bytes \(e.g. 128B, 4K, 1M\). -1 represents an unlimited amount. \(Default: -1\)`))
 				Eventually(session).Should(Say("SEE ALSO:"))
 				Eventually(session).Should(Say("create-org, org-quotas, set-org-quota"))
 				Eventually(session).Should(Exit(0))

--- a/integration/v7/isolated/update_org_quota_command_test.go
+++ b/integration/v7/isolated/update_org_quota_command_test.go
@@ -16,7 +16,7 @@ var _ = Describe("update-org-quota command", func() {
 				Eventually(session).Should(Say("NAME:"))
 				Eventually(session).Should(Say("update-org-quota - Update an existing organization quota"))
 				Eventually(session).Should(Say("USAGE:"))
-				Eventually(session).Should(Say(`cf update-org-quota QUOTA [-m TOTAL_MEMORY] [-i INSTANCE_MEMORY] \[-n NEW_NAME\] \[-r ROUTES\] \[-s SERVICE_INSTANCES\] \[-a APP_INSTANCES\] \[--allow-paid-service-plans | --disallow-paid-service-plans\] \[--reserved-route-ports RESERVED_ROUTE_PORTS\]`))
+				Eventually(session).Should(Say(`cf update-org-quota QUOTA [-m TOTAL_MEMORY] [-i INSTANCE_MEMORY] \[-n NEW_NAME\] \[-r ROUTES\] \[-s SERVICE_INSTANCES\] \[-a APP_INSTANCES\] \[--allow-paid-service-plans | --disallow-paid-service-plans\] \[--reserved-route-ports RESERVED_ROUTE_PORTS\] \[-l LOG_VOLUME\]`))
 				Eventually(session).Should(Say("ALIAS:"))
 				Eventually(session).Should(Say("update-quota"))
 				Eventually(session).Should(Say("OPTIONS:"))
@@ -29,6 +29,7 @@ var _ = Describe("update-org-quota command", func() {
 				Eventually(session).Should(Say(`-r\s+Total number of routes. -1 represents an unlimited amount.`))
 				Eventually(session).Should(Say(`--reserved-route-ports\s+Maximum number of routes that may be created with ports. -1 represents an unlimited amount.`))
 				Eventually(session).Should(Say(`-s\s+Total number of service instances. -1 represents an unlimited amount.`))
+				Eventually(session).Should(Say(`-l\s+Total log volume per second all processes can have \(e.g. 128B, 4K, 1M\). -1 represents an unlimited amount.`))
 				Eventually(session).Should(Say("SEE ALSO:"))
 				Eventually(session).Should(Say("org, org-quota"))
 				Eventually(session).Should(Exit(0))
@@ -57,7 +58,8 @@ var _ = Describe("update-org-quota command", func() {
 			serviceInstances := "2"
 			appInstances := "3"
 			reservedRoutePorts := "1"
-			session := helpers.CF("create-org-quota", quotaName, "-m", totalMemory, "-i", instanceMemory, "-r", routes, "-s", serviceInstances, "-a", appInstances, "--allow-paid-service-plans", "--reserved-route-ports", reservedRoutePorts)
+			totalLogVolume := "1M"
+			session := helpers.CF("create-org-quota", quotaName, "-m", totalMemory, "-i", instanceMemory, "-r", routes, "-s", serviceInstances, "-a", appInstances, "--allow-paid-service-plans", "--reserved-route-ports", reservedRoutePorts, "-l", totalLogVolume)
 			Eventually(session).Should(Exit(0))
 		})
 
@@ -71,7 +73,8 @@ var _ = Describe("update-org-quota command", func() {
 			serviceInstances := "1"
 			appInstances := "2"
 			reservedRoutePorts := "0"
-			session := helpers.CF("update-org-quota", quotaName, "-m", totalMemory, "-i", instanceMemory, "-s", serviceInstances, "-a", appInstances, "--disallow-paid-service-plans", "--reserved-route-ports", reservedRoutePorts)
+			totalLogVolume := "500K"
+			session := helpers.CF("update-org-quota", quotaName, "-m", totalMemory, "-i", instanceMemory, "-s", serviceInstances, "-a", appInstances, "--disallow-paid-service-plans", "--reserved-route-ports", reservedRoutePorts, "-l", totalLogVolume)
 			Eventually(session).Should(Say(`Updating org quota %s as %s\.\.\.`, quotaName, username))
 			Eventually(session).Should(Exit(0))
 
@@ -83,6 +86,7 @@ var _ = Describe("update-org-quota command", func() {
 			Eventually(session).Should(Say(`paid service plans:\s+%s`, "disallowed"))
 			Eventually(session).Should(Say(`app instances:\s+%s`, appInstances))
 			Eventually(session).Should(Say(`route ports:\s+%s`, reservedRoutePorts))
+			//TODO: add an assertion for log quota information
 			Eventually(session).Should(Exit(0))
 		})
 

--- a/integration/v7/isolated/update_org_quota_command_test.go
+++ b/integration/v7/isolated/update_org_quota_command_test.go
@@ -30,7 +30,7 @@ var _ = Describe("update-org-quota command", func() {
 				Eventually(session).Should(Say(`-r\s+Total number of routes. -1 represents an unlimited amount.`))
 				Eventually(session).Should(Say(`--reserved-route-ports\s+Maximum number of routes that may be created with ports. -1 represents an unlimited amount.`))
 				Eventually(session).Should(Say(`-s\s+Total number of service instances. -1 represents an unlimited amount.`))
-				Eventually(session).Should(Say(`-l\s+Total log volume per second all processes can have \(e.g. 128B, 4K, 1M\). -1 represents an unlimited amount.`))
+				Eventually(session).Should(Say(`-l\s+Total log volume per second all processes can have, in bytes \(e.g. 128B, 4K, 1M\). -1 represents an unlimited amount.`))
 				Eventually(session).Should(Say("SEE ALSO:"))
 				Eventually(session).Should(Say("org, org-quota"))
 				Eventually(session).Should(Exit(0))

--- a/resources/quota_resource.go
+++ b/resources/quota_resource.go
@@ -23,6 +23,7 @@ type AppLimit struct {
 	TotalMemory       *types.NullInt `json:"total_memory_in_mb,omitempty"`
 	InstanceMemory    *types.NullInt `json:"per_process_memory_in_mb,omitempty"`
 	TotalAppInstances *types.NullInt `json:"total_instances,omitempty"`
+	TotalLogVolume    *types.NullInt `json:"log_rate_limit_in_bytes_per_second,omitempty"`
 }
 
 func (al *AppLimit) UnmarshalJSON(rawJSON []byte) error {
@@ -52,6 +53,13 @@ func (al *AppLimit) UnmarshalJSON(rawJSON []byte) error {
 
 	if al.TotalAppInstances == nil {
 		al.TotalAppInstances = &types.NullInt{
+			IsSet: false,
+			Value: 0,
+		}
+	}
+
+	if al.TotalLogVolume == nil {
+		al.TotalLogVolume = &types.NullInt{
 			IsSet: false,
 			Value: 0,
 		}

--- a/resources/quota_resource_test.go
+++ b/resources/quota_resource_test.go
@@ -20,6 +20,9 @@ var _ = Describe("quota limits", func() {
 			Entry("total memory", AppLimit{TotalMemory: &types.NullInt{IsSet: true, Value: 1}}, []byte(`{"total_memory_in_mb":1}`)),
 			Entry("total memory", AppLimit{TotalMemory: nil}, []byte(`{}`)),
 			Entry("total memory", AppLimit{TotalMemory: &types.NullInt{IsSet: false}}, []byte(`{"total_memory_in_mb":null}`)),
+			Entry("total log volume", AppLimit{TotalLogVolume: &types.NullInt{IsSet: true, Value: 1}}, []byte(`{"log_rate_limit_in_bytes_per_second":1}`)),
+			Entry("total log volume", AppLimit{TotalLogVolume: nil}, []byte(`{}`)),
+			Entry("total log volume", AppLimit{TotalLogVolume: &types.NullInt{IsSet: false}}, []byte(`{"log_rate_limit_in_bytes_per_second":null}`)),
 			Entry("instance memory", AppLimit{InstanceMemory: &types.NullInt{IsSet: true, Value: 1}}, []byte(`{"per_process_memory_in_mb":1}`)),
 			Entry("instance memory", AppLimit{InstanceMemory: nil}, []byte(`{}`)),
 			Entry("instance memory", AppLimit{InstanceMemory: &types.NullInt{IsSet: false}}, []byte(`{"per_process_memory_in_mb":null}`)),
@@ -37,35 +40,48 @@ var _ = Describe("quota limits", func() {
 			},
 			Entry(
 				"no null values",
-				[]byte(`{"total_memory_in_mb":1,"per_process_memory_in_mb":2,"total_instances":3}`),
+				[]byte(`{"total_memory_in_mb":1,"per_process_memory_in_mb":2,"total_instances":3,"log_rate_limit_in_bytes_per_second":4}`),
 				AppLimit{
 					TotalMemory:       &types.NullInt{IsSet: true, Value: 1},
 					InstanceMemory:    &types.NullInt{IsSet: true, Value: 2},
 					TotalAppInstances: &types.NullInt{IsSet: true, Value: 3},
+					TotalLogVolume:    &types.NullInt{IsSet: true, Value: 4},
 				}),
 			Entry(
 				"total memory is null",
-				[]byte(`{"total_memory_in_mb":null,"per_process_memory_in_mb":2,"total_instances":3}`),
+				[]byte(`{"total_memory_in_mb":null,"per_process_memory_in_mb":2,"total_instances":3,"log_rate_limit_in_bytes_per_second":4}`),
 				AppLimit{
 					TotalMemory:       &types.NullInt{IsSet: false, Value: 0},
 					InstanceMemory:    &types.NullInt{IsSet: true, Value: 2},
 					TotalAppInstances: &types.NullInt{IsSet: true, Value: 3},
+					TotalLogVolume:    &types.NullInt{IsSet: true, Value: 4},
 				}),
 			Entry(
 				"per process memory is null",
-				[]byte(`{"total_memory_in_mb":1,"per_process_memory_in_mb":null,"total_instances":3}`),
+				[]byte(`{"total_memory_in_mb":1,"per_process_memory_in_mb":null,"total_instances":3,"log_rate_limit_in_bytes_per_second":4}`),
 				AppLimit{
 					TotalMemory:       &types.NullInt{IsSet: true, Value: 1},
 					InstanceMemory:    &types.NullInt{IsSet: false, Value: 0},
 					TotalAppInstances: &types.NullInt{IsSet: true, Value: 3},
+					TotalLogVolume:    &types.NullInt{IsSet: true, Value: 4},
 				}),
 			Entry(
 				"total instances is null",
-				[]byte(`{"total_memory_in_mb":1,"per_process_memory_in_mb":2,"total_instances":null}`),
+				[]byte(`{"total_memory_in_mb":1,"per_process_memory_in_mb":2,"total_instances":null,"log_rate_limit_in_bytes_per_second":4}`),
 				AppLimit{
 					TotalMemory:       &types.NullInt{IsSet: true, Value: 1},
 					InstanceMemory:    &types.NullInt{IsSet: true, Value: 2},
 					TotalAppInstances: &types.NullInt{IsSet: false, Value: 0},
+					TotalLogVolume:    &types.NullInt{IsSet: true, Value: 4},
+				}),
+			Entry(
+				"total log volume is null",
+				[]byte(`{"total_memory_in_mb":1,"per_process_memory_in_mb":2,"total_instances":3,"log_rate_limit_in_bytes_per_second":null}`),
+				AppLimit{
+					TotalMemory:       &types.NullInt{IsSet: true, Value: 1},
+					InstanceMemory:    &types.NullInt{IsSet: true, Value: 2},
+					TotalAppInstances: &types.NullInt{IsSet: true, Value: 3},
+					TotalLogVolume:    &types.NullInt{IsSet: false, Value: 0},
 				}),
 		)
 	})


### PR DESCRIPTION
* `create-org-quota` accepts `-l` flag.
* `update-org-quota` accepts `-l` flag.

cc @mkocher @jdgonzaleza @pivotalgeorge 