### PR TITLE
Use default of 1GB memory instead of 32M

### DIFF
--- a/integration/v7/isolated/scale_command_test.go
+++ b/integration/v7/isolated/scale_command_test.go
@@ -104,7 +104,7 @@ var _ = Describe("scale command", func() {
 				helpers.WithProcfileApp(func(appDir string) {
 					Eventually(helpers.CustomCF(helpers.CFEnv{WorkingDirectory: appDir}, "push", appName)).Should(Exit(0))
 				})
-				helpers.WaitForAppMemoryToTakeEffect(appName, 0, 0, false, "32M")
+				helpers.WaitForAppMemoryToTakeEffect(appName, 0, 0, false, "1G")
 			})
 
 			When("scale option flags are not provided", func() {
@@ -161,7 +161,7 @@ var _ = Describe("scale command", func() {
 						Consistently(session).ShouldNot(Say("Stopping"))
 						Consistently(session).ShouldNot(Say("Starting"))
 
-						helpers.WaitForAppMemoryToTakeEffect(appName, 0, 0, true, "32M")
+						helpers.WaitForAppMemoryToTakeEffect(appName, 0, 0, true, "1G")
 
 						session = helpers.CF("app", appName)
 						Eventually(session).Should(Exit(0))

--- a/integration/v7/isolated/start_command_test.go
+++ b/integration/v7/isolated/start_command_test.go
@@ -129,7 +129,7 @@ var _ = Describe("start command", func() {
 					Eventually(session).Should(Say(`routes:\s+%s.%s`, appName, helpers.DefaultSharedDomain()))
 					Eventually(session).Should(Say(`type:\s+web`))
 					Eventually(session).Should(Say(`instances:\s+1/1`))
-					Eventually(session).Should(Say(`memory usage:\s+32M`))
+					Eventually(session).Should(Say(`memory usage:\s+1024M`))
 					Eventually(session).Should(Say(`\s+state\s+since\s+cpu\s+memory\s+disk\s+logging\s+details`))
 					Eventually(session).Should(Say(`#0\s+(starting|running)\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z`))
 


### PR DESCRIPTION
- a regular deploy of cf-deployment has a default memory limit of 1G
- if we prefer to use 32M, we should change the tests to push an app specifying that as the limit instead

*I checked the "allow edits and access to secrets by maintainers, so any approver should be able to push commits if they see small issues*

Thank you for contributing to the CF CLI! Please read the following:


* Please make sure you have implemented changes in line with the [contributing guidelines](https://github.com/cloudfoundry/cli/blob/master/.github/CONTRIBUTING.md)
* We're not allowed to accept any PRs without a signed CLA, no matter how small.
If your contribution falls under a company CLA but your membership is not public, expect delays while we confirm.
* All new code requires tests to protect against regressions.
* Contributions must be made against the appropriate branch. See the [contributing guidelines](https://github.com/cloudfoundry/cli/blob/master/.github/CONTRIBUTING.md)
* Contributions must conform to our [style guide](https://github.com/cloudfoundry/cli/wiki/CLI-Product-Specific-Style-Guide). Please reach out to us if you have questions.


## Does this PR modify CLI v6, CLI v7, or CLI v8?
Modifies tests to make github actions integration test work better, so should be backported to all versions still under testing

Please see the contribution doc above or review [Architecture Guide](https://github.com/cloudfoundry/cli/wiki/Architecture-Guide).

## Description of the Change
Use default of 1GB memory instead of 32M

We must be able to understand the design of your change from this description.
Keep in mind that the maintainer reviewing this PR may not be familiar with or
have worked with the code here recently, so please walk us through the concepts.


## Why Is This PR Valuable?
Will allow folks to just run the tests instead of configuring their cloud foundry install

What benefits will be realized by the code change? What users would want this change? What user need is this change addressing? 

## Why Should This Be In Core?
n/a

Explain why this functionality should be in the cf CLI, as opposed to a plugin. 

## Applicable Issues
#2326 

List any applicable Github Issues here

## How Urgent Is The Change?
As urgent as we want integration tests to work on github actions

Is the change urgent? If so, explain why it is time-sensitive.

## Other Relevant Parties
@cloudfoundry/wg-app-runtime-interfaces-cli-approvers 
@cloudfoundry/wg-app-runtime-interfaces-cli-reviewers 

Who else is affected by the change? 
