### PR TITLE
Org field suspended v8

### DIFF
--- a/api/cloudcontroller/ccv3/organization_test.go
+++ b/api/cloudcontroller/ccv3/organization_test.go
@@ -450,6 +450,7 @@ var _ = Describe("Organizations", func() {
 
 				expectedBody := map[string]interface{}{
 					"name": "some-org-name",
+					"suspended": false,
 				}
 
 				server.AppendHandlers(
@@ -485,6 +486,7 @@ var _ = Describe("Organizations", func() {
 
 				expectedBody := map[string]interface{}{
 					"name": "some-org-name",
+					"suspended": false,
 				}
 
 				server.AppendHandlers(
@@ -525,6 +527,7 @@ var _ = Describe("Organizations", func() {
 
 				expectedBody := map[string]interface{}{
 					"name": "some-org-name",
+					"suspended": false,
 				}
 
 				server.AppendHandlers(
@@ -584,6 +587,7 @@ var _ = Describe("Organizations", func() {
 
 				expectedBody := map[string]interface{}{
 					"name": "some-org-name",
+					"suspended": false,
 					"metadata": map[string]interface{}{
 						"labels": map[string]string{
 							"k1": "v1",

--- a/resources/organization_resource.go
+++ b/resources/organization_resource.go
@@ -12,7 +12,8 @@ type Organization struct {
 	Name string `json:"name"`
 	// QuotaGUID is the GUID of the organization Quota applied to this Organization
 	QuotaGUID string `json:"-"`
-
+	//  Suspended is the status of the organization applied to this Organization
+	Suspended bool `json:"suspended"`
 	// Metadata is used for custom tagging of API resources
 	Metadata *Metadata `json:"metadata,omitempty"`
 }


### PR DESCRIPTION
## Where this PR should be backported?

- [ ] [main](https://github.com/cloudfoundry/cli/tree/main) - all changes should by default start here
- [x] [v8](https://github.com/cloudfoundry/cli/tree/v8)
- [ ] [v7](https://github.com/cloudfoundry/cli/tree/v7)

## Description of the Change

The V3 API allows you to see the status of organizations. make this field visible in order to make it available for other developments that use the cloudfoundry go cli library.

Exemple, the community cf_exporter release uses the go library from the cloudfoundry cli in order to retrieve the metrics on the organizations. Currently only the name, guid and quota metrics are reported.
Would it be possible to recover the status of the organizations.

This feature is necessary for applications that use the cli product in go development such as cf_exporter in order to have additional metrics on the org.

This feature don't cause a breaking change. Users will not be affected by this change

Make the Suspended value returned by the V3 cloudfoundry API available to orgs metrics.

All units-full are SUCCESS.