### PR TITLE
Install ginkgo "out of the box" (v7 branch)

### DIFF
--- a/.github/workflows/tests-integration-reusable.yml
+++ b/.github/workflows/tests-integration-reusable.yml
@@ -249,8 +249,6 @@ jobs:
 
         make build
 
-        go install github.com/onsi/ginkgo/v2/ginkgo
-
         export CF_PASSWORD=${CF_INT_PASSWORD}
         cf api ${CF_INT_API} --skip-ssl-validation
         cf auth
@@ -280,8 +278,6 @@ jobs:
         export PATH="$PWD/out:$PATH"
 
         make build
-
-        go install github.com/onsi/ginkgo/v2/ginkgo
 
         export CF_PASSWORD=${CF_INT_PASSWORD}
         cf api ${CF_INT_API} --skip-ssl-validation

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -65,11 +65,6 @@ jobs:
         go-version-file: go.mod
         check-latest: true
 
-    - name: Set Up Test
-      run: |
-        go install github.com/onsi/ginkgo/v2/ginkgo
-        go install github.com/onsi/gomega/matchers
-
     - name: Run Units
       run: make units
 
@@ -95,11 +90,6 @@ jobs:
       with:
         go-version-file: go.mod
         check-latest: true
-
-    - name: Set up Test
-      run: |
-        go install github.com/onsi/ginkgo/v2/ginkgo
-        go install github.com/onsi/gomega/matchers
 
     - name: Get build-time dependencies
       run: |

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,6 @@ install-test-deps: ## Install "global" dependencies needed to run tests
 # Running `go install <pkg>` without a version specifier will use version specified in go.mod
 # See https://go.dev/ref/mod#go-install
 	go install github.com/onsi/ginkgo/v2/ginkgo
-	go install github.com/onsi/gomega/matchers
 
 integration-cleanup:
 	$(CURDIR)/bin/cleanup-integration

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,12 @@ fly-windows-units:
 format: ## Run go fmt
 	go fmt ./...
 
+install-test-deps: ## Install "global" dependencies needed to run tests
+# Running `go install <pkg>` without a version specifier will use version specified in go.mod
+# See https://go.dev/ref/mod#go-install
+	go install github.com/onsi/ginkgo/v2/ginkgo
+	go install github.com/onsi/gomega/matchers
+
 integration-cleanup:
 	$(CURDIR)/bin/cleanup-integration
 
@@ -79,12 +85,12 @@ integration-experimental: build integration-cleanup integration-shared-experimen
 
 ise: integration-shared-experimental
 integration-experimental-shared: integration-shared-experimental
-integration-shared-experimental: build integration-cleanup ## Run experimental integration tests that are shared between v6 and v7
+integration-shared-experimental: build install-test-deps integration-cleanup ## Run experimental integration tests that are shared between v6 and v7
 	$(ginkgo_int) -nodes $(NODES) integration/shared/experimental
 
 ive: integration-versioned-experimental
 integration-experimental-versioned: integration-versioned-experimental
-integration-versioned-experimental: build integration-cleanup ## Run experimental integration tests that are specific to your CLI version
+integration-versioned-experimental: build install-test-deps integration-cleanup ## Run experimental integration tests that are specific to your CLI version
 	$(ginkgo_int) -nodes $(NODES) integration/v7/experimental
 
 ig: integration-global
@@ -92,12 +98,12 @@ integration-global: build integration-cleanup integration-shared-global integrat
 
 isg: integration-shared-global
 integration-global-shared: integration-shared-global
-integration-shared-global: build integration-cleanup ## Serially run integration tests that make cross-cutting changes to their test CF foundation and are shared between v6 and v7
+integration-shared-global: build install-test-deps integration-cleanup ## Serially run integration tests that make cross-cutting changes to their test CF foundation and are shared between v6 and v7
 	$(ginkgo_int) integration/shared/global
 
 ivg: integration-versioned-global
 integration-global-versioned: integration-versioned-global
-integration-versioned-global: build integration-cleanup ## Serially run integration tests that make cross-cutting changes to their test CF foundation and are specific to your CLI version
+integration-versioned-global: build install-test-deps integration-cleanup ## Serially run integration tests that make cross-cutting changes to their test CF foundation and are specific to your CLI version
 	$(ginkgo_int) integration/v7/global
 
 ii: integration-isolated
@@ -105,29 +111,29 @@ integration-isolated: build integration-cleanup integration-shared-isolated inte
 
 isi: integration-shared-isolated
 integration-isolated-shared: integration-shared-isolated
-integration-shared-isolated: build integration-cleanup ## Run all parallel-enabled integration tests that are shared between v6 and v7
+integration-shared-isolated: build install-test-deps integration-cleanup ## Run all parallel-enabled integration tests that are shared between v6 and v7
 	$(ginkgo_int) -nodes $(NODES) integration/shared/isolated
 
 integration-performance: build integration-cleanup integration-shared-performance
 
 isp: integration-shared-performance
 integration-performance-shared: integration-shared-performance
-integration-shared-performance: build integration-cleanup
+integration-shared-performance: build install-test-deps integration-cleanup
 	$(ginkgo_int) integration/shared/performance
 
 ivi: integration-versioned-isolated
 integration-isolated-versioned: integration-versioned-isolated
-integration-versioned-isolated: build integration-cleanup ## Run all parallel-enabled integration tests, both versioned and shared across versions
+integration-versioned-isolated: build install-test-deps integration-cleanup ## Run all parallel-enabled integration tests, both versioned and shared across versions
 	$(ginkgo_int) -nodes $(NODES) integration/v7/isolated
 
-integration-plugin: build integration-cleanup ## Run all plugin-related integration tests
+integration-plugin: build install-test-deps integration-cleanup ## Run all plugin-related integration tests
 	$(ginkgo_int) -nodes $(NODES) integration/shared/plugin
 
 ip: integration-push
-integration-push: build integration-cleanup  ## Run all push-related integration tests
+integration-push: build install-test-deps integration-cleanup  ## Run all push-related integration tests
 	$(ginkgo_int) -nodes $(NODES) integration/v7/push
 
-integration-selfcontained: build
+integration-selfcontained: build install-test-deps 
 	$(ginkgo_int) -nodes $(NODES) integration/v7/selfcontained
 
 integration-tests: build integration-cleanup integration-isolated integration-push integration-global integration-selfcontained ## Run all isolated, push, selfcontained, and global integration tests
@@ -137,7 +143,7 @@ i: integration-tests-full
 integration-full-tests: integration-tests-full
 integration-tests-full: build integration-cleanup integration-isolated integration-push integration-experimental integration-plugin integration-global integration-selfcontained ## Run all isolated, push, experimental, plugin, selfcontained, and global integration tests
 
-integration-tests-full-ci: integration-cleanup
+integration-tests-full-ci: install-test-deps integration-cleanup
 	$(ginkgo_int) -nodes $(NODES)  -flake-attempts $(FLAKE_ATTEMPTS) \
 		integration/shared/isolated integration/v7/isolated integration/shared/plugin integration/shared/experimental integration/v7/experimental integration/v7/push
 	$(ginkgo_int) -flake-attempts $(FLAKE_ATTEMPTS) integration/shared/global integration/v7/global
@@ -199,18 +205,18 @@ test: units ## (synonym for units)
 
 units: units-full ## (synonym for units-full)
 
-units-plugin:
+units-plugin: install-test-deps
 	CF_HOME=$(CURDIR)/fixtures $(ginkgo_units) -nodes 1 -flake-attempts 2 -skip-package integration ./**/plugin* ./plugin
 
 ifeq ($(OS),Windows_NT)
-units-non-plugin:
+units-non-plugin: install-test-deps
 	@rm -f $(wildcard fixtures/plugins/*.exe)
 	@ginkgo version
 	CF_HOME=$(CURDIR)/fixtures CF_USERNAME="" CF_PASSWORD="" $(ginkgo_units) \
 		-skip-package integration,cf\ssh,plugin,cf\actors\plugin,cf\commands\plugin,cf\actors\plugin,util\randomword
 	CF_HOME=$(CURDIR)/fixtures $(ginkgo_units) -flake-attempts 3 cf/ssh
 else
-units-non-plugin:
+units-non-plugin: install-test-deps
 	@rm -f $(wildcard fixtures/plugins/*.exe)
 	@ginkgo version
 	CF_HOME=$(CURDIR)/fixtures CF_USERNAME="" CF_PASSWORD="" $(ginkgo_units) \
@@ -225,7 +231,7 @@ version: ## Print the version number of what would be built
 	@echo $(CF_BUILD_VERSION)+$(CF_BUILD_SHA).$(CF_BUILD_DATE)
 
 .PHONY: all build clean format version lint custom-lint
-.PHONY: test units units-full integration integration-tests-full integration-cleanup integration-experimental integration-plugin integration-isolated integration-push
+.PHONY: test units units-full install-test-deps integration integration-tests-full integration-cleanup integration-experimental integration-plugin integration-isolated integration-push
 .PHONY: check-target-env fly-windows-experimental fly-windows-isolated fly-windows-plugin fly-windows-push
 .PHONY: help
 


### PR DESCRIPTION
## Note

Functionally a duplicate of #2920, applied to the `v7` branch.

## Description of the Change

This change *to the `v7` branch* installs the version of Ginkgo specified in `go.mod`, modifies the `Makefile` to do this before each flavor of test, and simplifies the CI tasks that invoke these tests.

## Why Is This PR Valuable?

Prior to this change, the `Makefile` assumes the presence of a system-level installation of Ginkgo. That installation of Ginkgo will not necessarily match the version specified in our `go.mod`.

This introduces the (slight) possibility of subtle differences in the behavior of the test library. It also complicates spinning up a new environment, either for a developer or in CI.

## Applicable Issues

n/a

## How Urgent Is The Change?

Not urgent.

## Related PRs

- #2920 - for the `main` branch
- #2927 - for the `v8` branch