### PR TITLE
feat: add --wait flag to upgrade-service (v8)

### DIFF
--- a/command/v7/actor.go
+++ b/command/v7/actor.go
@@ -238,7 +238,7 @@ type Actor interface {
 	UpdateDestination(string, string, string) (v7action.Warnings, error)
 	UpdateDomainLabelsByDomainName(string, map[string]types.NullString) (v7action.Warnings, error)
 	UpdateManagedServiceInstance(params v7action.UpdateManagedServiceInstanceParams) (chan v7action.PollJobEvent, v7action.Warnings, error)
-	UpgradeManagedServiceInstance(serviceInstanceName, spaceGUID string) (v7action.Warnings, error)
+	UpgradeManagedServiceInstance(serviceInstanceName, spaceGUID string) (chan v7action.PollJobEvent, v7action.Warnings, error)
 	UpdateOrganizationLabelsByOrganizationName(string, map[string]types.NullString) (v7action.Warnings, error)
 	UpdateOrganizationQuota(quotaName string, newName string, limits v7action.QuotaLimits) (v7action.Warnings, error)
 	UpdateProcessByTypeAndApplication(processType string, appGUID string, updatedProcess resources.Process) (v7action.Warnings, error)

--- a/command/v7/upgrade_service_command.go
+++ b/command/v7/upgrade_service_command.go
@@ -4,6 +4,7 @@ import (
 	"code.cloudfoundry.org/cli/actor/actionerror"
 	"code.cloudfoundry.org/cli/command/flag"
 	"code.cloudfoundry.org/cli/command/translatableerror"
+	"code.cloudfoundry.org/cli/command/v7/shared"
 )
 
 type UpgradeServiceCommand struct {
@@ -11,6 +12,7 @@ type UpgradeServiceCommand struct {
 
 	RequiredArgs flag.ServiceInstance `positional-args:"yes"`
 	Force        bool                 `short:"f" long:"force" description:"Force upgrade without asking for confirmation"`
+	Wait         bool                 `short:"w" long:"wait" description:"Wait for the operation to complete"`
 
 	relatedCommands interface{} `related_commands:"services, update-service, update-user-provided-service"`
 }
@@ -38,7 +40,7 @@ func (cmd UpgradeServiceCommand) Execute(args []string) error {
 
 	serviceInstanceName := string(cmd.RequiredArgs.ServiceInstance)
 
-	warnings, actorError := cmd.Actor.UpgradeManagedServiceInstance(
+	stream, warnings, actorError := cmd.Actor.UpgradeManagedServiceInstance(
 		serviceInstanceName,
 		cmd.Config.TargetedSpace().GUID,
 	)
@@ -46,8 +48,6 @@ func (cmd UpgradeServiceCommand) Execute(args []string) error {
 
 	switch actorError.(type) {
 	case nil:
-		cmd.displayUpgradeInProgressMessage()
-		cmd.UI.DisplayOK()
 	case actionerror.ServiceInstanceUpgradeNotAvailableError:
 		cmd.UI.DisplayText(actorError.Error())
 		cmd.UI.DisplayOK()
@@ -57,6 +57,17 @@ func (cmd UpgradeServiceCommand) Execute(args []string) error {
 		return actorError
 	}
 
+	complete, err := shared.WaitForResult(stream, cmd.UI, cmd.Wait)
+	switch {
+	case err != nil:
+		return err
+	case complete:
+		cmd.UI.DisplayTextWithFlavor("Upgrade of service instance {{.ServiceInstanceName}} complete.", cmd.serviceInstanceName())
+	default:
+		cmd.UI.DisplayTextWithFlavor("Upgrade in progress. Use 'cf services' or 'cf service {{.ServiceInstanceName}}' to check operation status.", cmd.serviceInstanceName())
+	}
+
+	cmd.UI.DisplayOK()
 	return nil
 }
 
@@ -79,6 +90,7 @@ func (cmd UpgradeServiceCommand) displayEvent() error {
 			"Username":            user.Name,
 		},
 	)
+	cmd.UI.DisplayNewline()
 
 	return nil
 }
@@ -101,15 +113,8 @@ func (cmd UpgradeServiceCommand) displayPrompt() (bool, error) {
 	return upgrade, nil
 }
 
-func (cmd UpgradeServiceCommand) displayUpgradeInProgressMessage() {
-	cmd.UI.DisplayTextWithFlavor("Upgrade in progress. Use 'cf services' or 'cf service {{.ServiceInstance}}' to check operation status.",
-		map[string]interface{}{
-			"ServiceInstance": cmd.RequiredArgs.ServiceInstance,
-		})
-}
-
-func (cmd UpgradeServiceCommand) serviceInstanceName() map[string]interface{} {
-	return map[string]interface{}{
+func (cmd UpgradeServiceCommand) serviceInstanceName() map[string]any {
+	return map[string]any{
 		"ServiceInstanceName": cmd.RequiredArgs.ServiceInstance,
 	}
 }

--- a/command/v7/v7fakes/fake_actor.go
+++ b/command/v7/v7fakes/fake_actor.go
@@ -3550,19 +3550,21 @@ type FakeActor struct {
 		result1 v7action.Warnings
 		result2 error
 	}
-	UpgradeManagedServiceInstanceStub        func(string, string) (v7action.Warnings, error)
+	UpgradeManagedServiceInstanceStub        func(string, string) (chan v7action.PollJobEvent, v7action.Warnings, error)
 	upgradeManagedServiceInstanceMutex       sync.RWMutex
 	upgradeManagedServiceInstanceArgsForCall []struct {
 		arg1 string
 		arg2 string
 	}
 	upgradeManagedServiceInstanceReturns struct {
-		result1 v7action.Warnings
-		result2 error
+		result1 chan v7action.PollJobEvent
+		result2 v7action.Warnings
+		result3 error
 	}
 	upgradeManagedServiceInstanceReturnsOnCall map[int]struct {
-		result1 v7action.Warnings
-		result2 error
+		result1 chan v7action.PollJobEvent
+		result2 v7action.Warnings
+		result3 error
 	}
 	UploadBitsPackageStub        func(resources.Package, []sharedaction.V3Resource, io.Reader, int64) (resources.Package, v7action.Warnings, error)
 	uploadBitsPackageMutex       sync.RWMutex
@@ -18883,7 +18885,7 @@ func (fake *FakeActor) UpdateUserProvidedServiceInstanceReturnsOnCall(i int, res
 	}{result1, result2}
 }
 
-func (fake *FakeActor) UpgradeManagedServiceInstance(arg1 string, arg2 string) (v7action.Warnings, error) {
+func (fake *FakeActor) UpgradeManagedServiceInstance(arg1 string, arg2 string) (chan v7action.PollJobEvent, v7action.Warnings, error) {
 	fake.upgradeManagedServiceInstanceMutex.Lock()
 	ret, specificReturn := fake.upgradeManagedServiceInstanceReturnsOnCall[len(fake.upgradeManagedServiceInstanceArgsForCall)]
 	fake.upgradeManagedServiceInstanceArgsForCall = append(fake.upgradeManagedServiceInstanceArgsForCall, struct {
@@ -18896,10 +18898,10 @@ func (fake *FakeActor) UpgradeManagedServiceInstance(arg1 string, arg2 string) (
 		return fake.UpgradeManagedServiceInstanceStub(arg1, arg2)
 	}
 	if specificReturn {
-		return ret.result1, ret.result2
+		return ret.result1, ret.result2, ret.result3
 	}
 	fakeReturns := fake.upgradeManagedServiceInstanceReturns
-	return fakeReturns.result1, fakeReturns.result2
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
 func (fake *FakeActor) UpgradeManagedServiceInstanceCallCount() int {
@@ -18908,7 +18910,7 @@ func (fake *FakeActor) UpgradeManagedServiceInstanceCallCount() int {
 	return len(fake.upgradeManagedServiceInstanceArgsForCall)
 }
 
-func (fake *FakeActor) UpgradeManagedServiceInstanceCalls(stub func(string, string) (v7action.Warnings, error)) {
+func (fake *FakeActor) UpgradeManagedServiceInstanceCalls(stub func(string, string) (chan v7action.PollJobEvent, v7action.Warnings, error)) {
 	fake.upgradeManagedServiceInstanceMutex.Lock()
 	defer fake.upgradeManagedServiceInstanceMutex.Unlock()
 	fake.UpgradeManagedServiceInstanceStub = stub
@@ -18921,30 +18923,33 @@ func (fake *FakeActor) UpgradeManagedServiceInstanceArgsForCall(i int) (string, 
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeActor) UpgradeManagedServiceInstanceReturns(result1 v7action.Warnings, result2 error) {
+func (fake *FakeActor) UpgradeManagedServiceInstanceReturns(result1 chan v7action.PollJobEvent, result2 v7action.Warnings, result3 error) {
 	fake.upgradeManagedServiceInstanceMutex.Lock()
 	defer fake.upgradeManagedServiceInstanceMutex.Unlock()
 	fake.UpgradeManagedServiceInstanceStub = nil
 	fake.upgradeManagedServiceInstanceReturns = struct {
-		result1 v7action.Warnings
-		result2 error
-	}{result1, result2}
+		result1 chan v7action.PollJobEvent
+		result2 v7action.Warnings
+		result3 error
+	}{result1, result2, result3}
 }
 
-func (fake *FakeActor) UpgradeManagedServiceInstanceReturnsOnCall(i int, result1 v7action.Warnings, result2 error) {
+func (fake *FakeActor) UpgradeManagedServiceInstanceReturnsOnCall(i int, result1 chan v7action.PollJobEvent, result2 v7action.Warnings, result3 error) {
 	fake.upgradeManagedServiceInstanceMutex.Lock()
 	defer fake.upgradeManagedServiceInstanceMutex.Unlock()
 	fake.UpgradeManagedServiceInstanceStub = nil
 	if fake.upgradeManagedServiceInstanceReturnsOnCall == nil {
 		fake.upgradeManagedServiceInstanceReturnsOnCall = make(map[int]struct {
-			result1 v7action.Warnings
-			result2 error
+			result1 chan v7action.PollJobEvent
+			result2 v7action.Warnings
+			result3 error
 		})
 	}
 	fake.upgradeManagedServiceInstanceReturnsOnCall[i] = struct {
-		result1 v7action.Warnings
-		result2 error
-	}{result1, result2}
+		result1 chan v7action.PollJobEvent
+		result2 v7action.Warnings
+		result3 error
+	}{result1, result2, result3}
 }
 
 func (fake *FakeActor) UploadBitsPackage(arg1 resources.Package, arg2 []sharedaction.V3Resource, arg3 io.Reader, arg4 int64) (resources.Package, v7action.Warnings, error) {


### PR DESCRIPTION
This is the v8 companion PR for #2401 

## Does this PR modify CLI v6, CLI v7, or CLI v8?
- It's a feature (or fix) for v8

## Description of the Change
Most of the service commands (e.g. "cf update-service") take a --wait flag to wait for completion. For some reason "cf upgrade-service" did not, and this commit resolves that inconsistency.

This is a redone version of #2285 which was reverted in #2317

## Why Is This PR Valuable?
- consistency of experience

## Why Should This Be In Core?
- consistency

## Applicable Issues
- #2285
- #2317 

## How Urgent Is The Change?

Not very