### PR TITLE
Fix uaa error in user authentication

### DIFF
--- a/api/uaa/error_converter.go
+++ b/api/uaa/error_converter.go
@@ -53,7 +53,7 @@ func convert(rawHTTPStatusErr RawHTTPStatusError) error {
 		if uaaErrorResponse.Type == "invalid_token" {
 			return InvalidAuthTokenError{Message: uaaErrorResponse.Description}
 		}
-		if uaaErrorResponse.Type == "unauthorized" {
+		if uaaErrorResponse.Type == "unauthorized" || uaaErrorResponse.Type == "invalid_client" {
 			if uaaErrorResponse.Description == "Your account has been locked because of too many failed attempts to login." {
 				return AccountLockedError{Message: "Your account has been locked because of too many failed attempts to login."}
 			}

--- a/api/uaa/error_converter_test.go
+++ b/api/uaa/error_converter_test.go
@@ -119,10 +119,26 @@ var _ = Describe("Error Wrapper", func() {
 					})
 				})
 
-				Context("unauthorized with bad credentials", func() {
+				Context("unauthorized - with bad credentials", func() {
 					BeforeEach(func() {
 						fakeConnectionErr.RawResponse = []byte(`{
   "error": "unauthorized",
+  "error_description": "Bad credentials"
+}`)
+						fakeConnection.MakeReturns(fakeConnectionErr)
+					})
+
+					It("returns a BadCredentialsError", func() {
+						Expect(fakeConnection.MakeCallCount()).To(Equal(1))
+
+						Expect(makeErr).To(MatchError(UnauthorizedError{Message: "Bad credentials"}))
+					})
+				})
+
+				Context("invalid_client - with bad credentials", func() {
+					BeforeEach(func() {
+						fakeConnectionErr.RawResponse = []byte(`{
+  "error": "invalid_client",
   "error_description": "Bad credentials"
 }`)
 						fakeConnection.MakeReturns(fakeConnectionErr)


### PR DESCRIPTION
cf auth some-username some-password

Returns before UAA 76.26.0 unauthorized, after invalid_client

Reason is: https://github.com/cloudfoundry/uaa/issues/2545

Thank you for contributing to the CF CLI! Please read the following:

* Please make sure you have implemented changes in line with the [contributing guidelines](https://github.com/cloudfoundry/cli/blob/main/.github/CONTRIBUTING.md)
* We're not allowed to accept any PRs without a signed CLA, no matter how small.
If your contribution falls under a company CLA but your membership is not public, expect delays while we confirm.
* All new code requires tests to protect against regressions.
* Contributions must be made against the appropriate branch. See the [contributing guidelines](https://github.com/cloudfoundry/cli/blob/main/.github/CONTRIBUTING.md)
* Contributions must conform to our [style guide](https://github.com/cloudfoundry/cli/wiki/CLI-Product-Specific-Style-Guide). Please reach out to us if you have questions.


#### Note: Please create separate PR for every branch (main, v8 and v7) as needed.

## Description of the Change

We must be able to understand the design of your change from this description.
Keep in mind that the maintainer reviewing this PR may not be familiar with or
have worked with the code here recently, so please walk us through the concepts.


## Why Is This PR Valuable?

Returns before UAA 76.26.0 unauthorized, after invalid_client

Reason is: https://github.com/cloudfoundry/uaa/issues/2545

## Applicable Issues

https://github.com/cloudfoundry/uaa/issues/2545

## How Urgent Is The Change?

Medium

## Other Relevant Parties

Who else is affected by the change? 
