### PR TITLE
Allow user to rename app if buildpack is deleted

### DIFF
--- a/actor/v7action/application.go
+++ b/actor/v7action/application.go
@@ -400,6 +400,17 @@ func (actor Actor) UpdateApplication(app resources.Application) (resources.Appli
 	return updatedApp, Warnings(warnings), nil
 }
 
+// UpdateApplicationName updates the name of an application
+func (actor Actor) UpdateApplicationName(newAppName string, appGUID string) (resources.Application, Warnings, error) {
+
+	updatedApp, warnings, err := actor.CloudControllerClient.UpdateApplicationName(newAppName, appGUID)
+	if err != nil {
+		return resources.Application{}, Warnings(warnings), err
+	}
+
+	return updatedApp, Warnings(warnings), nil
+}
+
 func (actor Actor) getDeployment(deploymentGUID string) (resources.Deployment, Warnings, error) {
 	deployment, warnings, err := actor.CloudControllerClient.GetDeployment(deploymentGUID)
 	if err != nil {
@@ -444,8 +455,8 @@ func (actor Actor) RenameApplicationByNameAndSpaceGUID(appName, newAppName, spac
 	if err != nil {
 		return resources.Application{}, allWarnings, err
 	}
-	application.Name = newAppName
-	application, warnings, err = actor.UpdateApplication(application)
+	appGUID := application.GUID
+	application, warnings, err = actor.UpdateApplication(newAppName, appGUID)
 	allWarnings = append(allWarnings, warnings...)
 	if err != nil {
 		return resources.Application{}, allWarnings, err

--- a/actor/v7action/application.go
+++ b/actor/v7action/application.go
@@ -456,7 +456,7 @@ func (actor Actor) RenameApplicationByNameAndSpaceGUID(appName, newAppName, spac
 		return resources.Application{}, allWarnings, err
 	}
 	appGUID := application.GUID
-	application, warnings, err = actor.UpdateApplication(newAppName, appGUID)
+	application, warnings, err = actor.UpdateApplicationName(newAppName, appGUID)
 	allWarnings = append(allWarnings, warnings...)
 	if err != nil {
 		return resources.Application{}, allWarnings, err

--- a/actor/v7action/application_test.go
+++ b/actor/v7action/application_test.go
@@ -775,9 +775,10 @@ var _ = Describe("Application Actions", func() {
 
 	Describe("UpdateApplicationName", func() {
 		var (
-			newAppName, appGUID   string
-			warnings             Warnings
-			err                  error
+			resultApp           resources.Application
+			newAppName, appGUID string
+			warnings            Warnings
+			err                 error
 		)
 
 		JustBeforeEach(func() {
@@ -817,7 +818,9 @@ var _ = Describe("Application Actions", func() {
 				Expect(warnings).To(ConsistOf("some-warning"))
 
 				Expect(fakeCloudControllerClient.UpdateApplicationNameCallCount()).To(Equal(1))
-				Expect(fakeCloudControllerClient.UpdateApplicationNameArgsForCall(0)).To(Equal("some-new-app-name", "some-space-guid"))
+				appName, appGuid := fakeCloudControllerClient.UpdateApplicationNameArgsForCall(0)
+				Expect(appName).To(Equal("some-new-app-name"))
+				Expect(appGuid).To(Equal("some-app-guid"))
 			})
 		})
 
@@ -2127,13 +2130,9 @@ var _ = Describe("Application Actions", func() {
 					GUID: "old-app-guid",
 				}))
 				Expect(warnings).To(ConsistOf("get-app-warning", "update-app-warning"))
-
-				Expect(fakeCloudControllerClient.UpdateApplicationNameArgsForCall(0)).To(Equal(
-					resources.Application{
-						Name: "new-app-name",
-						GUID: "old-app-guid",
-					}))
-
+				appName, appGuid := fakeCloudControllerClient.UpdateApplicationNameArgsForCall(0)
+				Expect(appName).To(Equal("new-app-name"))
+				Expect(appGuid).To(Equal("old-app-guid"))
 			})
 		})
 

--- a/actor/v7action/cloud_controller_client.go
+++ b/actor/v7action/cloud_controller_client.go
@@ -159,6 +159,7 @@ type CloudControllerClient interface {
 	UnshareServiceInstanceFromSpace(serviceInstanceGUID string, sharedToSpaceGUID string) (ccv3.Warnings, error)
 	UpdateAppFeature(appGUID string, enabled bool, featureName string) (ccv3.Warnings, error)
 	UpdateApplication(app resources.Application) (resources.Application, ccv3.Warnings, error)
+	UpdateApplicationName(newAppName string, appGUID string) (resources.Application, ccv3.Warnings, error)
 	UpdateApplicationApplyManifest(appGUID string, rawManifest []byte) (ccv3.JobURL, ccv3.Warnings, error)
 	UpdateApplicationEnvironmentVariables(appGUID string, envVars resources.EnvironmentVariables) (resources.EnvironmentVariables, ccv3.Warnings, error)
 	UpdateApplicationRestart(appGUID string) (resources.Application, ccv3.Warnings, error)

--- a/actor/v7action/v7actionfakes/fake_cloud_controller_client.go
+++ b/actor/v7action/v7actionfakes/fake_cloud_controller_client.go
@@ -2271,6 +2271,22 @@ type FakeCloudControllerClient struct {
 		result2 ccv3.Warnings
 		result3 error
 	}
+	UpdateApplicationNameStub        func(string, string) (resources.Application, ccv3.Warnings, error)
+	updateApplicationNameMutex       sync.RWMutex
+	updateApplicationNameArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
+	updateApplicationNameReturns struct {
+		result1 resources.Application
+		result2 ccv3.Warnings
+		result3 error
+	}
+	updateApplicationNameReturnsOnCall map[int]struct {
+		result1 resources.Application
+		result2 ccv3.Warnings
+		result3 error
+	}
 	UpdateApplicationRestartStub        func(string) (resources.Application, ccv3.Warnings, error)
 	updateApplicationRestartMutex       sync.RWMutex
 	updateApplicationRestartArgsForCall []struct {
@@ -12601,6 +12617,73 @@ func (fake *FakeCloudControllerClient) UpdateApplicationEnvironmentVariablesRetu
 	}{result1, result2, result3}
 }
 
+func (fake *FakeCloudControllerClient) UpdateApplicationName(arg1 string, arg2 string) (resources.Application, ccv3.Warnings, error) {
+	fake.updateApplicationNameMutex.Lock()
+	ret, specificReturn := fake.updateApplicationNameReturnsOnCall[len(fake.updateApplicationNameArgsForCall)]
+	fake.updateApplicationNameArgsForCall = append(fake.updateApplicationNameArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("UpdateApplicationName", []interface{}{arg1, arg2})
+	fake.updateApplicationNameMutex.Unlock()
+	if fake.UpdateApplicationNameStub != nil {
+		return fake.UpdateApplicationNameStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	fakeReturns := fake.updateApplicationNameReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeCloudControllerClient) UpdateApplicationNameCallCount() int {
+	fake.updateApplicationNameMutex.RLock()
+	defer fake.updateApplicationNameMutex.RUnlock()
+	return len(fake.updateApplicationNameArgsForCall)
+}
+
+func (fake *FakeCloudControllerClient) UpdateApplicationNameCalls(stub func(string, string) (resources.Application, ccv3.Warnings, error)) {
+	fake.updateApplicationNameMutex.Lock()
+	defer fake.updateApplicationNameMutex.Unlock()
+	fake.UpdateApplicationNameStub = stub
+}
+
+func (fake *FakeCloudControllerClient) UpdateApplicationNameArgsForCall(i int) (string, string) {
+	fake.updateApplicationNameMutex.RLock()
+	defer fake.updateApplicationNameMutex.RUnlock()
+	argsForCall := fake.updateApplicationNameArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeCloudControllerClient) UpdateApplicationNameReturns(result1 resources.Application, result2 ccv3.Warnings, result3 error) {
+	fake.updateApplicationNameMutex.Lock()
+	defer fake.updateApplicationNameMutex.Unlock()
+	fake.UpdateApplicationNameStub = nil
+	fake.updateApplicationNameReturns = struct {
+		result1 resources.Application
+		result2 ccv3.Warnings
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeCloudControllerClient) UpdateApplicationNameReturnsOnCall(i int, result1 resources.Application, result2 ccv3.Warnings, result3 error) {
+	fake.updateApplicationNameMutex.Lock()
+	defer fake.updateApplicationNameMutex.Unlock()
+	fake.UpdateApplicationNameStub = nil
+	if fake.updateApplicationNameReturnsOnCall == nil {
+		fake.updateApplicationNameReturnsOnCall = make(map[int]struct {
+			result1 resources.Application
+			result2 ccv3.Warnings
+			result3 error
+		})
+	}
+	fake.updateApplicationNameReturnsOnCall[i] = struct {
+		result1 resources.Application
+		result2 ccv3.Warnings
+		result3 error
+	}{result1, result2, result3}
+}
+
 func (fake *FakeCloudControllerClient) UpdateApplicationRestart(arg1 string) (resources.Application, ccv3.Warnings, error) {
 	fake.updateApplicationRestartMutex.Lock()
 	ret, specificReturn := fake.updateApplicationRestartReturnsOnCall[len(fake.updateApplicationRestartArgsForCall)]
@@ -14843,6 +14926,8 @@ func (fake *FakeCloudControllerClient) Invocations() map[string][][]interface{} 
 	defer fake.updateApplicationApplyManifestMutex.RUnlock()
 	fake.updateApplicationEnvironmentVariablesMutex.RLock()
 	defer fake.updateApplicationEnvironmentVariablesMutex.RUnlock()
+	fake.updateApplicationNameMutex.RLock()
+	defer fake.updateApplicationNameMutex.RUnlock()
 	fake.updateApplicationRestartMutex.RLock()
 	defer fake.updateApplicationRestartMutex.RUnlock()
 	fake.updateApplicationStartMutex.RLock()

--- a/api/cloudcontroller/ccv3/application.go
+++ b/api/cloudcontroller/ccv3/application.go
@@ -66,6 +66,20 @@ func (client *Client) UpdateApplication(app resources.Application) (resources.Ap
 	return responseBody, warnings, err
 }
 
+// UpdateApplicationName updates an application with the new name given
+func (client *Client) UpdateApplicationName(newAppName string, appGUID string) (resources.Application, Warnings, error) {
+	var responseBody resources.Application
+
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName:  internal.PatchApplicationRequest,
+		URIParams:    internal.Params{"app_guid": appGUID},
+		RequestBody:  {"name": newAppName},
+		ResponseBody: &responseBody,
+	})
+
+	return responseBody, warnings, err
+}
+
 // UpdateApplicationRestart restarts the given application.
 func (client *Client) UpdateApplicationRestart(appGUID string) (resources.Application, Warnings, error) {
 	var responseBody resources.Application

--- a/api/cloudcontroller/ccv3/application.go
+++ b/api/cloudcontroller/ccv3/application.go
@@ -69,11 +69,10 @@ func (client *Client) UpdateApplication(app resources.Application) (resources.Ap
 // UpdateApplicationName updates an application with the new name given
 func (client *Client) UpdateApplicationName(newAppName string, appGUID string) (resources.Application, Warnings, error) {
 	var responseBody resources.Application
-
 	_, warnings, err := client.MakeRequest(RequestParams{
 		RequestName:  internal.PatchApplicationRequest,
 		URIParams:    internal.Params{"app_guid": appGUID},
-		RequestBody:  {"name": newAppName},
+		RequestBody:  struct{ Name string }{Name: newAppName},
 		ResponseBody: &responseBody,
 	})
 

--- a/api/cloudcontroller/ccv3/application.go
+++ b/api/cloudcontroller/ccv3/application.go
@@ -72,7 +72,7 @@ func (client *Client) UpdateApplicationName(newAppName string, appGUID string) (
 	_, warnings, err := client.MakeRequest(RequestParams{
 		RequestName:  internal.PatchApplicationRequest,
 		URIParams:    internal.Params{"app_guid": appGUID},
-		RequestBody:  struct{ Name string }{Name: newAppName},
+		RequestBody:  resources.ApplicationNameOnly{Name: newAppName},
 		ResponseBody: &responseBody,
 	})
 

--- a/api/cloudcontroller/ccv3/application_test.go
+++ b/api/cloudcontroller/ccv3/application_test.go
@@ -635,7 +635,7 @@ var _ = Describe("Application", func() {
 			BeforeEach(func() {
 				requester.MakeRequestCalls(func(requestParams RequestParams) (JobURL, Warnings, error) {
 					requestParams.ResponseBody.(*resources.Application).GUID = appGUID
-					requestParams.ResponseBody.(*resources.Application).Name = requestParams.RequestBody.(struct{ Name string }).Name
+					requestParams.ResponseBody.(*resources.Application).Name = requestParams.RequestBody.(resources.ApplicationNameOnly).Name
 					requestParams.ResponseBody.(*resources.Application).StackName = "some-stack-name"
 					requestParams.ResponseBody.(*resources.Application).LifecycleType = constant.AppLifecycleTypeBuildpack
 					requestParams.ResponseBody.(*resources.Application).LifecycleBuildpacks = []string{"some-buildpack"}
@@ -649,7 +649,7 @@ var _ = Describe("Application", func() {
 				actualParams := requester.MakeRequestArgsForCall(0)
 				Expect(actualParams.RequestName).To(Equal(internal.PatchApplicationRequest))
 				Expect(actualParams.URIParams).To(Equal(internal.Params{"app_guid": "some-app-guid"}))
-				Expect(actualParams.RequestBody).To(Equal(struct{ Name string }{Name: newAppName}))
+				Expect(actualParams.RequestBody).To(Equal(resources.ApplicationNameOnly{Name: newAppName}))
 				_, ok := actualParams.ResponseBody.(*resources.Application)
 				Expect(ok).To(BeTrue())
 			})

--- a/api/cloudcontroller/ccv3/application_test.go
+++ b/api/cloudcontroller/ccv3/application_test.go
@@ -617,7 +617,7 @@ var _ = Describe("Application", func() {
 	Describe("UpdateApplicationName", func() {
 		var (
 			newAppName string
-			appGUID string
+			appGUID    string
 
 			updatedApp resources.Application
 			warnings   Warnings
@@ -635,21 +635,22 @@ var _ = Describe("Application", func() {
 			BeforeEach(func() {
 				requester.MakeRequestCalls(func(requestParams RequestParams) (JobURL, Warnings, error) {
 					requestParams.ResponseBody.(*resources.Application).GUID = appGUID
-					requestParams.ResponseBody.(*resources.Application).Name = requestParams.RequestBody.name
+					requestParams.ResponseBody.(*resources.Application).Name = requestParams.RequestBody.(struct{ Name string }).Name
 					requestParams.ResponseBody.(*resources.Application).StackName = "some-stack-name"
 					requestParams.ResponseBody.(*resources.Application).LifecycleType = constant.AppLifecycleTypeBuildpack
 					requestParams.ResponseBody.(*resources.Application).LifecycleBuildpacks = []string{"some-buildpack"}
 					requestParams.ResponseBody.(*resources.Application).SpaceGUID = "some-space-guid"
 					return "", Warnings{"this is a warning"}, nil
 				})
+			})
 
 			It("makes the correct request", func() {
 				Expect(requester.MakeRequestCallCount()).To(Equal(1))
 				actualParams := requester.MakeRequestArgsForCall(0)
 				Expect(actualParams.RequestName).To(Equal(internal.PatchApplicationRequest))
 				Expect(actualParams.URIParams).To(Equal(internal.Params{"app_guid": "some-app-guid"}))
-				Expect(actualParams.RequestBody).To(Equal({"name": newAppName}))
-				_, ok := actualParams.ResponseBody.name
+				Expect(actualParams.RequestBody).To(Equal(struct{ Name string }{Name: newAppName}))
+				_, ok := actualParams.ResponseBody.(*resources.Application)
 				Expect(ok).To(BeTrue())
 			})
 

--- a/resources/application_resource.go
+++ b/resources/application_resource.go
@@ -27,6 +27,12 @@ type Application struct {
 	State constant.ApplicationState
 }
 
+// ApplicationNameOnly represents only the name field of a Cloud Controller V3 Application
+type ApplicationNameOnly struct {
+	// Name is the name given to the application.
+	Name string `json:"name,omitempty"`
+}
+
 // MarshalJSON converts an Application into a Cloud Controller Application.
 func (a Application) MarshalJSON() ([]byte, error) {
 	ccApp := ccApplication{


### PR DESCRIPTION
cc @reedr3 

Thank you for contributing to the CF CLI! Please read the following:

* Please make sure you have implemented changes in line with the [contributing guidelines](https://github.com/cloudfoundry/cli/blob/master/.github/CONTRIBUTING.md)
* We're not allowed to accept any PRs without a signed CLA, no matter how small.
If your contribution falls under a company CLA but your membership is not public, expect delays while we confirm.
* All new code requires tests to protect against regressions.
* Contributions must be made against the appropriate branch. See the [contributing guidelines](https://github.com/cloudfoundry/cli/blob/master/.github/CONTRIBUTING.md)
* Contributions must conform to our [style guide](https://github.com/cloudfoundry/cli/wiki/CLI-Product-Specific-Style-Guide). Please reach out to us if you have questions.

## Does this PR modify CLI v6, CLI v7, or CLI v8?
Going to default branch, probably will request a backport to v8

Please see the contribution doc above or review [Architecture Guide](https://github.com/cloudfoundry/cli/wiki/Architecture-Guide).

## Description of the Change
A user had an app that they wanted to rename, but the buildpack the app was using had previously been deleted from the cloud foundry deployment.  When the user called `cf rename` they received an error about the buildpack not being available.  CAPI supports only renaming an app, but the cf cli is passing not just the rename on `cf rename` but the stack and buildpack information.  This pr allows only rename by only passing to capi the new name information and not the stack and buildpack information.

We must be able to understand the design of your change from this description.
Keep in mind that the maintainer reviewing this PR may not be familiar with or
have worked with the code here recently, so please walk us through the concepts.

## Why Is This PR Valuable?

What benefits will be realized by the code change? What users would want this change? What user need is this change addressing? 

CAPI allows the user to only do renames via its API so we should also support this

## Why Should This Be In Core?

Explain why this functionality should be in the cf CLI, as opposed to a plugin. 
Not new functionality, just fixing existing functionality.

## Applicable Issues

List any applicable Github Issues here

## How Urgent Is The Change?

Is the change urgent? If so, explain why it is time-sensitive.

## Other Relevant Parties

Who else is affected by the change? 
