### PR TITLE
main: Fix integration tests by updating Capi s3 location

### DIFF
--- a/.github/workflows/tests-integration-reusable.yml
+++ b/.github/workflows/tests-integration-reusable.yml
@@ -147,8 +147,8 @@ jobs:
         CF_INT_CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
       run: |
         # find latest capi
-        FILENAME="$(aws s3 ls capi-releases --no-sign-request --recursive --region us-east-1 | sort | tail -n 1 | awk '{print $4}')"
-        aws s3 cp s3://capi-releases/$FILENAME $FILENAME --no-sign-request --region us-east-1 --no-progress
+        FILENAME="$(aws s3 ls capi-releases-app-runtime-interfaces --no-sign-request --recursive --region us-east-1 | sort | tail -n 1 | awk '{print $4}')"
+        aws s3 cp s3://capi-releases-app-runtime-interfaces/$FILENAME $FILENAME --no-sign-request --region us-east-1 --no-progress
         eval "$(bbl print-env --metadata-file metadata.json)"
         bosh upload-release --sha2 "$FILENAME"
         rm $FILENAME


### PR DESCRIPTION
## Where this PR should be backported?

- [X] [main](https://github.com/cloudfoundry/cli/tree/main)
- [X] [v8](https://github.com/cloudfoundry/cli/tree/v8)
- [X] [v7](https://github.com/cloudfoundry/cli/tree/v7)

## Description of the Change

Capi team removed the AWS account and migrated their releases to a new location.