### PR TITLE
Use `max_page` size for apps, service keys & routes

### DIFF
--- a/actor/v7action/application_summary.go
+++ b/actor/v7action/application_summary.go
@@ -40,6 +40,7 @@ func (actor Actor) GetAppSummariesForSpace(spaceGUID string, labelSelector strin
 	keys := []ccv3.Query{
 		{Key: ccv3.SpaceGUIDFilter, Values: []string{spaceGUID}},
 		{Key: ccv3.OrderBy, Values: []string{ccv3.NameOrder}},
+		{Key: ccv3.PerPage, Values: []string{ccv3.MaxPerPage}},
 	}
 	if len(labelSelector) > 0 {
 		keys = append(keys, ccv3.Query{Key: ccv3.LabelSelectorFilter, Values: []string{labelSelector}})

--- a/actor/v7action/application_summary_test.go
+++ b/actor/v7action/application_summary_test.go
@@ -276,6 +276,7 @@ var _ = Describe("Application Summary Actions", func() {
 					ccv3.Query{Key: ccv3.OrderBy, Values: []string{"name"}},
 					ccv3.Query{Key: ccv3.SpaceGUIDFilter, Values: []string{"some-space-guid"}},
 					ccv3.Query{Key: ccv3.LabelSelectorFilter, Values: []string{"some-key=some-value"}},
+					ccv3.Query{Key: ccv3.PerPage, Values: []string{ccv3.MaxPerPage}},
 				))
 
 				Expect(fakeCloudControllerClient.GetProcessesCallCount()).To(Equal(1))
@@ -296,6 +297,7 @@ var _ = Describe("Application Summary Actions", func() {
 					Expect(fakeCloudControllerClient.GetApplicationsArgsForCall(0)).To(ConsistOf(
 						ccv3.Query{Key: ccv3.OrderBy, Values: []string{"name"}},
 						ccv3.Query{Key: ccv3.SpaceGUIDFilter, Values: []string{"some-space-guid"}},
+						ccv3.Query{Key: ccv3.PerPage, Values: []string{ccv3.MaxPerPage}},
 					))
 				})
 			})

--- a/actor/v7action/route.go
+++ b/actor/v7action/route.go
@@ -84,7 +84,8 @@ func (actor Actor) GetRouteDestinationByAppGUID(route resources.Route, appGUID s
 func (actor Actor) GetRoutesBySpace(spaceGUID string, labelSelector string) ([]resources.Route, Warnings, error) {
 	allWarnings := Warnings{}
 	queries := []ccv3.Query{
-		ccv3.Query{Key: ccv3.SpaceGUIDFilter, Values: []string{spaceGUID}},
+		{Key: ccv3.SpaceGUIDFilter, Values: []string{spaceGUID}},
+		{Key: ccv3.PerPage, Values: []string{ccv3.MaxPerPage}},
 	}
 	if len(labelSelector) > 0 {
 		queries = append(queries, ccv3.Query{Key: ccv3.LabelSelectorFilter, Values: []string{labelSelector}})
@@ -189,7 +190,8 @@ func (actor Actor) GetRoute(routePath string, spaceGUID string) (resources.Route
 func (actor Actor) GetRoutesByOrg(orgGUID string, labelSelector string) ([]resources.Route, Warnings, error) {
 	allWarnings := Warnings{}
 	queries := []ccv3.Query{
-		ccv3.Query{Key: ccv3.OrganizationGUIDFilter, Values: []string{orgGUID}},
+		{Key: ccv3.OrganizationGUIDFilter, Values: []string{orgGUID}},
+		{Key: ccv3.PerPage, Values: []string{ccv3.MaxPerPage}},
 	}
 	if len(labelSelector) > 0 {
 		queries = append(queries, ccv3.Query{Key: ccv3.LabelSelectorFilter, Values: []string{labelSelector}})

--- a/actor/v7action/route_test.go
+++ b/actor/v7action/route_test.go
@@ -296,9 +296,11 @@ var _ = Describe("Route Actions", func() {
 
 				Expect(fakeCloudControllerClient.GetRoutesCallCount()).To(Equal(1))
 				query := fakeCloudControllerClient.GetRoutesArgsForCall(0)
-				Expect(query).To(HaveLen(1))
+				Expect(query).To(HaveLen(2))
 				Expect(query[0].Key).To(Equal(ccv3.SpaceGUIDFilter))
 				Expect(query[0].Values).To(ConsistOf("space-guid"))
+				Expect(query[1].Key).To(Equal(ccv3.PerPage))
+				Expect(query[1].Values).To(ConsistOf(ccv3.MaxPerPage))
 			})
 
 			When("a label selector is provided", func() {
@@ -312,6 +314,7 @@ var _ = Describe("Route Actions", func() {
 					Expect(fakeCloudControllerClient.GetRoutesCallCount()).To(Equal(1))
 					expectedQuery := []ccv3.Query{
 						{Key: ccv3.SpaceGUIDFilter, Values: []string{"space-guid"}},
+						{Key: ccv3.PerPage, Values: []string{ccv3.MaxPerPage}},
 						{Key: ccv3.LabelSelectorFilter, Values: []string{"ink=blink"}},
 					}
 					actualQuery := fakeCloudControllerClient.GetRoutesArgsForCall(0)
@@ -631,9 +634,11 @@ var _ = Describe("Route Actions", func() {
 
 				Expect(fakeCloudControllerClient.GetRoutesCallCount()).To(Equal(1))
 				query := fakeCloudControllerClient.GetRoutesArgsForCall(0)
-				Expect(query).To(HaveLen(1))
+				Expect(query).To(HaveLen(2))
 				Expect(query[0].Key).To(Equal(ccv3.OrganizationGUIDFilter))
 				Expect(query[0].Values).To(ConsistOf("org-guid"))
+				Expect(query[1].Key).To(Equal(ccv3.PerPage))
+				Expect(query[1].Values).To(ConsistOf(ccv3.MaxPerPage))
 			})
 
 			When("a label selector is provided", func() {
@@ -647,6 +652,7 @@ var _ = Describe("Route Actions", func() {
 					Expect(fakeCloudControllerClient.GetRoutesCallCount()).To(Equal(1))
 					expectedQuery := []ccv3.Query{
 						{Key: ccv3.OrganizationGUIDFilter, Values: []string{"org-guid"}},
+						{Key: ccv3.PerPage, Values: []string{ccv3.MaxPerPage}},
 						{Key: ccv3.LabelSelectorFilter, Values: []string{"env=prod"}},
 					}
 					actualQuery := fakeCloudControllerClient.GetRoutesArgsForCall(0)

--- a/actor/v7action/service_key.go
+++ b/actor/v7action/service_key.go
@@ -62,6 +62,7 @@ func (actor Actor) GetServiceKeysByServiceInstance(serviceInstanceName, spaceGUI
 			keys, warnings, err = actor.CloudControllerClient.GetServiceCredentialBindings(
 				ccv3.Query{Key: ccv3.ServiceInstanceGUIDFilter, Values: []string{serviceInstance.GUID}},
 				ccv3.Query{Key: ccv3.TypeFilter, Values: []string{"key"}},
+				ccv3.Query{Key: ccv3.PerPage, Values: []string{ccv3.MaxPerPage}},
 			)
 			return
 		},

--- a/actor/v7action/service_key_test.go
+++ b/actor/v7action/service_key_test.go
@@ -248,6 +248,7 @@ var _ = Describe("Service Key Action", func() {
 			Expect(fakeCloudControllerClient.GetServiceCredentialBindingsArgsForCall(0)).To(ConsistOf(
 				ccv3.Query{Key: ccv3.ServiceInstanceGUIDFilter, Values: []string{serviceInstanceGUID}},
 				ccv3.Query{Key: ccv3.TypeFilter, Values: []string{"key"}},
+				ccv3.Query{Key: ccv3.PerPage, Values: []string{ccv3.MaxPerPage}},
 			))
 		})
 


### PR DESCRIPTION
## Where this PR should be backported?

- [x] [main](https://github.com/cloudfoundry/cli/tree/main) - all changes should by default start here
- [x] [v8](https://github.com/cloudfoundry/cli/tree/v8) -> #2794 
- [ ] [v7](https://github.com/cloudfoundry/cli/tree/v7)

## Description of the Change

To reduce the number of db queries in cloud controller it is beneficial to use a larger page size (5k) for potentially large entities.
This was already done for `marketplace` and `services` in commit b823ae53f394acf64ad7fb09f550c508a3c46e0a. This commit does the same for `apps`, `routes` and `service-keys`
