### PR TITLE
produce release for linux-arm64

### DIFF
--- a/.github/workflows/release-build-sign-upload.yml
+++ b/.github/workflows/release-build-sign-upload.yml
@@ -190,6 +190,7 @@ jobs:
       run: |
         make out/cf-cli_linux_i686
         make out/cf-cli_linux_x86-64
+        make out/cf-cli_linux_arm64
 
     - name: Store Linux Binaries
       uses: actions/upload-artifact@v2
@@ -241,6 +242,20 @@ jobs:
         	cat cf8-cli.spec.template >> cf-cli.spec
         	rpmbuild --target x86_64 --define "_topdir $(pwd)/build" -bb cf-cli.spec
         	mv build/RPMS/x86_64/cf8-cli*.rpm $root/packaged/cf8-cli-installer_${BUILD_VERSION}_x86-64.rpm
+          popd
+        )
+
+        echo "Build aarch64 RedHat package"
+        (
+          pushd cli-ci/ci/installers/rpm
+        	cp $root/out/cf-cli_linux_arm64 cf8
+        	cp ../../license/NOTICE .
+        	cp ../../license/LICENSE-WITH-3RD-PARTY-LICENSES LICENSE
+        	cp ../completion/cf8 cf8.bash
+        	echo "Version: ${RPM_VERSION}" > cf-cli.spec
+        	cat cf8-cli.spec.template >> cf-cli.spec
+        	rpmbuild --target aarch64 --define "_topdir $(pwd)/build" -bb cf-cli.spec
+        	mv build/RPMS/aarch64/cf8-cli*.rpm $root/packaged/cf8-cli-installer_${BUILD_VERSION}_aarch64.rpm
           popd
         )
 
@@ -358,6 +373,38 @@ jobs:
 
             fakeroot dpkg --build cf cf8-cli-installer_${BUILD_VERSION}_x86-64.deb
             mv cf8-cli-installer_${BUILD_VERSION}_x86-64.deb $root/packaged-deb
+          popd
+        )
+
+        echo "Build arm64 Debian package"
+        (
+          SIZE="$(BLOCKSIZE=1000 du $root/out/cf-cli_linux_arm64 | cut -f 1)"
+
+          pushd cli-ci/ci/installers/deb
+            mkdir -p cf/usr/bin cf/usr/share/doc/cf8-cli/ cf/DEBIAN cf/usr/share/bash-completion/completions
+
+            cp copyright_preamble cf/DEBIAN/copyright
+            sed 's/^$/ ./' $root/LICENSE >> cf/DEBIAN/copyright
+            cat copyright_comment_header >> cf/DEBIAN/copyright
+            sed 's/^$/ ./' ../../license/3RD-PARTY-LICENSES >> cf/DEBIAN/copyright
+
+            cp cf/DEBIAN/copyright cf/usr/share/doc/cf8-cli/copyright
+
+            cp ../../license/NOTICE cf/usr/share/doc/cf8-cli
+            cp ../../license/LICENSE-WITH-3RD-PARTY-LICENSES cf/usr/share/doc/cf8-cli/LICENSE
+
+            cp control_v8.template cf/DEBIAN/control
+            echo "Installed-Size: ${SIZE}" >> cf/DEBIAN/control
+            echo "Version: ${BUILD_VERSION}" >> cf/DEBIAN/control
+            echo "Architecture: amd64" >> cf/DEBIAN/control
+
+            cp ../completion/cf8 cf/usr/share/bash-completion/completions/cf8
+
+            cp $root/out/cf-cli_linux_arm64 cf/usr/bin/cf8
+            ln -frs cf/usr/bin/cf8 cf/usr/bin/cf
+
+            fakeroot dpkg --build cf cf8-cli-installer_${BUILD_VERSION}_arm64.deb
+            mv cf8-cli-installer_${BUILD_VERSION}_arm64.deb $root/packaged-deb
           popd
         )
 
@@ -751,9 +798,11 @@ jobs:
         }
 
         pushd signed
-          mkdir linux_i686 linux_x86-64
+          mkdir linux_i686 linux_x86-64 linux_arm64
           mv cf-cli-linux-binaries/cf-cli_linux_i686 linux_i686/cf8
           mv cf-cli-linux-binaries/cf-cli_linux_x86-64 linux_x86-64/cf8
+          mv cf-cli-linux-binaries/cf-cli_linux_arm64 linux_arm64/cf8
+
           pushd linux_i686
             prepare_artifacts
             tar -cvzf cf8-cli_${INSTALLER_RELEASE_VERSION}_linux_i686.tgz *
@@ -761,6 +810,10 @@ jobs:
           pushd linux_x86-64
             prepare_artifacts
             tar -cvzf cf8-cli_${INSTALLER_RELEASE_VERSION}_linux_x86-64.tgz *
+          popd
+          pushd linux_arm64
+            prepare_artifacts
+            tar -cvzf cf8-cli_${INSTALLER_RELEASE_VERSION}_linux_arm64.tgz *
           popd
 
           mkdir osx
@@ -797,6 +850,7 @@ jobs:
           signed/cf-cli-windows-packages/cf*zip \
           signed/linux_i686/*tgz \
           signed/linux_x86-64/*tgz \
+          signed/linux_arm64/*tgz \
           signed/osx/*tgz \
           signed/win32/*zip \
           signed/winx64/*zip

--- a/.github/workflows/release-build-sign-upload.yml
+++ b/.github/workflows/release-build-sign-upload.yml
@@ -288,33 +288,33 @@ jobs:
         for arch in "${!arch_array[@]}"; do
           echo "Build ${arch_array[$arch]} Debian package"
           (
-            SIZE="$(BLOCKSIZE=1000 du $root/out/cf-cli_linux_$arch | cut -f 1)"
+            SIZE="$(BLOCKSIZE=1000 du $root/out/cf-cli_linux_${arch} | cut -f 1)"
 
             pushd cli-ci/ci/installers/deb
-              mkdir -p cf/usr/bin cf/usr/share/doc/cf${VERSION_MAJOR}-cli/ cf/DEBIAN cf/usr/share/bash-completion/completions
+              mkdir -p cf/usr/bin cf/usr/share/doc/cf8-cli/ cf/DEBIAN cf/usr/share/bash-completion/completions
 
               cp copyright_preamble cf/DEBIAN/copyright
               sed 's/^$/ ./' $root/LICENSE >> cf/DEBIAN/copyright
               cat copyright_comment_header >> cf/DEBIAN/copyright
               sed 's/^$/ ./' ../../license/3RD-PARTY-LICENSES >> cf/DEBIAN/copyright
 
-              cp cf/DEBIAN/copyright cf/usr/share/doc/cf${VERSION_MAJOR}-cli/copyright
+              cp cf/DEBIAN/copyright cf/usr/share/doc/cf8-cli/copyright
 
-              cp ../../license/NOTICE cf/usr/share/doc/cf${VERSION_MAJOR}-cli
-              cp ../../license/LICENSE-WITH-3RD-PARTY-LICENSES cf/usr/share/doc/cf${VERSION_MAJOR}-cli/LICENSE
+              cp ../../license/NOTICE cf/usr/share/doc/cf8-cli
+              cp ../../license/LICENSE-WITH-3RD-PARTY-LICENSES cf/usr/share/doc/cf8-cli/LICENSE
 
-              cp control_v${VERSION_MAJOR}.template cf/DEBIAN/control
+              cp control_v8.template cf/DEBIAN/control
               echo "Installed-Size: ${SIZE}" >> cf/DEBIAN/control
               echo "Version: ${VERSION_BUILD}" >> cf/DEBIAN/control
               echo "Architecture: $arch" >> cf/DEBIAN/control
 
-              cp ../completion/cf${VERSION_MAJOR} cf/usr/share/bash-completion/completions/cf${VERSION_MAJOR}
+              cp ../completion/cf8 cf/usr/share/bash-completion/completions/cf8
 
-              cp $root/out/cf-cli_linux_$arch cf/usr/bin/cf${VERSION_MAJOR}
-              ln -frs cf/usr/bin/cf${VERSION_MAJOR} cf/usr/bin/cf
+              cp $root/out/cf-cli_linux_$arch cf/usr/bin/cf8
+              ln -frs cf/usr/bin/cf8 cf/usr/bin/cf
 
-              fakeroot dpkg --build cf cf${VERSION_MAJOR}-cli-installer_${VERSION_BUILD}_${arch}.deb
-              mv cf${VERSION_MAJOR}-cli-installer_${VERSION_BUILD}_${arch}.deb $root/packaged-deb
+              fakeroot dpkg --build cf cf8-cli-installer_${VERSION_BUILD}_${arch}.deb
+              mv cf8-cli-installer_${VERSION_BUILD}_${arch}.deb $root/packaged-deb
               rm -rf cf
             popd
           )

--- a/.github/workflows/release-build-sign-upload.yml
+++ b/.github/workflows/release-build-sign-upload.yml
@@ -206,6 +206,7 @@ jobs:
         set -ex
         set -o pipefail
 
+        declare -A arch_array=([i686]="32-bit" [x86_64]="64-bit" [aarch64]='aarch/arm-64bit')
         root=$PWD
 
         cat<< EOF >~/.rpmmacros
@@ -216,48 +217,21 @@ jobs:
 
         mkdir -pv $root/packaged
 
-        echo "Build 32-bit RedHat package"
-        (
-          pushd cli-ci/ci/installers/rpm
-        	cp $root/out/cf-cli_linux_i686 cf8
-        	cp ../../license/NOTICE .
-        	cp ../../license/LICENSE-WITH-3RD-PARTY-LICENSES LICENSE
-        	cp ../completion/cf8 cf8.bash
-        	echo "Version: ${RPM_VERSION}" > cf-cli.spec
-        	cat cf8-cli.spec.template >> cf-cli.spec
-        	rpmbuild --target i386 --define "_topdir $(pwd)/build" -bb cf-cli.spec
-        	mv build/RPMS/i386/cf8-cli*.rpm $root/packaged/cf8-cli-installer_${BUILD_VERSION}_i686.rpm
-          popd
-        )
-
-
-        echo "Build 64-bit RedHat package"
-        (
-          pushd cli-ci/ci/installers/rpm
-        	cp $root/out/cf-cli_linux_x86-64 cf8
-        	cp ../../license/NOTICE .
-        	cp ../../license/LICENSE-WITH-3RD-PARTY-LICENSES LICENSE
-        	cp ../completion/cf8 cf8.bash
-        	echo "Version: ${RPM_VERSION}" > cf-cli.spec
-        	cat cf8-cli.spec.template >> cf-cli.spec
-        	rpmbuild --target x86_64 --define "_topdir $(pwd)/build" -bb cf-cli.spec
-        	mv build/RPMS/x86_64/cf8-cli*.rpm $root/packaged/cf8-cli-installer_${BUILD_VERSION}_x86-64.rpm
-          popd
-        )
-
-        echo "Build aarch64 RedHat package"
-        (
-          pushd cli-ci/ci/installers/rpm
-        	cp $root/out/cf-cli_linux_arm64 cf8
-        	cp ../../license/NOTICE .
-        	cp ../../license/LICENSE-WITH-3RD-PARTY-LICENSES LICENSE
-        	cp ../completion/cf8 cf8.bash
-        	echo "Version: ${RPM_VERSION}" > cf-cli.spec
-        	cat cf8-cli.spec.template >> cf-cli.spec
-        	rpmbuild --target aarch64 --define "_topdir $(pwd)/build" -bb cf-cli.spec
-        	mv build/RPMS/aarch64/cf8-cli*.rpm $root/packaged/cf8-cli-installer_${BUILD_VERSION}_aarch64.rpm
-          popd
-        )
+        for arch in "${!arch_array[@]}"; do
+          echo "Build ${arch_array[$arch]} RedHat package"
+          (
+            pushd cli-ci/ci/installers/rpm
+            cp $root/out/cf-cli_linux_$arch cf8
+            cp ../../license/NOTICE .
+            cp ../../license/LICENSE-WITH-3RD-PARTY-LICENSES LICENSE
+            cp ../completion/cf8 cf8.bash
+            echo "Version: ${RPM_VERSION}" > cf-cli.spec
+            cat cf8-cli.spec.template >> cf-cli.spec
+            rpmbuild --target $arch --define "_topdir $(pwd)/build" -bb cf-cli.spec
+            mv build/RPMS/$arch/cf8-cli*.rpm $root/packaged/cf8-cli-installer_${VERSION_BUILD}_${arch}.rpm
+            popd
+          )
+        done
 
     - name: Load GPG key
       env:
@@ -307,107 +281,45 @@ jobs:
         set -ex
         set -o pipefail
 
+        declare -A arch_array=([i686]="32-bit" [x86_64]="64-bit" [arm64]='arm-64bit')
         root=$PWD
 
         mkdir -pv $root/packaged-deb
+        for arch in "${!arch_array[@]}"; do
+          echo "Build ${arch_array[$arch]} Debian package"
+          (
+            SIZE="$(BLOCKSIZE=1000 du $root/out/cf-cli_linux_$arch | cut -f 1)"
 
-        echo "Build 32-bit Debian package"
-        (
-          SIZE="$(BLOCKSIZE=1000 du $root/out/cf-cli_linux_i686 | cut -f 1)"
+            pushd cli-ci/ci/installers/deb
+              mkdir -p cf/usr/bin cf/usr/share/doc/cf${VERSION_MAJOR}-cli/ cf/DEBIAN cf/usr/share/bash-completion/completions
 
-          pushd cli-ci/ci/installers/deb
-            mkdir -p cf/usr/bin cf/usr/share/doc/cf8-cli/ cf/DEBIAN cf/usr/share/bash-completion/completions
+              cp copyright_preamble cf/DEBIAN/copyright
+              sed 's/^$/ ./' $root/LICENSE >> cf/DEBIAN/copyright
+              cat copyright_comment_header >> cf/DEBIAN/copyright
+              sed 's/^$/ ./' ../../license/3RD-PARTY-LICENSES >> cf/DEBIAN/copyright
 
-            cp copyright_preamble cf/DEBIAN/copyright
-            sed 's/^$/ ./' $root/LICENSE >> cf/DEBIAN/copyright
-            cat copyright_comment_header >> cf/DEBIAN/copyright
-            sed 's/^$/ ./' ../../license/3RD-PARTY-LICENSES >> cf/DEBIAN/copyright
+              cp cf/DEBIAN/copyright cf/usr/share/doc/cf${VERSION_MAJOR}-cli/copyright
 
-            cp cf/DEBIAN/copyright cf/usr/share/doc/cf8-cli/copyright
+              cp ../../license/NOTICE cf/usr/share/doc/cf${VERSION_MAJOR}-cli
+              cp ../../license/LICENSE-WITH-3RD-PARTY-LICENSES cf/usr/share/doc/cf${VERSION_MAJOR}-cli/LICENSE
 
-            cp ../../license/NOTICE cf/usr/share/doc/cf8-cli
-            cp ../../license/LICENSE-WITH-3RD-PARTY-LICENSES cf/usr/share/doc/cf8-cli/LICENSE
+              cp control_v${VERSION_MAJOR}.template cf/DEBIAN/control
+              echo "Installed-Size: ${SIZE}" >> cf/DEBIAN/control
+              echo "Version: ${VERSION_BUILD}" >> cf/DEBIAN/control
+              echo "Architecture: $arch" >> cf/DEBIAN/control
 
-            cp control_v8.template cf/DEBIAN/control
-            echo "Installed-Size: ${SIZE}" >> cf/DEBIAN/control
-            echo "Version: ${BUILD_VERSION}" >> cf/DEBIAN/control
-            echo "Architecture: i386" >> cf/DEBIAN/control
+              cp ../completion/cf${VERSION_MAJOR} cf/usr/share/bash-completion/completions/cf${VERSION_MAJOR}
 
-            cp ../completion/cf8 cf/usr/share/bash-completion/completions/cf8
+              cp $root/out/cf-cli_linux_$arch cf/usr/bin/cf${VERSION_MAJOR}
+              ln -frs cf/usr/bin/cf${VERSION_MAJOR} cf/usr/bin/cf
 
-            cp $root/out/cf-cli_linux_i686 cf/usr/bin/cf8
-            ln -frs cf/usr/bin/cf8 cf/usr/bin/cf
-
-            fakeroot dpkg --build cf cf8-cli-installer_${BUILD_VERSION}_i686.deb
-            mv cf8-cli-installer_${BUILD_VERSION}_i686.deb $root/packaged-deb
-            rm -rf cf
-          popd
-        )
-
-        echo "Build 64-bit Debian package"
-        (
-          SIZE="$(BLOCKSIZE=1000 du $root/out/cf-cli_linux_x86-64 | cut -f 1)"
-
-          pushd cli-ci/ci/installers/deb
-            mkdir -p cf/usr/bin cf/usr/share/doc/cf8-cli/ cf/DEBIAN cf/usr/share/bash-completion/completions
-
-            cp copyright_preamble cf/DEBIAN/copyright
-            sed 's/^$/ ./' $root/LICENSE >> cf/DEBIAN/copyright
-            cat copyright_comment_header >> cf/DEBIAN/copyright
-            sed 's/^$/ ./' ../../license/3RD-PARTY-LICENSES >> cf/DEBIAN/copyright
-
-            cp cf/DEBIAN/copyright cf/usr/share/doc/cf8-cli/copyright
-
-            cp ../../license/NOTICE cf/usr/share/doc/cf8-cli
-            cp ../../license/LICENSE-WITH-3RD-PARTY-LICENSES cf/usr/share/doc/cf8-cli/LICENSE
-
-            cp control_v8.template cf/DEBIAN/control
-            echo "Installed-Size: ${SIZE}" >> cf/DEBIAN/control
-            echo "Version: ${BUILD_VERSION}" >> cf/DEBIAN/control
-            echo "Architecture: amd64" >> cf/DEBIAN/control
-
-            cp ../completion/cf8 cf/usr/share/bash-completion/completions/cf8
-
-            cp $root/out/cf-cli_linux_x86-64 cf/usr/bin/cf8
-            ln -frs cf/usr/bin/cf8 cf/usr/bin/cf
-
-            fakeroot dpkg --build cf cf8-cli-installer_${BUILD_VERSION}_x86-64.deb
-            mv cf8-cli-installer_${BUILD_VERSION}_x86-64.deb $root/packaged-deb
-          popd
-        )
-
-        echo "Build arm64 Debian package"
-        (
-          SIZE="$(BLOCKSIZE=1000 du $root/out/cf-cli_linux_arm64 | cut -f 1)"
-
-          pushd cli-ci/ci/installers/deb
-            mkdir -p cf/usr/bin cf/usr/share/doc/cf8-cli/ cf/DEBIAN cf/usr/share/bash-completion/completions
-
-            cp copyright_preamble cf/DEBIAN/copyright
-            sed 's/^$/ ./' $root/LICENSE >> cf/DEBIAN/copyright
-            cat copyright_comment_header >> cf/DEBIAN/copyright
-            sed 's/^$/ ./' ../../license/3RD-PARTY-LICENSES >> cf/DEBIAN/copyright
-
-            cp cf/DEBIAN/copyright cf/usr/share/doc/cf8-cli/copyright
-
-            cp ../../license/NOTICE cf/usr/share/doc/cf8-cli
-            cp ../../license/LICENSE-WITH-3RD-PARTY-LICENSES cf/usr/share/doc/cf8-cli/LICENSE
-
-            cp control_v8.template cf/DEBIAN/control
-            echo "Installed-Size: ${SIZE}" >> cf/DEBIAN/control
-            echo "Version: ${BUILD_VERSION}" >> cf/DEBIAN/control
-            echo "Architecture: arm64" >> cf/DEBIAN/control
-
-            cp ../completion/cf8 cf/usr/share/bash-completion/completions/cf8
-
-            cp $root/out/cf-cli_linux_arm64 cf/usr/bin/cf8
-            ln -frs cf/usr/bin/cf8 cf/usr/bin/cf
-
-            fakeroot dpkg --build cf cf8-cli-installer_${BUILD_VERSION}_arm64.deb
-            mv cf8-cli-installer_${BUILD_VERSION}_arm64.deb $root/packaged-deb
-          popd
-        )
-
+              fakeroot dpkg --build cf cf${VERSION_MAJOR}-cli-installer_${VERSION_BUILD}_${arch}.deb
+              mv cf${VERSION_MAJOR}-cli-installer_${VERSION_BUILD}_${arch}.deb $root/packaged-deb
+              rm -rf cf
+            popd
+          )
+        done
+      
     - name: Print DEB Packages Info
       run: |
         ls -R

--- a/.github/workflows/release-build-sign-upload.yml
+++ b/.github/workflows/release-build-sign-upload.yml
@@ -396,7 +396,7 @@ jobs:
             cp control_v8.template cf/DEBIAN/control
             echo "Installed-Size: ${SIZE}" >> cf/DEBIAN/control
             echo "Version: ${BUILD_VERSION}" >> cf/DEBIAN/control
-            echo "Architecture: amd64" >> cf/DEBIAN/control
+            echo "Architecture: arm64" >> cf/DEBIAN/control
 
             cp ../completion/cf8 cf/usr/share/bash-completion/completions/cf8
 

--- a/.github/workflows/release-update-repos.yml
+++ b/.github/workflows/release-update-repos.yml
@@ -246,6 +246,7 @@ jobs:
         mkdir installers
         curl -L "https://cli.run.pivotal.io/stable?release=debian32&version=${BUILD_VERSION}&source=github-rel" > installers/cf8-cli-installer_${BUILD_VERSION}_i686.deb
         curl -L "https://cli.run.pivotal.io/stable?release=debian64&version=${BUILD_VERSION}&source=github-rel" > installers/cf8-cli-installer_${BUILD_VERSION}_x86-64.deb
+        curl -L "https://cli.run.pivotal.io/stable?release=debianarm64&version=${BUILD_VERSION}&source=github-rel" > installers/cf8-cli-installer_${BUILD_VERSION}_arm64.deb
 
     - name: Update Debian Repository
       env:

--- a/.github/workflows/release-update-repos.yml
+++ b/.github/workflows/release-update-repos.yml
@@ -83,6 +83,12 @@ jobs:
         # Because CLAW always returns 200 we have to check if we got archive
         file cf8-cli-linux-tarball/cf8-cli_${BUILD_VERSION}_linux64.tgz | grep -q gzip || exit 1
 
+        curl -L "https://packages.cloudfoundry.org/stable?release=linuxarm64-binary&version=${BUILD_VERSION}&source=github-rel" \
+          > cf8-cli-linux-tarball/cf8-cli_${BUILD_VERSION}_linuxarm64.tgz
+
+        # Because CLAW always returns 200 we have to check if we got archive
+        file cf8-cli-linux-tarball/cf8-cli_${BUILD_VERSION}_linuxarm64.tgz | grep -q gzip || exit 1
+
         pushd cf8-cli-osx-tarball
           CLI_OSX_SHA256=$(shasum -a 256 cf8-cli_*_osx.tgz | cut -d ' ' -f 1)
         popd
@@ -91,8 +97,13 @@ jobs:
           CLI_LINUX_64_SHA256=$(shasum -a 256 cf8-cli_*_linux64.tgz | cut -d ' ' -f 1)
         popd
 
+        pushd cf8-cli-linux-tarball
+          CLI_LINUX_ARM64_SHA256=$(shasum -a 256 cf8-cli_*_linuxarm64.tgz | cut -d ' ' -f 1)
+        popd
+
         echo "CLI_OSX_SHA256=${CLI_OSX_SHA256}" >> $GITHUB_ENV
         echo "CLI_LINUX_64_SHA256=${CLI_LINUX_64_SHA256}" >> $GITHUB_ENV
+        echo "CLI_LINUX_ARM64_SHA256=${CLI_LINUX_ARM64_SHA256}" >> $GITHUB_ENV
 
     - name: Generate Homebrew formula file
       run: |

--- a/bin/generate-release-notes
+++ b/bin/generate-release-notes
@@ -9,14 +9,14 @@ Package Manager Installation
 
 Installers
 ----------
-- Debian [64 bit](https://packages.cloudfoundry.org/stable?release=debian64&version=$VERSION&source=github-rel) / [32 bit](https://packages.cloudfoundry.org/stable?release=debian32&version=$VERSION&source=github-rel) (deb)
-- Redhat [64 bit](https://packages.cloudfoundry.org/stable?release=redhat64&version=$VERSION&source=github-rel) / [32 bit](https://packages.cloudfoundry.org/stable?release=redhat32&version=$VERSION&source=github-rel) (rpm)
+- Debian [64 bit](https://packages.cloudfoundry.org/stable?release=debian64&version=$VERSION&source=github-rel) / [32 bit](https://packages.cloudfoundry.org/stable?release=debian32&version=$VERSION&source=github-rel) (deb) / [arm64](https://packages.cloudfoundry.org/stable?release=debianarm64&version=$VERSION&source=github-rel)
+- Redhat [64 bit](https://packages.cloudfoundry.org/stable?release=redhat64&version=$VERSION&source=github-rel) / [32 bit](https://packages.cloudfoundry.org/stable?release=redhat32&version=$VERSION&source=github-rel) (rpm) / [aarch64](https://packages.cloudfoundry.org/stable?release=redhataarch64&version=$VERSION&source=github-rel)
 - Mac OS X [64 bit](https://packages.cloudfoundry.org/stable?release=macosx64&version=$VERSION&source=github-rel) (pkg)
 - Windows [64 bit](https://packages.cloudfoundry.org/stable?release=windows64&version=$VERSION&source=github-rel) / [32 bit](https://packages.cloudfoundry.org/stable?release=windows32&version=$VERSION&source=github-rel) (zip)
 
 Binaries
 --------
-- Linux [64 bit](https://packages.cloudfoundry.org/stable?release=linux64-binary&version=$VERSION&source=github-rel) / [32 bit](https://packages.cloudfoundry.org/stable?release=linux32-binary&version=$VERSION&source=github-rel) (tgz)
+- Linux [64 bit](https://packages.cloudfoundry.org/stable?release=linux64-binary&version=$VERSION&source=github-rel) / [32 bit](https://packages.cloudfoundry.org/stable?release=linux32-binary&version=$VERSION&source=github-rel) (tgz) / [arm64](https://packages.cloudfoundry.org/stable?release=linuxarm64-binary&version=$VERSION&source=github-rel)
 - Mac OS X [64 bit](https://packages.cloudfoundry.org/stable?release=macosx64-binary&version=$VERSION&source=github-rel) (tgz)
 - Windows [64 bit](https://packages.cloudfoundry.org/stable?release=windows64-exe&version=$VERSION&source=github-rel) / [32 bit](https://packages.cloudfoundry.org/stable?release=windows32-exe&version=$VERSION&source=github-rel) (zip)
 


### PR DESCRIPTION
## Does this PR modify CLI v6, CLI v7, or CLI v8?
all

## Description of the Change

Edit pipelines to produce release for Linux arm64 arch.
included are linux binary, RPM and deb packages

## Why Is This PR Valuable?

We need to be able to run the CLI from linux/arm64 architectures.
Chances are we're not in deep need to run it from our RPI's but from linux containers on top of M1/2... Mac. 

## Why Should This Be In Core?

n/a

## Applicable Issues

https://github.com/cloudfoundry/cli/issues/2338
https://github.com/cloudfoundry/cli/issues/2293

## How Urgent Is The Change?

I believe we needed it last year. Second most suitable time would be next release.

## Other Relevant Parties

All those fellas in the apple garden running cf from linux containers would benefit. Also those enjoying ARM64 instances in their various clouds.
