### PR TITLE
create private domain doesn't fail when domain already exists

### DIFF
--- a/integration/v7/isolated/create_private_domain_test.go
+++ b/integration/v7/isolated/create_private_domain_test.go
@@ -106,12 +106,12 @@ var _ = Describe("create-private-domain command", func() {
 						privateDomain1 = helpers.NewDomain(orgName, helpers.NewDomainName())
 						privateDomain1.Create()
 					})
-					It("should fail and return an error", func() {
+					It("succeeds", func() {
 						session := helpers.CF("create-private-domain", orgName, privateDomain1.Name)
 
 						Eventually(session.Err).Should(Say("The domain name \"%s\" is already in use", privateDomain1.Name))
-						Eventually(session).Should(Say("FAILED"))
-						Eventually(session).Should(Exit(1))
+						Eventually(session).Should(Say("OK"))
+						Eventually(session).Should(Exit(0))
 					})
 				})
 			})


### PR DESCRIPTION
Thank you for contributing to the CF CLI! Please read the following:


* Please make sure you have implemented changes in line with the [contributing guidelines](https://github.com/cloudfoundry/cli/blob/main/.github/CONTRIBUTING.md)
* We're not allowed to accept any PRs without a signed CLA, no matter how small.
If your contribution falls under a company CLA but your membership is not public, expect delays while we confirm.
* All new code requires tests to protect against regressions.
* Contributions must be made against the appropriate branch. See the [contributing guidelines](https://github.com/cloudfoundry/cli/blob/main/.github/CONTRIBUTING.md)
* Contributions must conform to our [style guide](https://github.com/cloudfoundry/cli/wiki/CLI-Product-Specific-Style-Guide). Please reach out to us if you have questions.


## Where this PR should be backported?

- [x] [main](https://github.com/cloudfoundry/cli/tree/main) - all changes should by default start here
- [x] [v8](https://github.com/cloudfoundry/cli/tree/v8)
- [x] [v7](https://github.com/cloudfoundry/cli/tree/v7)

## Description of the Change

create private domain doesn't fail when domain already exists

## Why Is This PR Valuable?

Puts in more in line with standards and in line with create-route
