### PR TITLE
Invoke `POST /v3/apps/app-guid/actions/restart` on `cf restart app-name`

### DIFF
--- a/command/v7/shared/app_stager.go
+++ b/command/v7/shared/app_stager.go
@@ -67,6 +67,7 @@ type stagingAndStartActor interface {
 	StagePackage(packageGUID, appName, spaceGUID string) (<-chan resources.Droplet, <-chan v7action.Warnings, <-chan error)
 	StartApplication(appGUID string) (v7action.Warnings, error)
 	StopApplication(appGUID string) (v7action.Warnings, error)
+	RestartApplication(appGUID string, noWait bool) (v7action.Warnings, error)
 }
 
 func NewAppStager(actor stagingAndStartActor, ui command.UI, config command.Config, logCache sharedaction.LogCacheClient) AppStager {
@@ -188,6 +189,16 @@ func (stager *Stager) StartApp(
 			},
 		)
 		stager.UI.DisplayNewline()
+
+		if appAction == constant.ApplicationRestarting {
+			stager.UI.DisplayText("Restarting app...")
+			warnings, err := stager.Actor.RestartApplication(app.GUID, false)
+			stager.UI.DisplayWarnings(warnings)
+			if err != nil {
+				return err
+			}
+			return nil
+		}
 
 		if app.Started() {
 			if appAction == constant.ApplicationStarting {


### PR DESCRIPTION
Previously, `cf restart` would synchronously stop and then start the app.
Although this behaviour is documented by the CF V3 API, the cli could use the
dedicated `restart` endpoint. Thus API implementations are able to figure out
how to properly implement a restart vs stop+start

For example, the CF on K8S implementation - Korifi - could benefit from such a
change to implement app restart by leveraging the native K8S behaviour of a
rolling retart, i.e. an app restart (and also restage, or re-push) could have
no app downtime

With this draft PR we would like to check whether you are willing to accept
such a PR. If so, we could polish it - small refactoring, introducing tests,
etc.
