### PR TITLE
[documentation] supported platforms

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -79,8 +79,8 @@ export PATH=<path-to-cli-directory>/out:$PATH # Puts the built CLI first in your
 
 ### Compiling for Other Operating Systems and Architectures
 
-The supported platforms for the CF CLI are Linux (32-bit and 64-bit), Windows
-(32-bit and 64-bit) and OSX (aka Darwin). The commands that build the binaries
+The supported platforms for the CF CLI are Linux (x86, x86-64 and arm64) , Windows
+(x86 and x86-64) and OSX (aka Darwin x86-64 and arm64). The commands that build the binaries
 can be seen in the [Makefile](/Makefile) where the target begins with the
 `out/cf-cli`.
 


### PR DESCRIPTION
## Where this PR should be backported?

- [X] [main](https://github.com/cloudfoundry/cli/tree/main) - all changes should by default start here
- [] [v8](https://github.com/cloudfoundry/cli/tree/v8)
- [] [v7](https://github.com/cloudfoundry/cli/tree/v7)

## Description of the Change

A little update on the documentation for supported platforms in 

## Why Is This PR Valuable?

Update the  documentation

## Applicable Issues

https://github.com/cloudfoundry/cli/issues/2293

## How Urgent Is The Change?

Not urgent

## Other Relevant Parties

Who else is affected by the change? 
