### PR TITLE
[Bugfix] Idempotency when trying to share a service twice (v8)

### DIFF
--- a/api/cloudcontroller/ccerror/service_instance_already_shared_error.go
+++ b/api/cloudcontroller/ccerror/service_instance_already_shared_error.go
@@ -1,0 +1,11 @@
+package ccerror
+
+// ServiceInstanceAlreadySharedError is returned when a
+// service instance is already shared.
+type ServiceInstanceAlreadySharedError struct {
+	Message string
+}
+
+func (e ServiceInstanceAlreadySharedError) Error() string {
+	return e.Message
+}

--- a/api/cloudcontroller/ccv3/errors.go
+++ b/api/cloudcontroller/ccv3/errors.go
@@ -154,6 +154,7 @@ func handleUnprocessableEntity(errorResponse ccerror.V3Error) error {
 	roleExistsRegexp := regexp.MustCompile(`User '.*' already has '.*' role.*`)
 	quotaExistsRegexp := regexp.MustCompile(`.* Quota '.*' already exists\.`)
 	securityGroupExistsRegexp := regexp.MustCompile(`Security group with name '.*' already exists\.`)
+	serviceInstanceSharedRegexp := regexp.MustCompile(`A service instance called .* has already been shared with .*\.`)
 
 	// boolean switch case with partial/regex string matchers
 	switch {
@@ -174,6 +175,8 @@ func handleUnprocessableEntity(errorResponse ccerror.V3Error) error {
 	case strings.Contains(errorString,
 		"The service instance name is taken"):
 		return ccerror.ServiceInstanceNameTakenError{Message: err.Message}
+	case serviceInstanceSharedRegexp.MatchString(errorString):
+		return ccerror.ServiceInstanceAlreadySharedError{Message: err.Message}
 	case orgNameTakenRegexp.MatchString(errorString):
 		return ccerror.OrganizationNameTakenError{UnprocessableEntityError: err}
 	case roleExistsRegexp.MatchString(errorString):

--- a/api/cloudcontroller/ccv3/errors_test.go
+++ b/api/cloudcontroller/ccv3/errors_test.go
@@ -507,6 +507,27 @@ var _ = Describe("Error Wrapper", func() {
 						})
 					})
 
+					When("the service instance has already been shared", func() {
+						BeforeEach(func() {
+							serverResponse = `
+{
+  "errors": [
+    {
+      "code": 10008,
+      "detail": "A service instance called foo has already been shared with foo-space.",
+      "title": "CF-UnprocessableEntity"
+    }
+  ]
+}`
+						})
+
+						It("returns an ServiceInstanceAlreadySharedError", func() {
+							Expect(makeError).To(MatchError(ccerror.ServiceInstanceAlreadySharedError{
+								Message: "A service instance called foo has already been shared with foo-space.",
+							}))
+						})
+					})					
+
 					When("the buildpack is invalid", func() {
 						BeforeEach(func() {
 							serverResponse = `

--- a/command/v7/share_service_command.go
+++ b/command/v7/share_service_command.go
@@ -2,6 +2,7 @@ package v7
 
 import (
 	"code.cloudfoundry.org/cli/actor/v7action"
+	"code.cloudfoundry.org/cli/api/cloudcontroller/ccerror"
 	"code.cloudfoundry.org/cli/command/flag"
 	"code.cloudfoundry.org/cli/types"
 )
@@ -38,7 +39,14 @@ func (cmd ShareServiceCommand) Execute(args []string) error {
 		})
 
 	cmd.UI.DisplayWarnings(warnings)
-	if err != nil {
+
+	switch err.(type) {
+	case nil:
+	case ccerror.ServiceInstanceAlreadySharedError:
+		cmd.UI.DisplayOK()
+		cmd.UI.DisplayTextWithFlavor("A service instance called {{.ServiceInstanceName}} has already been shared", map[string]interface{}{"ServiceInstanceName": cmd.RequiredArgs.ServiceInstance})
+		return nil
+	default:
 		return err
 	}
 


### PR DESCRIPTION
## Where this PR should be backported?

- [ ] [main](https://github.com/cloudfoundry/cli/tree/main) - all changes should by default start here
- [x] [v8](https://github.com/cloudfoundry/cli/tree/v8)
- [ ] [v7](https://github.com/cloudfoundry/cli/tree/v7)

## Description of the Change

While `cf create-service` has an Exitcode of `0` if a service with the name already exist, does `cf share-service` have an Exitcode of `1` for the similar situation.
This behavior is different to cf cli v7.

cli v7:
```
Sharing service instance foo into org test / space dev2 as admin...
Service instance foo is already shared with that space.
OK
```

cli v8:
```
Sharing service instance foo into org test / space dev2 as admin...
A service instance called foo has already been shared with dev2.
FAILED
```
 
The PR is changing the behavior of `cf8 share-service` to return an exit code of `0` if the service is already shared and make it consistent with `v7`.

## Why Is This PR Valuable?

Make `cf share-service` idempotent and consistent with v7

## Applicable Issues

#2669

## How Urgent Is The Change?

Is the change urgent? If so, explain why it is time-sensitive.

## Other Relevant Parties

Who else is affected by the change? 
