### PR TITLE
Add "total_domains" to quota json unmarshalling

### DIFF
--- a/api/cloudcontroller/ccv3/organization_quota_test.go
+++ b/api/cloudcontroller/ccv3/organization_quota_test.go
@@ -168,6 +168,9 @@ var _ = Describe("Organization Quotas", func() {
 								TotalRoutes:        &types.NullInt{Value: 8, IsSet: true},
 								TotalReservedPorts: &types.NullInt{Value: 4, IsSet: true},
 							},
+							Domains: resources.DomainLimit{
+								TotalDomains: &types.NullInt{IsSet: false, Value: 0},
+							},
 						},
 					},
 					resources.OrganizationQuota{
@@ -187,6 +190,9 @@ var _ = Describe("Organization Quotas", func() {
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 10, IsSet: true},
 								TotalReservedPorts: &types.NullInt{Value: 5, IsSet: true},
+							},
+							Domains: resources.DomainLimit{
+								TotalDomains: &types.NullInt{IsSet: false, Value: 0},
 							},
 						},
 					},
@@ -271,6 +277,9 @@ var _ = Describe("Organization Quotas", func() {
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 10, IsSet: true},
 								TotalReservedPorts: &types.NullInt{Value: 5, IsSet: true},
+							},
+							Domains: resources.DomainLimit{
+								TotalDomains: &types.NullInt{IsSet: false, Value: 0},
 							},
 						},
 					},
@@ -401,6 +410,9 @@ var _ = Describe("Organization Quotas", func() {
 								TotalRoutes:        &types.NullInt{Value: 8, IsSet: true},
 								TotalReservedPorts: &types.NullInt{Value: 4, IsSet: true},
 							},
+							Domains: resources.DomainLimit{
+								TotalDomains: &types.NullInt{IsSet: false, Value: 0},
+							},
 						},
 					},
 				))
@@ -478,6 +490,9 @@ var _ = Describe("Organization Quotas", func() {
 						TotalRoutes:        &types.NullInt{Value: 6, IsSet: true},
 						TotalReservedPorts: &types.NullInt{Value: 5, IsSet: true},
 					},
+					Domains: resources.DomainLimit{
+						TotalDomains: &types.NullInt{IsSet: true, Value: 1},
+					},
 				},
 			}
 		})
@@ -510,7 +525,7 @@ var _ = Describe("Organization Quotas", func() {
 						"total_reserved_ports": 5
 					 },
 					 "domains": {
-						"total_domains": null
+						"total_domains": 1
 					 },
 					 "links": {
 						"self": {
@@ -534,6 +549,9 @@ var _ = Describe("Organization Quotas", func() {
 					"routes": map[string]interface{}{
 						"total_routes":         6,
 						"total_reserved_ports": 5,
+					},
+					"domains": map[string]interface{}{
+						"total_domains": 1,
 					},
 				}
 
@@ -781,7 +799,8 @@ var _ = Describe("Organization Quotas", func() {
 						"paid_services_allowed":   true,
 						"total_service_instances": 0,
 					},
-					"routes": map[string]interface{}{},
+					"routes":  map[string]interface{}{},
+					"domains": map[string]interface{}{},
 				}
 
 				server.AppendHandlers(
@@ -814,6 +833,9 @@ var _ = Describe("Organization Quotas", func() {
 						Routes: resources.RouteLimit{
 							TotalRoutes:        &types.NullInt{IsSet: false, Value: 0},
 							TotalReservedPorts: &types.NullInt{IsSet: false, Value: 0},
+						},
+						Domains: resources.DomainLimit{
+							TotalDomains: &types.NullInt{IsSet: false, Value: 0},
 						},
 					},
 				}))

--- a/api/cloudcontroller/ccv3/space_quota_test.go
+++ b/api/cloudcontroller/ccv3/space_quota_test.go
@@ -154,6 +154,9 @@ var _ = Describe("Space Quotas", func() {
 							TotalRoutes:        &types.NullInt{IsSet: true, Value: 6},
 							TotalReservedPorts: &types.NullInt{IsSet: true, Value: 7},
 						},
+						Domains: resources.DomainLimit{
+							TotalDomains: &types.NullInt{IsSet: true, Value: 0},
+						},
 					},
 					OrgGUID: "some-org-guid",
 				}
@@ -178,6 +181,9 @@ var _ = Describe("Space Quotas", func() {
   "routes": {
     "total_routes": 6,
     "total_reserved_ports": 7
+  },
+  "domains": {
+	"total_domains": 2
   },
   "relationships": {
     "organization": {
@@ -255,6 +261,9 @@ var _ = Describe("Space Quotas", func() {
 								TotalRoutes:        &types.NullInt{IsSet: true, Value: 6},
 								TotalReservedPorts: &types.NullInt{IsSet: true, Value: 7},
 							},
+							Domains: resources.DomainLimit{
+								TotalDomains: &types.NullInt{IsSet: true, Value: 2},
+							},
 						},
 						OrgGUID: "some-org-guid",
 					}))
@@ -305,6 +314,9 @@ var _ = Describe("Space Quotas", func() {
   "routes": {
     "total_routes": 8,
     "total_reserved_ports": 9
+  },
+  "domains": {
+	"total_domains": 2
   },
   "relationships": {
     "organization": {
@@ -388,6 +400,9 @@ var _ = Describe("Space Quotas", func() {
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{IsSet: true, Value: 8},
 								TotalReservedPorts: &types.NullInt{IsSet: true, Value: 9},
+							},
+							Domains: resources.DomainLimit{
+								TotalDomains: &types.NullInt{IsSet: true, Value: 2},
 							},
 						},
 						OrgGUID:    "some-org-guid",
@@ -543,7 +558,7 @@ var _ = Describe("Space Quotas", func() {
 							"total_reserved_ports": 5
 						  },
 						  "domains": {
-							"total_private_domains": 7
+							"total_domains": 7
 						  },
 						  "relationships": {
 							"organization": {
@@ -584,6 +599,9 @@ var _ = Describe("Space Quotas", func() {
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 10, IsSet: true},
 								TotalReservedPorts: &types.NullInt{Value: 5, IsSet: true},
+							},
+							Domains: resources.DomainLimit{
+								TotalDomains: &types.NullInt{IsSet: true, Value: 7},
 							},
 						},
 					},
@@ -686,7 +704,7 @@ var _ = Describe("Space Quotas", func() {
 						"total_reserved_ports": 4
 					  },
 					  "domains": {
-						"total_private_domains": 7
+						"total_domains": 7
 					  },
 					  "relationships": {
 						"organization": {
@@ -727,7 +745,7 @@ var _ = Describe("Space Quotas", func() {
 							"total_reserved_ports": 5
 						  },
 						  "domains": {
-							"total_private_domains": 7
+							"total_domains": 7
 						  },
 						  "relationships": {
 							"organization": {
@@ -778,6 +796,9 @@ var _ = Describe("Space Quotas", func() {
 								TotalRoutes:        &types.NullInt{Value: 8, IsSet: true},
 								TotalReservedPorts: &types.NullInt{Value: 4, IsSet: true},
 							},
+							Domains: resources.DomainLimit{
+								TotalDomains: &types.NullInt{IsSet: true, Value: 7},
+							},
 						},
 						OrgGUID: "org-guid-1",
 					},
@@ -798,6 +819,9 @@ var _ = Describe("Space Quotas", func() {
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 10, IsSet: true},
 								TotalReservedPorts: &types.NullInt{Value: 5, IsSet: true},
+							},
+							Domains: resources.DomainLimit{
+								TotalDomains: &types.NullInt{IsSet: true, Value: 7},
 							},
 						},
 					},
@@ -839,7 +863,7 @@ var _ = Describe("Space Quotas", func() {
 							"total_reserved_ports": 5
 						  },
 						  "domains": {
-							"total_private_domains": 7
+							"total_domains": 7
 						  },
 						  "relationships": {
 							"organization": {
@@ -882,6 +906,9 @@ var _ = Describe("Space Quotas", func() {
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 10, IsSet: true},
 								TotalReservedPorts: &types.NullInt{Value: 5, IsSet: true},
+							},
+							Domains: resources.DomainLimit{
+								TotalDomains: &types.NullInt{IsSet: true, Value: 7},
 							},
 						},
 					},
@@ -1064,6 +1091,9 @@ var _ = Describe("Space Quotas", func() {
 						"total_routes": null,
 						"total_reserved_ports": null
 					 },
+					 "domains": {
+					   "total_domains": null
+					 },
 					 "links": {
 						"self": {
 						   "href": "https://api.foil-venom.lite.cli.fun/v3/space_quotas/08357710-8106-4d14-b0ea-03154a36fb79"
@@ -1116,6 +1146,9 @@ var _ = Describe("Space Quotas", func() {
 						Routes: resources.RouteLimit{
 							TotalRoutes:        &types.NullInt{IsSet: false, Value: 0},
 							TotalReservedPorts: &types.NullInt{IsSet: false, Value: 0},
+						},
+						Domains: resources.DomainLimit{
+							TotalDomains: &types.NullInt{IsSet: false, Value: 0},
 						},
 					},
 				}))

--- a/resources/quota_resource.go
+++ b/resources/quota_resource.go
@@ -17,6 +17,8 @@ type Quota struct {
 	Services ServiceLimit `json:"services"`
 	// Routes contain the various limits that are associated with routes
 	Routes RouteLimit `json:"routes"`
+	// Domains contain the various limits that are associated with domains
+	Domains DomainLimit `json:"domains"`
 }
 
 type AppLimit struct {
@@ -119,6 +121,31 @@ func (sl *RouteLimit) UnmarshalJSON(rawJSON []byte) error {
 
 	if sl.TotalReservedPorts == nil {
 		sl.TotalReservedPorts = &types.NullInt{
+			IsSet: false,
+			Value: 0,
+		}
+	}
+
+	return nil
+}
+
+type DomainLimit struct {
+	TotalDomains *types.NullInt `json:"total_domains,omitempty"`
+}
+
+func (sl *DomainLimit) UnmarshalJSON(rawJSON []byte) error {
+	type Alias DomainLimit
+
+	var aux Alias
+	err := json.Unmarshal(rawJSON, &aux)
+	if err != nil {
+		return err
+	}
+
+	*sl = DomainLimit(aux)
+
+	if sl.TotalDomains == nil {
+		sl.TotalDomains = &types.NullInt{
 			IsSet: false,
 			Value: 0,
 		}

--- a/resources/quota_resource_test.go
+++ b/resources/quota_resource_test.go
@@ -175,4 +175,40 @@ var _ = Describe("quota limits", func() {
 		)
 
 	})
+
+	Describe("DomainLimit", func() {
+		DescribeTable("MarshalJSON",
+			func(domainLimit DomainLimit, expectedBytes []byte) {
+				bytes, err := json.Marshal(domainLimit)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bytes).To(Equal(expectedBytes))
+			},
+			Entry("total domain", DomainLimit{TotalDomains: &types.NullInt{IsSet: true, Value: 1}}, []byte(`{"total_domains":1}`)),
+			Entry("total domain", DomainLimit{TotalDomains: nil}, []byte(`{}`)),
+			Entry("total domain", DomainLimit{TotalDomains: &types.NullInt{IsSet: false}}, []byte(`{"total_domains":null}`)),
+		)
+
+		DescribeTable("UnmarshalJSON",
+			func(givenBytes []byte, expectedStruct DomainLimit) {
+				var actualStruct DomainLimit
+				err := json.Unmarshal(givenBytes, &actualStruct)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(actualStruct).To(Equal(expectedStruct))
+			},
+			Entry(
+				"no null values",
+				[]byte(`{"total_domains":1}`),
+				DomainLimit{
+					TotalDomains: &types.NullInt{IsSet: true, Value: 1},
+				}),
+			Entry(
+				"total domains is null",
+				[]byte(`{"total_domains":null}`),
+				DomainLimit{
+					TotalDomains: &types.NullInt{IsSet: false, Value: 0},
+				}),
+		)
+
+	})
+
 })


### PR DESCRIPTION
- [x] [main](https://github.com/cloudfoundry/cli/pull/2883)
- [x] [v7](https://github.com/cloudfoundry/cli/pull/2886)
- [x] [v8](https://github.com/cloudfoundry/cli/pull/2889)

# Description of the Change
Consumers of this library can access the total_domains field from the api with this change.

# Why Is This PR Valuable?
The value of this parameters is not included into unmarshalled data and is missing at the moment. The value should be available from the API as documented in https://v3-apidocs.cloudfoundry.org/version/3.163.0/#organization-quotas-in-v3

