### PR TITLE
Add "total_service_keys" to quota json unmarshalling

### DIFF
--- a/api/cloudcontroller/ccv3/organization_quota_test.go
+++ b/api/cloudcontroller/ccv3/organization_quota_test.go
@@ -163,6 +163,7 @@ var _ = Describe("Organization Quotas", func() {
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 10, IsSet: true},
 								PaidServicePlans:      &trueValue,
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 20},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 8, IsSet: true},
@@ -183,6 +184,7 @@ var _ = Describe("Organization Quotas", func() {
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 8, IsSet: true},
 								PaidServicePlans:      &falseValue,
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 20},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 10, IsSet: true},
@@ -267,6 +269,7 @@ var _ = Describe("Organization Quotas", func() {
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 8, IsSet: true},
 								PaidServicePlans:      &falseValue,
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 20},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 10, IsSet: true},
@@ -396,6 +399,7 @@ var _ = Describe("Organization Quotas", func() {
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 10, IsSet: true},
 								PaidServicePlans:      &trueValue,
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 20},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 8, IsSet: true},

--- a/api/cloudcontroller/ccv3/space_quota_test.go
+++ b/api/cloudcontroller/ccv3/space_quota_test.go
@@ -250,6 +250,7 @@ var _ = Describe("Space Quotas", func() {
 							Services: resources.ServiceLimit{
 								PaidServicePlans:      &trueValue,
 								TotalServiceInstances: &types.NullInt{IsSet: true, Value: 5},
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 700},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{IsSet: true, Value: 6},
@@ -384,6 +385,7 @@ var _ = Describe("Space Quotas", func() {
 							Services: resources.ServiceLimit{
 								PaidServicePlans:      &trueValue,
 								TotalServiceInstances: &types.NullInt{IsSet: true, Value: 6},
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 7},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{IsSet: true, Value: 8},
@@ -580,6 +582,7 @@ var _ = Describe("Space Quotas", func() {
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 8, IsSet: true},
 								PaidServicePlans:      &falseValue,
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 20},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 10, IsSet: true},
@@ -773,6 +776,7 @@ var _ = Describe("Space Quotas", func() {
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 10, IsSet: true},
 								PaidServicePlans:      &trueValue,
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 20},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 8, IsSet: true},
@@ -794,6 +798,7 @@ var _ = Describe("Space Quotas", func() {
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 8, IsSet: true},
 								PaidServicePlans:      &falseValue,
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 20},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 10, IsSet: true},
@@ -878,6 +883,7 @@ var _ = Describe("Space Quotas", func() {
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 8, IsSet: true},
 								PaidServicePlans:      &falseValue,
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 20},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 10, IsSet: true},

--- a/resources/quota_resource.go
+++ b/resources/quota_resource.go
@@ -71,6 +71,7 @@ func (al *AppLimit) UnmarshalJSON(rawJSON []byte) error {
 type ServiceLimit struct {
 	TotalServiceInstances *types.NullInt `json:"total_service_instances,omitempty"`
 	PaidServicePlans      *bool          `json:"paid_services_allowed,omitempty"`
+	TotalServiceKeys      *types.NullInt `json:"total_service_keys,omitempty"`
 }
 
 func (sl *ServiceLimit) UnmarshalJSON(rawJSON []byte) error {


### PR DESCRIPTION
Thank you for contributing to the CF CLI! Please read the following:


* Please make sure you have implemented changes in line with the [contributing guidelines](https://github.com/cloudfoundry/cli/blob/main/.github/CONTRIBUTING.md)
* We're not allowed to accept any PRs without a signed CLA, no matter how small.
If your contribution falls under a company CLA but your membership is not public, expect delays while we confirm.
* All new code requires tests to protect against regressions.
* Contributions must be made against the appropriate branch. See the [contributing guidelines](https://github.com/cloudfoundry/cli/blob/main/.github/CONTRIBUTING.md)
* Contributions must conform to our [style guide](https://github.com/cloudfoundry/cli/wiki/CLI-Product-Specific-Style-Guide). Please reach out to us if you have questions.


## Where this PR should be backported?

- [x] [main](https://github.com/cloudfoundry/cli/tree/main) - all changes should by default start here
- [x] [v8](https://github.com/cloudfoundry/cli/tree/v8)
- [ ] [v7](https://github.com/cloudfoundry/cli/tree/v7)

## Description of the Change

We must be able to understand the design of your change from this description.
Keep in mind that the maintainer reviewing this PR may not be familiar with or
have worked with the code here recently, so please walk us through the concepts.


## Why Is This PR Valuable?

The value of `total_service_keys` is not included into unmarshalled data and is missing at the moment. The value should be available from the API as documented in https://v3-apidocs.cloudfoundry.org/version/3.163.0/#space-quotas-in-v3


## Applicable Issues

List any applicable GitHub Issues here

## How Urgent Is The Change?

Is the change urgent? If so, explain why it is time-sensitive.

## Other Relevant Parties

Who else is affected by the change? 
