### PR TITLE
Don't fetch unneeded pages (v8)

### DIFF
--- a/actor/v7action/application.go
+++ b/actor/v7action/application.go
@@ -226,7 +226,8 @@ func (actor Actor) GetUnstagedNewestPackageGUID(appGUID string) (string, Warning
 	packages, warnings, err := actor.CloudControllerClient.GetPackages(
 		ccv3.Query{Key: ccv3.AppGUIDFilter, Values: []string{appGUID}},
 		ccv3.Query{Key: ccv3.OrderBy, Values: []string{ccv3.CreatedAtDescendingOrder}},
-		ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}})
+		ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+		ccv3.Query{Key: ccv3.Page, Values: []string{"1"}})
 	allWarnings = append(allWarnings, warnings...)
 	if err != nil {
 		return "", allWarnings, err
@@ -241,6 +242,7 @@ func (actor Actor) GetUnstagedNewestPackageGUID(appGUID string) (string, Warning
 		newestPackage.GUID,
 		ccv3.Query{Key: ccv3.StatesFilter, Values: []string{"STAGED"}},
 		ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+		ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 	)
 	allWarnings = append(allWarnings, warnings...)
 	if err != nil {

--- a/actor/v7action/application_test.go
+++ b/actor/v7action/application_test.go
@@ -1959,6 +1959,7 @@ var _ = Describe("Application Actions", func() {
 						ccv3.Query{Key: ccv3.AppGUIDFilter, Values: []string{"some-app-guid"}},
 						ccv3.Query{Key: ccv3.OrderBy, Values: []string{ccv3.CreatedAtDescendingOrder}},
 						ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+						ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 					))
 				})
 
@@ -1998,8 +1999,9 @@ var _ = Describe("Application Actions", func() {
 				packageGuid, queries := fakeCloudControllerClient.GetPackageDropletsArgsForCall(0)
 				Expect(packageGuid).To(Equal("package-guid"))
 				Expect(queries).To(ConsistOf(
-					ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
 					ccv3.Query{Key: ccv3.StatesFilter, Values: []string{"STAGED"}},
+					ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+					ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 				))
 			})
 

--- a/actor/v7action/build_test.go
+++ b/actor/v7action/build_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Build Actions", func() {
 			BeforeEach(func() {
 				fakeCloudControllerClient.GetApplicationsReturns([]resources.Application{{GUID: appGUID}}, ccv3.Warnings{"get-apps-warning"}, nil)
 				fakeCloudControllerClient.GetPackagesReturns(
-					[]resources.Package{{GUID: "some-other-package-guid"}},
+					[]resources.Package{},
 					ccv3.Warnings{"get-packages-warning"},
 					nil,
 				)
@@ -180,7 +180,10 @@ var _ = Describe("Build Actions", func() {
 
 					Expect(fakeCloudControllerClient.GetPackagesCallCount()).To(Equal(1))
 					Expect(fakeCloudControllerClient.GetPackagesArgsForCall(0)).To(Equal([]ccv3.Query{
+						{Key: ccv3.GUIDFilter, Values: []string{packageGUID}},
 						{Key: ccv3.AppGUIDFilter, Values: []string{appGUID}},
+						{Key: ccv3.PerPage, Values: []string{"1"}},
+						{Key: ccv3.Page, Values: []string{"1"}},
 					}))
 
 					Expect(fakeCloudControllerClient.CreateBuildCallCount()).To(Equal(1))

--- a/actor/v7action/deployment.go
+++ b/actor/v7action/deployment.go
@@ -25,6 +25,7 @@ func (actor Actor) GetLatestActiveDeploymentForApp(appGUID string) (resources.De
 		ccv3.Query{Key: ccv3.StatusValueFilter, Values: []string{string(constant.DeploymentStatusValueActive)}},
 		ccv3.Query{Key: ccv3.OrderBy, Values: []string{ccv3.CreatedAtDescendingOrder}},
 		ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+		ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 	)
 
 	if err != nil {

--- a/actor/v7action/deployment_test.go
+++ b/actor/v7action/deployment_test.go
@@ -108,6 +108,7 @@ var _ = Describe("Deployment Actions", func() {
 					{Key: ccv3.StatusValueFilter, Values: []string{string(constant.DeploymentStatusValueActive)}},
 					{Key: ccv3.OrderBy, Values: []string{ccv3.CreatedAtDescendingOrder}},
 					{Key: ccv3.PerPage, Values: []string{"1"}},
+					{Key: ccv3.Page, Values: []string{"1"}},
 				},
 			))
 		})

--- a/actor/v7action/domain.go
+++ b/actor/v7action/domain.go
@@ -172,6 +172,8 @@ func (actor Actor) GetDomainAndOrgGUIDsByName(domainName string, orgName string)
 func (actor Actor) getDomainByName(domainName string) (resources.Domain, ccv3.Warnings, error) {
 	domains, warnings, err := actor.CloudControllerClient.GetDomains(
 		ccv3.Query{Key: ccv3.NameFilter, Values: []string{domainName}},
+		ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+		ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 	)
 	switch {
 	case err != nil:

--- a/actor/v7action/domain_test.go
+++ b/actor/v7action/domain_test.go
@@ -63,6 +63,8 @@ var _ = Describe("Domain Actions", func() {
 			givenQuery := fakeCloudControllerClient.GetDomainsArgsForCall(0)
 			Expect(givenQuery).To(Equal([]ccv3.Query{
 				{Key: ccv3.NameFilter, Values: []string{domainName}},
+				{Key: ccv3.PerPage, Values: []string{"1"}},
+				{Key: ccv3.Page, Values: []string{"1"}},
 			}))
 
 			Expect(fakeCloudControllerClient.CheckRouteCallCount()).To(Equal(1))
@@ -438,7 +440,11 @@ var _ = Describe("Domain Actions", func() {
 		})
 
 		When("the API layer call is successful", func() {
-			expectedQuery := []ccv3.Query{{Key: ccv3.NameFilter, Values: []string{domain1Name}}}
+			expectedQuery := []ccv3.Query{
+				{Key: ccv3.NameFilter, Values: []string{domain1Name}},
+				{Key: ccv3.PerPage, Values: []string{"1"}},
+				{Key: ccv3.Page, Values: []string{"1"}},
+			}
 			BeforeEach(func() {
 				fakeCloudControllerClient.GetDomainsReturns(
 					ccv3Domains,
@@ -512,7 +518,11 @@ var _ = Describe("Domain Actions", func() {
 
 			Expect(fakeCloudControllerClient.GetDomainsCallCount()).To(Equal(1))
 			actualQuery := fakeCloudControllerClient.GetDomainsArgsForCall(0)
-			Expect(actualQuery).To(Equal([]ccv3.Query{{Key: ccv3.NameFilter, Values: []string{"private-domain.com"}}}))
+			Expect(actualQuery).To(Equal([]ccv3.Query{
+				{Key: ccv3.NameFilter, Values: []string{"private-domain.com"}},
+				{Key: ccv3.PerPage, Values: []string{"1"}},
+				{Key: ccv3.Page, Values: []string{"1"}},
+			}))
 
 			Expect(fakeCloudControllerClient.SharePrivateDomainToOrgsCallCount()).To(Equal(1))
 			domainGuid, sharedOrgs := fakeCloudControllerClient.SharePrivateDomainToOrgsArgsForCall(0)
@@ -634,7 +644,11 @@ var _ = Describe("Domain Actions", func() {
 			It("returns the error and doesnt get the domain", func() {
 				Expect(fakeCloudControllerClient.GetOrganizationsCallCount()).To(Equal(1))
 				actualQuery := fakeCloudControllerClient.GetOrganizationsArgsForCall(0)
-				Expect(actualQuery).To(Equal([]ccv3.Query{{Key: ccv3.NameFilter, Values: []string{orgName}}}))
+				Expect(actualQuery).To(Equal([]ccv3.Query{
+					{Key: ccv3.NameFilter, Values: []string{orgName}},
+					{Key: ccv3.PerPage, Values: []string{"1"}},
+					{Key: ccv3.Page, Values: []string{"1"}},
+				}))
 
 				Expect(fakeCloudControllerClient.GetDomainsCallCount()).To(Equal(0))
 
@@ -665,11 +679,19 @@ var _ = Describe("Domain Actions", func() {
 				It("returns the error and doesnt get the domain", func() {
 					Expect(fakeCloudControllerClient.GetOrganizationsCallCount()).To(Equal(1))
 					actualQuery := fakeCloudControllerClient.GetOrganizationsArgsForCall(0)
-					Expect(actualQuery).To(Equal([]ccv3.Query{{Key: ccv3.NameFilter, Values: []string{orgName}}}))
+					Expect(actualQuery).To(Equal([]ccv3.Query{
+						{Key: ccv3.NameFilter, Values: []string{orgName}},
+						{Key: ccv3.PerPage, Values: []string{"1"}},
+						{Key: ccv3.Page, Values: []string{"1"}},
+					}))
 
 					Expect(fakeCloudControllerClient.GetDomainsCallCount()).To(Equal(1))
 					actualQuery = fakeCloudControllerClient.GetDomainsArgsForCall(0)
-					Expect(actualQuery).To(Equal([]ccv3.Query{{Key: ccv3.NameFilter, Values: []string{domainName}}}))
+					Expect(actualQuery).To(Equal([]ccv3.Query{
+						{Key: ccv3.NameFilter, Values: []string{domainName}},
+						{Key: ccv3.PerPage, Values: []string{"1"}},
+						{Key: ccv3.Page, Values: []string{"1"}},
+					}))
 
 					Expect(executeErr).To(MatchError(errors.New("get-domains-error")))
 					Expect(warnings).To(ConsistOf("get-orgs-warning", "get-domains-warning"))
@@ -690,11 +712,19 @@ var _ = Describe("Domain Actions", func() {
 				It("returns the GUIDs", func() {
 					Expect(fakeCloudControllerClient.GetOrganizationsCallCount()).To(Equal(1))
 					actualQuery := fakeCloudControllerClient.GetOrganizationsArgsForCall(0)
-					Expect(actualQuery).To(Equal([]ccv3.Query{{Key: ccv3.NameFilter, Values: []string{orgName}}}))
+					Expect(actualQuery).To(Equal([]ccv3.Query{
+						{Key: ccv3.NameFilter, Values: []string{orgName}},
+						{Key: ccv3.PerPage, Values: []string{"1"}},
+						{Key: ccv3.Page, Values: []string{"1"}},
+					}))
 
 					Expect(fakeCloudControllerClient.GetDomainsCallCount()).To(Equal(1))
 					actualQuery = fakeCloudControllerClient.GetDomainsArgsForCall(0)
-					Expect(actualQuery).To(Equal([]ccv3.Query{{Key: ccv3.NameFilter, Values: []string{domainName}}}))
+					Expect(actualQuery).To(Equal([]ccv3.Query{
+						{Key: ccv3.NameFilter, Values: []string{domainName}},
+						{Key: ccv3.PerPage, Values: []string{"1"}},
+						{Key: ccv3.Page, Values: []string{"1"}},
+					}))
 
 					Expect(executeErr).ToNot(HaveOccurred())
 					Expect(warnings).To(ConsistOf("get-orgs-warning", "get-domains-warning"))

--- a/actor/v7action/droplet.go
+++ b/actor/v7action/droplet.go
@@ -156,6 +156,8 @@ func (actor Actor) DownloadDropletByGUIDAndAppName(dropletGUID string, appName s
 	droplets, getDropletWarnings, err := actor.CloudControllerClient.GetDroplets(
 		ccv3.Query{Key: ccv3.GUIDFilter, Values: []string{dropletGUID}},
 		ccv3.Query{Key: ccv3.AppGUIDFilter, Values: []string{app.GUID}},
+		ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+		ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 	)
 	allWarnings = append(allWarnings, getDropletWarnings...)
 	if err != nil {

--- a/actor/v7action/droplet_test.go
+++ b/actor/v7action/droplet_test.go
@@ -783,6 +783,8 @@ var _ = Describe("Droplet Actions", func() {
 				Expect(fakeCloudControllerClient.GetDropletsArgsForCall(0)).To(ConsistOf(
 					ccv3.Query{Key: ccv3.GUIDFilter, Values: []string{"some-droplet-guid"}},
 					ccv3.Query{Key: ccv3.AppGUIDFilter, Values: []string{"some-app-guid"}},
+					ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+					ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 				))
 
 				Expect(fakeCloudControllerClient.DownloadDropletCallCount()).To(Equal(1))

--- a/actor/v7action/event.go
+++ b/actor/v7action/event.go
@@ -30,6 +30,7 @@ func (actor Actor) GetRecentEventsByApplicationNameAndSpace(appName string, spac
 	ccEvents, warnings, err := actor.CloudControllerClient.GetEvents(
 		ccv3.Query{Key: ccv3.TargetGUIDFilter, Values: []string{app.GUID}},
 		ccv3.Query{Key: ccv3.OrderBy, Values: []string{ccv3.CreatedAtDescendingOrder}},
+		ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 	)
 	allWarnings = append(allWarnings, warnings...)
 

--- a/actor/v7action/isolation_segment.go
+++ b/actor/v7action/isolation_segment.go
@@ -101,6 +101,8 @@ func (actor Actor) AssignIsolationSegmentToSpaceByNameAndSpace(isolationSegmentN
 func (actor Actor) GetIsolationSegmentByName(name string) (resources.IsolationSegment, Warnings, error) {
 	isolationSegments, warnings, err := actor.CloudControllerClient.GetIsolationSegments(
 		ccv3.Query{Key: ccv3.NameFilter, Values: []string{name}},
+		ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+		ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 	)
 	if err != nil {
 		return resources.IsolationSegment{}, Warnings(warnings), err

--- a/actor/v7action/isolation_segment_test.go
+++ b/actor/v7action/isolation_segment_test.go
@@ -110,6 +110,8 @@ var _ = Describe("Isolation Segment Actions", func() {
 					Expect(fakeCloudControllerClient.GetIsolationSegmentsCallCount()).To(Equal(1))
 					Expect(fakeCloudControllerClient.GetIsolationSegmentsArgsForCall(0)).To(ConsistOf(
 						ccv3.Query{Key: ccv3.NameFilter, Values: []string{"some-iso-seg"}},
+						ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+						ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 					))
 
 					Expect(fakeCloudControllerClient.DeleteIsolationSegmentCallCount()).To(Equal(1))
@@ -266,6 +268,8 @@ var _ = Describe("Isolation Segment Actions", func() {
 					Expect(fakeCloudControllerClient.GetIsolationSegmentsCallCount()).To(Equal(1))
 					Expect(fakeCloudControllerClient.GetIsolationSegmentsArgsForCall(0)).To(ConsistOf(
 						ccv3.Query{Key: ccv3.NameFilter, Values: []string{"some-iso-seg"}},
+						ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+						ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 					))
 
 					Expect(fakeCloudControllerClient.UpdateSpaceIsolationSegmentRelationshipCallCount()).To(Equal(1))
@@ -438,6 +442,8 @@ var _ = Describe("Isolation Segment Actions", func() {
 				Expect(fakeCloudControllerClient.GetIsolationSegmentsCallCount()).To(Equal(1))
 				Expect(fakeCloudControllerClient.GetIsolationSegmentsArgsForCall(0)).To(ConsistOf(
 					ccv3.Query{Key: ccv3.NameFilter, Values: []string{"some-iso-seg"}},
+					ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+					ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 				))
 			})
 		})

--- a/actor/v7action/label_test.go
+++ b/actor/v7action/label_test.go
@@ -142,6 +142,8 @@ var _ = Describe("labels", func() {
 				Expect(fakeCloudControllerClient.GetDomainsCallCount()).To(Equal(1))
 				Expect(fakeCloudControllerClient.GetDomainsArgsForCall(0)).To(ConsistOf(
 					ccv3.Query{Key: ccv3.NameFilter, Values: []string{resourceName}},
+					ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+					ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 				))
 			})
 
@@ -221,6 +223,8 @@ var _ = Describe("labels", func() {
 				Expect(fakeCloudControllerClient.GetOrganizationsCallCount()).To(Equal(1))
 				Expect(fakeCloudControllerClient.GetOrganizationsArgsForCall(0)).To(ConsistOf(
 					ccv3.Query{Key: ccv3.NameFilter, Values: []string{resourceName}},
+					ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+					ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 				))
 			})
 
@@ -311,6 +315,8 @@ var _ = Describe("labels", func() {
 				Expect(fakeCloudControllerClient.GetDomainsCallCount()).To(Equal(1))
 				Expect(fakeCloudControllerClient.GetDomainsArgsForCall(0)).To(ConsistOf(
 					ccv3.Query{Key: ccv3.NameFilter, Values: []string{"sub.example.com"}},
+					ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+					ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 				))
 			})
 
@@ -321,6 +327,8 @@ var _ = Describe("labels", func() {
 					ccv3.Query{Key: ccv3.DomainGUIDFilter, Values: []string{"domain-guid"}},
 					ccv3.Query{Key: ccv3.HostsFilter, Values: []string{""}},
 					ccv3.Query{Key: ccv3.PathsFilter, Values: []string{"/my-route/path"}},
+					ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+					ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 				))
 			})
 
@@ -413,6 +421,8 @@ var _ = Describe("labels", func() {
 				Expect(fakeCloudControllerClient.GetSpacesArgsForCall(0)).To(ConsistOf(
 					ccv3.Query{Key: ccv3.NameFilter, Values: []string{resourceName}},
 					ccv3.Query{Key: ccv3.OrganizationGUIDFilter, Values: []string{orgGUID}},
+					ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+					ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 				))
 			})
 
@@ -494,6 +504,8 @@ var _ = Describe("labels", func() {
 				Expect(fakeCloudControllerClient.GetStacksCallCount()).To(Equal(1))
 				Expect(fakeCloudControllerClient.GetStacksArgsForCall(0)).To(ConsistOf(
 					ccv3.Query{Key: ccv3.NameFilter, Values: []string{resourceName}},
+					ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+					ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 				))
 			})
 
@@ -938,6 +950,8 @@ var _ = Describe("labels", func() {
 				Expect(fakeCloudControllerClient.GetDomainsCallCount()).To(Equal(1))
 				Expect(fakeCloudControllerClient.GetDomainsArgsForCall(0)).To(ConsistOf(
 					ccv3.Query{Key: ccv3.NameFilter, Values: []string{resourceName}},
+					ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+					ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 				))
 			})
 
@@ -1022,6 +1036,8 @@ var _ = Describe("labels", func() {
 					ccv3.Query{Key: ccv3.DomainGUIDFilter, Values: []string{"domain-guid"}},
 					ccv3.Query{Key: ccv3.HostsFilter, Values: []string{""}},
 					ccv3.Query{Key: ccv3.PathsFilter, Values: []string{"/my-route/path"}},
+					ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+					ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 				))
 			})
 
@@ -1102,6 +1118,8 @@ var _ = Describe("labels", func() {
 				Expect(fakeCloudControllerClient.GetStacksCallCount()).To(Equal(1))
 				Expect(fakeCloudControllerClient.GetStacksArgsForCall(0)).To(ConsistOf(
 					ccv3.Query{Key: ccv3.NameFilter, Values: []string{resourceName}},
+					ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+					ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 				))
 			})
 

--- a/actor/v7action/organization.go
+++ b/actor/v7action/organization.go
@@ -35,6 +35,8 @@ func (actor Actor) GetOrganizationByGUID(orgGUID string) (resources.Organization
 func (actor Actor) GetOrganizationByName(name string) (resources.Organization, Warnings, error) {
 	orgs, warnings, err := actor.CloudControllerClient.GetOrganizations(
 		ccv3.Query{Key: ccv3.NameFilter, Values: []string{name}},
+		ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+		ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 	)
 	if err != nil {
 		return resources.Organization{}, Warnings(warnings), err

--- a/actor/v7action/organization_quota.go
+++ b/actor/v7action/organization_quota.go
@@ -76,10 +76,9 @@ func (actor Actor) GetOrganizationQuotas() ([]resources.OrganizationQuota, Warni
 
 func (actor Actor) GetOrganizationQuotaByName(orgQuotaName string) (resources.OrganizationQuota, Warnings, error) {
 	ccv3OrgQuotas, warnings, err := actor.CloudControllerClient.GetOrganizationQuotas(
-		ccv3.Query{
-			Key:    ccv3.NameFilter,
-			Values: []string{orgQuotaName},
-		},
+		ccv3.Query{Key: ccv3.NameFilter, Values: []string{orgQuotaName}},
+		ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+		ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 	)
 	if err != nil {
 		return resources.OrganizationQuota{}, Warnings(warnings), err

--- a/actor/v7action/organization_quota_test.go
+++ b/actor/v7action/organization_quota_test.go
@@ -102,10 +102,9 @@ var _ = Describe("Organization Quota Actions", func() {
 				Expect(fakeCloudControllerClient.GetOrganizationQuotasCallCount()).To(Equal(1))
 				passedQuotaQuery := fakeCloudControllerClient.GetOrganizationQuotasArgsForCall(0)
 				Expect(passedQuotaQuery).To(Equal([]ccv3.Query{
-					{
-						Key:    "names",
-						Values: []string{quotaName},
-					},
+					{Key: ccv3.NameFilter, Values: []string{quotaName}},
+					{Key: ccv3.PerPage, Values: []string{"1"}},
+					{Key: ccv3.Page, Values: []string{"1"}},
 				}))
 				Expect(fakeCloudControllerClient.ApplyOrganizationQuotaCallCount()).To(Equal(1))
 				passedQuotaGUID, passedOrgGUID := fakeCloudControllerClient.ApplyOrganizationQuotaArgsForCall(0)
@@ -158,6 +157,8 @@ var _ = Describe("Organization Quota Actions", func() {
 				query := fakeCloudControllerClient.GetOrganizationQuotasArgsForCall(0)
 				Expect(query).To(Equal([]ccv3.Query{
 					{Key: ccv3.NameFilter, Values: []string{quotaName}},
+					{Key: ccv3.PerPage, Values: []string{"1"}},
+					{Key: ccv3.Page, Values: []string{"1"}},
 				}))
 
 				Expect(fakeCloudControllerClient.DeleteOrganizationQuotaCallCount()).To(Equal(1))
@@ -368,6 +369,8 @@ var _ = Describe("Organization Quota Actions", func() {
 				query := fakeCloudControllerClient.GetOrganizationQuotasArgsForCall(0)
 				Expect(query).To(ConsistOf(
 					ccv3.Query{Key: ccv3.NameFilter, Values: []string{quotaName}},
+					ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+					ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 				))
 
 				Expect(warnings).To(ConsistOf("some-quota-warning"))

--- a/actor/v7action/organization_test.go
+++ b/actor/v7action/organization_test.go
@@ -208,6 +208,8 @@ var _ = Describe("Organization Actions", func() {
 				Expect(fakeCloudControllerClient.GetOrganizationsCallCount()).To(Equal(1))
 				Expect(fakeCloudControllerClient.GetOrganizationsArgsForCall(0)).To(ConsistOf(
 					ccv3.Query{Key: ccv3.NameFilter, Values: []string{"some-org-name"}},
+					ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+					ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 				))
 			})
 		})
@@ -434,10 +436,11 @@ var _ = Describe("Organization Actions", func() {
 						Expect(warnings).To(ConsistOf("warning-1", "warning-2", "warning-5", "warning-6", "warning-7", "warning-8"))
 
 						Expect(fakeCloudControllerClient.GetOrganizationsCallCount()).To(Equal(1))
-						Expect(fakeCloudControllerClient.GetOrganizationsArgsForCall(0)).To(Equal([]ccv3.Query{{
-							Key:    ccv3.NameFilter,
-							Values: []string{"some-org"},
-						}}))
+						Expect(fakeCloudControllerClient.GetOrganizationsArgsForCall(0)).To(Equal([]ccv3.Query{
+							{Key: ccv3.NameFilter, Values: []string{"some-org"}},
+							{Key: ccv3.PerPage, Values: []string{"1"}},
+							{Key: ccv3.Page, Values: []string{"1"}},
+						}))
 
 						Expect(fakeCloudControllerClient.DeleteOrganizationCallCount()).To(Equal(1))
 						Expect(fakeCloudControllerClient.DeleteOrganizationArgsForCall(0)).To(Equal("some-org-guid"))

--- a/actor/v7action/package.go
+++ b/actor/v7action/package.go
@@ -131,18 +131,11 @@ func (actor Actor) CreateAndUploadBitsPackageByApplicationNameAndSpace(appName s
 
 func (actor Actor) GetNewestReadyPackageForApplication(app resources.Application) (resources.Package, Warnings, error) {
 	ccv3Packages, warnings, err := actor.CloudControllerClient.GetPackages(
-		ccv3.Query{
-			Key:    ccv3.AppGUIDFilter,
-			Values: []string{app.GUID},
-		},
-		ccv3.Query{
-			Key:    ccv3.StatesFilter,
-			Values: []string{string(constant.PackageReady)},
-		},
-		ccv3.Query{
-			Key:    ccv3.OrderBy,
-			Values: []string{ccv3.CreatedAtDescendingOrder},
-		},
+		ccv3.Query{Key: ccv3.AppGUIDFilter, Values: []string{app.GUID}},
+		ccv3.Query{Key: ccv3.StatesFilter, Values: []string{string(constant.PackageReady)}},
+		ccv3.Query{Key: ccv3.OrderBy, Values: []string{ccv3.CreatedAtDescendingOrder}},
+		ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+		ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 	)
 
 	if err != nil {

--- a/actor/v7action/package_test.go
+++ b/actor/v7action/package_test.go
@@ -191,6 +191,8 @@ var _ = Describe("Package Actions", func() {
 						ccv3.Query{Key: ccv3.AppGUIDFilter, Values: []string{"some-app-guid"}},
 						ccv3.Query{Key: ccv3.StatesFilter, Values: []string{"READY"}},
 						ccv3.Query{Key: ccv3.OrderBy, Values: []string{ccv3.CreatedAtDescendingOrder}},
+						ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+						ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 					))
 
 					Expect(err).ToNot(HaveOccurred())
@@ -1093,18 +1095,11 @@ var _ = Describe("Package Actions", func() {
 
 				queries := fakeCloudControllerClient.GetPackagesArgsForCall(0)
 				Expect(queries).To(Equal([]ccv3.Query{
-					ccv3.Query{
-						Key:    ccv3.AppGUIDFilter,
-						Values: []string{sourceApp.GUID},
-					},
-					ccv3.Query{
-						Key:    ccv3.StatesFilter,
-						Values: []string{string(constant.PackageReady)},
-					},
-					ccv3.Query{
-						Key:    ccv3.OrderBy,
-						Values: []string{ccv3.CreatedAtDescendingOrder},
-					},
+					{Key: ccv3.AppGUIDFilter, Values: []string{sourceApp.GUID}},
+					{Key: ccv3.StatesFilter, Values: []string{string(constant.PackageReady)}},
+					{Key: ccv3.OrderBy, Values: []string{ccv3.CreatedAtDescendingOrder}},
+					{Key: ccv3.PerPage, Values: []string{"1"}},
+					{Key: ccv3.Page, Values: []string{"1"}},
 				}))
 			})
 		})

--- a/actor/v7action/revisions.go
+++ b/actor/v7action/revisions.go
@@ -43,11 +43,12 @@ func (actor *Actor) GetRevisionsByApplicationNameAndSpace(appName string, spaceG
 }
 
 func (actor Actor) GetRevisionByApplicationAndVersion(appGUID string, revisionVersion int) (resources.Revision, Warnings, error) {
-	query := ccv3.Query{
-		Key:    ccv3.VersionsFilter,
-		Values: []string{strconv.Itoa(revisionVersion)},
+	query := []ccv3.Query{
+		{Key: ccv3.VersionsFilter, Values: []string{strconv.Itoa(revisionVersion)}},
+		{Key: ccv3.PerPage, Values: []string{"2"}},
+		{Key: ccv3.Page, Values: []string{"1"}},
 	}
-	revisions, warnings, apiErr := actor.CloudControllerClient.GetApplicationRevisions(appGUID, query)
+	revisions, warnings, apiErr := actor.CloudControllerClient.GetApplicationRevisions(appGUID, query...)
 	if apiErr != nil {
 		return resources.Revision{}, Warnings(warnings), apiErr
 	}

--- a/actor/v7action/revisions_test.go
+++ b/actor/v7action/revisions_test.go
@@ -212,14 +212,15 @@ var _ = Describe("Revisions Actions", func() {
 			})
 
 			It("returns the revision", func() {
-				expectedQuery := ccv3.Query{
-					Key:    ccv3.VersionsFilter,
-					Values: []string{strconv.Itoa(revisionVersion)},
+				expectedQuery := []ccv3.Query{
+					{Key: ccv3.VersionsFilter, Values: []string{strconv.Itoa(revisionVersion)}},
+					{Key: ccv3.PerPage, Values: []string{"2"}},
+					{Key: ccv3.Page, Values: []string{"1"}},
 				}
 				Expect(fakeCloudControllerClient.GetApplicationRevisionsCallCount()).To(Equal(1), "GetApplicationRevisions call count")
 				appGuid, query := fakeCloudControllerClient.GetApplicationRevisionsArgsForCall(0)
 				Expect(appGuid).To(Equal("some-app-guid"))
-				Expect(query).To(ContainElement(expectedQuery))
+				Expect(query).To(ConsistOf(expectedQuery))
 
 				Expect(fakeConfig.APIVersionCallCount()).To(Equal(1), "APIVersion call count")
 				Expect(fakeCloudControllerClient.GetDropletsCallCount()).To(Equal(0), "GetDroplets call count")
@@ -252,14 +253,15 @@ var _ = Describe("Revisions Actions", func() {
 				})
 
 				It("fills in deployable based on droplet status", func() {
-					expectedQuery := ccv3.Query{
-						Key:    ccv3.VersionsFilter,
-						Values: []string{strconv.Itoa(revisionVersion)},
+					expectedQuery := []ccv3.Query{
+						{Key: ccv3.VersionsFilter, Values: []string{strconv.Itoa(revisionVersion)}},
+						{Key: ccv3.PerPage, Values: []string{"2"}},
+						{Key: ccv3.Page, Values: []string{"1"}},
 					}
 					Expect(fakeCloudControllerClient.GetApplicationRevisionsCallCount()).To(Equal(1), "GetApplicationRevisions call count")
 					appGuid, query := fakeCloudControllerClient.GetApplicationRevisionsArgsForCall(0)
 					Expect(appGuid).To(Equal("some-app-guid"))
-					Expect(query).To(ContainElement(expectedQuery))
+					Expect(query).To(ConsistOf(expectedQuery))
 
 					Expect(fakeConfig.APIVersionCallCount()).To(Equal(1), "APIVersion call count")
 					Expect(fakeCloudControllerClient.GetDropletsCallCount()).To(Equal(1), "GetDroplets call count")

--- a/actor/v7action/role.go
+++ b/actor/v7action/role.go
@@ -167,18 +167,11 @@ func (actor Actor) getUserGuidForDeleteRole(isClient bool, userNameOrGUID string
 
 func (actor Actor) GetRoleGUID(queryKey ccv3.QueryKey, orgOrSpaceGUID string, userGUID string, roleType constant.RoleType) (string, Warnings, error) {
 	ccv3Roles, _, warnings, err := actor.CloudControllerClient.GetRoles(
-		ccv3.Query{
-			Key:    ccv3.UserGUIDFilter,
-			Values: []string{userGUID},
-		},
-		ccv3.Query{
-			Key:    ccv3.RoleTypesFilter,
-			Values: []string{string(roleType)},
-		},
-		ccv3.Query{
-			Key:    queryKey,
-			Values: []string{orgOrSpaceGUID},
-		},
+		ccv3.Query{Key: ccv3.UserGUIDFilter, Values: []string{userGUID}},
+		ccv3.Query{Key: ccv3.RoleTypesFilter, Values: []string{string(roleType)}},
+		ccv3.Query{Key: queryKey, Values: []string{orgOrSpaceGUID}},
+		ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+		ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 	)
 
 	if err != nil {

--- a/actor/v7action/role_test.go
+++ b/actor/v7action/role_test.go
@@ -417,18 +417,11 @@ var _ = Describe("Role Actions", func() {
 					passedRolesQuery := fakeCloudControllerClient.GetRolesArgsForCall(0)
 					Expect(passedRolesQuery).To(Equal(
 						[]ccv3.Query{
-							{
-								Key:    ccv3.UserGUIDFilter,
-								Values: []string{userNameOrGUID},
-							},
-							{
-								Key:    ccv3.RoleTypesFilter,
-								Values: []string{string(constant.SpaceDeveloperRole)},
-							},
-							{
-								Key:    ccv3.SpaceGUIDFilter,
-								Values: []string{spaceGUID},
-							},
+							{Key: ccv3.UserGUIDFilter, Values: []string{userNameOrGUID}},
+							{Key: ccv3.RoleTypesFilter, Values: []string{string(constant.SpaceDeveloperRole)}},
+							{Key: ccv3.SpaceGUIDFilter, Values: []string{spaceGUID}},
+							{Key: ccv3.PerPage, Values: []string{"1"}},
+							{Key: ccv3.Page, Values: []string{"1"}},
 						},
 					))
 					passedRoleGUID := fakeCloudControllerClient.DeleteRoleArgsForCall(0)
@@ -468,18 +461,11 @@ var _ = Describe("Role Actions", func() {
 					passedRolesQuery := fakeCloudControllerClient.GetRolesArgsForCall(0)
 					Expect(passedRolesQuery).To(Equal(
 						[]ccv3.Query{
-							{
-								Key:    ccv3.UserGUIDFilter,
-								Values: []string{"user-guid"},
-							},
-							{
-								Key:    ccv3.RoleTypesFilter,
-								Values: []string{string(constant.SpaceDeveloperRole)},
-							},
-							{
-								Key:    ccv3.SpaceGUIDFilter,
-								Values: []string{spaceGUID},
-							},
+							{Key: ccv3.UserGUIDFilter, Values: []string{"user-guid"}},
+							{Key: ccv3.RoleTypesFilter, Values: []string{string(constant.SpaceDeveloperRole)}},
+							{Key: ccv3.SpaceGUIDFilter, Values: []string{spaceGUID}},
+							{Key: ccv3.PerPage, Values: []string{"1"}},
+							{Key: ccv3.Page, Values: []string{"1"}},
 						},
 					))
 
@@ -691,18 +677,11 @@ var _ = Describe("Role Actions", func() {
 					passedRolesQuery := fakeCloudControllerClient.GetRolesArgsForCall(0)
 					Expect(passedRolesQuery).To(Equal(
 						[]ccv3.Query{
-							{
-								Key:    ccv3.UserGUIDFilter,
-								Values: []string{userGUID},
-							},
-							{
-								Key:    ccv3.RoleTypesFilter,
-								Values: []string{string(constant.SpaceDeveloperRole)},
-							},
-							{
-								Key:    ccv3.SpaceGUIDFilter,
-								Values: []string{orgOrSpaceGUID},
-							},
+							{Key: ccv3.UserGUIDFilter, Values: []string{userGUID}},
+							{Key: ccv3.RoleTypesFilter, Values: []string{string(constant.SpaceDeveloperRole)}},
+							{Key: ccv3.SpaceGUIDFilter, Values: []string{orgOrSpaceGUID}},
+							{Key: ccv3.PerPage, Values: []string{"1"}},
+							{Key: ccv3.Page, Values: []string{"1"}},
 						},
 					))
 					Expect(warnings).To(ConsistOf("get-roles-warning"))
@@ -732,18 +711,11 @@ var _ = Describe("Role Actions", func() {
 					passedRolesQuery := fakeCloudControllerClient.GetRolesArgsForCall(0)
 					Expect(passedRolesQuery).To(Equal(
 						[]ccv3.Query{
-							{
-								Key:    ccv3.UserGUIDFilter,
-								Values: []string{userGUID},
-							},
-							{
-								Key:    ccv3.RoleTypesFilter,
-								Values: []string{string(constant.SpaceDeveloperRole)},
-							},
-							{
-								Key:    ccv3.OrganizationGUIDFilter,
-								Values: []string{orgOrSpaceGUID},
-							},
+							{Key: ccv3.UserGUIDFilter, Values: []string{userGUID}},
+							{Key: ccv3.RoleTypesFilter, Values: []string{string(constant.SpaceDeveloperRole)}},
+							{Key: ccv3.OrganizationGUIDFilter, Values: []string{orgOrSpaceGUID}},
+							{Key: ccv3.PerPage, Values: []string{"1"}},
+							{Key: ccv3.Page, Values: []string{"1"}},
 						},
 					))
 					Expect(warnings).To(ConsistOf("get-roles-warning"))
@@ -766,18 +738,11 @@ var _ = Describe("Role Actions", func() {
 				passedRolesQuery := fakeCloudControllerClient.GetRolesArgsForCall(0)
 				Expect(passedRolesQuery).To(Equal(
 					[]ccv3.Query{
-						{
-							Key:    ccv3.UserGUIDFilter,
-							Values: []string{"user-guid"},
-						},
-						{
-							Key:    ccv3.RoleTypesFilter,
-							Values: []string{string(constant.SpaceDeveloperRole)},
-						},
-						{
-							Key:    ccv3.SpaceGUIDFilter,
-							Values: []string{orgOrSpaceGUID},
-						},
+						{Key: ccv3.UserGUIDFilter, Values: []string{"user-guid"}},
+						{Key: ccv3.RoleTypesFilter, Values: []string{string(constant.SpaceDeveloperRole)}},
+						{Key: ccv3.SpaceGUIDFilter, Values: []string{orgOrSpaceGUID}},
+						{Key: ccv3.PerPage, Values: []string{"1"}},
+						{Key: ccv3.Page, Values: []string{"1"}},
 					},
 				))
 				Expect(warnings).To(ConsistOf("get-roles-warning"))
@@ -883,18 +848,11 @@ var _ = Describe("Role Actions", func() {
 					passedRolesQuery := fakeCloudControllerClient.GetRolesArgsForCall(0)
 					Expect(passedRolesQuery).To(Equal(
 						[]ccv3.Query{
-							{
-								Key:    ccv3.UserGUIDFilter,
-								Values: []string{userNameOrGUID},
-							},
-							{
-								Key:    ccv3.RoleTypesFilter,
-								Values: []string{string(constant.OrgBillingManagerRole)},
-							},
-							{
-								Key:    ccv3.OrganizationGUIDFilter,
-								Values: []string{orgGUID},
-							},
+							{Key: ccv3.UserGUIDFilter, Values: []string{userNameOrGUID}},
+							{Key: ccv3.RoleTypesFilter, Values: []string{string(constant.OrgBillingManagerRole)}},
+							{Key: ccv3.OrganizationGUIDFilter, Values: []string{orgGUID}},
+							{Key: ccv3.PerPage, Values: []string{"1"}},
+							{Key: ccv3.Page, Values: []string{"1"}},
 						},
 					))
 					passedRoleGUID := fakeCloudControllerClient.DeleteRoleArgsForCall(0)
@@ -934,18 +892,11 @@ var _ = Describe("Role Actions", func() {
 					passedRolesQuery := fakeCloudControllerClient.GetRolesArgsForCall(0)
 					Expect(passedRolesQuery).To(Equal(
 						[]ccv3.Query{
-							{
-								Key:    ccv3.UserGUIDFilter,
-								Values: []string{"user-guid"},
-							},
-							{
-								Key:    ccv3.RoleTypesFilter,
-								Values: []string{string(constant.OrgBillingManagerRole)},
-							},
-							{
-								Key:    ccv3.OrganizationGUIDFilter,
-								Values: []string{orgGUID},
-							},
+							{Key: ccv3.UserGUIDFilter, Values: []string{"user-guid"}},
+							{Key: ccv3.RoleTypesFilter, Values: []string{string(constant.OrgBillingManagerRole)}},
+							{Key: ccv3.OrganizationGUIDFilter, Values: []string{orgGUID}},
+							{Key: ccv3.PerPage, Values: []string{"1"}},
+							{Key: ccv3.Page, Values: []string{"1"}},
 						},
 					))
 

--- a/actor/v7action/route.go
+++ b/actor/v7action/route.go
@@ -144,10 +144,9 @@ func (actor Actor) parseRoutePath(routePath string) (string, string, string, res
 
 func (actor Actor) GetRoute(routePath string, spaceGUID string) (resources.Route, Warnings, error) {
 	filters := []ccv3.Query{
-		{
-			Key:    ccv3.SpaceGUIDFilter,
-			Values: []string{spaceGUID},
-		},
+		{Key: ccv3.SpaceGUIDFilter, Values: []string{spaceGUID}},
+		{Key: ccv3.PerPage, Values: []string{"1"}},
+		{Key: ccv3.Page, Values: []string{"1"}},
 	}
 
 	host, path, port, domain, allWarnings, err := actor.parseRoutePath(routePath)
@@ -370,6 +369,8 @@ func (actor Actor) GetRouteByAttributes(domain resources.Domain, hostname string
 		{Key: ccv3.DomainGUIDFilter, Values: []string{domain.GUID}},
 		{Key: ccv3.HostsFilter, Values: []string{hostname}},
 		{Key: ccv3.PathsFilter, Values: []string{path}},
+		{Key: ccv3.PerPage, Values: []string{"1"}},
+		{Key: ccv3.Page, Values: []string{"1"}},
 	}
 
 	if domain.IsTCP() {

--- a/actor/v7action/route_binding.go
+++ b/actor/v7action/route_binding.go
@@ -128,6 +128,8 @@ func (actor Actor) getRouteBinding(serviceInstanceGUID, routeGUID string) (resou
 	bindings, _, warnings, err := actor.CloudControllerClient.GetRouteBindings(
 		ccv3.Query{Key: ccv3.RouteGUIDFilter, Values: []string{routeGUID}},
 		ccv3.Query{Key: ccv3.ServiceInstanceGUIDFilter, Values: []string{serviceInstanceGUID}},
+		ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+		ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 	)
 
 	switch {
@@ -156,6 +158,8 @@ func (actor Actor) getRouteForBinding(params getRouteForBindingParams) (resource
 				ccv3.Query{Key: ccv3.DomainGUIDFilter, Values: []string{domain.GUID}},
 				ccv3.Query{Key: ccv3.HostsFilter, Values: []string{params.Hostname}},
 				ccv3.Query{Key: ccv3.PathsFilter, Values: []string{params.Path}},
+				ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+				ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 			)
 			return
 		},

--- a/actor/v7action/route_binding_test.go
+++ b/actor/v7action/route_binding_test.go
@@ -169,6 +169,8 @@ var _ = Describe("Route Binding Action", func() {
 				Expect(fakeCloudControllerClient.GetDomainsCallCount()).To(Equal(1))
 				Expect(fakeCloudControllerClient.GetDomainsArgsForCall(0)).To(ConsistOf(
 					ccv3.Query{Key: ccv3.NameFilter, Values: []string{domainName}},
+					ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+					ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 				))
 			})
 
@@ -210,6 +212,8 @@ var _ = Describe("Route Binding Action", func() {
 					ccv3.Query{Key: ccv3.DomainGUIDFilter, Values: []string{domainGUID}},
 					ccv3.Query{Key: ccv3.HostsFilter, Values: []string{hostname}},
 					ccv3.Query{Key: ccv3.PathsFilter, Values: []string{path}},
+					ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+					ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 				))
 			})
 
@@ -458,6 +462,8 @@ var _ = Describe("Route Binding Action", func() {
 				Expect(fakeCloudControllerClient.GetDomainsCallCount()).To(Equal(1))
 				Expect(fakeCloudControllerClient.GetDomainsArgsForCall(0)).To(ConsistOf(
 					ccv3.Query{Key: ccv3.NameFilter, Values: []string{domainName}},
+					ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+					ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 				))
 			})
 
@@ -499,6 +505,8 @@ var _ = Describe("Route Binding Action", func() {
 					ccv3.Query{Key: ccv3.DomainGUIDFilter, Values: []string{domainGUID}},
 					ccv3.Query{Key: ccv3.HostsFilter, Values: []string{hostname}},
 					ccv3.Query{Key: ccv3.PathsFilter, Values: []string{path}},
+					ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+					ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 				))
 			})
 
@@ -546,6 +554,8 @@ var _ = Describe("Route Binding Action", func() {
 				Expect(fakeCloudControllerClient.GetRouteBindingsArgsForCall(0)).To(ConsistOf(
 					ccv3.Query{Key: ccv3.RouteGUIDFilter, Values: []string{routeGUID}},
 					ccv3.Query{Key: ccv3.ServiceInstanceGUIDFilter, Values: []string{serviceInstanceGUID}},
+					ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+					ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 				))
 			})
 

--- a/actor/v7action/route_test.go
+++ b/actor/v7action/route_test.go
@@ -397,15 +397,14 @@ var _ = Describe("Route Actions", func() {
 
 				Expect(fakeCloudControllerClient.GetRoutesCallCount()).To(Equal(1))
 				query = fakeCloudControllerClient.GetRoutesArgsForCall(0)
-				Expect(query).To(HaveLen(4))
-				Expect(query[0].Key).To(Equal(ccv3.SpaceGUIDFilter))
-				Expect(query[0].Values).To(ConsistOf("space-guid"))
-				Expect(query[1].Key).To(Equal(ccv3.DomainGUIDFilter))
-				Expect(query[1].Values).To(ConsistOf("domain-guid"))
-				Expect(query[2].Key).To(Equal(ccv3.HostsFilter))
-				Expect(query[2].Values).To(ConsistOf("hostname"))
-				Expect(query[3].Key).To(Equal(ccv3.PathsFilter))
-				Expect(query[3].Values).To(ConsistOf("/the-path"))
+				Expect(query).To(ConsistOf(
+					ccv3.Query{Key: ccv3.SpaceGUIDFilter, Values: []string{"space-guid"}},
+					ccv3.Query{Key: ccv3.DomainGUIDFilter, Values: []string{"domain-guid"}},
+					ccv3.Query{Key: ccv3.HostsFilter, Values: []string{"hostname"}},
+					ccv3.Query{Key: ccv3.PathsFilter, Values: []string{"/the-path"}},
+					ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+					ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
+				))
 			})
 		})
 
@@ -438,8 +437,14 @@ var _ = Describe("Route Actions", func() {
 
 				Expect(fakeCloudControllerClient.GetRoutesCallCount()).To(Equal(1))
 				query = fakeCloudControllerClient.GetRoutesArgsForCall(0)
-				Expect(query[2].Key).To(Equal(ccv3.HostsFilter))
-				Expect(query[2].Values).To(ConsistOf(""))
+				Expect(query).To(ConsistOf(
+					ccv3.Query{Key: ccv3.SpaceGUIDFilter, Values: []string{"space-guid"}},
+					ccv3.Query{Key: ccv3.DomainGUIDFilter, Values: []string{"domain-guid"}},
+					ccv3.Query{Key: ccv3.HostsFilter, Values: []string{""}},
+					ccv3.Query{Key: ccv3.PathsFilter, Values: []string{""}},
+					ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+					ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
+				))
 			})
 		})
 
@@ -481,8 +486,15 @@ var _ = Describe("Route Actions", func() {
 
 				Expect(fakeCloudControllerClient.GetRoutesCallCount()).To(Equal(1))
 				query = fakeCloudControllerClient.GetRoutesArgsForCall(0)
-				Expect(query[4].Key).To(Equal(ccv3.PortsFilter))
-				Expect(query[4].Values).To(ConsistOf("8080"))
+				Expect(query).To(ConsistOf(
+					ccv3.Query{Key: ccv3.SpaceGUIDFilter, Values: []string{"space-guid"}},
+					ccv3.Query{Key: ccv3.DomainGUIDFilter, Values: []string{"domain-guid"}},
+					ccv3.Query{Key: ccv3.HostsFilter, Values: []string{""}},
+					ccv3.Query{Key: ccv3.PathsFilter, Values: []string{""}},
+					ccv3.Query{Key: ccv3.PortsFilter, Values: []string{"8080"}},
+					ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+					ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
+				))
 			})
 		})
 
@@ -1216,6 +1228,8 @@ var _ = Describe("Route Actions", func() {
 					query := fakeCloudControllerClient.GetDomainsArgsForCall(0)
 					Expect(query).To(ConsistOf([]ccv3.Query{
 						{Key: ccv3.NameFilter, Values: []string{"domain.com"}},
+						{Key: ccv3.PerPage, Values: []string{"1"}},
+						{Key: ccv3.Page, Values: []string{"1"}},
 					}))
 
 					// Get the route based on the domain GUID
@@ -1225,6 +1239,8 @@ var _ = Describe("Route Actions", func() {
 						{Key: ccv3.DomainGUIDFilter, Values: []string{"domain-guid"}},
 						{Key: ccv3.HostsFilter, Values: []string{"hostname"}},
 						{Key: ccv3.PathsFilter, Values: []string{"/path"}},
+						{Key: ccv3.PerPage, Values: []string{"1"}},
+						{Key: ccv3.Page, Values: []string{"1"}},
 					}))
 
 					// Delete the route asynchronously
@@ -1265,6 +1281,8 @@ var _ = Describe("Route Actions", func() {
 					query := fakeCloudControllerClient.GetDomainsArgsForCall(0)
 					Expect(query).To(ConsistOf([]ccv3.Query{
 						{Key: ccv3.NameFilter, Values: []string{"domain.com"}},
+						{Key: ccv3.PerPage, Values: []string{"1"}},
+						{Key: ccv3.Page, Values: []string{"1"}},
 					}))
 
 					// Get the route based on the domain GUID
@@ -1275,6 +1293,8 @@ var _ = Describe("Route Actions", func() {
 						{Key: ccv3.HostsFilter, Values: []string{""}},
 						{Key: ccv3.PathsFilter, Values: []string{""}},
 						{Key: ccv3.PortsFilter, Values: []string{"1026"}},
+						{Key: ccv3.PerPage, Values: []string{"1"}},
+						{Key: ccv3.Page, Values: []string{"1"}},
 					}))
 
 					// Delete the route asynchronously
@@ -1443,6 +1463,8 @@ var _ = Describe("Route Actions", func() {
 						ccv3.Query{Key: ccv3.DomainGUIDFilter, Values: []string{domainGUID}},
 						ccv3.Query{Key: ccv3.HostsFilter, Values: []string{hostname}},
 						ccv3.Query{Key: ccv3.PathsFilter, Values: []string{path}},
+						ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+						ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 					))
 
 					Expect(warnings).To(ConsistOf("get-routes-warning"))
@@ -1512,6 +1534,8 @@ var _ = Describe("Route Actions", func() {
 						ccv3.Query{Key: ccv3.PortsFilter, Values: []string{fmt.Sprintf("%d", port)}},
 						ccv3.Query{Key: ccv3.HostsFilter, Values: []string{""}},
 						ccv3.Query{Key: ccv3.PathsFilter, Values: []string{""}},
+						ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+						ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 					))
 
 					Expect(warnings).To(ConsistOf("get-routes-warning"))

--- a/actor/v7action/security_group.go
+++ b/actor/v7action/security_group.go
@@ -75,7 +75,11 @@ func (actor Actor) CreateSecurityGroup(name, filePath string) (Warnings, error) 
 func (actor Actor) GetSecurityGroup(securityGroupName string) (resources.SecurityGroup, Warnings, error) {
 	allWarnings := Warnings{}
 
-	securityGroups, warnings, err := actor.CloudControllerClient.GetSecurityGroups(ccv3.Query{Key: ccv3.NameFilter, Values: []string{securityGroupName}})
+	securityGroups, warnings, err := actor.CloudControllerClient.GetSecurityGroups(
+		ccv3.Query{Key: ccv3.NameFilter, Values: []string{securityGroupName}},
+		ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+		ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
+	)
 	allWarnings = append(allWarnings, warnings...)
 
 	if err != nil {
@@ -92,7 +96,11 @@ func (actor Actor) GetSecurityGroup(securityGroupName string) (resources.Securit
 func (actor Actor) GetSecurityGroupSummary(securityGroupName string) (SecurityGroupSummary, Warnings, error) {
 	allWarnings := Warnings{}
 	securityGroupSummary := SecurityGroupSummary{}
-	securityGroups, warnings, err := actor.CloudControllerClient.GetSecurityGroups(ccv3.Query{Key: ccv3.NameFilter, Values: []string{securityGroupName}})
+	securityGroups, warnings, err := actor.CloudControllerClient.GetSecurityGroups(
+		ccv3.Query{Key: ccv3.NameFilter, Values: []string{securityGroupName}},
+		ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+		ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
+	)
 
 	allWarnings = append(allWarnings, warnings...)
 
@@ -247,7 +255,11 @@ func (actor Actor) UpdateSecurityGroup(name, filePath string) (Warnings, error) 
 	}
 
 	// fetch security group from API
-	securityGroups, warnings, err := actor.CloudControllerClient.GetSecurityGroups(ccv3.Query{Key: ccv3.NameFilter, Values: []string{name}})
+	securityGroups, warnings, err := actor.CloudControllerClient.GetSecurityGroups(
+		ccv3.Query{Key: ccv3.NameFilter, Values: []string{name}},
+		ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+		ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
+	)
 	allWarnings = append(allWarnings, warnings...)
 	if err != nil {
 		return allWarnings, err

--- a/actor/v7action/security_group_test.go
+++ b/actor/v7action/security_group_test.go
@@ -324,6 +324,8 @@ var _ = Describe("Security Group Actions", func() {
 					Expect(fakeCloudControllerClient.GetSecurityGroupsCallCount()).To(Equal(1))
 					Expect(fakeCloudControllerClient.GetSecurityGroupsArgsForCall(0)).To(ConsistOf(
 						ccv3.Query{Key: ccv3.NameFilter, Values: []string{"security-group-name"}},
+						ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+						ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 					))
 
 					Expect(fakeCloudControllerClient.GetSpacesCallCount()).To(Equal(0))
@@ -403,6 +405,8 @@ var _ = Describe("Security Group Actions", func() {
 					Expect(fakeCloudControllerClient.GetSecurityGroupsCallCount()).To(Equal(1))
 					Expect(fakeCloudControllerClient.GetSecurityGroupsArgsForCall(0)).To(ConsistOf(
 						ccv3.Query{Key: ccv3.NameFilter, Values: []string{"security-group-name"}},
+						ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+						ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 					))
 
 					Expect(fakeCloudControllerClient.GetSpacesCallCount()).To(Equal(1))
@@ -1016,6 +1020,8 @@ var _ = Describe("Security Group Actions", func() {
 				orgsQuery := fakeCloudControllerClient.GetOrganizationsArgsForCall(0)
 				Expect(orgsQuery).To(Equal([]ccv3.Query{
 					{Key: ccv3.NameFilter, Values: []string{orgName}},
+					{Key: ccv3.PerPage, Values: []string{"1"}},
+					{Key: ccv3.Page, Values: []string{"1"}},
 				}))
 
 				Expect(fakeCloudControllerClient.GetSpacesCallCount()).To(Equal(1))
@@ -1023,12 +1029,16 @@ var _ = Describe("Security Group Actions", func() {
 				Expect(spacesQuery).To(Equal([]ccv3.Query{
 					{Key: ccv3.NameFilter, Values: []string{spaceName}},
 					{Key: ccv3.OrganizationGUIDFilter, Values: []string{"some-org-guid"}},
+					{Key: ccv3.PerPage, Values: []string{"1"}},
+					{Key: ccv3.Page, Values: []string{"1"}},
 				}))
 
 				Expect(fakeCloudControllerClient.GetSecurityGroupsCallCount()).To(Equal(1))
 				securityGroupsQuery := fakeCloudControllerClient.GetSecurityGroupsArgsForCall(0)
 				Expect(securityGroupsQuery).To(Equal([]ccv3.Query{
 					{Key: ccv3.NameFilter, Values: []string{securityGroupName}},
+					{Key: ccv3.PerPage, Values: []string{"1"}},
+					{Key: ccv3.Page, Values: []string{"1"}},
 				}))
 
 				Expect(fakeCloudControllerClient.UnbindSecurityGroupStagingSpaceCallCount()).To(Equal(1))
@@ -1171,6 +1181,8 @@ var _ = Describe("Security Group Actions", func() {
 			givenQuery := fakeCloudControllerClient.GetSecurityGroupsArgsForCall(0)
 			Expect(givenQuery).To(ConsistOf(
 				ccv3.Query{Key: ccv3.NameFilter, Values: []string{securityGroupName}},
+				ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+				ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 			))
 
 			givenSecurityGroup := fakeCloudControllerClient.UpdateSecurityGroupArgsForCall(0)
@@ -1282,6 +1294,8 @@ var _ = Describe("Security Group Actions", func() {
 					query := fakeCloudControllerClient.GetSecurityGroupsArgsForCall(0)
 					Expect(query).To(Equal([]ccv3.Query{
 						{Key: ccv3.NameFilter, Values: []string{securityGroupName}},
+						{Key: ccv3.PerPage, Values: []string{"1"}},
+						{Key: ccv3.Page, Values: []string{"1"}},
 					}))
 
 					Expect(fakeCloudControllerClient.UpdateSecurityGroupCallCount()).To(Equal(1))
@@ -1307,6 +1321,8 @@ var _ = Describe("Security Group Actions", func() {
 					query := fakeCloudControllerClient.GetSecurityGroupsArgsForCall(0)
 					Expect(query).To(Equal([]ccv3.Query{
 						{Key: ccv3.NameFilter, Values: []string{securityGroupName}},
+						{Key: ccv3.PerPage, Values: []string{"1"}},
+						{Key: ccv3.Page, Values: []string{"1"}},
 					}))
 
 					Expect(fakeCloudControllerClient.UpdateSecurityGroupCallCount()).To(Equal(1))
@@ -1332,6 +1348,8 @@ var _ = Describe("Security Group Actions", func() {
 					query := fakeCloudControllerClient.GetSecurityGroupsArgsForCall(0)
 					Expect(query).To(Equal([]ccv3.Query{
 						{Key: ccv3.NameFilter, Values: []string{securityGroupName}},
+						{Key: ccv3.PerPage, Values: []string{"1"}},
+						{Key: ccv3.Page, Values: []string{"1"}},
 					}))
 
 					Expect(fakeCloudControllerClient.UpdateSecurityGroupCallCount()).To(Equal(1))
@@ -1357,6 +1375,8 @@ var _ = Describe("Security Group Actions", func() {
 					query := fakeCloudControllerClient.GetSecurityGroupsArgsForCall(0)
 					Expect(query).To(Equal([]ccv3.Query{
 						{Key: ccv3.NameFilter, Values: []string{securityGroupName}},
+						{Key: ccv3.PerPage, Values: []string{"1"}},
+						{Key: ccv3.Page, Values: []string{"1"}},
 					}))
 
 					Expect(fakeCloudControllerClient.UpdateSecurityGroupCallCount()).To(Equal(1))

--- a/actor/v7action/service_app_binding.go
+++ b/actor/v7action/service_app_binding.go
@@ -125,6 +125,8 @@ func (actor Actor) getServiceAppBinding(serviceInstanceGUID, appGUID string) (re
 		ccv3.Query{Key: ccv3.TypeFilter, Values: []string{"app"}},
 		ccv3.Query{Key: ccv3.ServiceInstanceGUIDFilter, Values: []string{serviceInstanceGUID}},
 		ccv3.Query{Key: ccv3.AppGUIDFilter, Values: []string{appGUID}},
+		ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+		ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 	)
 
 	switch {

--- a/actor/v7action/service_app_binding_test.go
+++ b/actor/v7action/service_app_binding_test.go
@@ -425,6 +425,8 @@ var _ = Describe("Service App Binding Action", func() {
 					ccv3.Query{Key: ccv3.TypeFilter, Values: []string{"app"}},
 					ccv3.Query{Key: ccv3.AppGUIDFilter, Values: []string{appGUID}},
 					ccv3.Query{Key: ccv3.ServiceInstanceGUIDFilter, Values: []string{serviceInstanceGUID}},
+					ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+					ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 				))
 			})
 

--- a/actor/v7action/service_broker.go
+++ b/actor/v7action/service_broker.go
@@ -18,10 +18,9 @@ func (actor Actor) GetServiceBrokers() ([]resources.ServiceBroker, Warnings, err
 
 func (actor Actor) GetServiceBrokerByName(serviceBrokerName string) (resources.ServiceBroker, Warnings, error) {
 	query := []ccv3.Query{
-		{
-			Key:    ccv3.NameFilter,
-			Values: []string{serviceBrokerName},
-		},
+		{Key: ccv3.NameFilter, Values: []string{serviceBrokerName}},
+		{Key: ccv3.PerPage, Values: []string{"1"}},
+		{Key: ccv3.Page, Values: []string{"1"}},
 	}
 	serviceBrokers, warnings, err := actor.CloudControllerClient.GetServiceBrokers(query...)
 	if err != nil {

--- a/actor/v7action/service_broker_test.go
+++ b/actor/v7action/service_broker_test.go
@@ -113,10 +113,11 @@ var _ = Describe("Service Broker Actions", func() {
 
 			It("returns the service broker and warnings", func() {
 				Expect(fakeCloudControllerClient.GetServiceBrokersCallCount()).To(Equal(1))
-				Expect(fakeCloudControllerClient.GetServiceBrokersArgsForCall(0)).To(ConsistOf(ccv3.Query{
-					Key:    ccv3.NameFilter,
-					Values: []string{serviceBroker1Name},
-				}))
+				Expect(fakeCloudControllerClient.GetServiceBrokersArgsForCall(0)).To(ConsistOf(
+					ccv3.Query{Key: ccv3.NameFilter, Values: []string{serviceBroker1Name}},
+					ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+					ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
+				))
 
 				Expect(executeErr).ToNot(HaveOccurred())
 				Expect(warnings).To(ConsistOf("some-service-broker-warning"))

--- a/actor/v7action/service_instance_sharing_test.go
+++ b/actor/v7action/service_instance_sharing_test.go
@@ -75,10 +75,9 @@ var _ = Describe("Service Instance Sharing", func() {
 				Expect(fakeCloudControllerClient.GetOrganizationsCallCount()).To(Equal(1))
 				Expect(fakeCloudControllerClient.GetOrganizationsArgsForCall(0)).To(Equal(
 					[]ccv3.Query{
-						{
-							Key:    ccv3.NameFilter,
-							Values: []string{shareToOrgName},
-						},
+						{Key: ccv3.NameFilter, Values: []string{shareToOrgName}},
+						{Key: ccv3.PerPage, Values: []string{"1"}},
+						{Key: ccv3.Page, Values: []string{"1"}},
 					}))
 				Expect(fakeCloudControllerClient.GetSpacesCallCount()).To(Equal(0))
 			})
@@ -112,14 +111,10 @@ var _ = Describe("Service Instance Sharing", func() {
 					Expect(fakeCloudControllerClient.GetSpacesCallCount()).To(Equal(1))
 					Expect(fakeCloudControllerClient.GetSpacesArgsForCall(0)).To(Equal(
 						[]ccv3.Query{
-							{
-								Key:    ccv3.NameFilter,
-								Values: []string{shareToSpaceName},
-							},
-							{
-								Key:    ccv3.OrganizationGUIDFilter,
-								Values: []string{targetedOrgGUID},
-							},
+							{Key: ccv3.NameFilter, Values: []string{shareToSpaceName}},
+							{Key: ccv3.OrganizationGUIDFilter, Values: []string{targetedOrgGUID}},
+							{Key: ccv3.PerPage, Values: []string{"1"}},
+							{Key: ccv3.Page, Values: []string{"1"}},
 						}))
 				})
 
@@ -147,14 +142,10 @@ var _ = Describe("Service Instance Sharing", func() {
 					Expect(fakeCloudControllerClient.GetSpacesCallCount()).To(Equal(1))
 					Expect(fakeCloudControllerClient.GetSpacesArgsForCall(0)).To(Equal(
 						[]ccv3.Query{
-							{
-								Key:    ccv3.NameFilter,
-								Values: []string{shareToSpaceName},
-							},
-							{
-								Key:    ccv3.OrganizationGUIDFilter,
-								Values: []string{shareToOrgGUID},
-							},
+							{Key: ccv3.NameFilter, Values: []string{shareToSpaceName}},
+							{Key: ccv3.OrganizationGUIDFilter, Values: []string{shareToOrgGUID}},
+							{Key: ccv3.PerPage, Values: []string{"1"}},
+							{Key: ccv3.Page, Values: []string{"1"}},
 						}))
 				})
 

--- a/actor/v7action/service_key.go
+++ b/actor/v7action/service_key.go
@@ -155,6 +155,8 @@ func (actor Actor) getServiceKeyByServiceInstanceAndName(serviceInstanceName, se
 				ccv3.Query{Key: ccv3.ServiceInstanceGUIDFilter, Values: []string{serviceInstance.GUID}},
 				ccv3.Query{Key: ccv3.TypeFilter, Values: []string{"key"}},
 				ccv3.Query{Key: ccv3.NameFilter, Values: []string{serviceKeyName}},
+				ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+				ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 			)
 			return
 		},

--- a/actor/v7action/service_key_test.go
+++ b/actor/v7action/service_key_test.go
@@ -367,6 +367,8 @@ var _ = Describe("Service Key Action", func() {
 				ccv3.Query{Key: ccv3.ServiceInstanceGUIDFilter, Values: []string{serviceInstanceGUID}},
 				ccv3.Query{Key: ccv3.TypeFilter, Values: []string{"key"}},
 				ccv3.Query{Key: ccv3.NameFilter, Values: []string{serviceKeyName}},
+				ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+				ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 			))
 		})
 
@@ -508,6 +510,8 @@ var _ = Describe("Service Key Action", func() {
 				ccv3.Query{Key: ccv3.ServiceInstanceGUIDFilter, Values: []string{serviceInstanceGUID}},
 				ccv3.Query{Key: ccv3.TypeFilter, Values: []string{"key"}},
 				ccv3.Query{Key: ccv3.NameFilter, Values: []string{serviceKeyName}},
+				ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+				ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 			))
 		})
 
@@ -724,6 +728,8 @@ var _ = Describe("Service Key Action", func() {
 					ccv3.Query{Key: ccv3.TypeFilter, Values: []string{"key"}},
 					ccv3.Query{Key: ccv3.NameFilter, Values: []string{serviceKeyName}},
 					ccv3.Query{Key: ccv3.ServiceInstanceGUIDFilter, Values: []string{serviceInstanceGUID}},
+					ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+					ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 				))
 			})
 

--- a/actor/v7action/space.go
+++ b/actor/v7action/space.go
@@ -81,6 +81,8 @@ func (actor Actor) GetSpaceByNameAndOrganization(spaceName string, orgGUID strin
 	ccv3Spaces, _, warnings, err := actor.CloudControllerClient.GetSpaces(
 		ccv3.Query{Key: ccv3.NameFilter, Values: []string{spaceName}},
 		ccv3.Query{Key: ccv3.OrganizationGUIDFilter, Values: []string{orgGUID}},
+		ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+		ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 	)
 
 	if err != nil {

--- a/actor/v7action/space_feature_test.go
+++ b/actor/v7action/space_feature_test.go
@@ -70,6 +70,8 @@ var _ = Describe("space features", func() {
 			Expect(query).To(ConsistOf(
 				ccv3.Query{Key: ccv3.NameFilter, Values: []string{spaceName}},
 				ccv3.Query{Key: ccv3.OrganizationGUIDFilter, Values: []string{orgGUID}},
+				ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+				ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 			))
 
 			Expect(fakeCloudControllerClient.GetSpaceFeatureCallCount()).To(Equal(1))
@@ -200,6 +202,8 @@ var _ = Describe("space features", func() {
 					Expect(query).To(ConsistOf(
 						ccv3.Query{Key: ccv3.NameFilter, Values: []string{spaceName}},
 						ccv3.Query{Key: ccv3.OrganizationGUIDFilter, Values: []string{orgGUID}},
+						ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+						ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 					))
 
 					Expect(fakeCloudControllerClient.UpdateSpaceFeatureCallCount()).To(Equal(1))
@@ -245,6 +249,8 @@ var _ = Describe("space features", func() {
 					Expect(query).To(ConsistOf(
 						ccv3.Query{Key: ccv3.NameFilter, Values: []string{spaceName}},
 						ccv3.Query{Key: ccv3.OrganizationGUIDFilter, Values: []string{orgGUID}},
+						ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+						ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 					))
 
 					Expect(fakeCloudControllerClient.UpdateSpaceFeatureCallCount()).To(Equal(1))
@@ -280,6 +286,8 @@ var _ = Describe("space features", func() {
 			Expect(query).To(ConsistOf(
 				ccv3.Query{Key: ccv3.NameFilter, Values: []string{spaceName}},
 				ccv3.Query{Key: ccv3.OrganizationGUIDFilter, Values: []string{orgGUID}},
+				ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+				ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 			))
 
 			Expect(fakeCloudControllerClient.UpdateSpaceFeatureCallCount()).To(Equal(1))

--- a/actor/v7action/space_quota.go
+++ b/actor/v7action/space_quota.go
@@ -81,14 +81,10 @@ func (actor Actor) DeleteSpaceQuotaByName(quotaName string, orgGUID string) (War
 
 func (actor Actor) GetSpaceQuotaByName(spaceQuotaName string, orgGUID string) (resources.SpaceQuota, Warnings, error) {
 	ccv3Quotas, warnings, err := actor.CloudControllerClient.GetSpaceQuotas(
-		ccv3.Query{
-			Key:    ccv3.OrganizationGUIDFilter,
-			Values: []string{orgGUID},
-		},
-		ccv3.Query{
-			Key:    ccv3.NameFilter,
-			Values: []string{spaceQuotaName},
-		},
+		ccv3.Query{Key: ccv3.OrganizationGUIDFilter, Values: []string{orgGUID}},
+		ccv3.Query{Key: ccv3.NameFilter, Values: []string{spaceQuotaName}},
+		ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+		ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 	)
 
 	if err != nil {

--- a/actor/v7action/space_quota_test.go
+++ b/actor/v7action/space_quota_test.go
@@ -105,14 +105,10 @@ var _ = Describe("Space Quota Actions", func() {
 				passedQuotaQuery := fakeCloudControllerClient.GetSpaceQuotasArgsForCall(0)
 				Expect(passedQuotaQuery).To(Equal(
 					[]ccv3.Query{
-						{
-							Key:    "organization_guids",
-							Values: []string{orgGUID},
-						},
-						{
-							Key:    "names",
-							Values: []string{quotaName},
-						},
+						{Key: "organization_guids", Values: []string{orgGUID}},
+						{Key: "names", Values: []string{quotaName}},
+						{Key: "per_page", Values: []string{"1"}},
+						{Key: "page", Values: []string{"1"}},
 					},
 				))
 
@@ -345,14 +341,10 @@ var _ = Describe("Space Quota Actions", func() {
 				Expect(fakeCloudControllerClient.GetSpaceQuotasCallCount()).To(Equal(1))
 				query := fakeCloudControllerClient.GetSpaceQuotasArgsForCall(0)
 				Expect(query).To(ConsistOf(
-					ccv3.Query{
-						Key:    ccv3.OrganizationGUIDFilter,
-						Values: []string{orgGUID},
-					},
-					ccv3.Query{
-						Key:    ccv3.NameFilter,
-						Values: []string{quotaName},
-					},
+					ccv3.Query{Key: ccv3.OrganizationGUIDFilter, Values: []string{orgGUID}},
+					ccv3.Query{Key: ccv3.NameFilter, Values: []string{quotaName}},
+					ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+					ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 				))
 
 				Expect(fakeCloudControllerClient.DeleteSpaceQuotaCallCount()).To(Equal(1))
@@ -488,6 +480,8 @@ var _ = Describe("Space Quota Actions", func() {
 				Expect(query).To(ConsistOf(
 					ccv3.Query{Key: ccv3.OrganizationGUIDFilter, Values: []string{orgGUID}},
 					ccv3.Query{Key: ccv3.NameFilter, Values: []string{quotaName}},
+					ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+					ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 				))
 
 				Expect(warnings).To(ConsistOf("some-quota-warning"))

--- a/actor/v7action/space_test.go
+++ b/actor/v7action/space_test.go
@@ -258,6 +258,8 @@ var _ = Describe("Space", func() {
 					Expect(fakeCloudControllerClient.GetSpacesArgsForCall(0)).To(ConsistOf(
 						ccv3.Query{Key: ccv3.NameFilter, Values: []string{spaceName}},
 						ccv3.Query{Key: ccv3.OrganizationGUIDFilter, Values: []string{orgGUID}},
+						ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+						ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 					))
 				})
 			})
@@ -281,6 +283,8 @@ var _ = Describe("Space", func() {
 					Expect(fakeCloudControllerClient.GetSpacesArgsForCall(0)).To(ConsistOf(
 						ccv3.Query{Key: ccv3.NameFilter, Values: []string{spaceName}},
 						ccv3.Query{Key: ccv3.OrganizationGUIDFilter, Values: []string{orgGUID}},
+						ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+						ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 					))
 					Expect(space).To(Equal(resources.Space{
 						GUID: "some-space-guid",
@@ -524,20 +528,18 @@ var _ = Describe("Space", func() {
 							Expect(warnings).To(ConsistOf("warning-1", "warning-2", "warning-3", "warning-4", "warning-5", "warning-6", "warning-7", "warning-8"))
 
 							Expect(fakeCloudControllerClient.GetOrganizationsCallCount()).To(Equal(1))
-							Expect(fakeCloudControllerClient.GetOrganizationsArgsForCall(0)).To(Equal([]ccv3.Query{{
-								Key:    ccv3.NameFilter,
-								Values: []string{"some-org"},
-							}}))
+							Expect(fakeCloudControllerClient.GetOrganizationsArgsForCall(0)).To(Equal([]ccv3.Query{
+								{Key: ccv3.NameFilter, Values: []string{"some-org"}},
+								{Key: ccv3.PerPage, Values: []string{"1"}},
+								{Key: ccv3.Page, Values: []string{"1"}},
+							}))
 
 							Expect(fakeCloudControllerClient.GetSpacesCallCount()).To(Equal(1))
-							Expect(fakeCloudControllerClient.GetSpacesArgsForCall(0)).To(Equal([]ccv3.Query{{
-								Key:    ccv3.NameFilter,
-								Values: []string{"some-space"},
-							},
-								{
-									Key:    ccv3.OrganizationGUIDFilter,
-									Values: []string{"some-org-guid"},
-								},
+							Expect(fakeCloudControllerClient.GetSpacesArgsForCall(0)).To(Equal([]ccv3.Query{
+								{Key: ccv3.NameFilter, Values: []string{"some-space"}},
+								{Key: ccv3.OrganizationGUIDFilter, Values: []string{"some-org-guid"}},
+								{Key: ccv3.PerPage, Values: []string{"1"}},
+								{Key: ccv3.Page, Values: []string{"1"}},
 							}))
 
 							Expect(fakeCloudControllerClient.DeleteSpaceCallCount()).To(Equal(1))

--- a/actor/v7action/stack.go
+++ b/actor/v7action/stack.go
@@ -9,6 +9,8 @@ import (
 func (actor *Actor) GetStackByName(stackName string) (resources.Stack, Warnings, error) {
 	stacks, warnings, err := actor.CloudControllerClient.GetStacks(
 		ccv3.Query{Key: ccv3.NameFilter, Values: []string{stackName}},
+		ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+		ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 	)
 
 	if err != nil {

--- a/actor/v7action/stack_test.go
+++ b/actor/v7action/stack_test.go
@@ -76,7 +76,11 @@ var _ = Describe("Stack", func() {
 					Description: "Some stack desc",
 				}
 
-				expectedParams := []ccv3.Query{{Key: ccv3.NameFilter, Values: []string{"some-stack-name"}}}
+				expectedParams := []ccv3.Query{
+					{Key: ccv3.NameFilter, Values: []string{"some-stack-name"}},
+					{Key: ccv3.PerPage, Values: []string{"1"}},
+					{Key: ccv3.Page, Values: []string{"1"}},
+				}
 
 				BeforeEach(func() {
 					fakeCloudControllerClient.GetStacksReturns(

--- a/actor/v7action/task.go
+++ b/actor/v7action/task.go
@@ -54,6 +54,8 @@ func (actor Actor) GetTaskBySequenceIDAndApplication(sequenceID int, appGUID str
 	tasks, warnings, err := actor.CloudControllerClient.GetApplicationTasks(
 		appGUID,
 		ccv3.Query{Key: ccv3.SequenceIDFilter, Values: []string{strconv.Itoa(sequenceID)}},
+		ccv3.Query{Key: ccv3.PerPage, Values: []string{"1"}},
+		ccv3.Query{Key: ccv3.Page, Values: []string{"1"}},
 	)
 	if err != nil {
 		return resources.Task{}, Warnings(warnings), err

--- a/api/cloudcontroller/ccv3/application.go
+++ b/api/cloudcontroller/ccv3/application.go
@@ -23,6 +23,8 @@ func (client *Client) GetApplicationByNameAndSpace(appName string, spaceGUID str
 	apps, warnings, err := client.GetApplications(
 		Query{Key: NameFilter, Values: []string{appName}},
 		Query{Key: SpaceGUIDFilter, Values: []string{spaceGUID}},
+		Query{Key: PerPage, Values: []string{"1"}},
+		Query{Key: Page, Values: []string{"1"}},
 	)
 	if err != nil {
 		return resources.Application{}, warnings, err

--- a/api/cloudcontroller/ccv3/application_test.go
+++ b/api/cloudcontroller/ccv3/application_test.go
@@ -358,6 +358,8 @@ var _ = Describe("Application", func() {
 				Expect(actualParams.Query).To(Equal([]Query{
 					{Key: NameFilter, Values: []string{"some-app-name"}},
 					{Key: SpaceGUIDFilter, Values: []string{"some-space-guid"}},
+					{Key: PerPage, Values: []string{"1"}},
+					{Key: Page, Values: []string{"1"}},
 				}))
 				_, ok := actualParams.ResponseBody.(resources.Application)
 				Expect(ok).To(BeTrue())

--- a/api/cloudcontroller/ccv3/event.go
+++ b/api/cloudcontroller/ccv3/event.go
@@ -40,19 +40,18 @@ func (e *Event) UnmarshalJSON(data []byte) error {
 }
 
 // GetEvents uses the /v3/audit_events endpoint to retrieve a list of audit events.
-// NOTE: This only returns the first page of results. We are intentionally not using the paginate helper to fetch all
-// pages here because we only needed the first page for the `cf events` output. If we need to, we can refactor this
-// later to fetch all pages and make `cf events` only filter down to the first page.
 func (client *Client) GetEvents(query ...Query) ([]Event, Warnings, error) {
-	var responseBody struct {
-		Resources []Event `json:"resources"`
-	}
+	var events []Event
 
-	_, warnings, err := client.MakeRequest(RequestParams{
+	_, warnings, err := client.MakeListRequest(RequestParams{
 		RequestName:  internal.GetEventsRequest,
-		ResponseBody: &responseBody,
 		Query:        query,
+		ResponseBody: Event{},
+		AppendToList: func(item interface{}) error {
+			events = append(events, item.(Event))
+			return nil
+		},
 	})
 
-	return responseBody.Resources, warnings, err
+	return events, warnings, err
 }

--- a/api/cloudcontroller/ccv3/event_test.go
+++ b/api/cloudcontroller/ccv3/event_test.go
@@ -31,7 +31,8 @@ var _ = Describe("Event", func() {
 			events, warnings, executeErr = client.GetEvents(
 				Query{Key: TargetGUIDFilter, Values: []string{"some-target-guid"}},
 				Query{Key: OrderBy, Values: []string{"-created_at"}},
-				Query{Key: PerPage, Values: []string{"1"}})
+				Query{Key: PerPage, Values: []string{"1"}},
+				Query{Key: Page, Values: []string{"1"}})
 		})
 
 		var response string
@@ -86,7 +87,7 @@ var _ = Describe("Event", func() {
 			BeforeEach(func() {
 				server.AppendHandlers(
 					CombineHandlers(
-						VerifyRequest(http.MethodGet, "/v3/audit_events", "target_guids=some-target-guid&order_by=-created_at&per_page=1"),
+						VerifyRequest(http.MethodGet, "/v3/audit_events", "target_guids=some-target-guid&order_by=-created_at&per_page=1&page=1"),
 						RespondWith(http.StatusAccepted, response, http.Header{"X-Cf-Warnings": {"warning"}}),
 					),
 				)
@@ -132,7 +133,7 @@ var _ = Describe("Event", func() {
 
 				server.AppendHandlers(
 					CombineHandlers(
-						VerifyRequest(http.MethodGet, "/v3/audit_events", "target_guids=some-target-guid&order_by=-created_at&per_page=1"),
+						VerifyRequest(http.MethodGet, "/v3/audit_events", "target_guids=some-target-guid&order_by=-created_at&per_page=1&page=1"),
 						RespondWith(http.StatusTeapot, response, http.Header{"X-Cf-Warnings": {"warning"}}),
 					),
 				)

--- a/api/cloudcontroller/ccv3/paginate.go
+++ b/api/cloudcontroller/ccv3/paginate.go
@@ -6,7 +6,7 @@ import (
 	"code.cloudfoundry.org/cli/api/cloudcontroller"
 )
 
-func (requester RealRequester) paginate(request *cloudcontroller.Request, obj interface{}, appendToExternalList func(interface{}) error) (IncludedResources, Warnings, error) {
+func (requester RealRequester) paginate(request *cloudcontroller.Request, obj interface{}, appendToExternalList func(interface{}) error, specificPage bool) (IncludedResources, Warnings, error) {
 	fullWarningsList := Warnings{}
 	var includes IncludedResources
 
@@ -26,7 +26,7 @@ func (requester RealRequester) paginate(request *cloudcontroller.Request, obj in
 		includes.ServiceOfferings = append(includes.ServiceOfferings, wrapper.IncludedResources.ServiceOfferings...)
 		includes.ServicePlans = append(includes.ServicePlans, wrapper.IncludedResources.ServicePlans...)
 
-		if wrapper.NextPage() == "" {
+		if specificPage || wrapper.NextPage() == "" {
 			break
 		}
 

--- a/api/cloudcontroller/ccv3/query.go
+++ b/api/cloudcontroller/ccv3/query.go
@@ -94,6 +94,8 @@ const (
 	OrderBy QueryKey = "order_by"
 	// PerPage is a query parameter for specifying the number of results per page.
 	PerPage QueryKey = "per_page"
+	// Page is a query parameter for specifying the number of the requested page.
+	Page QueryKey = "page"
 	// Include is a query parameter for specifying other resources associated with the
 	// resource returned by the endpoint
 	Include QueryKey = "include"

--- a/api/cloudcontroller/ccv3/requester.go
+++ b/api/cloudcontroller/ccv3/requester.go
@@ -95,7 +95,15 @@ func (requester *RealRequester) MakeListRequest(requestParams RequestParams) (In
 		return IncludedResources{}, nil, err
 	}
 
-	return requester.paginate(request, requestParams.ResponseBody, requestParams.AppendToList)
+	specificPage := false
+	for _, query := range requestParams.Query {
+		if query.Key == Page {
+			specificPage = true
+			break
+		}
+	}
+
+	return requester.paginate(request, requestParams.ResponseBody, requestParams.AppendToList, specificPage)
 }
 
 func (requester *RealRequester) MakeRequest(requestParams RequestParams) (JobURL, Warnings, error) {

--- a/api/cloudcontroller/ccv3/service_instance.go
+++ b/api/cloudcontroller/ccv3/service_instance.go
@@ -34,14 +34,10 @@ func (client *Client) GetServiceInstances(query ...Query) ([]resources.ServiceIn
 
 func (client *Client) GetServiceInstanceByNameAndSpace(name, spaceGUID string, query ...Query) (resources.ServiceInstance, IncludedResources, Warnings, error) {
 	query = append(query,
-		Query{
-			Key:    NameFilter,
-			Values: []string{name},
-		},
-		Query{
-			Key:    SpaceGUIDFilter,
-			Values: []string{spaceGUID},
-		},
+		Query{Key: NameFilter, Values: []string{name}},
+		Query{Key: SpaceGUIDFilter, Values: []string{spaceGUID}},
+		Query{Key: PerPage, Values: []string{"1"}},
+		Query{Key: Page, Values: []string{"1"}},
 	)
 
 	instances, included, warnings, err := client.GetServiceInstances(query...)

--- a/api/cloudcontroller/ccv3/service_instance_test.go
+++ b/api/cloudcontroller/ccv3/service_instance_test.go
@@ -156,18 +156,11 @@ var _ = Describe("Service Instance", func() {
 			actualParams := requester.MakeListRequestArgsForCall(0)
 			Expect(actualParams.RequestName).To(Equal(internal.GetServiceInstancesRequest))
 			Expect(actualParams.Query).To(ConsistOf(
-				Query{
-					Key:    NameFilter,
-					Values: []string{name},
-				},
-				Query{
-					Key:    SpaceGUIDFilter,
-					Values: []string{spaceGUID},
-				},
-				Query{
-					Key:    Include,
-					Values: []string{"unicorns"},
-				},
+				Query{Key: NameFilter, Values: []string{name}},
+				Query{Key: SpaceGUIDFilter, Values: []string{spaceGUID}},
+				Query{Key: PerPage, Values: []string{"1"}},
+				Query{Key: Page, Values: []string{"1"}},
+				Query{Key: Include, Values: []string{"unicorns"}},
 			))
 			Expect(actualParams.ResponseBody).To(BeAssignableToTypeOf(resources.ServiceInstance{}))
 		})

--- a/api/cloudcontroller/ccv3/service_offering.go
+++ b/api/cloudcontroller/ccv3/service_offering.go
@@ -49,7 +49,11 @@ func (client *Client) GetServiceOfferingByGUID(guid string) (resources.ServiceOf
 }
 
 func (client *Client) GetServiceOfferingByNameAndBroker(serviceOfferingName, serviceBrokerName string) (resources.ServiceOffering, Warnings, error) {
-	query := []Query{{Key: NameFilter, Values: []string{serviceOfferingName}}}
+	query := []Query{
+		{Key: NameFilter, Values: []string{serviceOfferingName}},
+		{Key: PerPage, Values: []string{"2"}},
+		{Key: Page, Values: []string{"1"}},
+	}
 	if serviceBrokerName != "" {
 		query = append(query, Query{Key: ServiceBrokerNamesFilter, Values: []string{serviceBrokerName}})
 	}

--- a/api/cloudcontroller/ccv3/service_offering_test.go
+++ b/api/cloudcontroller/ccv3/service_offering_test.go
@@ -331,6 +331,8 @@ var _ = Describe("Service Offering", func() {
 					"RequestName": Equal(internal.GetServiceOfferingsRequest),
 					"Query": Equal([]Query{
 						{Key: NameFilter, Values: []string{serviceOfferingName}},
+						{Key: PerPage, Values: []string{"2"}},
+						{Key: Page, Values: []string{"1"}},
 						{Key: FieldsServiceBroker, Values: []string{"name", "guid"}},
 					}),
 					"ResponseBody": Equal(resources.ServiceOffering{}),
@@ -406,6 +408,8 @@ var _ = Describe("Service Offering", func() {
 				Expect(requester.MakeListRequestArgsForCall(0).Query).To(ConsistOf(
 					Query{Key: NameFilter, Values: []string{serviceOfferingName}},
 					Query{Key: ServiceBrokerNamesFilter, Values: []string{"myServiceBroker"}},
+					Query{Key: PerPage, Values: []string{"2"}},
+					Query{Key: Page, Values: []string{"1"}},
 					Query{Key: FieldsServiceBroker, Values: []string{"name", "guid"}},
 				))
 			})


### PR DESCRIPTION
- introduce `Page` query key
- when set, stop automatic pagination
- add `PerPage` and `Page` query keys to all list endpoints where only a single item from the returned list is used
- use `MakeListRequest` function in `GetEvents` and set `Page` query key in caller
- adapt `StagePackage` function to include `GUIDFilter` instead of iterating over the returned package list and comparing guids

Fixes #2599