### PR TITLE
fix: hide password for create-service-broker (v8)

### DIFF
--- a/command/flag/arguments.go
+++ b/command/flag/arguments.go
@@ -324,8 +324,8 @@ type ServiceBroker struct {
 type ServiceBrokerArgs struct {
 	ServiceBroker string `positional-arg-name:"SERVICE_BROKER" required:"true" description:"The service broker name"`
 	Username      string `positional-arg-name:"USERNAME" required:"true" description:"The username"`
-	Password      string `positional-arg-name:"PASSWORD" required:"true" description:"The password"`
-	URL           string `positional-arg-name:"URL" required:"true" description:"The URL of the service broker"`
+	PasswordOrURL string `positional-arg-name:"URL" required:"true" description:"The URL of the service broker"`
+	URL           string `positional-arg-name:"URL" description:"The URL of the service broker"`
 }
 
 type RenameServiceBrokerArgs struct {

--- a/command/v7/create_service_broker_command.go
+++ b/command/v7/create_service_broker_command.go
@@ -1,6 +1,9 @@
 package v7
 
 import (
+	"os"
+
+	"code.cloudfoundry.org/cli/command"
 	"code.cloudfoundry.org/cli/command/flag"
 	"code.cloudfoundry.org/cli/resources"
 	"code.cloudfoundry.org/cli/util/configv3"
@@ -9,14 +12,20 @@ import (
 type CreateServiceBrokerCommand struct {
 	BaseCommand
 
-	RequiredArgs    flag.ServiceBrokerArgs `positional-args:"yes"`
+	PositionalArgs  flag.ServiceBrokerArgs `positional-args:"yes"`
 	SpaceScoped     bool                   `long:"space-scoped" description:"Make the broker's service plans only visible within the targeted space"`
-	usage           interface{}            `usage:"CF_NAME create-service-broker SERVICE_BROKER USERNAME PASSWORD URL [--space-scoped]"`
-	relatedCommands interface{}            `related_commands:"enable-service-access, service-brokers, target"`
+	usage           any                    `usage:"CF_NAME create-service-broker SERVICE_BROKER USERNAME PASSWORD URL [--space-scoped]\n   CF_NAME create-service-broker SERVICE_BROKER USERNAME URL [--space-scoped] (omit password to specify interactively or via environment variable)\n\nWARNING:\n   Providing your password as a command line option is highly discouraged\n   Your password may be visible to others and may be recorded in your shell history"`
+	relatedCommands any                    `related_commands:"enable-service-access, service-brokers, target"`
+	envPassword     any                    `environmentName:"CF_BROKER_PASSWORD" environmentDescription:"Password associated with user. Overridden if PASSWORD argument is provided" environmentDefault:"password"`
 }
 
 func (cmd *CreateServiceBrokerCommand) Execute(args []string) error {
 	err := cmd.SharedActor.CheckTarget(cmd.SpaceScoped, cmd.SpaceScoped)
+	if err != nil {
+		return err
+	}
+
+	brokerName, username, password, url, err := promptUserForBrokerPasswordIfRequired(cmd.PositionalArgs, cmd.UI)
 	if err != nil {
 		return err
 	}
@@ -31,9 +40,9 @@ func (cmd *CreateServiceBrokerCommand) Execute(args []string) error {
 		space = cmd.Config.TargetedSpace()
 		cmd.UI.DisplayTextWithFlavor(
 			"Creating service broker {{.ServiceBroker}} in org {{.Org}} / space {{.Space}} as {{.Username}}...",
-			map[string]interface{}{
+			map[string]any{
 				"Username":      user.Name,
-				"ServiceBroker": cmd.RequiredArgs.ServiceBroker,
+				"ServiceBroker": brokerName,
 				"Org":           cmd.Config.TargetedOrganizationName(),
 				"Space":         space.Name,
 			},
@@ -41,19 +50,19 @@ func (cmd *CreateServiceBrokerCommand) Execute(args []string) error {
 	} else {
 		cmd.UI.DisplayTextWithFlavor(
 			"Creating service broker {{.ServiceBroker}} as {{.Username}}...",
-			map[string]interface{}{
+			map[string]any{
 				"Username":      user.Name,
-				"ServiceBroker": cmd.RequiredArgs.ServiceBroker,
+				"ServiceBroker": brokerName,
 			},
 		)
 	}
 
 	warnings, err := cmd.Actor.CreateServiceBroker(
 		resources.ServiceBroker{
-			Name:      cmd.RequiredArgs.ServiceBroker,
-			Username:  cmd.RequiredArgs.Username,
-			Password:  cmd.RequiredArgs.Password,
-			URL:       cmd.RequiredArgs.URL,
+			Name:      brokerName,
+			Username:  username,
+			Password:  password,
+			URL:       url,
 			SpaceGUID: space.GUID,
 		},
 	)
@@ -64,4 +73,21 @@ func (cmd *CreateServiceBrokerCommand) Execute(args []string) error {
 
 	cmd.UI.DisplayOK()
 	return nil
+}
+
+func promptUserForBrokerPasswordIfRequired(args flag.ServiceBrokerArgs, ui command.UI) (string, string, string, string, error) {
+	if args.URL != "" {
+		return args.ServiceBroker, args.Username, args.PasswordOrURL, args.URL, nil
+	}
+
+	if password, ok := os.LookupEnv("CF_BROKER_PASSWORD"); ok {
+		return args.ServiceBroker, args.Username, password, args.PasswordOrURL, nil
+	}
+
+	password, err := ui.DisplayPasswordPrompt("Service Broker Password")
+	if err != nil {
+		return "", "", "", "", err
+	}
+
+	return args.ServiceBroker, args.Username, password, args.PasswordOrURL, nil
 }

--- a/command/v7/create_user_provided_service_command.go
+++ b/command/v7/create_user_provided_service_command.go
@@ -24,7 +24,7 @@ func (cmd CreateUserProvidedServiceCommand) Execute(args []string) error {
 		return err
 	}
 
-	if err := PromptUserForCredentialsIfRequired(&cmd.Credentials, cmd.UI); err != nil {
+	if err := promptUserForCredentialsIfRequired(&cmd.Credentials, cmd.UI); err != nil {
 		return err
 	}
 
@@ -69,7 +69,7 @@ func (cmd CreateUserProvidedServiceCommand) displayMessage() error {
 	return nil
 }
 
-func PromptUserForCredentialsIfRequired(flag *flag.CredentialsOrJSON, ui command.UI) error {
+func promptUserForCredentialsIfRequired(flag *flag.CredentialsOrJSON, ui command.UI) error {
 	if len(flag.UserPromptCredentials) > 0 {
 		flag.Value = make(map[string]interface{})
 

--- a/command/v7/update_user_provided_service_command.go
+++ b/command/v7/update_user_provided_service_command.go
@@ -25,7 +25,7 @@ func (cmd *UpdateUserProvidedServiceCommand) Execute(args []string) error {
 		return err
 	}
 
-	if err := PromptUserForCredentialsIfRequired(&cmd.Credentials, cmd.UI); err != nil {
+	if err := promptUserForCredentialsIfRequired(&cmd.Credentials, cmd.UI); err != nil {
 		return err
 	}
 

--- a/integration/v7/isolated/create_service_broker_command_test.go
+++ b/integration/v7/isolated/create_service_broker_command_test.go
@@ -28,22 +28,9 @@ var _ = Describe("create-service-broker command", func() {
 		When("--help flag is set", func() {
 			It("displays command usage to output", func() {
 				session := helpers.CF("create-service-broker", "--help")
-				Eventually(session).Should(Say("NAME:"))
-				Eventually(session).Should(Say("\\s+create-service-broker - Create a service broker"))
-
-				Eventually(session).Should(Say("USAGE:"))
-				Eventually(session).Should(Say("\\s+cf create-service-broker SERVICE_BROKER USERNAME PASSWORD URL \\[--space-scoped\\]"))
-
-				Eventually(session).Should(Say("ALIAS:"))
-				Eventually(session).Should(Say("\\s+csb"))
-
-				Eventually(session).Should(Say("OPTIONS:"))
-				Eventually(session).Should(Say("\\s+--space-scoped      Make the broker's service plans only visible within the targeted space"))
-
-				Eventually(session).Should(Say("SEE ALSO:"))
-				Eventually(session).Should(Say("\\s+enable-service-access, service-brokers, target"))
-
 				Eventually(session).Should(Exit(0))
+
+				expectToRenderCreateServiceBrokerHelp(session)
 			})
 		})
 	})
@@ -185,24 +172,36 @@ var _ = Describe("create-service-broker command", func() {
 	When("no arguments are provided", func() {
 		It("displays an error, naming each of the missing args and the help text", func() {
 			session := helpers.CF("create-service-broker")
-			Eventually(session.Err).Should(Say("Incorrect Usage: the required arguments `SERVICE_BROKER`, `USERNAME`, `PASSWORD` and `URL` were not provided"))
-
-			Eventually(session).Should(Say("NAME:"))
-			Eventually(session).Should(Say("\\s+create-service-broker - Create a service broker"))
-
-			Eventually(session).Should(Say("USAGE:"))
-			Eventually(session).Should(Say("\\s+cf create-service-broker SERVICE_BROKER USERNAME PASSWORD URL \\[--space-scoped\\]"))
-
-			Eventually(session).Should(Say("ALIAS:"))
-			Eventually(session).Should(Say("\\s+csb"))
-
-			Eventually(session).Should(Say("OPTIONS:"))
-			Eventually(session).Should(Say("\\s+--space-scoped      Make the broker's service plans only visible within the targeted space"))
-
-			Eventually(session).Should(Say("SEE ALSO:"))
-			Eventually(session).Should(Say("\\s+enable-service-access, service-brokers, target"))
-
 			Eventually(session).Should(Exit(1))
+
+			expectToRenderCreateServiceBrokerHelp(session)
 		})
 	})
 })
+
+func expectToRenderCreateServiceBrokerHelp(s *Session) {
+	Expect(s).To(SatisfyAll(
+		Say(`NAME:`),
+		Say(`\s+create-service-broker - Create a service broker`),
+
+		Say(`USAGE:`),
+		Say(`\s+cf create-service-broker SERVICE_BROKER USERNAME PASSWORD URL \[--space-scoped\]`),
+		Say(`\s+cf create-service-broker SERVICE_BROKER USERNAME URL \[--space-scoped\]`),
+
+		Say(`WARNING:`),
+		Say(`\s+Providing your password as a command line option is highly discouraged`),
+		Say(`\s+Your password may be visible to others and may be recorded in your shell history`),
+
+		Say(`ALIAS:`),
+		Say(`\s+csb`),
+
+		Say(`OPTIONS:`),
+		Say(`\s+--space-scoped      Make the broker's service plans only visible within the targeted space`),
+
+		Say(`ENVIRONMENT:`),
+		Say(`\s+CF_BROKER_PASSWORD=password\s+Password associated with user. Overridden if PASSWORD argument is provided`),
+
+		Say(`SEE ALSO:`),
+		Say(`\s+enable-service-access, service-brokers, target`),
+	))
+}

--- a/integration/v7/isolated/update_service_broker_command_test.go
+++ b/integration/v7/isolated/update_service_broker_command_test.go
@@ -141,10 +141,10 @@ var _ = Describe("update-service-broker command", func() {
 	When("passing incorrect parameters", func() {
 		It("prints an error message", func() {
 			session := helpers.CF("update-service-broker", "b1")
-
-			Eventually(session.Err).Should(Say("Incorrect Usage: the required arguments `USERNAME`, `PASSWORD` and `URL` were not provided"))
-			eventuallyRendersUpdateServiceBrokerHelp(session)
 			Eventually(session).Should(Exit(1))
+
+			Expect(session.Err).To(Say("Incorrect Usage: the required arguments `USERNAME` and `URL` were not provided"))
+			expectToRenderUpdateServiceBrokerHelp(session)
 		})
 	})
 
@@ -157,18 +157,26 @@ var _ = Describe("update-service-broker command", func() {
 	When("passing --help", func() {
 		It("displays command usage to output", func() {
 			session := helpers.CF("update-service-broker", "--help")
-
-			eventuallyRendersUpdateServiceBrokerHelp(session)
 			Eventually(session).Should(Exit(0))
+
+			expectToRenderUpdateServiceBrokerHelp(session)
 		})
 	})
 })
 
-func eventuallyRendersUpdateServiceBrokerHelp(s *Session) {
-	Eventually(s).Should(Say("NAME:"))
-	Eventually(s).Should(Say("update-service-broker - Update a service broker"))
-	Eventually(s).Should(Say("USAGE:"))
-	Eventually(s).Should(Say("cf update-service-broker SERVICE_BROKER USERNAME PASSWORD URL"))
-	Eventually(s).Should(Say("SEE ALSO:"))
-	Eventually(s).Should(Say("rename-service-broker, service-brokers"))
+func expectToRenderUpdateServiceBrokerHelp(s *Session) {
+	Expect(s).To(SatisfyAll(
+		Say("NAME:"),
+		Say("update-service-broker - Update a service broker"),
+		Say("USAGE:"),
+		Say("cf update-service-broker SERVICE_BROKER USERNAME PASSWORD URL"),
+		Say("cf update-service-broker SERVICE_BROKER USERNAME URL"),
+		Say(`WARNING:`),
+		Say(`\s+Providing your password as a command line option is highly discouraged`),
+		Say(`\s+Your password may be visible to others and may be recorded in your shell history`),
+		Say(`ENVIRONMENT:`),
+		Say(`\s+CF_BROKER_PASSWORD=password\s+Password associated with user. Overridden if PASSWORD argument is provided`),
+		Say("SEE ALSO:"),
+		Say("rename-service-broker, service-brokers"),
+	))
 }


### PR DESCRIPTION
## Does this PR modify CLI v6, CLI v7, or CLI v8?
- v8

Please see the contribution doc above or review [Architecture Guide](https://github.com/cloudfoundry/cli/wiki/Architecture-Guide).

## Description of the Change
The `cf create-service-broker` command did not allow the password to be specified as an environment variable or via a prompt, meaning that users with certain logging options ended up with a password in the log. This fix brings the `cf create-service-broker` and `cf update-service-broker` into line with `cf auth` and `cf login` which allow credentials to be specified via environment variables and interactive prompts.

## Why Is This PR Valuable?

It fixes a security issue that users have raised

## Why Should This Be In Core?

Because it's a fix to an existing core command

## Applicable Issues

List any applicable GitHub Issues here

## How Urgent Is The Change?

Is the change urgent? If so, explain why it is time-sensitive.

## Other Relevant Parties

Who else is affected by the change? 
