### PR TITLE
Support `cf login -u` when targeting Korifi / Kubernetes

### DIFF
--- a/actor/v7action/k8s_auth.go
+++ b/actor/v7action/k8s_auth.go
@@ -52,11 +52,37 @@ func NewKubernetesAuthActor(config Config, k8sConfigGetter KubernetesConfigGette
 }
 
 func (actor kubernetesAuthActor) Authenticate(credentials map[string]string, origin string, grantType constant.GrantType) error {
-	actor.config.SetKubernetesAuthInfo(credentials["k8s-auth-info"])
-	return nil
+	username := credentials["k8s-auth-info"]
+	availableUsernames, err := actor.getAvailableUsernames()
+	if err != nil {
+		return err
+	}
+
+	for _, u := range availableUsernames {
+		if u == username {
+			actor.config.SetKubernetesAuthInfo(username)
+			return nil
+		}
+	}
+
+	return errors.New("kubernetes user not found in configuration: " + username)
 }
 
 func (actor kubernetesAuthActor) GetLoginPrompts() (map[string]coreconfig.AuthPrompt, error) {
+	availableUsernames, err := actor.getAvailableUsernames()
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(availableUsernames)
+
+	return map[string]coreconfig.AuthPrompt{"k8s-auth-info": {
+		Type:        coreconfig.AuthPromptTypeMenu,
+		Entries:     availableUsernames,
+		DisplayName: "Choose your Kubernetes authentication info",
+	}}, nil
+}
+
+func (actor kubernetesAuthActor) getAvailableUsernames() ([]string, error) {
 	conf, err := actor.k8sConfigGetter.Get()
 	if err != nil {
 		return nil, err
@@ -66,17 +92,11 @@ func (actor kubernetesAuthActor) GetLoginPrompts() (map[string]coreconfig.AuthPr
 		return nil, errors.New("no kubernetes authentication infos configured")
 	}
 
-	var prompts []string
+	var usernames []string
 	for authInfo := range conf.AuthInfos {
-		prompts = append(prompts, authInfo)
+		usernames = append(usernames, authInfo)
 	}
-	sort.Strings(prompts)
-
-	return map[string]coreconfig.AuthPrompt{"k8s-auth-info": {
-		Type:        coreconfig.AuthPromptTypeMenu,
-		Entries:     prompts,
-		DisplayName: "Choose your Kubernetes authentication info",
-	}}, nil
+	return usernames, nil
 }
 
 func (actor kubernetesAuthActor) GetCurrentUser() (configv3.User, error) {

--- a/actor/v7action/k8s_auth.go
+++ b/actor/v7action/k8s_auth.go
@@ -52,7 +52,7 @@ func NewKubernetesAuthActor(config Config, k8sConfigGetter KubernetesConfigGette
 }
 
 func (actor kubernetesAuthActor) Authenticate(credentials map[string]string, origin string, grantType constant.GrantType) error {
-	username := credentials["k8s-auth-info"]
+	username := credentials["username"]
 	availableUsernames, err := actor.getAvailableUsernames()
 	if err != nil {
 		return err
@@ -75,7 +75,7 @@ func (actor kubernetesAuthActor) GetLoginPrompts() (map[string]coreconfig.AuthPr
 	}
 	sort.Strings(availableUsernames)
 
-	return map[string]coreconfig.AuthPrompt{"k8s-auth-info": {
+	return map[string]coreconfig.AuthPrompt{"username": {
 		Type:        coreconfig.AuthPromptTypeMenu,
 		Entries:     availableUsernames,
 		DisplayName: "Choose your Kubernetes authentication info",

--- a/actor/v7action/k8s_auth_test.go
+++ b/actor/v7action/k8s_auth_test.go
@@ -34,14 +34,49 @@ var _ = Describe("KubernetesAuthActor", func() {
 	})
 
 	Describe("Authenticate", func() {
+		var username string
+		BeforeEach(func() {
+			username = "bar"
+		})
+
 		JustBeforeEach(func() {
-			err = k8sAuthActor.Authenticate(map[string]string{"k8s-auth-info": "bar"}, "", constant.GrantTypePassword)
+			err = k8sAuthActor.Authenticate(map[string]string{"k8s-auth-info": username}, "", constant.GrantTypePassword)
 		})
 
 		It("sets the Kubernetes auth-info", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(config.SetKubernetesAuthInfoCallCount()).To(Equal(1))
 			Expect(config.SetKubernetesAuthInfoArgsForCall(0)).To(Equal("bar"))
+		})
+
+		When("the given username is not in the k8s config", func() {
+			BeforeEach(func() {
+				username = "no-such-person"
+			})
+
+			It("returns the error", func() {
+				Expect(err).To(MatchError("kubernetes user not found in configuration: " + username))
+			})
+		})
+
+		When("getting the k8s config fails", func() {
+			BeforeEach(func() {
+				k8sConfigGetter.GetReturns(nil, errors.New("oomph!"))
+			})
+
+			It("returns the error", func() {
+				Expect(err).To(MatchError("oomph!"))
+			})
+		})
+
+		When("no auth infos are in the k8s config", func() {
+			BeforeEach(func() {
+				k8sConfigGetter.GetReturns(&clientcmdapi.Config{}, nil)
+			})
+
+			It("returns an error", func() {
+				Expect(err).To(MatchError("no kubernetes authentication infos configured"))
+			})
 		})
 	})
 

--- a/actor/v7action/k8s_auth_test.go
+++ b/actor/v7action/k8s_auth_test.go
@@ -40,7 +40,7 @@ var _ = Describe("KubernetesAuthActor", func() {
 		})
 
 		JustBeforeEach(func() {
-			err = k8sAuthActor.Authenticate(map[string]string{"k8s-auth-info": username}, "", constant.GrantTypePassword)
+			err = k8sAuthActor.Authenticate(map[string]string{"username": username}, "", constant.GrantTypePassword)
 		})
 
 		It("sets the Kubernetes auth-info", func() {
@@ -90,16 +90,16 @@ var _ = Describe("KubernetesAuthActor", func() {
 		It("returns an auth prompt menu", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(authPrompts).To(HaveLen(1))
-			Expect(authPrompts).To(HaveKey("k8s-auth-info"))
+			Expect(authPrompts).To(HaveKey("username"))
 
-			authPrompt := authPrompts["k8s-auth-info"]
+			authPrompt := authPrompts["username"]
 			Expect(authPrompt.Type).To(Equal(coreconfig.AuthPromptTypeMenu))
 			Expect(authPrompt.DisplayName).To(Equal("Choose your Kubernetes authentication info"))
 			Expect(authPrompt.Entries).To(ConsistOf("foo", "bar"))
 		})
 
 		It("sorts the entries", func() {
-			authPrompt := authPrompts["k8s-auth-info"]
+			authPrompt := authPrompts["username"]
 			Expect(authPrompt.Entries).To(Equal([]string{"bar", "foo"}))
 		})
 

--- a/command/v7/auth_command.go
+++ b/command/v7/auth_command.go
@@ -77,10 +77,6 @@ func (cmd AuthCommand) Execute(args []string) error {
 		grantType = constant.GrantTypeClientCredentials
 		credentials["client_id"] = username
 		credentials["client_secret"] = password
-	} else if cmd.Config.IsCFOnK8s() {
-		credentials = map[string]string{
-			"k8s-auth-info": username,
-		}
 	} else {
 		credentials = map[string]string{
 			"username": username,

--- a/command/v7/auth_command.go
+++ b/command/v7/auth_command.go
@@ -118,9 +118,16 @@ func (cmd AuthCommand) getUsernamePassword() (string, string, error) {
 	if password == "" {
 		if envPassword := cmd.Config.CFPassword(); envPassword != "" {
 			password = envPassword
-		} else if !cmd.Config.IsCFOnK8s() {
+		} else {
 			passwordMissing = true
 		}
+	}
+
+	if cmd.Config.IsCFOnK8s() {
+		if !passwordMissing {
+			cmd.UI.DisplayWarning("Warning: password is ignored when authenticating against Kubernetes.")
+		}
+		passwordMissing = false
 	}
 
 	if userMissing || passwordMissing {

--- a/command/v7/auth_command.go
+++ b/command/v7/auth_command.go
@@ -1,7 +1,6 @@
 package v7
 
 import (
-	"errors"
 	"fmt"
 
 	"code.cloudfoundry.org/cli/api/uaa/constant"
@@ -79,25 +78,6 @@ func (cmd AuthCommand) Execute(args []string) error {
 		credentials["client_id"] = username
 		credentials["client_secret"] = password
 	} else if cmd.Config.IsCFOnK8s() {
-		prompts, err := cmd.Actor.GetLoginPrompts()
-		if err != nil {
-			return err
-		}
-		prompt, ok := prompts["k8s-auth-info"]
-		if !ok {
-			return errors.New("kubernetes login context is missing")
-		}
-
-		userFound := false
-		for _, val := range prompt.Entries {
-			if val == username {
-				userFound = true
-				break
-			}
-		}
-		if !userFound {
-			return errors.New("kubernetes user not found in configuration: " + username)
-		}
 		credentials = map[string]string{
 			"k8s-auth-info": username,
 		}

--- a/command/v7/auth_command_test.go
+++ b/command/v7/auth_command_test.go
@@ -124,6 +124,24 @@ var _ = Describe("auth Command", func() {
 				})
 			})
 		})
+
+		When("the password is given", func() {
+			BeforeEach(func() {
+				cmd.RequiredArgs.Username = "myuser"
+				cmd.RequiredArgs.Password = "mypassword"
+			})
+
+			When("authenticating against korifi", func() {
+				BeforeEach(func() {
+					fakeConfig.IsCFOnK8sReturns(true)
+				})
+
+				It("succeeds but warns", func() {
+					Expect(err).NotTo(HaveOccurred())
+					Expect(testUI.Err).To(Say("Warning: password is ignored when authenticating against Kubernetes."))
+				})
+			})
+		})
 	})
 
 	When("there is an auth error", func() {

--- a/command/v7/auth_command_test.go
+++ b/command/v7/auth_command_test.go
@@ -1,7 +1,6 @@
 package v7_test
 
 import (
-	"code.cloudfoundry.org/cli/cf/configuration/coreconfig"
 	"errors"
 
 	"code.cloudfoundry.org/cli/api/uaa"
@@ -19,13 +18,12 @@ import (
 
 var _ = Describe("auth Command", func() {
 	var (
-		cmd             AuthCommand
-		testUI          *ui.UI
-		fakeActor       *v7fakes.FakeActor
-		fakeConfig      *commandfakes.FakeConfig
-		binaryName      string
-		err             error
-		k8sLoginPrompts map[string]coreconfig.AuthPrompt
+		cmd        AuthCommand
+		testUI     *ui.UI
+		fakeActor  *v7fakes.FakeActor
+		fakeConfig *commandfakes.FakeConfig
+		binaryName string
+		err        error
 	)
 
 	BeforeEach(func() {
@@ -45,11 +43,6 @@ var _ = Describe("auth Command", func() {
 		fakeConfig.BinaryNameReturns(binaryName)
 		fakeConfig.UAAOAuthClientReturns("cf")
 		fakeConfig.APIVersionReturns("3.99.0")
-		k8sLoginPrompts = map[string]coreconfig.AuthPrompt{
-			"k8s-auth-info": {
-				Entries: []string{"myuser"},
-			},
-		}
 	})
 
 	JustBeforeEach(func() {
@@ -124,7 +117,6 @@ var _ = Describe("auth Command", func() {
 			When("authenticating against Korifi", func() {
 				BeforeEach(func() {
 					fakeConfig.IsCFOnK8sReturns(true)
-					fakeActor.GetLoginPromptsReturns(k8sLoginPrompts, nil)
 				})
 
 				It("succeeds", func() {
@@ -321,33 +313,22 @@ var _ = Describe("auth Command", func() {
 				BeforeEach(func() {
 					cmd.RequiredArgs.Username = "myuser"
 					fakeConfig.IsCFOnK8sReturns(true)
-					fakeActor.GetLoginPromptsReturns(k8sLoginPrompts, nil)
 				})
 
-				When("the specified username doesn't match any k8s context", func() {
+				It("attempts to authenticate with the correct username", func() {
+					Expect(fakeActor.AuthenticateCallCount()).To(Equal(1))
+					credentials, _, _ := fakeActor.AuthenticateArgsForCall(0)
+					Expect(credentials).To(Equal(map[string]string{"k8s-auth-info": "myuser"}))
+				})
+
+				When("there is an error authenticating with the given username", func() {
 					BeforeEach(func() {
-						cmd.RequiredArgs.Username = "some-unknown-user"
+						fakeActor.AuthenticateReturns(errors.New("stuff go boom"))
 					})
 
 					It("errors", func() {
-						Expect(err).To(MatchError(errors.New("kubernetes user not found in configuration: some-unknown-user")))
+						Expect(err).To(MatchError("stuff go boom"))
 					})
-				})
-
-				When("the prompts don't contain k8s authentication information", func() {
-					BeforeEach(func() {
-						k8sLoginPrompts = map[string]coreconfig.AuthPrompt{
-							"some-other-auth-info": {
-								Entries: []string{"myuser"},
-							},
-						}
-						fakeActor.GetLoginPromptsReturns(k8sLoginPrompts, nil)
-					})
-
-					It("errors", func() {
-						Expect(err).To(MatchError(errors.New("kubernetes login context is missing")))
-					})
-
 				})
 
 			})

--- a/command/v7/auth_command_test.go
+++ b/command/v7/auth_command_test.go
@@ -318,7 +318,7 @@ var _ = Describe("auth Command", func() {
 				It("attempts to authenticate with the correct username", func() {
 					Expect(fakeActor.AuthenticateCallCount()).To(Equal(1))
 					credentials, _, _ := fakeActor.AuthenticateArgsForCall(0)
-					Expect(credentials).To(Equal(map[string]string{"k8s-auth-info": "myuser"}))
+					Expect(credentials).To(HaveKeyWithValue("username", "myuser"))
 				})
 
 				When("there is an error authenticating with the given username", func() {


### PR DESCRIPTION
## Does this PR modify CLI v6, CLI v7, or CLI v8?
The PR modifies v8

## Description of the Change
`cf login -u` now works when authenticating against Kubernetes. It will warn if a password is provided. We added the same warning to `cf auth`

## Why Is This PR Valuable?
It furthers support for Korifi by supporting more workflows

## Why Should This Be In Core?
To further support integration with Korifi

## Applicable Issues
https://github.com/cloudfoundry/korifi/issues/2195

## How Urgent Is The Change?
This change isn't urgent but merging sooner will avoid us needing to rebasing later

## Other Relevant Parties
We aren't aware of any
