### PR TITLE
Replace 'set-output' deprecated command in GHA

### DIFF
--- a/.github/workflows/build-sign-upload.yml
+++ b/.github/workflows/build-sign-upload.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Set environment
       id: set-secrets-environment
-      run: echo "::set-output name=secrets-environment::PROD"
+      run: echo "secrets-environment=PROD" >> $GITHUB_OUTPUT
 
     - name: Checkout cli
       uses: actions/checkout@v2
@@ -45,14 +45,14 @@ jobs:
       id: set-build-version
       run: |
         version=$(cat BUILD_VERSION)
-        echo "::set-output name=build-version::$version"
+        echo "build-version=$version" >> $GITHUB_OUTPUT
 
     - name: Parse Golang Version
       id: set-go-version
       run: |
         go_version=($(grep -E '^go 1\.[[:digit:]]{1,2}' go.mod))
         echo "golang version: ${go_version[1]}"
-        echo "::set-output name=go-version::${go_version[1]}"
+        echo "go-version=${go_version[1]}" >> $GITHUB_OUTPUT
 
     # This is for debugging. It's equivalent to fly intercept
     # - name: Setup upterm session
@@ -188,8 +188,8 @@ jobs:
     - name: Print go environment
       id: go-cache-paths
       run: |
-        echo "::set-output name=go-build::$(go env GOCACHE)"
-        echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+        echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+        echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
         go env
 
     - name: Go Assets Cache
@@ -457,8 +457,8 @@ jobs:
     - name: Print go environment
       id: go-cache-paths
       run: |
-        echo "::set-output name=go-build::$(go env GOCACHE)"
-        echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+        echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+        echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
         go env
 
     - name: Go Assets Cache

--- a/.github/workflows/units.yml
+++ b/.github/workflows/units.yml
@@ -45,7 +45,7 @@ jobs:
       run: |
         go_version=($(grep -E '^go 1\.[[:digit:]]{1,2}' go.mod))
         echo "golang version: ${go_version[1]}"
-        echo "::set-output name=go-version::${go_version[1]}"
+        echo "go-version=${go_version[1]}" >> $GITHUB_OUTPUT
 
   lint:
     name: Lint code

--- a/.github/workflows/update-repos.yml
+++ b/.github/workflows/update-repos.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Set environment
       id: set-secrets-environment
-      run: echo "::set-output name=secrets-environment::PROD"
+      run: echo "secrets-environment=PROD" >> $GITHUB_OUTPUT
 
     - name: Checkout cli
       uses: actions/checkout@v2
@@ -37,7 +37,7 @@ jobs:
       id: set-build-version
       run: |
         version=$(cat BUILD_VERSION)
-        echo "::set-output name=build-version::$version"
+        echo "build-version=$version" >> $GITHUB_OUTPUT
 
   update-homebrew:
     name: Update Homebrew Repository


### PR DESCRIPTION
## Does this PR modify CLI v6, CLI v7, or CLI v8?

No, just GHA

## Description of the Change

Replaces a deprecated command used to set environment variables used in GHA workflows, now uses a native concat to insert these variables.

## Why Is This PR Valuable?

The command will stop working soon, these changes will prevent our workflows to break.
