### PR TITLE
Add "total_service_keys" to quota json unmarshalling

### DIFF
--- a/api/cloudcontroller/ccv3/organization_quota_test.go
+++ b/api/cloudcontroller/ccv3/organization_quota_test.go
@@ -477,6 +477,7 @@ var _ = Describe("Organization Quotas", func() {
 					Services: resources.ServiceLimit{
 						TotalServiceInstances: &types.NullInt{Value: 0, IsSet: true},
 						PaidServicePlans:      &trueValue,
+						TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 1},
 					},
 					Routes: resources.RouteLimit{
 						TotalRoutes:        &types.NullInt{Value: 6, IsSet: true},
@@ -507,7 +508,7 @@ var _ = Describe("Organization Quotas", func() {
 					 "services": {
 						"paid_services_allowed": true,
 						"total_service_instances": 0,
-						"total_service_keys": null
+						"total_service_keys": 1
 					 },
 					 "routes": {
 						"total_routes": 6,
@@ -534,6 +535,7 @@ var _ = Describe("Organization Quotas", func() {
 					"services": map[string]interface{}{
 						"paid_services_allowed":   true,
 						"total_service_instances": 0,
+						"total_service_keys":      1,
 					},
 					"routes": map[string]interface{}{
 						"total_routes":         6,
@@ -814,6 +816,7 @@ var _ = Describe("Organization Quotas", func() {
 						Services: resources.ServiceLimit{
 							TotalServiceInstances: &types.NullInt{IsSet: true, Value: 0},
 							PaidServicePlans:      &trueValue,
+							TotalServiceKeys:      &types.NullInt{IsSet: false, Value: 0},
 						},
 						Routes: resources.RouteLimit{
 							TotalRoutes:        &types.NullInt{IsSet: false, Value: 0},

--- a/api/cloudcontroller/ccv3/organization_quota_test.go
+++ b/api/cloudcontroller/ccv3/organization_quota_test.go
@@ -163,6 +163,7 @@ var _ = Describe("Organization Quotas", func() {
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 10, IsSet: true},
 								PaidServicePlans:      &trueValue,
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 20},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 8, IsSet: true},
@@ -183,6 +184,7 @@ var _ = Describe("Organization Quotas", func() {
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 8, IsSet: true},
 								PaidServicePlans:      &falseValue,
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 20},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 10, IsSet: true},
@@ -267,6 +269,7 @@ var _ = Describe("Organization Quotas", func() {
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 8, IsSet: true},
 								PaidServicePlans:      &falseValue,
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 20},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 10, IsSet: true},
@@ -396,6 +399,7 @@ var _ = Describe("Organization Quotas", func() {
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 10, IsSet: true},
 								PaidServicePlans:      &trueValue,
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 20},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 8, IsSet: true},

--- a/api/cloudcontroller/ccv3/space_quota_test.go
+++ b/api/cloudcontroller/ccv3/space_quota_test.go
@@ -1118,6 +1118,7 @@ var _ = Describe("Space Quotas", func() {
 						Services: resources.ServiceLimit{
 							TotalServiceInstances: &types.NullInt{IsSet: true, Value: 0},
 							PaidServicePlans:      &trueValue,
+							TotalServiceKeys:      &types.NullInt{IsSet: false, Value: 0},
 						},
 						Routes: resources.RouteLimit{
 							TotalRoutes:        &types.NullInt{IsSet: false, Value: 0},

--- a/api/cloudcontroller/ccv3/space_quota_test.go
+++ b/api/cloudcontroller/ccv3/space_quota_test.go
@@ -250,6 +250,7 @@ var _ = Describe("Space Quotas", func() {
 							Services: resources.ServiceLimit{
 								PaidServicePlans:      &trueValue,
 								TotalServiceInstances: &types.NullInt{IsSet: true, Value: 5},
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 700},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{IsSet: true, Value: 6},
@@ -384,6 +385,7 @@ var _ = Describe("Space Quotas", func() {
 							Services: resources.ServiceLimit{
 								PaidServicePlans:      &trueValue,
 								TotalServiceInstances: &types.NullInt{IsSet: true, Value: 6},
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 7},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{IsSet: true, Value: 8},
@@ -580,6 +582,7 @@ var _ = Describe("Space Quotas", func() {
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 8, IsSet: true},
 								PaidServicePlans:      &falseValue,
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 20},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 10, IsSet: true},
@@ -773,6 +776,7 @@ var _ = Describe("Space Quotas", func() {
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 10, IsSet: true},
 								PaidServicePlans:      &trueValue,
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 20},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 8, IsSet: true},
@@ -794,6 +798,7 @@ var _ = Describe("Space Quotas", func() {
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 8, IsSet: true},
 								PaidServicePlans:      &falseValue,
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 20},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 10, IsSet: true},
@@ -878,6 +883,7 @@ var _ = Describe("Space Quotas", func() {
 							Services: resources.ServiceLimit{
 								TotalServiceInstances: &types.NullInt{Value: 8, IsSet: true},
 								PaidServicePlans:      &falseValue,
+								TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 20},
 							},
 							Routes: resources.RouteLimit{
 								TotalRoutes:        &types.NullInt{Value: 10, IsSet: true},

--- a/resources/quota_resource.go
+++ b/resources/quota_resource.go
@@ -92,6 +92,13 @@ func (sl *ServiceLimit) UnmarshalJSON(rawJSON []byte) error {
 		}
 	}
 
+	if sl.TotalServiceKeys == nil {
+		sl.TotalServiceKeys = &types.NullInt{
+			IsSet: false,
+			Value: 0,
+		}
+	}
+
 	return nil
 }
 

--- a/resources/quota_resource.go
+++ b/resources/quota_resource.go
@@ -71,6 +71,7 @@ func (al *AppLimit) UnmarshalJSON(rawJSON []byte) error {
 type ServiceLimit struct {
 	TotalServiceInstances *types.NullInt `json:"total_service_instances,omitempty"`
 	PaidServicePlans      *bool          `json:"paid_services_allowed,omitempty"`
+	TotalServiceKeys      *types.NullInt `json:"total_service_keys,omitempty"`
 }
 
 func (sl *ServiceLimit) UnmarshalJSON(rawJSON []byte) error {

--- a/resources/quota_resource_test.go
+++ b/resources/quota_resource_test.go
@@ -103,6 +103,9 @@ var _ = Describe("quota limits", func() {
 			Entry("paid service plans", ServiceLimit{PaidServicePlans: &trueValue}, []byte(`{"paid_services_allowed":true}`)),
 			Entry("paid service plans", ServiceLimit{PaidServicePlans: nil}, []byte(`{}`)),
 			Entry("paid service plans", ServiceLimit{PaidServicePlans: &falseValue}, []byte(`{"paid_services_allowed":false}`)),
+			Entry("total service keys", ServiceLimit{TotalServiceKeys: &types.NullInt{IsSet: true, Value: 1}}, []byte(`{"total_service_keys":1}`)),
+			Entry("total service keys", ServiceLimit{TotalServiceKeys: nil}, []byte(`{}`)),
+			Entry("total service keys", ServiceLimit{TotalServiceKeys: &types.NullInt{IsSet: false}}, []byte(`{"total_service_keys":null}`)),
 		)
 
 		DescribeTable("UnmarshalJSON",
@@ -114,17 +117,19 @@ var _ = Describe("quota limits", func() {
 			},
 			Entry(
 				"no null values",
-				[]byte(`{"total_service_instances":1,"paid_services_allowed":true}`),
+				[]byte(`{"total_service_instances":1,"paid_services_allowed":true,"total_service_keys":1}`),
 				ServiceLimit{
 					TotalServiceInstances: &types.NullInt{IsSet: true, Value: 1},
 					PaidServicePlans:      &trueValue,
+					TotalServiceKeys:      &types.NullInt{IsSet: true, Value: 1},
 				}),
 			Entry(
-				"total service instances is null and paid services allowed is false",
-				[]byte(`{"total_service_instances":null,"paid_services_allowed":false}`),
+				"total service instances is null and paid services allowed is false and total_service_keys is null",
+				[]byte(`{"total_service_instances":null,"paid_services_allowed":false,"total_service_keys":null}`),
 				ServiceLimit{
 					TotalServiceInstances: &types.NullInt{IsSet: false, Value: 0},
 					PaidServicePlans:      &falseValue,
+					TotalServiceKeys:      &types.NullInt{IsSet: false, Value: 0},
 				}),
 		)
 	})


### PR DESCRIPTION
- [x] [main](https://github.com/cloudfoundry/cli/pull/2881)
- [x] [v7](https://github.com/cloudfoundry/cli/pull/2884)
- [x] [v8](https://github.com/cloudfoundry/cli/pull/2887)
- [ ] 
# Description of the Change
Consumers of this library can access the total_service_keys field from the api with this change.

# Why Is This PR Valuable?
The value of this parameters is not included into unmarshalled data and is missing at the moment. The value should be available from the API as documented in https://v3-apidocs.cloudfoundry.org/version/3.163.0/#organization-quotas-in-v3

