### PR TITLE
feat: --update-if-exists flag for create-service-broker (main)

### DIFF
--- a/command/v7/update_service_broker_command.go
+++ b/command/v7/update_service_broker_command.go
@@ -1,6 +1,7 @@
 package v7
 
 import (
+	"code.cloudfoundry.org/cli/command"
 	"code.cloudfoundry.org/cli/command/flag"
 	"code.cloudfoundry.org/cli/resources"
 )
@@ -35,28 +36,32 @@ func (cmd UpdateServiceBrokerCommand) Execute(args []string) error {
 		return err
 	}
 
-	cmd.UI.DisplayTextWithFlavor(
+	return updateServiceBroker(cmd.UI, cmd.Actor, user.Name, serviceBroker.GUID, brokerName, username, password, url)
+}
+
+func updateServiceBroker(ui command.UI, actor Actor, user, brokerGUID, brokerName, username, password, url string) error {
+	ui.DisplayTextWithFlavor(
 		"Updating service broker {{.ServiceBroker}} as {{.Username}}...",
 		map[string]any{
-			"Username":      user.Name,
+			"Username":      user,
 			"ServiceBroker": brokerName,
 		},
 	)
 
-	warnings, err = cmd.Actor.UpdateServiceBroker(
-		serviceBroker.GUID,
+	warnings, err := actor.UpdateServiceBroker(
+		brokerGUID,
 		resources.ServiceBroker{
 			Username: username,
 			Password: password,
 			URL:      url,
 		},
 	)
-	cmd.UI.DisplayWarnings(warnings)
+	ui.DisplayWarnings(warnings)
 	if err != nil {
 		return err
 	}
 
-	cmd.UI.DisplayOK()
+	ui.DisplayOK()
 
 	return nil
 }


### PR DESCRIPTION
## Does this PR modify CLI v6, CLI v7, or CLI v8?
- v8

## Description of the Change

A very common pattern is to have scripting like:
```
cf create-service-broker $SERVICE_BROKER_NAME $USERNAME $PASSWORD $APP_URL || cf update-service-broker $SERVICE_BROKER_NAME $USERNAME $PASSWORD $APP_URL
```

This is not ideal because:
- it's a duplicated pattern that the CF CLI could handle better
- it does not check the error type
- it results in a failure being logged, when in fact there was none

Adding a --update-if-exists flag to the CF CLI allows the following
alternative:
```
cf create-service-broker $SERVICE_BROKER_NAME $USERNAME $PASSWORD $APP_URL --update-if-exists
```

## Why Is This PR Valuable?

It gives script users a better and safer experience using the CF CLI

## Why Should This Be In Core?

It's a change to a core command

## Applicable Issues

None

## How Urgent Is The Change?

It's likely that a lot of create-broker scripts will need to be updated for password hiding enabled in #2400. Although not strictly urgent, it makes sense for this to be in the same release.

## Other Relevant Parties

None