### PR TITLE
Add appGUID attribute to droplet resource

### DIFF
--- a/resources/droplet_resource.go
+++ b/resources/droplet_resource.go
@@ -1,12 +1,16 @@
 package resources
 
 import (
+	"code.cloudfoundry.org/cli/api/cloudcontroller"
 	"code.cloudfoundry.org/cli/api/cloudcontroller/ccv3/constant"
+	"encoding/json"
 )
 
 // Droplet represents a Cloud Controller droplet's metadata. A droplet is a set of
 // compiled bits for a given application.
 type Droplet struct {
+	// AppGUID is the unique identifier of the application associated with the droplet.
+	AppGUID string `json:"app_guid"`
 	//Buildpacks are the detected buildpacks from the staging process.
 	Buildpacks []DropletBuildpack `json:"buildpacks,omitempty"`
 	// CreatedAt is the timestamp that the Cloud Controller created the droplet.
@@ -34,4 +38,78 @@ type DropletBuildpack struct {
 	DetectOutput string `json:"detect_output"`
 	// Version is the version of the detected buildpack.
 	Version string `json:"version"`
+}
+
+func (d Droplet) MarshallJSON() ([]byte, error) {
+	type Data struct {
+		GUID string `json:"guid,omitempty"`
+	}
+
+	type RelationshipData struct {
+		Data Data `json:"data,omitempty"`
+	}
+
+	type Relationships struct {
+		App RelationshipData `json:"app,omitempty"`
+	}
+
+	type ccDroplet struct {
+		GUID          string                `json:"guid,omitempty"`
+		Buildpacks    []DropletBuildpack    `json:"buildpacks,omitempty"`
+		CreatedAt     string                `json:"created_at,omitempty"`
+		Image         string                `json:"image,omitempty"`
+		Stack         string                `json:"stack,omitempty"`
+		State         constant.DropletState `json:"state,omitempty"`
+		Relationships *Relationships        `json:"relationships,omitempty"`
+	}
+
+	ccD := ccDroplet{
+		GUID:       d.GUID,
+		Buildpacks: d.Buildpacks,
+		CreatedAt:  d.CreatedAt,
+		Image:      d.Image,
+		Stack:      d.Stack,
+		State:      d.State,
+	}
+
+	if d.AppGUID != "" {
+		ccD.Relationships = &Relationships{
+			App: RelationshipData{Data{GUID: d.AppGUID}},
+		}
+	}
+
+	return json.Marshal(ccD)
+}
+
+func (d *Droplet) UnmarshalJSON(data []byte) error {
+	var alias struct {
+		GUID          string                `json:"guid,omitempty"`
+		Buildpacks    []DropletBuildpack    `json:"buildpacks,omitempty"`
+		CreatedAt     string                `json:"created_at,omitempty"`
+		Image         string                `json:"image,omitempty"`
+		Stack         string                `json:"stack,omitempty"`
+		State         constant.DropletState `json:"state,omitempty"`
+		Relationships struct {
+			App struct {
+				Data struct {
+					GUID string `json:"guid,omitempty"`
+				} `json:"data,omitempty"`
+			} `json:"app,omitempty"`
+		}
+	}
+
+	err := cloudcontroller.DecodeJSON(data, &alias)
+	if err != nil {
+		return err
+	}
+
+	d.GUID = alias.GUID
+	d.Buildpacks = alias.Buildpacks
+	d.CreatedAt = alias.CreatedAt
+	d.Image = alias.Image
+	d.Stack = alias.Stack
+	d.State = alias.State
+	d.AppGUID = alias.Relationships.App.Data.GUID
+
+	return nil
 }


### PR DESCRIPTION
## Where this PR should be backported?

- [x] [main](https://github.com/cloudfoundry/cli/tree/main) - all changes should by default start here
- [x] [v8](https://github.com/cloudfoundry/cli/tree/v8) ([PR on the v8 branch](https://github.com/cloudfoundry/cli/pull/2801))
- [ ] [v7](https://github.com/cloudfoundry/cli/tree/v7)

## Description of the Change

The V3 API allows you to access to the relationships existing beween a droplet and its related app.
This PR make this relationship visible trough a new `AppGUID` attribute in the resource `droplet`.

The community `cf_exporter` currently use the `/v2/spaces/:guid/summary` endpoint to gain access to buildpack associated to an application. Have this relationship visible would help get rid of calls on this endpoint and retrieve buildpacks attached to an application through its droplets.

This feature is necessary for applications using the cli product in go development to established relationship between an `application` resource and its droplets.

This feature will not cause breaking change.