### PR TITLE
Fix race condition in config handling (v7)

### DIFF
--- a/integration/shared/isolated/config_test.go
+++ b/integration/shared/isolated/config_test.go
@@ -2,7 +2,9 @@ package isolated
 
 import (
 	"io/ioutil"
+	"os"
 	"path/filepath"
+	"time"
 
 	helpers "code.cloudfoundry.org/cli/integration/helpers"
 	. "github.com/onsi/ginkgo/v2"
@@ -43,6 +45,9 @@ var _ = Describe("Config", func() {
 					tmpFile, err := ioutil.TempFile(configDir, "temp-config")
 					Expect(err).ToNot(HaveOccurred())
 					tmpFile.Close()
+					oldTime := time.Now().Add(-time.Minute * 10)
+					err = os.Chtimes(tmpFile.Name(), oldTime, oldTime)
+					Expect(err).ToNot(HaveOccurred())
 				}
 			})
 

--- a/util/configv3/load_config.go
+++ b/util/configv3/load_config.go
@@ -179,8 +179,11 @@ func removeOldTempConfigFiles() error {
 
 	for _, oldTempFileName := range oldTempFileNames {
 		fi, err := os.Lstat(oldTempFileName)
-		// ignore if file doesn't exist anymore due to race conditions if multiple cli commands are running in parallel
-		if err != nil && !errors.Is(err, os.ErrNotExist) {
+		if err != nil {
+			// ignore if file doesn't exist anymore due to race conditions if multiple cli commands are running in parallel
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
 			return err
 		}
 		// only delete old orphans which are not caught by the signal handler in WriteConfig

--- a/util/configv3/load_config.go
+++ b/util/configv3/load_config.go
@@ -2,6 +2,7 @@ package configv3
 
 import (
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"math"
 	"os"
@@ -177,7 +178,8 @@ func removeOldTempConfigFiles() error {
 
 	for _, oldTempFileName := range oldTempFileNames {
 		err = os.Remove(oldTempFileName)
-		if err != nil {
+		// ignore if file doesn't exist anymore due to race conditions if multiple cli commands are running
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
 	}

--- a/util/configv3/load_config.go
+++ b/util/configv3/load_config.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"time"
 
 	"code.cloudfoundry.org/cli/command/translatableerror"
 	"golang.org/x/crypto/ssh/terminal"
@@ -177,8 +178,16 @@ func removeOldTempConfigFiles() error {
 	}
 
 	for _, oldTempFileName := range oldTempFileNames {
+		fi, err := os.Lstat(oldTempFileName)
+		// ignore if file doesn't exist anymore due to race conditions if multiple cli commands are running in parallel
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		// only delete old orphans which are not caught by the signal handler in WriteConfig
+		if fi.ModTime().After(time.Now().Add(-5 * time.Minute)) {
+			continue
+		}
 		err = os.Remove(oldTempFileName)
-		// ignore if file doesn't exist anymore due to race conditions if multiple cli commands are running
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			return err
 		}

--- a/util/configv3/load_config_test.go
+++ b/util/configv3/load_config_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"time"
 
 	"code.cloudfoundry.org/cli/command/translatableerror"
 	"code.cloudfoundry.org/cli/integration/helpers"
@@ -60,22 +61,48 @@ var _ = Describe("Config", func() {
 		})
 
 		When("there are old temp-config* files lingering from previous failed attempts to write the config", func() {
-			BeforeEach(func() {
-				configDir := filepath.Join(homeDir, ".cf")
-				Expect(os.MkdirAll(configDir, 0777)).To(Succeed())
-				for i := 0; i < 3; i++ {
-					tmpFile, fileErr := ioutil.TempFile(configDir, "temp-config")
-					Expect(fileErr).ToNot(HaveOccurred())
-					tmpFile.Close()
-				}
+			Context("and the files are younger than 5 minutes", func() {
+				BeforeEach(func() {
+					configDir := filepath.Join(homeDir, ".cf")
+					Expect(os.MkdirAll(configDir, 0777)).To(Succeed())
+					for i := 0; i < 3; i++ {
+						configDir := filepath.Join(homeDir, ".cf")
+						tmpFile, fileErr := ioutil.TempFile(configDir, "temp-config")
+						Expect(fileErr).ToNot(HaveOccurred())
+						tmpFile.Close()
+					}
+				})
+
+				It("keeps the files", func() {
+					Expect(loadErr).ToNot(HaveOccurred())
+
+					oldTempFileNames, configErr := filepath.Glob(filepath.Join(homeDir, ".cf", "temp-config?*"))
+					Expect(configErr).ToNot(HaveOccurred())
+					Expect(oldTempFileNames).To(HaveLen(3))
+				})
 			})
 
-			It("removes the lingering temp-config* files", func() {
-				Expect(loadErr).ToNot(HaveOccurred())
+			Context("and the files are older than 5 minutes", func() {
+				BeforeEach(func() {
+					configDir := filepath.Join(homeDir, ".cf")
+					Expect(os.MkdirAll(configDir, 0777)).To(Succeed())
+					for i := 0; i < 3; i++ {
+						tmpFile, fileErr := ioutil.TempFile(configDir, "temp-config")
+						Expect(fileErr).ToNot(HaveOccurred())
+						tmpFile.Close()
+						oldTime := time.Now().Add(-time.Minute * 10)
+						err := os.Chtimes(tmpFile.Name(), oldTime, oldTime)
+						Expect(err).ToNot(HaveOccurred())
+					}
+				})
 
-				oldTempFileNames, configErr := filepath.Glob(filepath.Join(homeDir, ".cf", "temp-config?*"))
-				Expect(configErr).ToNot(HaveOccurred())
-				Expect(oldTempFileNames).To(BeEmpty())
+				It("removes the lingering temp-config* files", func() {
+					Expect(loadErr).ToNot(HaveOccurred())
+
+					oldTempFileNames, configErr := filepath.Glob(filepath.Join(homeDir, ".cf", "temp-config?*"))
+					Expect(configErr).ToNot(HaveOccurred())
+					Expect(oldTempFileNames).To(BeEmpty())
+				})
 			})
 		})
 


### PR DESCRIPTION
## Description of the Change

The CLI encounters race conditions when handling config files if multiple commands are executed in parallel.

Currently, the CLI writes a new config for every command executed due to the code in [command_parser.go](https://github.com/cloudfoundry/cli/blob/ae68111aeda81647283e94e3aee84115e4d27544/util/command_parser/command_parser.go#L72-L77). However, it also deletes all temporary config files when reading the config, leading to race conditions between multiple processes. This PR introduces two changes to mitigate this problem:

1. **Ignore "File Not Found" errors when attempting to delete a file.** This change addresses the issue where multiple processes list and delete temporary files simultaneously.
2. **Only delete temp config files older than 5 minutes.** This change resolves the problem where one process creates a temporary config that it later wants to rename, while a second process deletes this temp config in the meantime. Orphan files should be rare, as they are normally pruned by the signal handler, as seen in https://github.com/cloudfoundry/cli/blob/04df8ae6dd68b64c2080c863c1ddf4c3e06abcd6/util/configv3/write_config.go#L63-L66

## Why Is This PR Valuable?

Enables usage of the CF CLI in scripts which execute commands in parallel

## Applicable Issues

fixes #2232 

## How Urgent Is The Change?

Medium

## Other Relevant Parties

Anyone using the CLI in scripts with parallel execution. Multiple users have encountered this issue, as discussed in #2232.

## Related PRs

- [main](https://github.com/cloudfoundry/cli/pull/2937)
- [v8](https://github.com/cloudfoundry/cli/pull/2931)