### PR TITLE
update routes command to not require a space with --org-level argument

### DIFF
--- a/cf/commands/route/routes.go
+++ b/cf/commands/route/routes.go
@@ -53,7 +53,11 @@ func (cmd *ListRoutes) Requirements(requirementsFactory requirements.Factory, fc
 	reqs := []requirements.Requirement{
 		usageReq,
 		requirementsFactory.NewLoginRequirement(),
-		requirementsFactory.NewTargetedSpaceRequirement(),
+	}
+
+	orglevel := fc.Bool("orglevel")
+	if !orglevel {
+		reqs = append(reqs, requirementsFactory.NewTargetedSpaceRequirement())
 	}
 
 	return reqs, nil

--- a/cf/commands/route/routes_test.go
+++ b/cf/commands/route/routes_test.go
@@ -64,6 +64,12 @@ var _ = Describe("routes command", func() {
 			Expect(runCommand()).To(BeFalse())
 		})
 
+		It("does not fail when an org is not targeted and --orglevel is an argument", func() {
+			requirementsFactory.NewTargetedSpaceRequirementReturns(requirements.Failing{Message: "not logged in"})
+
+			Expect(runCommand("--orglevel")).To(BeTrue())
+		})
+
 		Context("when arguments are provided", func() {
 			var cmd commandregistry.Command
 			var flagContext flags.FlagContext


### PR DESCRIPTION
## Does this PR modify CLI v6, CLI v7, or CLI v8?

This PR modifies CLI v8.

## Description of the Change

As described in #2346, the CLI currently returns an error when running `cf routes --org-level` if a space is not targeted. However, this behavior is not desirable since listing routes at the organization level shouldn't require targeting a space. This PR fixes the behavior to remove the space requirement when `--org-level` is specified.

## Why Is This PR Valuable?

This PR fixes a minor bug affecting all users of CLI v8.

## Why Should This Be In Core?

This PR is fixing a bug in the functionality that is already a part of the core

## Applicable Issues

Closes #2346 

## How Urgent Is The Change?

Not very urgent

## Other Relevant Parties

All users of CLI v8 are affected by the bug and thus would be affected by the fix.
