### PR TITLE
Return error for log rate limits larger than math.MaxInt

### DIFF
--- a/command/flag/bytes_with_unlimited.go
+++ b/command/flag/bytes_with_unlimited.go
@@ -1,6 +1,7 @@
 package flag
 
 import (
+	"math"
 	"regexp"
 	"strings"
 
@@ -36,7 +37,7 @@ func (m *BytesWithUnlimited) UnmarshalFlag(val string) error {
 		return err
 	}
 
-	m.Value = int(size)
+	m.Value = size
 	m.IsSet = true
 
 	return nil
@@ -46,14 +47,14 @@ func (m *BytesWithUnlimited) IsValidValue(val string) error {
 	return m.UnmarshalFlag(val)
 }
 
-func ConvertToBytes(val string) (uint64, error) {
+func ConvertToBytes(val string) (int, error) {
 	size, err := bytefmt.ToBytes(val)
 
-	if err != nil || strings.Contains(strings.ToLower(val), ".") {
-		return size, &flags.Error{
+	if err != nil || strings.Contains(strings.ToLower(val), ".") || size > math.MaxInt {
+		return 0, &flags.Error{
 			Type:    flags.ErrRequired,
 			Message: `Byte quantity must be an integer with a unit of measurement like B, K, KB, M, MB, G, or GB`,
 		}
 	}
-	return size, nil
+	return int(size), nil
 }

--- a/command/flag/bytes_with_unlimited_test.go
+++ b/command/flag/bytes_with_unlimited_test.go
@@ -86,7 +86,7 @@ var _ = Describe("BytesWithUnlimited", func() {
 		})
 
 		When("the value is 0", func() {
-			It("set's the value to 0", func() {
+			It("sets the value to 0", func() {
 				err := bytesWithUnlimited.UnmarshalFlag("0")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(bytesWithUnlimited.Value).To(BeEquivalentTo(0))
@@ -120,6 +120,16 @@ var _ = Describe("BytesWithUnlimited", func() {
 		When("a decimal is used", func() {
 			It("returns an error", func() {
 				err := bytesWithUnlimited.UnmarshalFlag("1.2M")
+				Expect(err).To(MatchError(&flags.Error{
+					Type:    flags.ErrRequired,
+					Message: `Byte quantity must be an integer with a unit of measurement like B, K, KB, M, MB, G, or GB`,
+				}))
+			})
+		})
+
+		When("the value is too large", func() {
+			It("returns an error", func() {
+				err := bytesWithUnlimited.UnmarshalFlag("9999999TB")
 				Expect(err).To(MatchError(&flags.Error{
 					Type:    flags.ErrRequired,
 					Message: `Byte quantity must be an integer with a unit of measurement like B, K, KB, M, MB, G, or GB`,


### PR DESCRIPTION
This fix prevents the CLI from accepting a number
that would overflow for the log rate limit.

Co-authored-by: Rebecca Roberts <robertsre@vmware.com>

Thank you for contributing to the CF CLI! Please read the following:


## Does this PR modify CLI v6, CLI v7, or CLI v8?

v8


## Description of the Change

CLI would overflow when a huge log rate limit is passed. This could cause the CLI to send a large negative number to CAPI. 
This change returns an error to prevent this.


## How Urgent Is The Change?

Not particularly urgent-- change to fix an edge case.

## Other Relevant Parties
 None
