### PR TITLE
Included GHA package ecosystem for dependabot in v7 and v8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,17 @@ updates:
     interval: daily
     time: '11:00'
   open-pull-requests-limit: 2
+- package-ecosystem: "github-actions"
+  directory: "/"
+  target-branch: "v8"
+  schedule:
+    interval: daily
+    time: '11:00'
+  open-pull-requests-limit: 2
+- package-ecosystem: "github-actions"
+  directory: "/"
+  target-branch: "v7"
+  schedule:
+    interval: daily
+    time: '11:00'
+  open-pull-requests-limit: 2


### PR DESCRIPTION
This change has the purpose of keeping all pipeline configuration synced and up to date across main branches (v7 and v8)