### PR TITLE
Add "total_service_keys" to quota json unmarshalling

### DIFF
--- a/api/cloudcontroller/ccv3/organization_quota_test.go
+++ b/api/cloudcontroller/ccv3/organization_quota_test.go
@@ -160,6 +160,7 @@ var _ = Describe("Organization Quotas", func() {
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 10, IsSet: true},
 								PaidServicePlans:      &trueValue,
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 20},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 8, IsSet: true},
@@ -179,6 +180,7 @@ var _ = Describe("Organization Quotas", func() {
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 8, IsSet: true},
 								PaidServicePlans:      &falseValue,
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 20},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 10, IsSet: true},
@@ -261,6 +263,7 @@ var _ = Describe("Organization Quotas", func() {
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 8, IsSet: true},
 								PaidServicePlans:      &falseValue,
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 20},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 10, IsSet: true},
@@ -388,6 +391,7 @@ var _ = Describe("Organization Quotas", func() {
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 10, IsSet: true},
 								PaidServicePlans:      &trueValue,
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 20},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 8, IsSet: true},

--- a/api/cloudcontroller/ccv3/organization_quota_test.go
+++ b/api/cloudcontroller/ccv3/organization_quota_test.go
@@ -468,6 +468,7 @@ var _ = Describe("Organization Quotas", func() {
 					Services: resources.ServiceLimit{
 						TotalServiceInstances: &types.NullInt{Value: 0, IsSet: true},
 						PaidServicePlans:      &trueValue,
+						TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 1},
 					},
 					Routes: resources.RouteLimit{
 						TotalRoutes:        &types.NullInt{Value: 6, IsSet: true},
@@ -497,7 +498,7 @@ var _ = Describe("Organization Quotas", func() {
 					 "services": {
 						"paid_services_allowed": true,
 						"total_service_instances": 0,
-						"total_service_keys": null
+						"total_service_keys": 1
 					 },
 					 "routes": {
 						"total_routes": 6,
@@ -523,6 +524,7 @@ var _ = Describe("Organization Quotas", func() {
 					"services": map[string]interface{}{
 						"paid_services_allowed":   true,
 						"total_service_instances": 0,
+						"total_service_keys":      1,
 					},
 					"routes": map[string]interface{}{
 						"total_routes":         6,
@@ -799,6 +801,7 @@ var _ = Describe("Organization Quotas", func() {
 						Services: resources.ServiceLimit{
 							TotalServiceInstances: &types.NullInt{IsSet: true, Value: 0},
 							PaidServicePlans:      &trueValue,
+							TotalServiceKeys:      &types.NullInt{IsSet: false, Value: 0},
 						},
 						Routes: resources.RouteLimit{
 							TotalRoutes:        &types.NullInt{IsSet: false, Value: 0},

--- a/api/cloudcontroller/ccv3/space_quota_test.go
+++ b/api/cloudcontroller/ccv3/space_quota_test.go
@@ -1098,6 +1098,7 @@ var _ = Describe("Space Quotas", func() {
 						Services: resources.ServiceLimit{
 							TotalServiceInstances: &types.NullInt{IsSet: true, Value: 0},
 							PaidServicePlans:      &trueValue,
+							TotalServiceKeys:      &types.NullInt{IsSet: false, Value: 0},
 						},
 						Routes: resources.RouteLimit{
 							TotalRoutes:        &types.NullInt{IsSet: false, Value: 0},

--- a/api/cloudcontroller/ccv3/space_quota_test.go
+++ b/api/cloudcontroller/ccv3/space_quota_test.go
@@ -246,6 +246,7 @@ var _ = Describe("Space Quotas", func() {
 							Services: resources.ServiceLimit{
 								PaidServicePlans:      &trueValue,
 								TotalServiceInstances: &types.NullInt{IsSet: true, Value: 5},
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 700},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{IsSet: true, Value: 6},
@@ -376,6 +377,7 @@ var _ = Describe("Space Quotas", func() {
 							Services: resources.ServiceLimit{
 								PaidServicePlans:      &trueValue,
 								TotalServiceInstances: &types.NullInt{IsSet: true, Value: 6},
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 7},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{IsSet: true, Value: 8},
@@ -570,6 +572,7 @@ var _ = Describe("Space Quotas", func() {
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 8, IsSet: true},
 								PaidServicePlans:      &falseValue,
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 20},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 10, IsSet: true},
@@ -760,6 +763,7 @@ var _ = Describe("Space Quotas", func() {
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 10, IsSet: true},
 								PaidServicePlans:      &trueValue,
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 20},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 8, IsSet: true},
@@ -780,6 +784,7 @@ var _ = Describe("Space Quotas", func() {
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 8, IsSet: true},
 								PaidServicePlans:      &falseValue,
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 20},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 10, IsSet: true},
@@ -862,6 +867,7 @@ var _ = Describe("Space Quotas", func() {
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 8, IsSet: true},
 								PaidServicePlans:      &falseValue,
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 20},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 10, IsSet: true},

--- a/resources/quota_resource.go
+++ b/resources/quota_resource.go
@@ -63,6 +63,7 @@ func (al *AppLimit) UnmarshalJSON(rawJSON []byte) error {
 type ServiceLimit struct {
 	TotalServiceInstances *types.NullInt `json:"total_service_instances,omitempty"`
 	PaidServicePlans      *bool          `json:"paid_services_allowed,omitempty"`
+	TotalServiceKeys      *types.NullInt `json:"total_service_keys,omitempty"`
 }
 
 func (sl *ServiceLimit) UnmarshalJSON(rawJSON []byte) error {

--- a/resources/quota_resource.go
+++ b/resources/quota_resource.go
@@ -84,6 +84,13 @@ func (sl *ServiceLimit) UnmarshalJSON(rawJSON []byte) error {
 		}
 	}
 
+	if sl.TotalServiceKeys == nil {
+		sl.TotalServiceKeys = &types.NullInt{
+			IsSet: false,
+			Value: 0,
+		}
+	}
+
 	return nil
 }
 

--- a/resources/quota_resource_test.go
+++ b/resources/quota_resource_test.go
@@ -87,6 +87,9 @@ var _ = Describe("quota limits", func() {
 			Entry("paid service plans", ServiceLimit{PaidServicePlans: &trueValue}, []byte(`{"paid_services_allowed":true}`)),
 			Entry("paid service plans", ServiceLimit{PaidServicePlans: nil}, []byte(`{}`)),
 			Entry("paid service plans", ServiceLimit{PaidServicePlans: &falseValue}, []byte(`{"paid_services_allowed":false}`)),
+			Entry("total service keys", ServiceLimit{TotalServiceKeys: &types.NullInt{IsSet: true, Value: 1}}, []byte(`{"total_service_keys":1}`)),
+			Entry("total service keys", ServiceLimit{TotalServiceKeys: nil}, []byte(`{}`)),
+			Entry("total service keys", ServiceLimit{TotalServiceKeys: &types.NullInt{IsSet: false}}, []byte(`{"total_service_keys":null}`)),
 		)
 
 		DescribeTable("UnmarshalJSON",
@@ -98,17 +101,19 @@ var _ = Describe("quota limits", func() {
 			},
 			Entry(
 				"no null values",
-				[]byte(`{"total_service_instances":1,"paid_services_allowed":true}`),
+				[]byte(`{"total_service_instances":1,"paid_services_allowed":true,"total_service_keys":1}`),
 				ServiceLimit{
 					TotalServiceInstances: &types.NullInt{IsSet: true, Value: 1},
 					PaidServicePlans:      &trueValue,
+					TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 1},
 				}),
 			Entry(
-				"total service instances is null and paid services allowed is false",
-				[]byte(`{"total_service_instances":null,"paid_services_allowed":false}`),
+				"total service instances is null and paid services allowed is false and total_service_keys is null",
+				[]byte(`{"total_service_instances":null,"paid_services_allowed":false,"total_service_keys":null}`),
 				ServiceLimit{
 					TotalServiceInstances: &types.NullInt{IsSet: false, Value: 0},
 					PaidServicePlans:      &falseValue,
+					TotalServiceKeys:      &types.NullInt{IsSet: false, Value: 0},
 				}),
 		)
 	})


### PR DESCRIPTION
- [x] [main](https://github.com/cloudfoundry/cli/pull/2881)
- [x] [v7](https://github.com/cloudfoundry/cli/pull/2884)
- [x] [v8](https://github.com/cloudfoundry/cli/pull/2887)

# Description of the Change
Consumers of this library can access the total_service_keys field from the api with this change.

# Why Is This PR Valuable?
The value of this parameters is not included into unmarshalled data and is missing at the moment. The value should be available from the API as documented in https://v3-apidocs.cloudfoundry.org/version/3.163.0/#organization-quotas-in-v3

