### PR TITLE
Add "total_domains" to quota json unmarshalling

### DIFF
--- a/api/cloudcontroller/ccv3/organization_quota_test.go
+++ b/api/cloudcontroller/ccv3/organization_quota_test.go
@@ -165,6 +165,9 @@ var _ = Describe("Organization Quotas", func() {
 								TotalRoutes:        &types.NullInt{Value: 8, IsSet: true},
 								TotalReservedPorts: &types.NullInt{Value: 4, IsSet: true},
 							},
+							Domains: resources.DomainLimit{
+								TotalDomains: &types.NullInt{IsSet: false, Value: 0},
+							},
 						},
 					},
 					resources.OrganizationQuota{
@@ -183,6 +186,9 @@ var _ = Describe("Organization Quotas", func() {
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 10, IsSet: true},
 								TotalReservedPorts: &types.NullInt{Value: 5, IsSet: true},
+							},
+							Domains: resources.DomainLimit{
+								TotalDomains: &types.NullInt{IsSet: false, Value: 0},
 							},
 						},
 					},
@@ -265,6 +271,9 @@ var _ = Describe("Organization Quotas", func() {
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 10, IsSet: true},
 								TotalReservedPorts: &types.NullInt{Value: 5, IsSet: true},
+							},
+							Domains: resources.DomainLimit{
+								TotalDomains: &types.NullInt{IsSet: false, Value: 0},
 							},
 						},
 					},
@@ -393,6 +402,9 @@ var _ = Describe("Organization Quotas", func() {
 								TotalRoutes:        &types.NullInt{Value: 8, IsSet: true},
 								TotalReservedPorts: &types.NullInt{Value: 4, IsSet: true},
 							},
+							Domains: resources.DomainLimit{
+								TotalDomains: &types.NullInt{IsSet: false, Value: 0},
+							},
 						},
 					},
 				))
@@ -469,6 +481,9 @@ var _ = Describe("Organization Quotas", func() {
 						TotalRoutes:        &types.NullInt{Value: 6, IsSet: true},
 						TotalReservedPorts: &types.NullInt{Value: 5, IsSet: true},
 					},
+					Domains: resources.DomainLimit{
+						TotalDomains: &types.NullInt{IsSet: true, Value: 1},
+					},
 				},
 			}
 		})
@@ -500,7 +515,7 @@ var _ = Describe("Organization Quotas", func() {
 						"total_reserved_ports": 5
 					 },
 					 "domains": {
-						"total_domains": null
+						"total_domains": 1
 					 },
 					 "links": {
 						"self": {
@@ -523,6 +538,9 @@ var _ = Describe("Organization Quotas", func() {
 					"routes": map[string]interface{}{
 						"total_routes":         6,
 						"total_reserved_ports": 5,
+					},
+					"domains": map[string]interface{}{
+						"total_domains": 1,
 					},
 				}
 
@@ -767,7 +785,8 @@ var _ = Describe("Organization Quotas", func() {
 						"paid_services_allowed":   true,
 						"total_service_instances": 0,
 					},
-					"routes": map[string]interface{}{},
+					"routes":  map[string]interface{}{},
+					"domains": map[string]interface{}{},
 				}
 
 				server.AppendHandlers(
@@ -799,6 +818,9 @@ var _ = Describe("Organization Quotas", func() {
 						Routes: resources.RouteLimit{
 							TotalRoutes:        &types.NullInt{IsSet: false, Value: 0},
 							TotalReservedPorts: &types.NullInt{IsSet: false, Value: 0},
+						},
+						Domains: resources.DomainLimit{
+							TotalDomains: &types.NullInt{IsSet: false, Value: 0},
 						},
 					},
 				}))

--- a/api/cloudcontroller/ccv3/space_quota_test.go
+++ b/api/cloudcontroller/ccv3/space_quota_test.go
@@ -153,6 +153,9 @@ var _ = Describe("Space Quotas", func() {
 							TotalRoutes:        &types.NullInt{IsSet: true, Value: 6},
 							TotalReservedPorts: &types.NullInt{IsSet: true, Value: 7},
 						},
+						Domains: resources.DomainLimit{
+							TotalDomains: &types.NullInt{IsSet: true, Value: 0},
+						},
 					},
 					OrgGUID: "some-org-guid",
 				}
@@ -176,6 +179,9 @@ var _ = Describe("Space Quotas", func() {
   "routes": {
     "total_routes": 6,
     "total_reserved_ports": 7
+  },
+  "domains": {
+	"total_domains": 2
   },
   "relationships": {
     "organization": {
@@ -251,6 +257,9 @@ var _ = Describe("Space Quotas", func() {
 								TotalRoutes:        &types.NullInt{IsSet: true, Value: 6},
 								TotalReservedPorts: &types.NullInt{IsSet: true, Value: 7},
 							},
+							Domains: resources.DomainLimit{
+								TotalDomains: &types.NullInt{IsSet: true, Value: 2},
+							},
 						},
 						OrgGUID: "some-org-guid",
 					}))
@@ -299,6 +308,9 @@ var _ = Describe("Space Quotas", func() {
   "routes": {
     "total_routes": 8,
     "total_reserved_ports": 9
+  },
+  "domains": {
+	"total_domains": 2
   },
   "relationships": {
     "organization": {
@@ -380,6 +392,9 @@ var _ = Describe("Space Quotas", func() {
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{IsSet: true, Value: 8},
 								TotalReservedPorts: &types.NullInt{IsSet: true, Value: 9},
+							},
+							Domains: resources.DomainLimit{
+								TotalDomains: &types.NullInt{IsSet: true, Value: 2},
 							},
 						},
 						OrgGUID:    "some-org-guid",
@@ -534,7 +549,7 @@ var _ = Describe("Space Quotas", func() {
 							"total_reserved_ports": 5
 						  },
 						  "domains": {
-							"total_private_domains": 7
+							"total_domains": 7
 						  },
 						  "relationships": {
 							"organization": {
@@ -574,6 +589,9 @@ var _ = Describe("Space Quotas", func() {
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 10, IsSet: true},
 								TotalReservedPorts: &types.NullInt{Value: 5, IsSet: true},
+							},
+							Domains: resources.DomainLimit{
+								TotalDomains: &types.NullInt{IsSet: true, Value: 7},
 							},
 						},
 					},
@@ -675,7 +693,7 @@ var _ = Describe("Space Quotas", func() {
 						"total_reserved_ports": 4
 					  },
 					  "domains": {
-						"total_private_domains": 7
+						"total_domains": 7
 					  },
 					  "relationships": {
 						"organization": {
@@ -715,7 +733,7 @@ var _ = Describe("Space Quotas", func() {
 							"total_reserved_ports": 5
 						  },
 						  "domains": {
-							"total_private_domains": 7
+							"total_domains": 7
 						  },
 						  "relationships": {
 							"organization": {
@@ -765,6 +783,9 @@ var _ = Describe("Space Quotas", func() {
 								TotalRoutes:        &types.NullInt{Value: 8, IsSet: true},
 								TotalReservedPorts: &types.NullInt{Value: 4, IsSet: true},
 							},
+							Domains: resources.DomainLimit{
+								TotalDomains: &types.NullInt{IsSet: true, Value: 7},
+							},
 						},
 						OrgGUID: "org-guid-1",
 					},
@@ -784,6 +805,9 @@ var _ = Describe("Space Quotas", func() {
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 10, IsSet: true},
 								TotalReservedPorts: &types.NullInt{Value: 5, IsSet: true},
+							},
+							Domains: resources.DomainLimit{
+								TotalDomains: &types.NullInt{IsSet: true, Value: 7},
 							},
 						},
 					},
@@ -824,7 +848,7 @@ var _ = Describe("Space Quotas", func() {
 							"total_reserved_ports": 5
 						  },
 						  "domains": {
-							"total_private_domains": 7
+							"total_domains": 7
 						  },
 						  "relationships": {
 							"organization": {
@@ -866,6 +890,9 @@ var _ = Describe("Space Quotas", func() {
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 10, IsSet: true},
 								TotalReservedPorts: &types.NullInt{Value: 5, IsSet: true},
+							},
+							Domains: resources.DomainLimit{
+								TotalDomains: &types.NullInt{IsSet: true, Value: 7},
 							},
 						},
 					},
@@ -1046,6 +1073,9 @@ var _ = Describe("Space Quotas", func() {
 						"total_routes": null,
 						"total_reserved_ports": null
 					 },
+					 "domains": {
+					   "total_domains": null
+					 },
 					 "links": {
 						"self": {
 						   "href": "https://api.foil-venom.lite.cli.fun/v3/space_quotas/08357710-8106-4d14-b0ea-03154a36fb79"
@@ -1096,6 +1126,9 @@ var _ = Describe("Space Quotas", func() {
 						Routes: resources.RouteLimit{
 							TotalRoutes:        &types.NullInt{IsSet: false, Value: 0},
 							TotalReservedPorts: &types.NullInt{IsSet: false, Value: 0},
+						},
+						Domains: resources.DomainLimit{
+							TotalDomains: &types.NullInt{IsSet: false, Value: 0},
 						},
 					},
 				}))

--- a/resources/quota_resource.go
+++ b/resources/quota_resource.go
@@ -17,6 +17,8 @@ type Quota struct {
 	Services ServiceLimit `json:"services"`
 	// Routes contain the various limits that are associated with routes
 	Routes RouteLimit `json:"routes"`
+	// Domains contain the various limits that are associated with domains
+	Domains DomainLimit `json:"domains"`
 }
 
 type AppLimit struct {
@@ -111,6 +113,31 @@ func (sl *RouteLimit) UnmarshalJSON(rawJSON []byte) error {
 
 	if sl.TotalReservedPorts == nil {
 		sl.TotalReservedPorts = &types.NullInt{
+			IsSet: false,
+			Value: 0,
+		}
+	}
+
+	return nil
+}
+
+type DomainLimit struct {
+	TotalDomains *types.NullInt `json:"total_domains,omitempty"`
+}
+
+func (sl *DomainLimit) UnmarshalJSON(rawJSON []byte) error {
+	type Alias DomainLimit
+
+	var aux Alias
+	err := json.Unmarshal(rawJSON, &aux)
+	if err != nil {
+		return err
+	}
+
+	*sl = DomainLimit(aux)
+
+	if sl.TotalDomains == nil {
+		sl.TotalDomains = &types.NullInt{
 			IsSet: false,
 			Value: 0,
 		}

--- a/resources/quota_resource_test.go
+++ b/resources/quota_resource_test.go
@@ -159,4 +159,40 @@ var _ = Describe("quota limits", func() {
 		)
 
 	})
+
+	Describe("DomainLimit", func() {
+		DescribeTable("MarshalJSON",
+			func(domainLimit DomainLimit, expectedBytes []byte) {
+				bytes, err := json.Marshal(domainLimit)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(bytes).To(Equal(expectedBytes))
+			},
+			Entry("total domain", DomainLimit{TotalDomains: &types.NullInt{IsSet: true, Value: 1}}, []byte(`{"total_domains":1}`)),
+			Entry("total domain", DomainLimit{TotalDomains: nil}, []byte(`{}`)),
+			Entry("total domain", DomainLimit{TotalDomains: &types.NullInt{IsSet: false}}, []byte(`{"total_domains":null}`)),
+		)
+
+		DescribeTable("UnmarshalJSON",
+			func(givenBytes []byte, expectedStruct DomainLimit) {
+				var actualStruct DomainLimit
+				err := json.Unmarshal(givenBytes, &actualStruct)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(actualStruct).To(Equal(expectedStruct))
+			},
+			Entry(
+				"no null values",
+				[]byte(`{"total_domains":1}`),
+				DomainLimit{
+					TotalDomains: &types.NullInt{IsSet: true, Value: 1},
+				}),
+			Entry(
+				"total domains is null",
+				[]byte(`{"total_domains":null}`),
+				DomainLimit{
+					TotalDomains: &types.NullInt{IsSet: false, Value: 0},
+				}),
+		)
+
+	})
+
 })


### PR DESCRIPTION
- [x] [main](https://github.com/cloudfoundry/cli/pull/2883)
- [x] [v7](https://github.com/cloudfoundry/cli/pull/2886)
- [x] [v8](https://github.com/cloudfoundry/cli/pull/2889)

# Description of the Change
Consumers of this library can access the total_domains field from the api with this change.

# Why Is This PR Valuable?
The value of this parameters is not included into unmarshalled data and is missing at the moment. The value should be available from the API as documented in https://v3-apidocs.cloudfoundry.org/version/3.163.0/#organization-quotas-in-v3

