### PR TITLE
Arm64 release v8

### DIFF
--- a/.github/workflows/release-build-sign-upload.yml
+++ b/.github/workflows/release-build-sign-upload.yml
@@ -192,6 +192,7 @@ jobs:
       run: |
         make out/cf-cli_linux_i686
         make out/cf-cli_linux_x86-64
+        make out/cf-cli_linux_arm64
 
     - name: Store Linux Binaries
       uses: actions/upload-artifact@v2
@@ -207,6 +208,7 @@ jobs:
         set -ex
         set -o pipefail
 
+        declare -A arch_array=([i686]="32-bit" [x86_64]="64-bit" [aarch64]='aarch/arm-64bit')
         root=$PWD
 
         cat<< EOF >~/.rpmmacros
@@ -216,35 +218,21 @@ jobs:
         RPM_VERSION=${VERSION_BUILD//-/_}
 
         mkdir -pv $root/packaged
-
-        echo "Build 32-bit RedHat package"
-        (
-          pushd cli-ci/ci/installers/rpm
-          cp $root/out/cf-cli_linux_i686 cf${VERSION_MAJOR}
-          cp ../../license/NOTICE .
-          cp ../../license/LICENSE-WITH-3RD-PARTY-LICENSES LICENSE
-          cp ../completion/cf${VERSION_MAJOR} cf${VERSION_MAJOR}.bash
-          echo "Version: ${RPM_VERSION}" > cf-cli.spec
-          cat cf${VERSION_MAJOR}-cli.spec.template >> cf-cli.spec
-          rpmbuild --target i386 --define "_topdir $(pwd)/build" -bb cf-cli.spec
-          mv build/RPMS/i386/cf${VERSION_MAJOR}-cli*.rpm $root/packaged/cf${VERSION_MAJOR}-cli-installer_${VERSION_BUILD}_i686.rpm
-          popd
-        )
-
-
-        echo "Build 64-bit RedHat package"
-        (
-          pushd cli-ci/ci/installers/rpm
-          cp $root/out/cf-cli_linux_x86-64 cf${VERSION_MAJOR}
-          cp ../../license/NOTICE .
-          cp ../../license/LICENSE-WITH-3RD-PARTY-LICENSES LICENSE
-          cp ../completion/cf${VERSION_MAJOR} cf${VERSION_MAJOR}.bash
-          echo "Version: ${RPM_VERSION}" > cf-cli.spec
-          cat cf${VERSION_MAJOR}-cli.spec.template >> cf-cli.spec
-          rpmbuild --target x86_64 --define "_topdir $(pwd)/build" -bb cf-cli.spec
-          mv build/RPMS/x86_64/cf${VERSION_MAJOR}-cli*.rpm $root/packaged/cf${VERSION_MAJOR}-cli-installer_${VERSION_BUILD}_x86-64.rpm
-          popd
-        )
+        for arch in "${!arch_array[@]}"; do
+          echo "Build ${arch_array[$arch]} RedHat package"
+          (
+            pushd cli-ci/ci/installers/rpm
+            cp $root/out/cf-cli_linux_${arch} cf${VERSION_MAJOR}
+            cp ../../license/NOTICE .
+            cp ../../license/LICENSE-WITH-3RD-PARTY-LICENSES LICENSE
+            cp ../completion/cf${VERSION_MAJOR} cf${VERSION_MAJOR}.bash
+            echo "Version: ${RPM_VERSION}" > cf-cli.spec
+            cat cf${VERSION_MAJOR}-cli.spec.template >> cf-cli.spec
+            rpmbuild --target $arch --define "_topdir $(pwd)/build" -bb cf-cli.spec
+            mv build/RPMS/$arch/cf${VERSION_MAJOR}-cli*.rpm $root/packaged/cf${VERSION_MAJOR}-cli-installer_${VERSION_BUILD}_${arch}.rpm
+            popd
+          )
+        done
 
     - name: Load GPG key
       env:
@@ -300,75 +288,45 @@ jobs:
       run: |
         set -ex
         set -o pipefail
-
+        
+        declare -A arch_array=([i686]="32-bit" [x86_64]="64-bit" [arm64]='arm-64bit')
         root=$PWD
 
         mkdir -pv $root/packaged-deb
+        for arch in "${!arch_array[@]}"; do
+          echo "Build ${arch_array[$arch]} Debian package"
+          (
+            SIZE="$(BLOCKSIZE=1000 du $root/out/cf-cli_linux_${arch} | cut -f 1)"
 
-        echo "Build 32-bit Debian package"
-        (
-          SIZE="$(BLOCKSIZE=1000 du $root/out/cf-cli_linux_i686 | cut -f 1)"
+            pushd cli-ci/ci/installers/deb
+              mkdir -p cf/usr/bin cf/usr/share/doc/cf${VERSION_MAJOR}-cli/ cf/DEBIAN cf/usr/share/bash-completion/completions
 
-          pushd cli-ci/ci/installers/deb
-            mkdir -p cf/usr/bin cf/usr/share/doc/cf${VERSION_MAJOR}-cli/ cf/DEBIAN cf/usr/share/bash-completion/completions
+              cp copyright_preamble cf/DEBIAN/copyright
+              sed 's/^$/ ./' $root/LICENSE >> cf/DEBIAN/copyright
+              cat copyright_comment_header >> cf/DEBIAN/copyright
+              sed 's/^$/ ./' ../../license/3RD-PARTY-LICENSES >> cf/DEBIAN/copyright
 
-            cp copyright_preamble cf/DEBIAN/copyright
-            sed 's/^$/ ./' $root/LICENSE >> cf/DEBIAN/copyright
-            cat copyright_comment_header >> cf/DEBIAN/copyright
-            sed 's/^$/ ./' ../../license/3RD-PARTY-LICENSES >> cf/DEBIAN/copyright
+              cp cf/DEBIAN/copyright cf/usr/share/doc/cf${VERSION_MAJOR}-cli/copyright
 
-            cp cf/DEBIAN/copyright cf/usr/share/doc/cf${VERSION_MAJOR}-cli/copyright
+              cp ../../license/NOTICE cf/usr/share/doc/cf${VERSION_MAJOR}-cli
+              cp ../../license/LICENSE-WITH-3RD-PARTY-LICENSES cf/usr/share/doc/cf${VERSION_MAJOR}-cli/LICENSE
 
-            cp ../../license/NOTICE cf/usr/share/doc/cf${VERSION_MAJOR}-cli
-            cp ../../license/LICENSE-WITH-3RD-PARTY-LICENSES cf/usr/share/doc/cf${VERSION_MAJOR}-cli/LICENSE
+              cp control_v${VERSION_MAJOR}.template cf/DEBIAN/control
+              echo "Installed-Size: ${SIZE}" >> cf/DEBIAN/control
+              echo "Version: ${VERSION_BUILD}" >> cf/DEBIAN/control
+              echo "Architecture: $arch" >> cf/DEBIAN/control
 
-            cp control_v8.template cf/DEBIAN/control
-            echo "Installed-Size: ${SIZE}" >> cf/DEBIAN/control
-            echo "Version: ${VERSION_BUILD}" >> cf/DEBIAN/control
-            echo "Architecture: i386" >> cf/DEBIAN/control
+              cp ../completion/cf${VERSION_MAJOR} cf/usr/share/bash-completion/completions/cf${VERSION_MAJOR}
 
-            cp ../completion/cf${VERSION_MAJOR} cf/usr/share/bash-completion/completions/cf${VERSION_MAJOR}
+              cp $root/out/cf-cli_linux_${arch} cf/usr/bin/cf${VERSION_MAJOR}
+              ln -frs cf/usr/bin/cf${VERSION_MAJOR} cf/usr/bin/cf
 
-            cp $root/out/cf-cli_linux_i686 cf/usr/bin/cf${VERSION_MAJOR}
-            ln -frs cf/usr/bin/cf${VERSION_MAJOR} cf/usr/bin/cf
-
-            fakeroot dpkg --build cf cf${VERSION_MAJOR}-cli-installer_${VERSION_BUILD}_i686.deb
-            mv cf${VERSION_MAJOR}-cli-installer_${VERSION_BUILD}_i686.deb $root/packaged-deb
-            rm -rf cf
-          popd
-        )
-
-        echo "Build 64-bit Debian package"
-        (
-          SIZE="$(BLOCKSIZE=1000 du $root/out/cf-cli_linux_x86-64 | cut -f 1)"
-
-          pushd cli-ci/ci/installers/deb
-            mkdir -p cf/usr/bin cf/usr/share/doc/cf${VERSION_MAJOR}-cli/ cf/DEBIAN cf/usr/share/bash-completion/completions
-
-            cp copyright_preamble cf/DEBIAN/copyright
-            sed 's/^$/ ./' $root/LICENSE >> cf/DEBIAN/copyright
-            cat copyright_comment_header >> cf/DEBIAN/copyright
-            sed 's/^$/ ./' ../../license/3RD-PARTY-LICENSES >> cf/DEBIAN/copyright
-
-            cp cf/DEBIAN/copyright cf/usr/share/doc/cf${VERSION_MAJOR}-cli/copyright
-
-            cp ../../license/NOTICE cf/usr/share/doc/cf${VERSION_MAJOR}-cli
-            cp ../../license/LICENSE-WITH-3RD-PARTY-LICENSES cf/usr/share/doc/cf${VERSION_MAJOR}-cli/LICENSE
-
-            cp control_v8.template cf/DEBIAN/control
-            echo "Installed-Size: ${SIZE}" >> cf/DEBIAN/control
-            echo "Version: ${VERSION_BUILD}" >> cf/DEBIAN/control
-            echo "Architecture: amd64" >> cf/DEBIAN/control
-
-            cp ../completion/cf${VERSION_MAJOR} cf/usr/share/bash-completion/completions/cf${VERSION_MAJOR}
-
-            cp $root/out/cf-cli_linux_x86-64 cf/usr/bin/cf${VERSION_MAJOR}
-            ln -frs cf/usr/bin/cf${VERSION_MAJOR} cf/usr/bin/cf
-
-            fakeroot dpkg --build cf cf${VERSION_MAJOR}-cli-installer_${VERSION_BUILD}_x86-64.deb
-            mv cf${VERSION_MAJOR}-cli-installer_${VERSION_BUILD}_x86-64.deb $root/packaged-deb
-          popd
-        )
+              fakeroot dpkg --build cf cf${VERSION_MAJOR}-cli-installer_${VERSION_BUILD}_${arch}.deb
+              mv cf${VERSION_MAJOR}-cli-installer_${VERSION_BUILD}_${arch}.deb $root/packaged-deb
+              rm -rf cf
+            popd
+          )
+        done
 
     - name: Print DEB Packages Info
       run: |
@@ -817,6 +775,7 @@ jobs:
           mkdir linux_i686 linux_x86-64
           mv cf-cli-linux-binaries/cf-cli_linux_i686 linux_i686/cf${VERSION_MAJOR}
           mv cf-cli-linux-binaries/cf-cli_linux_x86-64 linux_x86-64/cf${VERSION_MAJOR}
+          mv cf-cli-linux-binaries/cf-cli_linux_arm64 linux_arm64/cf${VERSION_MAJOR}
           pushd linux_i686
             prepare_artifacts
             tar -cvzf cf${VERSION_MAJOR}-cli_${INSTALLER_RELEASE_VERSION}_linux_i686.tgz *
@@ -824,6 +783,14 @@ jobs:
           pushd linux_x86-64
             prepare_artifacts
             tar -cvzf cf${VERSION_MAJOR}-cli_${INSTALLER_RELEASE_VERSION}_linux_x86-64.tgz *
+          popd
+          pushd linux_arm64
+            prepare_artifacts
+            tar -cvzf cf${VERSION_MAJOR}-cli_${VERSION_BUILD}_linux_arm64.tgz *
+          popd
+          pushd linux_arm64
+            prepare_artifacts
+            tar -cvzf cf${VERSION_MAJOR}-cli_${VERSION_BUILD}_linux_arm64.tgz *
           popd
 
           mkdir osx
@@ -865,6 +832,7 @@ jobs:
           signed/cf-cli-windows-packages/cf*zip \
           signed/linux_i686/*tgz \
           signed/linux_x86-64/*tgz \
+          signed/linux_arm64/*tgz \
           signed/osx/*tgz \
           signed/macosarm/*tgz \
           signed/win32/*zip \

--- a/.github/workflows/release-build-sign-upload.yml
+++ b/.github/workflows/release-build-sign-upload.yml
@@ -772,7 +772,7 @@ jobs:
         }
 
         pushd signed
-          mkdir linux_i686 linux_x86-64
+          mkdir linux_i686 linux_x86-64 linux_arm64
           mv cf-cli-linux-binaries/cf-cli_linux_i686 linux_i686/cf${VERSION_MAJOR}
           mv cf-cli-linux-binaries/cf-cli_linux_x86-64 linux_x86-64/cf${VERSION_MAJOR}
           mv cf-cli-linux-binaries/cf-cli_linux_arm64 linux_arm64/cf${VERSION_MAJOR}

--- a/.github/workflows/release-update-repos.yml
+++ b/.github/workflows/release-update-repos.yml
@@ -112,10 +112,14 @@ jobs:
         curl -L "${CLAW_URL}/stable?release=linux64-binary&version=${VERSION_BUILD}&source=github-rel" \
           > cf-cli-linux-tarball/cf-cli_linux64.tgz
 
+        curl -L "${CLAW_URL}/stable?release=linuxarm64-binary&version=${VERSION_BUILD}&source=github-rel" \
+          > cf-cli-linux-tarball/cf-cli_linuxarm64.tgz
+
         # Because CLAW always returns 200 we have to check if we got archive
         file cf-cli-osx-tarball/cf-cli_osx.tgz | grep -q gzip || exit 1
         file cf-cli-macosarm-tarball/cf-cli_macosarm.tgz | grep -q gzip || exit 1
         file cf-cli-linux-tarball/cf-cli_linux64.tgz | grep -q gzip || exit 1
+        file cf-cli-linux-tarball/cf-cli_linuxarm64.tgz | grep -q gzip || exit 1
 
         pushd cf-cli-osx-tarball
           CLI_OSX_SHA256=$(shasum -a 256 cf-cli_osx.tgz | cut -d ' ' -f 1)
@@ -129,9 +133,14 @@ jobs:
           CLI_LINUX_64_SHA256=$(shasum -a 256 cf-cli_linux64.tgz | cut -d ' ' -f 1)
         popd
 
-        echo "CLI_OSX_SHA256=${CLI_OSX_SHA256}" >> ${GITHUB_ENV}
-        echo "CLI_MACOSARM_SHA256=${CLI_MACOSARM_SHA256}" >> ${GITHUB_ENV}
-        echo "CLI_LINUX_64_SHA256=${CLI_LINUX_64_SHA256}" >> ${GITHUB_ENV}
+        pushd cf-cli-linux-tarball
+          CLI_LINUX_ARM64_SHA256=$(shasum -a 256 cf-cli_linuxarm64.tgz | cut -d ' ' -f 1)
+        popd
+
+        echo "CLI_OSX_SHA256=${CLI_OSX_SHA256}"           >> "${GITHUB_ENV}"
+        echo "CLI_MACOSARM_SHA256=${CLI_MACOSARM_SHA256}" >> "${GITHUB_ENV}"
+        echo "CLI_LINUX_64_SHA256=${CLI_LINUX_64_SHA256}" >> "${GITHUB_ENV}"
+        echo "CLI_LINUX_ARM64_SHA256=${CLI_LINUX_ARM64_SHA256}" >> "${GITHUB_ENV}"
 
     - name: Generate Homebrew formula file
       run: |
@@ -291,6 +300,7 @@ jobs:
         mkdir installers
         curl -L "${CLAW_URL}/stable?release=debian32&version=${VERSION_BUILD}&source=github-rel" > installers/cf${VERSION_MAJOR}-cli-installer_${VERSION_BUILD}_i686.deb
         curl -L "${CLAW_URL}/stable?release=debian64&version=${VERSION_BUILD}&source=github-rel" > installers/cf${VERSION_MAJOR}-cli-installer_${VERSION_BUILD}_x86-64.deb
+        curl -L "${CLAW_URL}/stable?release=debianarm64&version=${VERSION_BUILD}&source=github-rel" > installers/cf${VERSION_MAJOR}-cli-installer_${VERSION_BUILD}_arm64.deb
 
     - name: Update Debian Repository
       env:

--- a/.github/workflows/tests-integration-reusable.yml
+++ b/.github/workflows/tests-integration-reusable.yml
@@ -56,7 +56,7 @@ jobs:
     - id: read-min-capi
       name: Read MIN CAPI
       run: |
-        version=$(yq '.cf-d-capi-version-min' build_data.yml)
+        version=$(yq '.capi-version-min' build_data.yml)
         echo "version=$version" >> $GITHUB_OUTPUT
 
     - name: Checkout cf-deployment Min CAPI

--- a/bin/generate-release-notes
+++ b/bin/generate-release-notes
@@ -9,16 +9,17 @@ Package Manager Installation
 
 Installers
 ----------
-- Debian [64 bit](https://packages.cloudfoundry.org/stable?release=debian64&version=${VERSION}&source=github-rel) / [32 bit](https://packages.cloudfoundry.org/stable?release=debian32&version=${VERSION}&source=github-rel) (deb)
-- Redhat [64 bit](https://packages.cloudfoundry.org/stable?release=redhat64&version=${VERSION}&source=github-rel) / [32 bit](https://packages.cloudfoundry.org/stable?release=redhat32&version=${VERSION}&source=github-rel) (rpm)
-- macOS  [64 bit](https://packages.cloudfoundry.org/stable?release=macosx64&version=${VERSION}&source=github-rel) / [arm](https://packages.cloudfoundry.org/stable?release=macosarm&version=${VERSION}&source=github-rel) (pkg)
-- Windows [64 bit](https://packages.cloudfoundry.org/stable?release=windows64&version=${VERSION}&source=github-rel) / [32 bit](https://packages.cloudfoundry.org/stable?release=windows32&version=${VERSION}&source=github-rel) (zip)
+- Debian [64 bit](https://packages.cloudfoundry.org/stable?release=debian64&version=$VERSION&source=github-rel) / [32 bit](https://packages.cloudfoundry.org/stable?release=debian32&version=$VERSION&source=github-rel) (deb) / [arm64](https://packages.cloudfoundry.org/stable?release=debianarm64&version=$VERSION&source=github-rel) (deb)
+- Redhat [64 bit](https://packages.cloudfoundry.org/stable?release=redhat64&version=$VERSION&source=github-rel) / [32 bit](https://packages.cloudfoundry.org/stable?release=redhat32&version=$VERSION&source=github-rel) (rpm) / [aarch64](https://packages.cloudfoundry.org/stable?release=redhataarch64&version=$VERSION&source=github-rel) (rpm)
+- Mac OS X [64 bit](https://packages.cloudfoundry.org/stable?release=macosx64&version=$VERSION&source=github-rel) (pkg)
+- Mac OS X [64 bit](https://packages.cloudfoundry.org/stable?release=macosx64&version=$VERSION&source=github-rel) (pkg)
+- Windows [64 bit](https://packages.cloudfoundry.org/stable?release=windows64&version=$VERSION&source=github-rel) / [32 bit](https://packages.cloudfoundry.org/stable?release=windows32&version=$VERSION&source=github-rel) (zip)
 
 Binaries
 --------
-- Linux [64 bit](https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${VERSION}&source=github-rel) / [32 bit](https://packages.cloudfoundry.org/stable?release=linux32-binary&version=${VERSION}&source=github-rel) (tgz)
-- macOS [64 bit](https://packages.cloudfoundry.org/stable?release=macosx64-binary&version=${VERSION}&source=github-rel) / [arm](https://packages.cloudfoundry.org/stable?release=macosarm-binary&version=${VERSION}&source=github-rel) (tgz)
-- Windows [64 bit](https://packages.cloudfoundry.org/stable?release=windows64-exe&version=${VERSION}&source=github-rel) / [32 bit](https://packages.cloudfoundry.org/stable?release=windows32-exe&version=${VERSION}&source=github-rel) (zip)
+- Linux [64 bit](https://packages.cloudfoundry.org/stable?release=linux64-binary&version=$VERSION&source=github-rel) / [32 bit](https://packages.cloudfoundry.org/stable?release=linux32-binary&version=$VERSION&source=github-rel) (tgz) / [arm64](https://packages.cloudfoundry.org/stable?release=linuxarm64-binary&version=$VERSION&source=github-rel) (tgz)
+- Mac OS X [64 bit](https://packages.cloudfoundry.org/stable?release=macosx64-binary&version=$VERSION&source=github-rel) (tgz)
+- Windows [64 bit](https://packages.cloudfoundry.org/stable?release=windows64-exe&version=$VERSION&source=github-rel) / [32 bit](https://packages.cloudfoundry.org/stable?release=windows32-exe&version=$VERSION&source=github-rel) (zip)
 
 
 Docker

--- a/build_data.yml
+++ b/build_data.yml
@@ -1,2 +1,2 @@
 build-version: 8.7.1
-cf-d-capi-version-min: v16.11.0
+capi-version-min: v16.11.0


### PR DESCRIPTION
#2395 for v8
## Where this PR should be backported?

- [ ] [main](https://github.com/cloudfoundry/cli/tree/main)
- [X] [v8](https://github.com/cloudfoundry/cli/tree/v8)
- [ ] [v7](https://github.com/cloudfoundry/cli/tree/v7)

## Description of the Change
Edit pipelines to produce release for Linux arm64 arch.
included are linux binary, RPM and deb packages

## Why Is This PR Valuable?
We need to be able to run the CLI from linux/arm64 architectures.
Chances are we're not in deep need to run it from our RPI's but from linux containers on top of M1/2... Mac. 

## Applicable Issues
https://github.com/cloudfoundry/cli/pull/2395
https://github.com/cloudfoundry/cli/issues/2338
https://github.com/cloudfoundry/cli/issues/2293

