### PR TITLE
turn on dependabot for branches v7 and v8 in support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,17 @@ updates:
     interval: daily
     time: '11:00'
   open-pull-requests-limit: 2
+- package-ecosystem: gomod
+  directory: "/"
+  target-branch: "v8"
+  schedule:
+    interval: daily
+    time: '11:00'
+  open-pull-requests-limit: 2
+- package-ecosystem: gomod
+  directory: "/"
+  target-branch: "v7"
+  schedule:
+    interval: daily
+    time: '11:00'
+  open-pull-requests-limit: 2


### PR DESCRIPTION
This way we don't have to try and cherry pick back to each of these

Thank you for contributing to the CF CLI! Please read the following:


* Please make sure you have implemented changes in line with the [contributing guidelines](https://github.com/cloudfoundry/cli/blob/main/.github/CONTRIBUTING.md)
* We're not allowed to accept any PRs without a signed CLA, no matter how small.
If your contribution falls under a company CLA but your membership is not public, expect delays while we confirm.
* All new code requires tests to protect against regressions.
* Contributions must be made against the appropriate branch. See the [contributing guidelines](https://github.com/cloudfoundry/cli/blob/main/.github/CONTRIBUTING.md)
* Contributions must conform to our [style guide](https://github.com/cloudfoundry/cli/wiki/CLI-Product-Specific-Style-Guide). Please reach out to us if you have questions.


## Where this PR should be backported?

- [x] [main](https://github.com/cloudfoundry/cli/tree/main) - all changes should by default start here
- [ ] [v8](https://github.com/cloudfoundry/cli/tree/v8)
- [ ] [v7](https://github.com/cloudfoundry/cli/tree/v7)

## Description of the Change

make it easier to stay up to date

We must be able to understand the design of your change from this description.
Keep in mind that the maintainer reviewing this PR may not be familiar with or
have worked with the code here recently, so please walk us through the concepts.


## Why Is This PR Valuable?

cause I won't have to think about backports for dependencies

What benefits will be realized by the code change? What users would want this change? What user need is this change addressing? 

## Applicable Issues

List any applicable GitHub Issues here

## How Urgent Is The Change?

Is the change urgent? If so, explain why it is time-sensitive.

## Other Relevant Parties

Who else is affected by the change? 
@cloudfoundry/wg-app-runtime-interfaces-cli-approvers @cloudfoundry/wg-app-runtime-interfaces-cli-reviewers 