### PR TITLE
Add "per_app_tasks" to quota json unmarshalling

### DIFF
--- a/api/cloudcontroller/ccv3/organization_quota_test.go
+++ b/api/cloudcontroller/ccv3/organization_quota_test.go
@@ -464,6 +464,7 @@ var _ = Describe("Organization Quotas", func() {
 						TotalMemory:       &types.NullInt{Value: 2048, IsSet: true},
 						InstanceMemory:    &types.NullInt{Value: 1024, IsSet: true},
 						TotalAppInstances: &types.NullInt{Value: 0, IsSet: false},
+						PerAppTasks:       &types.NullInt{IsSet: false, Value: 0},
 					},
 					Services: resources.ServiceLimit{
 						TotalServiceInstances: &types.NullInt{Value: 0, IsSet: true},
@@ -519,6 +520,7 @@ var _ = Describe("Organization Quotas", func() {
 						"total_memory_in_mb":       2048,
 						"per_process_memory_in_mb": 1024,
 						"total_instances":          nil,
+						"per_app_tasks":            nil,
 					},
 					"services": map[string]interface{}{
 						"paid_services_allowed":   true,
@@ -795,6 +797,7 @@ var _ = Describe("Organization Quotas", func() {
 							TotalMemory:       &types.NullInt{IsSet: true, Value: 2048},
 							InstanceMemory:    &types.NullInt{IsSet: true, Value: 1024},
 							TotalAppInstances: &types.NullInt{IsSet: false, Value: 0},
+							PerAppTasks:       &types.NullInt{IsSet: false, Value: 0},
 						},
 						Services: resources.ServiceLimit{
 							TotalServiceInstances: &types.NullInt{IsSet: true, Value: 0},

--- a/api/cloudcontroller/ccv3/organization_quota_test.go
+++ b/api/cloudcontroller/ccv3/organization_quota_test.go
@@ -156,6 +156,7 @@ var _ = Describe("Organization Quotas", func() {
 								TotalMemory:       &types.NullInt{Value: 5120, IsSet: true},
 								InstanceMemory:    &types.NullInt{Value: 1024, IsSet: true},
 								TotalAppInstances: &types.NullInt{Value: 10, IsSet: true},
+								PerAppTasks:       &types.NullInt{Value: 5, IsSet: true},
 							},
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 10, IsSet: true},
@@ -175,6 +176,7 @@ var _ = Describe("Organization Quotas", func() {
 								TotalMemory:       &types.NullInt{Value: 10240, IsSet: true},
 								InstanceMemory:    &types.NullInt{Value: 1024, IsSet: true},
 								TotalAppInstances: &types.NullInt{Value: 8, IsSet: true},
+								PerAppTasks:       &types.NullInt{Value: 5, IsSet: true},
 							},
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 8, IsSet: true},
@@ -257,6 +259,7 @@ var _ = Describe("Organization Quotas", func() {
 								TotalMemory:       &types.NullInt{Value: 10240, IsSet: true},
 								InstanceMemory:    &types.NullInt{Value: 1024, IsSet: true},
 								TotalAppInstances: &types.NullInt{Value: 8, IsSet: true},
+								PerAppTasks:       &types.NullInt{Value: 5, IsSet: true},
 							},
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 8, IsSet: true},
@@ -384,6 +387,7 @@ var _ = Describe("Organization Quotas", func() {
 								TotalMemory:       &types.NullInt{Value: 5120, IsSet: true},
 								InstanceMemory:    &types.NullInt{Value: 1024, IsSet: true},
 								TotalAppInstances: &types.NullInt{Value: 10, IsSet: true},
+								PerAppTasks:       &types.NullInt{Value: 5, IsSet: true},
 							},
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 10, IsSet: true},

--- a/api/cloudcontroller/ccv3/space_quota_test.go
+++ b/api/cloudcontroller/ccv3/space_quota_test.go
@@ -1094,6 +1094,7 @@ var _ = Describe("Space Quotas", func() {
 							TotalMemory:       &types.NullInt{IsSet: true, Value: 2048},
 							InstanceMemory:    &types.NullInt{IsSet: true, Value: 1024},
 							TotalAppInstances: &types.NullInt{IsSet: false, Value: 0},
+							PerAppTasks:       &types.NullInt{IsSet: false, Value: 0},
 						},
 						Services: resources.ServiceLimit{
 							TotalServiceInstances: &types.NullInt{IsSet: true, Value: 0},

--- a/api/cloudcontroller/ccv3/space_quota_test.go
+++ b/api/cloudcontroller/ccv3/space_quota_test.go
@@ -242,6 +242,7 @@ var _ = Describe("Space Quotas", func() {
 								TotalMemory:       &types.NullInt{IsSet: true, Value: 2},
 								InstanceMemory:    &types.NullInt{IsSet: true, Value: 3},
 								TotalAppInstances: &types.NullInt{IsSet: true, Value: 4},
+								PerAppTasks:       &types.NullInt{IsSet: true, Value: 900},
 							},
 							Services: resources.ServiceLimit{
 								PaidServicePlans:      &trueValue,
@@ -372,6 +373,7 @@ var _ = Describe("Space Quotas", func() {
 								TotalMemory:       &types.NullInt{IsSet: true, Value: 2},
 								InstanceMemory:    &types.NullInt{IsSet: true, Value: 3},
 								TotalAppInstances: &types.NullInt{IsSet: true, Value: 4},
+								PerAppTasks:       &types.NullInt{IsSet: true, Value: 5},
 							},
 							Services: resources.ServiceLimit{
 								PaidServicePlans:      &trueValue,
@@ -566,6 +568,7 @@ var _ = Describe("Space Quotas", func() {
 								TotalMemory:       &types.NullInt{Value: 10240, IsSet: true},
 								InstanceMemory:    &types.NullInt{Value: 1024, IsSet: true},
 								TotalAppInstances: &types.NullInt{Value: 8, IsSet: true},
+								PerAppTasks:       &types.NullInt{Value: 5, IsSet: true},
 							},
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 8, IsSet: true},
@@ -756,6 +759,7 @@ var _ = Describe("Space Quotas", func() {
 								TotalMemory:       &types.NullInt{Value: 5120, IsSet: true},
 								InstanceMemory:    &types.NullInt{Value: 1024, IsSet: true},
 								TotalAppInstances: &types.NullInt{Value: 10, IsSet: true},
+								PerAppTasks:       &types.NullInt{Value: 5, IsSet: true},
 							},
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 10, IsSet: true},
@@ -776,6 +780,7 @@ var _ = Describe("Space Quotas", func() {
 								TotalMemory:       &types.NullInt{Value: 10240, IsSet: true},
 								InstanceMemory:    &types.NullInt{Value: 1024, IsSet: true},
 								TotalAppInstances: &types.NullInt{Value: 8, IsSet: true},
+								PerAppTasks:       &types.NullInt{Value: 5, IsSet: true},
 							},
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 8, IsSet: true},
@@ -858,6 +863,7 @@ var _ = Describe("Space Quotas", func() {
 								TotalMemory:       &types.NullInt{Value: 10240, IsSet: true},
 								InstanceMemory:    &types.NullInt{Value: 1024, IsSet: true},
 								TotalAppInstances: &types.NullInt{Value: 8, IsSet: true},
+								PerAppTasks:       &types.NullInt{Value: 5, IsSet: true},
 							},
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 8, IsSet: true},

--- a/resources/quota_resource.go
+++ b/resources/quota_resource.go
@@ -58,6 +58,13 @@ func (al *AppLimit) UnmarshalJSON(rawJSON []byte) error {
 		}
 	}
 
+	if al.PerAppTasks == nil {
+		al.PerAppTasks = &types.NullInt{
+			IsSet: false,
+			Value: 0,
+		}
+	}
+
 	return nil
 }
 

--- a/resources/quota_resource.go
+++ b/resources/quota_resource.go
@@ -23,6 +23,7 @@ type AppLimit struct {
 	TotalMemory       *types.NullInt `json:"total_memory_in_mb,omitempty"`
 	InstanceMemory    *types.NullInt `json:"per_process_memory_in_mb,omitempty"`
 	TotalAppInstances *types.NullInt `json:"total_instances,omitempty"`
+	PerAppTasks       *types.NullInt `json:"per_app_tasks,omitempty"`
 }
 
 func (al *AppLimit) UnmarshalJSON(rawJSON []byte) error {

--- a/resources/quota_resource_test.go
+++ b/resources/quota_resource_test.go
@@ -25,6 +25,9 @@ var _ = Describe("quota limits", func() {
 			Entry("total app instances", AppLimit{TotalAppInstances: &types.NullInt{IsSet: true, Value: 1}}, []byte(`{"total_instances":1}`)),
 			Entry("total app instances", AppLimit{TotalAppInstances: nil}, []byte(`{}`)),
 			Entry("total app instances", AppLimit{TotalAppInstances: &types.NullInt{IsSet: false}}, []byte(`{"total_instances":null}`)),
+			Entry("per app tasks", AppLimit{PerAppTasks: &types.NullInt{IsSet: true, Value: 1}}, []byte(`{"per_app_tasks":1}`)),
+			Entry("per app tasks", AppLimit{PerAppTasks: nil}, []byte(`{}`)),
+			Entry("per app tasks", AppLimit{PerAppTasks: &types.NullInt{IsSet: false}}, []byte(`{"per_app_tasks":null}`)),
 		)
 
 		DescribeTable("UnmarshalJSON",
@@ -36,35 +39,57 @@ var _ = Describe("quota limits", func() {
 			},
 			Entry(
 				"no null values",
-				[]byte(`{"total_memory_in_mb":1,"per_process_memory_in_mb":2,"total_instances":3}`),
+				[]byte(`{"total_memory_in_mb":1,"per_process_memory_in_mb":2,"total_instances":3,"per_app_tasks":1}`),
 				AppLimit{
 					TotalMemory:       &types.NullInt{IsSet: true, Value: 1},
 					InstanceMemory:    &types.NullInt{IsSet: true, Value: 2},
 					TotalAppInstances: &types.NullInt{IsSet: true, Value: 3},
+					PerAppTasks:       &types.NullInt{IsSet: true, Value: 1},
 				}),
 			Entry(
 				"total memory is null",
-				[]byte(`{"total_memory_in_mb":null,"per_process_memory_in_mb":2,"total_instances":3}`),
+				[]byte(`{"total_memory_in_mb":null,"per_process_memory_in_mb":2,"total_instances":3,"per_app_tasks":1}`),
 				AppLimit{
 					TotalMemory:       &types.NullInt{IsSet: false, Value: 0},
 					InstanceMemory:    &types.NullInt{IsSet: true, Value: 2},
 					TotalAppInstances: &types.NullInt{IsSet: true, Value: 3},
+					PerAppTasks:       &types.NullInt{IsSet: true, Value: 1},
 				}),
 			Entry(
 				"per process memory is null",
-				[]byte(`{"total_memory_in_mb":1,"per_process_memory_in_mb":null,"total_instances":3}`),
+				[]byte(`{"total_memory_in_mb":1,"per_process_memory_in_mb":null,"total_instances":3,"per_app_tasks":1}`),
 				AppLimit{
 					TotalMemory:       &types.NullInt{IsSet: true, Value: 1},
 					InstanceMemory:    &types.NullInt{IsSet: false, Value: 0},
 					TotalAppInstances: &types.NullInt{IsSet: true, Value: 3},
+					PerAppTasks:       &types.NullInt{IsSet: true, Value: 1},
 				}),
 			Entry(
 				"total instances is null",
-				[]byte(`{"total_memory_in_mb":1,"per_process_memory_in_mb":2,"total_instances":null}`),
+				[]byte(`{"total_memory_in_mb":1,"per_process_memory_in_mb":2,"total_instances":null,"per_app_tasks":1}`),
 				AppLimit{
 					TotalMemory:       &types.NullInt{IsSet: true, Value: 1},
 					InstanceMemory:    &types.NullInt{IsSet: true, Value: 2},
 					TotalAppInstances: &types.NullInt{IsSet: false, Value: 0},
+					PerAppTasks:       &types.NullInt{IsSet: true, Value: 1},
+				}),
+			Entry(
+				"total log volume is null",
+				[]byte(`{"total_memory_in_mb":1,"per_process_memory_in_mb":2,"total_instances":3,"per_app_tasks":1}`),
+				AppLimit{
+					TotalMemory:       &types.NullInt{IsSet: true, Value: 1},
+					InstanceMemory:    &types.NullInt{IsSet: true, Value: 2},
+					TotalAppInstances: &types.NullInt{IsSet: true, Value: 3},
+					PerAppTasks:       &types.NullInt{IsSet: true, Value: 1},
+				}),
+			Entry(
+				"per_app_tasks is null",
+				[]byte(`{"total_memory_in_mb":1,"per_process_memory_in_mb":2,"total_instances":3,"per_app_tasks":null}`),
+				AppLimit{
+					TotalMemory:       &types.NullInt{IsSet: true, Value: 1},
+					InstanceMemory:    &types.NullInt{IsSet: true, Value: 2},
+					TotalAppInstances: &types.NullInt{IsSet: true, Value: 3},
+					PerAppTasks:       &types.NullInt{IsSet: false, Value: 0},
 				}),
 		)
 	})


### PR DESCRIPTION
- [x] [main](https://github.com/cloudfoundry/cli/pull/2882)
- [x] [v7](https://github.com/cloudfoundry/cli/pull/2885)
- [x] [v8](https://github.com/cloudfoundry/cli/pull/2888)

# Description of the Change
Consumers of this library can access the per_app_tasks field from the api with this change.

# Why Is This PR Valuable?
The value of this parameters is not included into unmarshalled data and is missing at the moment. The value should be available from the API as documented in https://v3-apidocs.cloudfoundry.org/version/3.163.0/#organization-quotas-in-v3

