### PR TITLE
Add Chocolatey packaging for Windows

### DIFF
--- a/.github/win/choco/chocolateyinstall.ps1.tmpl
+++ b/.github/win/choco/chocolateyinstall.ps1.tmpl
@@ -1,0 +1,21 @@
+# stop on all errors
+$ErrorActionPreference = 'Stop';
+
+$packageName = 'cloudfoundry-cli'
+$registryUninstallerKeyName = 'cloudfoundry-cli'
+$version = '${version}'
+$url = '${claw_url}/stable?release=windows32-exe&version=${version}&source=github-rel'
+$url64 = '${claw_url}/stable?release=windows64-exe&version=${version}&source=github-rel'
+$checksum = '${checksum}'
+$checksum64 = '${checksum64}'
+$installDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$validExitCodes = @(0)
+
+Install-ChocolateyZipPackage -PackageName "$packageName" `
+  -Url "$url" `
+  -ChecksumType sha256 `
+  -Checksum "$checksum" `
+  -Url64bit "$url64" `
+  -ChecksumType64 sha256 `
+  -Checksum64 "$checksum64" `
+  -UnzipLocation "$installDir"

--- a/.github/win/choco/cloudfoundry-cli.nuspec.tmpl
+++ b/.github/win/choco/cloudfoundry-cli.nuspec.tmpl
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Do not remove this test for UTF-8: if “Ω” does not appear as greek uppercase omega letter enclosed in quotation
+  marks, you should use an editor that supports UTF-8, not this one.
+-->
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>cloudfoundry-cli</id>
+        <title>Cloud Foundry CLI</title>
+        <version>${version}</version>
+        <authors>Cloud Foundry Foundation</authors>
+        <owners>Cloud Foundry Foundation</owners>
+        <summary>Install official command line client for Cloud Foundry.</summary>
+        <description>Cloud Foundry CLI is the official command line client for Cloud Foundry
+        </description>
+        <projectUrl>https://github.com/cloudfoundry/cli</projectUrl>
+        <tags>cf cli cloudfoundry</tags>
+        <copyright>Cloud Foundry Foundation</copyright>
+        <licenseUrl>https://raw.githubusercontent.com/cloudfoundry/cli/master/LICENSE</licenseUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <iconUrl>https://raw.githubusercontent.com/cloudfoundry/cli/main/.github/win/cf.ico</iconUrl>
+        <packageSourceUrl>https://github.com/cloudfoundry/cli</packageSourceUrl>
+        <docsUrl>https://docs.cloudfoundry.org/cf-cli/</docsUrl>
+        <bugTrackerUrl>https://github.com/cloudfoundry/cli/issues</bugTrackerUrl>
+        <releaseNotes>https://github.com/cloudfoundry/cli/releases</releaseNotes>
+    </metadata>
+    <files>
+        <file src="tools\*.*" target="tools"/>
+    </files>
+</package>

--- a/.github/workflows/release-update-repos.yml
+++ b/.github/workflows/release-update-repos.yml
@@ -473,4 +473,102 @@ jobs:
     - name: Test Version Match
       run: cf -v | grep -q "${VERSION_BUILD}"
 
+  update-windows:
+    name: Update Windows Chocolatey Package
+    runs-on: windows-2019
+    needs: setup
+    environment: ${{ needs.setup.outputs.secrets-environment }}
+    env:
+      CLAW_URL:              ${{ needs.setup.outputs.claw-url }}
+      VERSION_BUILD:         ${{ needs.setup.outputs.version-build }}
+      VERSION_MAJOR:         ${{ needs.setup.outputs.version-major }}
+    steps:
+
+      - name: Setup
+        run: |
+          echo "VERSION_BUILD: ${VERSION_BUILD}"
+          echo "Environment: ${ENVIRONMENT}"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Chocolatey
+        env:
+          CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
+        run: |
+          Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+          choco setapikey -k $env:CHOCO_API_KEY -s https://push.chocolatey.org/
+
+      - name: Calculate Checksums
+        run: |
+          foreach ($bit in @('32', '64')) {
+            $file="cf-cli_win${bit}.zip"
+            Invoke-WebRequest "${env:CLAW_URL}/stable?release=windows${bit}-exe&version=${env:VERSION_BUILD}&source=github-rel" `
+              -OutFile $file
+            
+            if (-not (Test-Path -Path $file)) {
+              Write-Error "Failed to download $file" -ErrorAction Stop
+            }
+          
+            $hash = (Get-FileHash $file).Hash
+            Add-Content -Path "$env:GITHUB_ENV" -Value "CLI_WIN${bit}_SHA256=$hash"
+          }
+
+      - name: Render Chocolatey Templates
+        run: |
+          # Ensure current directory is accurate for WriteAllLines
+          [System.Environment]::CurrentDirectory = (Get-Location).Path
+
+          # Use WriteAllLines because it uses UTF8 without a BOM
+          $nuspec = (Get-Content -Encoding utf8 -Raw ./cli/.github/win/choco/cloudfoundry-cli.nuspec.tmpl).
+            Replace('${version}', $env:VERSION_BUILD)
+          [System.IO.File]::WriteAllLines('./cloudfoundry-cli.nuspec', $nuspec)
+
+          New-Item -Path ./tools -ItemType Directory -Force | Out-Null
+          (Get-Content -Encoding utf8 -Raw ./cli/.github/win/choco/chocolateyinstall.ps1.tmpl).
+            Replace('${version}', $env:VERSION_BUILD). `
+            Replace('${checksum}', $env:CLI_WIN32_SHA256). `
+            Replace('${checksum64}', $env:CLI_WIN64_SHA256). `
+            Replace('${claw_url}', $env:CLAW_URL) | `
+            Set-Content ./tools/chocolateyinstall.ps1 -Encoding utf8
+
+      - name: Create Chocolatey Package
+        run: |         
+          choco pack ./cloudfoundry-cli.nuspec
+
+      - name: Push Chocolatey Package
+        run: |
+          choco push "cloudfoundry-cli.$env:VERSION_BUILD.nupkg"
+
+  test-windows:
+    name: Test Windows Chocolatey Package
+    runs-on: windows-2019
+    needs:
+      - setup
+      - update-windows
+    environment: ${{ needs.setup.outputs.secrets-environment }}
+    env:
+      VERSION_BUILD: ${{ needs.setup.outputs.version-build }}
+      VERSION_MAJOR: ${{ needs.setup.outputs.version-major }}
+    steps:
+
+      - name: Install Chocolatey
+        run: |
+          Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+
+      - name: Install cf cli package
+        run: choco install cloudfoundry-cli --version $env:VERSION_MAJOR
+        
+      - name: Print CF CLI Versions
+        run: |
+          cf -v
+          Invoke-Expression "cf$env:VERSION_MAJOR -v"
+  
+      - name: Test Version Match
+        run: |
+          $found = (cf -v | Select-String "$env:VERSION_BUILD")
+          if ($null -eq $found) {
+            Write-Error "CF CLI version $env:VERSION_BUILD was not found" -ErrorAction Stop
+          }
+
 # vim: set sw=2 ts=2 sts=2 et tw=78 foldlevel=2 fdm=indent nospell:


### PR DESCRIPTION
This migrates and modernizes the [existing CF CLI Chocolatey packaging scripts](https://github.com/cloudfoundry-community/cf-chocolatey) that currently execute separately in AppVeyor. This enables the CF CLI to have a single point of release and management for all OSes.

## Prereqs
- The workflow requires a `CHOCO_API_KEY` secret so new packages can be submitted for moderation. Eventually we should ask for Chocolatey moderation to be removed since this is an official release channel.
- Windows2019 workers with .NET Framework 4.8 already installed. This workflow should work on Windows 2022, but I primarily tested this using 2019.
- The workflow installed Chocolatey as a first step. This could be baked into the base worker image.

## Fixed Chocolatey moderation issues
- Added checksums to 32bit and 64bit packages
- Removed ProjectSourceUrl that was the same as ProjectUrl causing a choco submission warning
