### PR TITLE
Bump go 1.21 -> 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module code.cloudfoundry.org/cli
 
-go 1.21
+go 1.22
 
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20170428003108-f4415fafc561


### PR DESCRIPTION
## Where this PR should be backported?

- [x] [main](https://github.com/cloudfoundry/cli/tree/main) - all changes should by default start here
- [x] [v8](https://github.com/cloudfoundry/cli/tree/v8)
- [x] [v7](https://github.com/cloudfoundry/cli/tree/v7)

## Description of the Change

Golang released a new version recently, and is ideal to keep CLI up to date with this new version
