### PR TITLE
test_rpc_server_example 

### DIFF
--- a/plugin/plugin_examples/test_rpc_server_example/test_rpc_server_example.go
+++ b/plugin/plugin_examples/test_rpc_server_example/test_rpc_server_example.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"code.cloudfoundry.org/cli/cf/flags"
 	"code.cloudfoundry.org/cli/plugin"
@@ -95,7 +96,7 @@ func getAllApps(cliConnection plugin.CliConnection) (AppsModel, error) {
 		}
 
 		apps := AppsModel{}
-		err = json.Unmarshal([]byte(output[0]), &apps)
+		err = json.Unmarshal([]byte(strings.Join(output, " ")), &apps)
 		if err != nil {
 			return AppsModel{}, err
 		}


### PR DESCRIPTION

## Where this PR should be backported?

- [ x] [main](https://github.com/cloudfoundry/cli/tree/main) - all changes should by default start here
- [ ] [v8](https://github.com/cloudfoundry/cli/tree/v8)
- [ ] [v7](https://github.com/cloudfoundry/cli/tree/v7)

## Description of the Change

Update plugin example test_rpc_server_example.  Existing code yields an error "unable to parse JSON".  The cliConnection returns an array of single-character results from the /v2/apps output.  An unmarshaling is attempted on the "output[0]" of this, yielding an error parsing "{" as valid json.
This PR (a) includes the strings module, so that (b) the "output" variable can be converted to a single text line before the existing []bytes coercion for json.Unmarshal.

## Why Is This PR Valuable?

What benefits will be realized by the code change? What users would want this change? What user need is this change addressing? 

This update keeps the example code up to date, so as people explore writing their own plugin, they have working examples (this is how I discovered it).

## Applicable Issues

No specific issue has been filed for this.

## How Urgent Is The Change?

Not particularly time-sensitive, however working examples foster good community.

## Other Relevant Parties

Who else is affected by the change? 

No other parties are affected.

## Other notes

Note CONTRIBUTING.md indicates go@1.18 should be used, however integration-plugin indicated go@1.19 should be used.  A "make integration-plugin" yields issues related to logging into my local CF, yet it's not clear what I am to do.  Manual testing with a build and manually installing the plugin yielded correct results.
