### PR TITLE
Match release-update-repos.yml to v7

### DIFF
--- a/.github/workflows/release-update-repos.yml
+++ b/.github/workflows/release-update-repos.yml
@@ -1,4 +1,5 @@
-name: "Release: Update Repositories"
+name:     "Release: Update Repositories"
+run-name: "Release: Update Repositories [${{ github.ref_name }}]"
 
 on:
   workflow_dispatch:
@@ -32,11 +33,11 @@ jobs:
     steps:
     - name: Set environment
       id: set-secrets-environment
-      run: echo "::set-output name=secrets-environment::PROD"
+      run: echo "secrets-environment=PROD" >> "${GITHUB_OUTPUT}"
 
     - name: Set CLAW URL
       id: set-claw-url
-      run: echo "::set-output name=claw-url::https://packages.cloudfoundry.org"
+      run: echo "claw-url=https://packages.cloudfoundry.org" >> "${GITHUB_OUTPUT}"
 
     - name: Checkout cli
       uses: actions/checkout@v4
@@ -50,12 +51,12 @@ jobs:
         VERSION_MINOR="${VERSION#*.}"
         VERSION_MINOR="${VERSION_MINOR%.*}"
 
-        echo "::set-output name=version-build::${VERSION}"
-        echo "::set-output name=version-major::${VERSION%%\.*}"
-        echo "::set-output name=version-minor::${VERSION_MINOR}"
-        echo "::set-output name=version-patch::${VERSION##*.}"
+        echo "version-build=${VERSION}"       >> "${GITHUB_OUTPUT}"
+        echo "version-major=${VERSION%%\.*}"  >> "${GITHUB_OUTPUT}"
+        echo "version-minor=${VERSION_MINOR}" >> "${GITHUB_OUTPUT}"
+        echo "version-patch=${VERSION##*.}"   >> "${GITHUB_OUTPUT}"
 
-        echo "VERSION_BUILD=${VERSION}" >> ${GITHUB_ENV}
+        echo "VERSION_BUILD=${VERSION}"       >> "${GITHUB_ENV}"
 
     - name: Test if CLAW serve this version
       env:
@@ -258,7 +259,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
@@ -358,8 +358,8 @@ jobs:
       CLAW_URL:              ${{ needs.setup.outputs.claw-url }}
       VERSION_BUILD:         ${{ needs.setup.outputs.version-build }}
       VERSION_MAJOR:         ${{ needs.setup.outputs.version-major }}
-
     steps:
+
     - name: Setup
       env:
         ENVIRONMENT:   ${{ github.event.inputs.environment }}
@@ -402,7 +402,7 @@ jobs:
         gnupg
         createrepo-c
         awscli
-  
+
     - name: Setup aws to upload installers to CLAW S3 bucket
       uses: aws-actions/configure-aws-credentials@v4
       env:


### PR DESCRIPTION
- spaces and environment variable setting consistency

Thank you for contributing to the CF CLI! Please read the following:


* Please make sure you have implemented changes in line with the [contributing guidelines](https://github.com/cloudfoundry/cli/blob/main/.github/CONTRIBUTING.md)
* We're not allowed to accept any PRs without a signed CLA, no matter how small.
If your contribution falls under a company CLA but your membership is not public, expect delays while we confirm.
* All new code requires tests to protect against regressions.
* Contributions must be made against the appropriate branch. See the [contributing guidelines](https://github.com/cloudfoundry/cli/blob/main/.github/CONTRIBUTING.md)
* Contributions must conform to our [style guide](https://github.com/cloudfoundry/cli/wiki/CLI-Product-Specific-Style-Guide). Please reach out to us if you have questions.


## Where this PR should be backported?

- [ ] [main](https://github.com/cloudfoundry/cli/tree/main) - all changes should by default start here
- [x] [v8](https://github.com/cloudfoundry/cli/tree/v8)
- [ ] [v7](https://github.com/cloudfoundry/cli/tree/v7)


## Description of the Change
Make release-update-repos.yml match the v7 branch


## Why Is This PR Valuable?

Consistency across branches on release logic

## Applicable Issues

List any applicable GitHub Issues here

## How Urgent Is The Change?

Is the change urgent? If so, explain why it is time-sensitive.

## Other Relevant Parties

Who else is affected by the change? 
