### PR TITLE
Add "total_service_keys" to quota json unmarshalling 

### DIFF
--- a/api/cloudcontroller/ccv3/organization_quota_test.go
+++ b/api/cloudcontroller/ccv3/organization_quota_test.go
@@ -163,6 +163,7 @@ var _ = Describe("Organization Quotas", func() {
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 10, IsSet: true},
 								PaidServicePlans:      &trueValue,
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 20},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 8, IsSet: true},
@@ -183,6 +184,7 @@ var _ = Describe("Organization Quotas", func() {
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 8, IsSet: true},
 								PaidServicePlans:      &falseValue,
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 20},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 10, IsSet: true},
@@ -267,6 +269,7 @@ var _ = Describe("Organization Quotas", func() {
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 8, IsSet: true},
 								PaidServicePlans:      &falseValue,
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 20},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 10, IsSet: true},
@@ -396,6 +399,7 @@ var _ = Describe("Organization Quotas", func() {
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 10, IsSet: true},
 								PaidServicePlans:      &trueValue,
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 20},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 8, IsSet: true},

--- a/api/cloudcontroller/ccv3/space_quota_test.go
+++ b/api/cloudcontroller/ccv3/space_quota_test.go
@@ -250,6 +250,7 @@ var _ = Describe("Space Quotas", func() {
 							Services: resources.ServiceLimit{
 								PaidServicePlans:      &trueValue,
 								TotalServiceInstances: &types.NullInt{IsSet: true, Value: 5},
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 700},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{IsSet: true, Value: 6},
@@ -384,6 +385,7 @@ var _ = Describe("Space Quotas", func() {
 							Services: resources.ServiceLimit{
 								PaidServicePlans:      &trueValue,
 								TotalServiceInstances: &types.NullInt{IsSet: true, Value: 6},
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 7},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{IsSet: true, Value: 8},
@@ -580,6 +582,7 @@ var _ = Describe("Space Quotas", func() {
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 8, IsSet: true},
 								PaidServicePlans:      &falseValue,
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 20},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 10, IsSet: true},
@@ -773,6 +776,7 @@ var _ = Describe("Space Quotas", func() {
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 10, IsSet: true},
 								PaidServicePlans:      &trueValue,
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 20},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 8, IsSet: true},
@@ -794,6 +798,7 @@ var _ = Describe("Space Quotas", func() {
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 8, IsSet: true},
 								PaidServicePlans:      &falseValue,
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 20},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 10, IsSet: true},
@@ -878,6 +883,7 @@ var _ = Describe("Space Quotas", func() {
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 8, IsSet: true},
 								PaidServicePlans:      &falseValue,
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 20},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 10, IsSet: true},

--- a/resources/quota_resource.go
+++ b/resources/quota_resource.go
@@ -71,6 +71,7 @@ func (al *AppLimit) UnmarshalJSON(rawJSON []byte) error {
 type ServiceLimit struct {
 	TotalServiceInstances *types.NullInt `json:"total_service_instances,omitempty"`
 	PaidServicePlans      *bool          `json:"paid_services_allowed,omitempty"`
+	TotalServiceKeys      *types.NullInt `json:"total_service_keys,omitempty"`
 }
 
 func (sl *ServiceLimit) UnmarshalJSON(rawJSON []byte) error {


### PR DESCRIPTION
## Where this PR should be backported?

- [x] [main](https://github.com/cloudfoundry/cli/tree/main) - all changes should by default start here
- [x] [v8](https://github.com/cloudfoundry/cli/tree/v8)
- [x] [v7](https://github.com/cloudfoundry/cli/tree/v7)

## Description of the Change

Consumers of this library can access the total_service_keys field from the api with this change.

## Why Is This PR Valuable?

The value of `total_service_keys` is not included into unmarshalled data and is missing at the moment. The value should be available from the API as documented in https://v3-apidocs.cloudfoundry.org/version/3.163.0/#organization-quotas-in-v3

## Applicable Issues


## How Urgent Is The Change?


## Other Relevant Parties

