### PR TITLE
Chocolatey packaging for Windows [V8]

### DIFF
--- a/.github/win/choco/chocolateyinstall.ps1.tmpl
+++ b/.github/win/choco/chocolateyinstall.ps1.tmpl
@@ -1,0 +1,21 @@
+# stop on all errors
+$ErrorActionPreference = 'Stop';
+
+$packageName = 'cloudfoundry-cli'
+$registryUninstallerKeyName = 'cloudfoundry-cli'
+$version = '${version}'
+$url = '${claw_url}/stable?release=windows32-exe&version=${version}&source=github-rel'
+$url64 = '${claw_url}/stable?release=windows64-exe&version=${version}&source=github-rel'
+$checksum = '${checksum}'
+$checksum64 = '${checksum64}'
+$installDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$validExitCodes = @(0)
+
+Install-ChocolateyZipPackage -PackageName "$packageName" `
+  -Url "$url" `
+  -ChecksumType sha256 `
+  -Checksum "$checksum" `
+  -Url64bit "$url64" `
+  -ChecksumType64 sha256 `
+  -Checksum64 "$checksum64" `
+  -UnzipLocation "$installDir"

--- a/.github/win/choco/cloudfoundry-cli.nuspec.tmpl
+++ b/.github/win/choco/cloudfoundry-cli.nuspec.tmpl
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Do not remove this test for UTF-8: if “Ω” does not appear as greek uppercase omega letter enclosed in quotation
+  marks, you should use an editor that supports UTF-8, not this one.
+-->
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>cloudfoundry-cli</id>
+        <title>Cloud Foundry CLI</title>
+        <version>${version}</version>
+        <authors>Cloud Foundry Foundation</authors>
+        <owners>Cloud Foundry Foundation</owners>
+        <summary>Install official command line client for Cloud Foundry.</summary>
+        <description>Cloud Foundry CLI is the official command line client for Cloud Foundry
+        </description>
+        <projectUrl>https://github.com/cloudfoundry/cli</projectUrl>
+        <tags>cf cli cloudfoundry</tags>
+        <copyright>Cloud Foundry Foundation</copyright>
+        <licenseUrl>https://raw.githubusercontent.com/cloudfoundry/cli/master/LICENSE</licenseUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <iconUrl>https://raw.githubusercontent.com/cloudfoundry/cli/main/.github/win/cf.ico</iconUrl>
+        <packageSourceUrl>https://github.com/cloudfoundry/cli</packageSourceUrl>
+        <docsUrl>https://docs.cloudfoundry.org/cf-cli/</docsUrl>
+        <bugTrackerUrl>https://github.com/cloudfoundry/cli/issues</bugTrackerUrl>
+        <releaseNotes>https://github.com/cloudfoundry/cli/releases</releaseNotes>
+    </metadata>
+    <files>
+        <file src="tools\*.*" target="tools"/>
+    </files>
+</package>

--- a/.github/workflows/release-update-repos.yml
+++ b/.github/workflows/release-update-repos.yml
@@ -473,4 +473,103 @@ jobs:
     - name: Test Version Match
       run: cf -v | grep -q "${VERSION_BUILD}"
 
+  update-windows:
+    name: Update Windows Chocolatey Package
+    runs-on: windows-2019
+    defaults:
+      run:
+        shell: pwsh
+    needs: setup
+    environment: ${{ needs.setup.outputs.secrets-environment }}
+    env:
+      CLAW_URL:              ${{ needs.setup.outputs.claw-url }}
+      VERSION_BUILD:         ${{ needs.setup.outputs.version-build }}
+      VERSION_MAJOR:         ${{ needs.setup.outputs.version-major }}
+    steps:
+
+      - name: Setup
+        run: |
+          echo "VERSION_BUILD: ${VERSION_BUILD}"
+          echo "Environment: ${ENVIRONMENT}"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Calculate Checksums
+        run: |
+          foreach ($bit in @('32', '64')) {
+            $file="cf-cli_win${bit}.zip"
+            Invoke-WebRequest "${env:CLAW_URL}/stable?release=windows${bit}-exe&version=${env:VERSION_BUILD}&source=github-rel" `
+              -OutFile $file
+            
+            if (-not (Test-Path -Path $file)) {
+              Write-Error "Failed to download $file" -ErrorAction Stop
+            }
+          
+            $hash = (Get-FileHash $file).Hash
+            Add-Content -Path "$env:GITHUB_ENV" -Value "CLI_WIN${bit}_SHA256=$hash"
+          }
+
+      - name: Render Chocolatey Templates
+        run: |
+          # Ensure current directory is accurate for WriteAllLines
+          [System.Environment]::CurrentDirectory = (Get-Location).Path
+
+          # Use WriteAllLines because it uses UTF8 without a BOM
+          $nuspec = (Get-Content -Encoding utf8 -Raw ./.github/win/choco/cloudfoundry-cli.nuspec.tmpl).
+            Replace('${version}', $env:VERSION_BUILD)
+          [System.IO.File]::WriteAllLines('./cloudfoundry-cli.nuspec', $nuspec)
+
+          New-Item -Path ./tools -ItemType Directory -Force | Out-Null
+          (Get-Content -Encoding utf8 -Raw ./.github/win/choco/chocolateyinstall.ps1.tmpl).
+            Replace('${version}', $env:VERSION_BUILD). `
+            Replace('${checksum}', $env:CLI_WIN32_SHA256). `
+            Replace('${checksum64}', $env:CLI_WIN64_SHA256). `
+            Replace('${claw_url}', $env:CLAW_URL) | `
+            Set-Content ./tools/chocolateyinstall.ps1 -Encoding utf8
+
+      - name: Create Chocolatey Package
+        run: |         
+          choco pack ./cloudfoundry-cli.nuspec
+
+      - name: Push Chocolatey Package
+        env:
+          CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
+        run: |
+          choco config set --name=defaultPushSource --value=https://push.chocolatey.org/
+          choco setapikey --key $env:CHOCO_API_KEY --source https://push.chocolatey.org/
+          choco push "cloudfoundry-cli.$env:VERSION_BUILD.nupkg"
+
+  test-windows:
+    name: Test Windows Chocolatey Package
+    runs-on: windows-2019
+    defaults:
+      run:
+        shell: pwsh
+    needs:
+      - setup
+      - update-windows
+    environment: ${{ needs.setup.outputs.secrets-environment }}
+    env:
+      VERSION_BUILD: ${{ needs.setup.outputs.version-build }}
+      VERSION_MAJOR: ${{ needs.setup.outputs.version-major }}
+    steps:
+
+      - name: Install cf cli package
+        run: choco install cloudfoundry-cli --version $env:VERSION_BUILD
+        
+      - name: Print Chocolatey CF CLI Versions
+        run: |
+          cd 'C:/ProgramData/chocolatey/lib/cloudfoundry-cli/tools'
+          ./cf -v
+          Invoke-Expression "./cf$env:VERSION_MAJOR -v"
+  
+      - name: Test Chocolatey Version Match
+        run: |
+          cd 'C:/ProgramData/chocolatey/lib/cloudfoundry-cli/tools'
+          $found = (./cf -v | Select-String "$env:VERSION_BUILD")
+          if ($null -eq $found) {
+            Write-Error "CF CLI version $env:VERSION_BUILD was not found" -ErrorAction Stop
+          }
+
 # vim: set sw=2 ts=2 sts=2 et tw=78 foldlevel=2 fdm=indent nospell:


### PR DESCRIPTION
Context https://github.com/cloudfoundry/cli/pull/2767

## Where this PR should be backported?

- [x] [main](https://github.com/cloudfoundry/cli/tree/main) - all changes should by default start here
- [x] [v8](https://github.com/cloudfoundry/cli/tree/v8)
- [ ] [v7](https://github.com/cloudfoundry/cli/tree/v7)

## Description of the Change

Update Chocolatey repo as part of our release process