### PR TITLE
Add state to buildpacks output

### DIFF
--- a/command/v7/buildpacks_command.go
+++ b/command/v7/buildpacks_command.go
@@ -48,7 +48,7 @@ func (cmd BuildpacksCommand) Execute(args []string) error {
 func (cmd BuildpacksCommand) displayTable(buildpacks []resources.Buildpack) {
 	if len(buildpacks) > 0 {
 		var keyValueTable = [][]string{
-			{"position", "name", "stack", "enabled", "locked", "filename"},
+			{"position", "name", "stack", "enabled", "locked", "state", "filename"},
 		}
 		for _, buildpack := range buildpacks {
 			keyValueTable = append(keyValueTable, []string{
@@ -57,6 +57,7 @@ func (cmd BuildpacksCommand) displayTable(buildpacks []resources.Buildpack) {
 				buildpack.Stack,
 				strconv.FormatBool(buildpack.Enabled.Value),
 				strconv.FormatBool(buildpack.Locked.Value),
+				buildpack.State,
 				buildpack.Filename,
 			})
 		}

--- a/command/v7/buildpacks_command_test.go
+++ b/command/v7/buildpacks_command_test.go
@@ -8,6 +8,7 @@ import (
 
 	"code.cloudfoundry.org/cli/actor/actionerror"
 	"code.cloudfoundry.org/cli/actor/v7action"
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/constant"
 	"code.cloudfoundry.org/cli/command/commandfakes"
 	. "code.cloudfoundry.org/cli/command/v7"
 	"code.cloudfoundry.org/cli/command/v7/v7fakes"
@@ -114,6 +115,7 @@ var _ = Describe("buildpacks Command", func() {
 							Position: types.NullInt{Value: 1, IsSet: true},
 							Enabled:  types.NullBool{Value: true, IsSet: true},
 							Locked:   types.NullBool{Value: false, IsSet: true},
+							State:    constant.BuildpackReady,
 							Filename: "buildpack-1.file",
 							Stack:    "buildpack-1-stack",
 						},
@@ -123,6 +125,7 @@ var _ = Describe("buildpacks Command", func() {
 							Position: types.NullInt{Value: 2, IsSet: true},
 							Enabled:  types.NullBool{Value: false, IsSet: true},
 							Locked:   types.NullBool{Value: true, IsSet: true},
+							State:    constant.BuildpackAwaitingUpload,
 							Filename: "buildpack-2.file",
 							Stack:    "",
 						},
@@ -133,9 +136,9 @@ var _ = Describe("buildpacks Command", func() {
 					Expect(executeErr).NotTo(HaveOccurred())
 					Expect(testUI.Err).To(Say("some-warning-1"))
 					Expect(testUI.Err).To(Say("some-warning-2"))
-					Expect(testUI.Out).To(Say(`position\s+name\s+stack\s+enabled\s+locked\s+filename`))
-					Expect(testUI.Out).To(Say(`1\s+buildpack-1\s+buildpack-1-stack\s+true\s+false\s+buildpack-1.file`))
-					Expect(testUI.Out).To(Say(`2\s+buildpack-2\s+false\s+true\s+buildpack-2.file`))
+					Expect(testUI.Out).To(Say(`position\s+name\s+stack\s+enabled\s+locked\s+state\s+filename`))
+					Expect(testUI.Out).To(Say(`1\s+buildpack-1\s+buildpack-1-stack\s+true\s+false\s+READY\s+buildpack-1.file`))
+					Expect(testUI.Out).To(Say(`2\s+buildpack-2\s+false\s+true\s+AWAITING_UPLOAD\s+buildpack-2.file`))
 				})
 			})
 			When("there are no buildpacks", func() {

--- a/integration/v7/isolated/buildpacks_command_test.go
+++ b/integration/v7/isolated/buildpacks_command_test.go
@@ -53,33 +53,36 @@ var _ = Describe("buildpacks command", func() {
 
 			username, _ := helpers.GetCredentials()
 			Eventually(session).Should(Say("Getting buildpacks as %s...", username))
-			Eventually(session).Should(Say(`position\s+name\s+stack\s+enabled\s+locked\s+filename`))
+			Eventually(session).Should(Say(`position\s+name\s+stack\s+enabled\s+locked\s+state\s+filename`))
 
 			positionRegex := `\d+`
 			enabledRegex := `true`
 			lockedRegex := `false`
 			stackRegex := `(cflinuxfs[23]|windows.+)`
+			stateRegex := `READY`
 
 			staticfileNameRegex := `staticfile_buildpack`
 			// staticfileFileRegex := `staticfile[-_]buildpack-\S+`
 			staticfileFileRegex := ""
-			Eventually(session).Should(Say(`%s\s+%s\s+%s\s+%s\s+%s\s+%s`,
+			Eventually(session).Should(Say(`%s\s+%s\s+%s\s+%s\s+%s\s+%s\s+%s`,
 				positionRegex,
 				staticfileNameRegex,
 				stackRegex,
 				enabledRegex,
 				lockedRegex,
+				stateRegex,
 				staticfileFileRegex))
 
 			binaryNameRegex := `binary_buildpack`
 			// binaryFileRegex := `binary[-_]buildpack-\S+`
 			binaryFileRegex := ""
-			Eventually(session).Should(Say(`%s\s+%s\s+%s\s+%s\s+%s\s+%s`,
+			Eventually(session).Should(Say(`%s\s+%s\s+%s\s+%s\s+%s\s+%s\s+%s`,
 				positionRegex,
 				binaryNameRegex,
 				stackRegex,
 				enabledRegex,
 				lockedRegex,
+				stateRegex,
 				binaryFileRegex))
 			Eventually(session).Should(Exit(0))
 		})
@@ -118,7 +121,7 @@ var _ = Describe("buildpacks command", func() {
 
 					username, _ := helpers.GetCredentials()
 					Expect(session).Should(Say("Getting buildpacks as %s...", username))
-					Expect(session).Should(Say(`position\s+name\s+stack\s+enabled\s+locked\s+filename`))
+					Expect(session).Should(Say(`position\s+name\s+stack\s+enabled\s+locked\s+state\s+filename`))
 
 					re := regexp.MustCompile(`(?:\n|\r)\d+\s+\w{8}`)
 					buildpackMatches := re.FindAll(session.Out.Contents(), -1)
@@ -128,13 +131,15 @@ var _ = Describe("buildpacks command", func() {
 					enabledRegex := `true`
 					lockedRegex := `false`
 					stackRegex := ``
+					stateRegex := `READY`
 
-					Expect(session).Should(Say(`%s\s+%s\s+%s\s+%s\s+%s\s+%s`,
+					Expect(session).Should(Say(`%s\s+%s\s+%s\s+%s\s+%s\s+%s\s+%s`,
 						positionRegex,
 						buildpack2,
 						stackRegex,
 						enabledRegex,
 						lockedRegex,
+						stateRegex,
 						""))
 				})
 			})


### PR DESCRIPTION
Fixes #2344. See #1952 (original issue) for more details.

## Where this PR should be backported?

- [x] [main](https://github.com/cloudfoundry/cli/tree/main) - all changes should by default start here
- [x] [v8](https://github.com/cloudfoundry/cli/tree/v8)
- [ ] [v7](https://github.com/cloudfoundry/cli/tree/v7)
