### PR TITLE
Add --wait, -w flag to run-task 

### DIFF
--- a/actor/actionerror/task_failed_error.go
+++ b/actor/actionerror/task_failed_error.go
@@ -1,0 +1,7 @@
+package actionerror
+
+type TaskFailedError struct{}
+
+func (TaskFailedError) Error() string {
+	return "Task failed to complete successfully"
+}

--- a/actor/v7action/cloud_controller_client.go
+++ b/actor/v7action/cloud_controller_client.go
@@ -136,6 +136,7 @@ type CloudControllerClient interface {
 	GetAppFeature(appGUID string, featureName string) (resources.ApplicationFeature, ccv3.Warnings, error)
 	GetStacks(query ...ccv3.Query) ([]resources.Stack, ccv3.Warnings, error)
 	GetStagingSecurityGroups(spaceGUID string, queries ...ccv3.Query) ([]resources.SecurityGroup, ccv3.Warnings, error)
+	GetTask(guid string) (resources.Task, ccv3.Warnings, error)
 	GetUser(userGUID string) (resources.User, ccv3.Warnings, error)
 	GetUsers(query ...ccv3.Query) ([]resources.User, ccv3.Warnings, error)
 	MakeRequestSendReceiveRaw(Method string, URL string, headers http.Header, requestBody []byte) ([]byte, *http.Response, error)

--- a/actor/v7action/task.go
+++ b/actor/v7action/task.go
@@ -2,13 +2,16 @@ package v7action
 
 import (
 	"strconv"
+	"time"
 
 	"sort"
 
 	"code.cloudfoundry.org/cli/actor/actionerror"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccerror"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3"
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/constant"
 	"code.cloudfoundry.org/cli/resources"
+	log "github.com/sirupsen/logrus"
 )
 
 // Run resources.Task runs the provided command in the application environment associated
@@ -66,4 +69,33 @@ func (actor Actor) GetTaskBySequenceIDAndApplication(sequenceID int, appGUID str
 func (actor Actor) TerminateTask(taskGUID string) (resources.Task, Warnings, error) {
 	task, warnings, err := actor.CloudControllerClient.UpdateTaskCancel(taskGUID)
 	return resources.Task(task), Warnings(warnings), err
+}
+
+func (actor Actor) PollTask(task resources.Task) (resources.Task, Warnings, error) {
+	var allWarnings Warnings
+
+	for task.State != constant.TaskSucceeded && task.State != constant.TaskFailed {
+
+		time.Sleep(actor.Config.PollingInterval())
+
+		ccTask, warnings, err := actor.CloudControllerClient.GetTask(task.GUID)
+		log.WithFields(log.Fields{
+			"task_guid": task.GUID,
+			"state":     task.State,
+		}).Debug("polling task state")
+
+		allWarnings = append(allWarnings, warnings...)
+
+		if err != nil {
+			return resources.Task{}, allWarnings, err
+		}
+
+		task = resources.Task(ccTask)
+	}
+
+	if task.State == constant.TaskFailed {
+		return task, allWarnings, actionerror.TaskFailedError{}
+	}
+
+	return task, allWarnings, nil
 }

--- a/actor/v7action/v7actionfakes/fake_cloud_controller_client.go
+++ b/actor/v7action/v7actionfakes/fake_cloud_controller_client.go
@@ -1903,6 +1903,21 @@ type FakeCloudControllerClient struct {
 		result2 ccv3.Warnings
 		result3 error
 	}
+	GetTaskStub        func(string) (resources.Task, ccv3.Warnings, error)
+	getTaskMutex       sync.RWMutex
+	getTaskArgsForCall []struct {
+		arg1 string
+	}
+	getTaskReturns struct {
+		result1 resources.Task
+		result2 ccv3.Warnings
+		result3 error
+	}
+	getTaskReturnsOnCall map[int]struct {
+		result1 resources.Task
+		result2 ccv3.Warnings
+		result3 error
+	}
 	GetUserStub        func(string) (resources.User, ccv3.Warnings, error)
 	getUserMutex       sync.RWMutex
 	getUserArgsForCall []struct {
@@ -10965,6 +10980,72 @@ func (fake *FakeCloudControllerClient) GetStagingSecurityGroupsReturnsOnCall(i i
 	}{result1, result2, result3}
 }
 
+func (fake *FakeCloudControllerClient) GetTask(arg1 string) (resources.Task, ccv3.Warnings, error) {
+	fake.getTaskMutex.Lock()
+	ret, specificReturn := fake.getTaskReturnsOnCall[len(fake.getTaskArgsForCall)]
+	fake.getTaskArgsForCall = append(fake.getTaskArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("GetTask", []interface{}{arg1})
+	fake.getTaskMutex.Unlock()
+	if fake.GetTaskStub != nil {
+		return fake.GetTaskStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	fakeReturns := fake.getTaskReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeCloudControllerClient) GetTaskCallCount() int {
+	fake.getTaskMutex.RLock()
+	defer fake.getTaskMutex.RUnlock()
+	return len(fake.getTaskArgsForCall)
+}
+
+func (fake *FakeCloudControllerClient) GetTaskCalls(stub func(string) (resources.Task, ccv3.Warnings, error)) {
+	fake.getTaskMutex.Lock()
+	defer fake.getTaskMutex.Unlock()
+	fake.GetTaskStub = stub
+}
+
+func (fake *FakeCloudControllerClient) GetTaskArgsForCall(i int) string {
+	fake.getTaskMutex.RLock()
+	defer fake.getTaskMutex.RUnlock()
+	argsForCall := fake.getTaskArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeCloudControllerClient) GetTaskReturns(result1 resources.Task, result2 ccv3.Warnings, result3 error) {
+	fake.getTaskMutex.Lock()
+	defer fake.getTaskMutex.Unlock()
+	fake.GetTaskStub = nil
+	fake.getTaskReturns = struct {
+		result1 resources.Task
+		result2 ccv3.Warnings
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeCloudControllerClient) GetTaskReturnsOnCall(i int, result1 resources.Task, result2 ccv3.Warnings, result3 error) {
+	fake.getTaskMutex.Lock()
+	defer fake.getTaskMutex.Unlock()
+	fake.GetTaskStub = nil
+	if fake.getTaskReturnsOnCall == nil {
+		fake.getTaskReturnsOnCall = make(map[int]struct {
+			result1 resources.Task
+			result2 ccv3.Warnings
+			result3 error
+		})
+	}
+	fake.getTaskReturnsOnCall[i] = struct {
+		result1 resources.Task
+		result2 ccv3.Warnings
+		result3 error
+	}{result1, result2, result3}
+}
+
 func (fake *FakeCloudControllerClient) GetUser(arg1 string) (resources.User, ccv3.Warnings, error) {
 	fake.getUserMutex.Lock()
 	ret, specificReturn := fake.getUserReturnsOnCall[len(fake.getUserArgsForCall)]
@@ -14952,6 +15033,8 @@ func (fake *FakeCloudControllerClient) Invocations() map[string][][]interface{} 
 	defer fake.getStacksMutex.RUnlock()
 	fake.getStagingSecurityGroupsMutex.RLock()
 	defer fake.getStagingSecurityGroupsMutex.RUnlock()
+	fake.getTaskMutex.RLock()
+	defer fake.getTaskMutex.RUnlock()
 	fake.getUserMutex.RLock()
 	defer fake.getUserMutex.RUnlock()
 	fake.getUsersMutex.RLock()

--- a/api/cloudcontroller/ccv3/internal/api_routes.go
+++ b/api/cloudcontroller/ccv3/internal/api_routes.go
@@ -103,6 +103,7 @@ const (
 	GetSpaceStagingSecurityGroupsRequest                        = "GetSpaceStagingSecurityGroups"
 	GetSSHEnabled                                               = "GetSSHEnabled"
 	GetStacksRequest                                            = "GetStacks"
+	GetTaskRequest                                              = "GetTask"
 	GetUserRequest                                              = "GetUser"
 	GetUsersRequest                                             = "GetUsers"
 	MapRouteRequest                                             = "MapRoute"
@@ -343,6 +344,7 @@ var APIRoutes = map[string]Route{
 	DeleteSpaceQuotaFromSpaceRequest:                            {Path: "/v3/space_quotas/:quota_guid/relationships/spaces/:space_guid", Method: http.MethodDelete},
 	GetStacksRequest:                                            {Path: "/v3/stacks", Method: http.MethodGet},
 	PatchStackRequest:                                           {Path: "/v3/stacks/:stack_guid", Method: http.MethodPatch},
+	GetTaskRequest:                                              {Path: "/v3/tasks/:task_guid", Method: http.MethodGet},
 	PutTaskCancelRequest:                                        {Path: "/v3/tasks/:task_guid/cancel", Method: http.MethodPut},
 	GetUsersRequest:                                             {Path: "/v3/users", Method: http.MethodGet},
 	GetUserRequest:                                              {Path: "/v3/users/:user_guid", Method: http.MethodGet},

--- a/api/cloudcontroller/ccv3/task.go
+++ b/api/cloudcontroller/ccv3/task.go
@@ -53,3 +53,17 @@ func (client *Client) UpdateTaskCancel(taskGUID string) (resources.Task, Warning
 
 	return responseBody, warnings, err
 }
+
+func (client *Client) GetTask(guid string) (resources.Task, Warnings, error) {
+	var responseBody resources.Task
+
+	_, warnings, err := client.MakeRequest(RequestParams{
+		RequestName: internal.GetTaskRequest,
+		URIParams: internal.Params{
+			"task_guid": guid,
+		},
+		ResponseBody: &responseBody,
+	})
+
+	return responseBody, warnings, err
+}

--- a/command/v7/actor.go
+++ b/command/v7/actor.go
@@ -189,6 +189,7 @@ type Actor interface {
 	PollPackage(pkg resources.Package) (resources.Package, v7action.Warnings, error)
 	PollStart(app resources.Application, noWait bool, handleProcessStats func(string)) (v7action.Warnings, error)
 	PollStartForRolling(app resources.Application, deploymentGUID string, noWait bool, handleProcessStats func(string)) (v7action.Warnings, error)
+	PollTask(task resources.Task) (resources.Task, v7action.Warnings, error)
 	PollUploadBuildpackJob(jobURL ccv3.JobURL) (v7action.Warnings, error)
 	PrepareBuildpackBits(inputPath string, tmpDirPath string, downloader v7action.Downloader) (string, error)
 	PurgeServiceInstance(serviceInstanceName, spaceGUID string) (v7action.Warnings, error)

--- a/command/v7/v7fakes/fake_actor.go
+++ b/command/v7/v7fakes/fake_actor.go
@@ -2578,6 +2578,21 @@ type FakeActor struct {
 		result1 v7action.Warnings
 		result2 error
 	}
+	PollTaskStub        func(resources.Task) (resources.Task, v7action.Warnings, error)
+	pollTaskMutex       sync.RWMutex
+	pollTaskArgsForCall []struct {
+		arg1 resources.Task
+	}
+	pollTaskReturns struct {
+		result1 resources.Task
+		result2 v7action.Warnings
+		result3 error
+	}
+	pollTaskReturnsOnCall map[int]struct {
+		result1 resources.Task
+		result2 v7action.Warnings
+		result3 error
+	}
 	PollUploadBuildpackJobStub        func(ccv3.JobURL) (v7action.Warnings, error)
 	pollUploadBuildpackJobMutex       sync.RWMutex
 	pollUploadBuildpackJobArgsForCall []struct {
@@ -14601,6 +14616,72 @@ func (fake *FakeActor) PollStartForRollingReturnsOnCall(i int, result1 v7action.
 	}{result1, result2}
 }
 
+func (fake *FakeActor) PollTask(arg1 resources.Task) (resources.Task, v7action.Warnings, error) {
+	fake.pollTaskMutex.Lock()
+	ret, specificReturn := fake.pollTaskReturnsOnCall[len(fake.pollTaskArgsForCall)]
+	fake.pollTaskArgsForCall = append(fake.pollTaskArgsForCall, struct {
+		arg1 resources.Task
+	}{arg1})
+	fake.recordInvocation("PollTask", []interface{}{arg1})
+	fake.pollTaskMutex.Unlock()
+	if fake.PollTaskStub != nil {
+		return fake.PollTaskStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	fakeReturns := fake.pollTaskReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeActor) PollTaskCallCount() int {
+	fake.pollTaskMutex.RLock()
+	defer fake.pollTaskMutex.RUnlock()
+	return len(fake.pollTaskArgsForCall)
+}
+
+func (fake *FakeActor) PollTaskCalls(stub func(resources.Task) (resources.Task, v7action.Warnings, error)) {
+	fake.pollTaskMutex.Lock()
+	defer fake.pollTaskMutex.Unlock()
+	fake.PollTaskStub = stub
+}
+
+func (fake *FakeActor) PollTaskArgsForCall(i int) resources.Task {
+	fake.pollTaskMutex.RLock()
+	defer fake.pollTaskMutex.RUnlock()
+	argsForCall := fake.pollTaskArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeActor) PollTaskReturns(result1 resources.Task, result2 v7action.Warnings, result3 error) {
+	fake.pollTaskMutex.Lock()
+	defer fake.pollTaskMutex.Unlock()
+	fake.PollTaskStub = nil
+	fake.pollTaskReturns = struct {
+		result1 resources.Task
+		result2 v7action.Warnings
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeActor) PollTaskReturnsOnCall(i int, result1 resources.Task, result2 v7action.Warnings, result3 error) {
+	fake.pollTaskMutex.Lock()
+	defer fake.pollTaskMutex.Unlock()
+	fake.PollTaskStub = nil
+	if fake.pollTaskReturnsOnCall == nil {
+		fake.pollTaskReturnsOnCall = make(map[int]struct {
+			result1 resources.Task
+			result2 v7action.Warnings
+			result3 error
+		})
+	}
+	fake.pollTaskReturnsOnCall[i] = struct {
+		result1 resources.Task
+		result2 v7action.Warnings
+		result3 error
+	}{result1, result2, result3}
+}
+
 func (fake *FakeActor) PollUploadBuildpackJob(arg1 ccv3.JobURL) (v7action.Warnings, error) {
 	fake.pollUploadBuildpackJobMutex.Lock()
 	ret, specificReturn := fake.pollUploadBuildpackJobReturnsOnCall[len(fake.pollUploadBuildpackJobArgsForCall)]
@@ -19499,6 +19580,8 @@ func (fake *FakeActor) Invocations() map[string][][]interface{} {
 	defer fake.pollStartMutex.RUnlock()
 	fake.pollStartForRollingMutex.RLock()
 	defer fake.pollStartForRollingMutex.RUnlock()
+	fake.pollTaskMutex.RLock()
+	defer fake.pollTaskMutex.RUnlock()
 	fake.pollUploadBuildpackJobMutex.RLock()
 	defer fake.pollUploadBuildpackJobMutex.RUnlock()
 	fake.prepareBuildpackBitsMutex.RLock()


### PR DESCRIPTION
When the wait flag is supplied to run-task, the cli will not exit until the task enters a terminal state; SUCCEEDED or FAILED.

The cli exits 0 when the task succeeds and exits 1 when the task fails.

This improves the scriptability of tasks. They can be run serially in a script.

Cherry-pick of 8671a5b (#1861) to v8
Addresses Issue #1104, #2238

Authored-by: Zach Robinson <zrobinson@pivotal.io>

Taking the fix from v8 #2359 