### PR TITLE
Add CVE scan GitHub workflow that is triggered on pull requests

### DIFF
--- a/.github/scripts/format-cve-scan-results.sh
+++ b/.github/scripts/format-cve-scan-results.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+[[ "${TRACE:-0}" == "1" ]] && set -o xtrace
+
+##
+# Formats CVE results in a markdown table to display a summary in a GitHub Action UI
+##
+
+# Check if the number of arguments is correct
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <filename of grype json results>"
+    exit 1
+fi
+
+_results_filename="${1}"
+
+# Check if the file exists
+if [ ! -f "${_results_filename}" ]; then
+    echo "Error: File '${_results_filename}' does not exist"
+    exit 1
+fi
+
+_number_of_cves_found=$(jq -r '.matches | length' "${_results_filename}")
+
+echo -e "# CVE Scan Results\n"
+
+if [ ${_number_of_cves_found} -eq 0 ]; then
+    echo -e "## Success! No vulnerabilities found.\n"
+else
+    echo -e "## Failure: ${_number_of_cves_found} vulnerabilities found.\n"
+
+    _table_headers='"NAME","INSTALLED","FIXED-IN","TYPE","VULNERABILITY","SEVERITY"'
+    _table_underlines='"----","---------","--------","----","-------------","--------"'
+
+    jq -r "[${_table_headers}],
+    [${_table_underlines}],
+    (.matches[] | [
+        .artifact.name,
+        .artifact.version,
+        .vulnerability.fix.versions[0],
+        .artifact.type,
+        .vulnerability.id,
+        .vulnerability.severity
+    ]) | @tsv" "${_results_filename}" \
+    | sed 's/|/\\|/g' \
+    | sed 's/\t/ | /g'
+fi

--- a/.github/workflows/check-cves.yml
+++ b/.github/workflows/check-cves.yml
@@ -1,0 +1,32 @@
+name: "Check CVEs"
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  check-cves:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out codebase
+      uses: actions/checkout@v4
+
+    - name: Scan current project
+      uses: anchore/scan-action@v3
+      with:
+        path: "."
+        add-cpes-if-none: true
+        by-cve: true
+        output-format: json
+
+    - name: Print scan results
+      run: .github/scripts/format-cve-scan-results.sh results.json > $GITHUB_STEP_SUMMARY
+      if: always()
+
+    - name: Archive CVE scan results
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: cve-scan-results-${{ github.sha }}-${{ github.run_id }}-${{ github.run_number }}
+        path: results.json


### PR DESCRIPTION
Thank you for contributing to the CF CLI! Please read the following:


* Please make sure you have implemented changes in line with the [contributing guidelines](https://github.com/cloudfoundry/cli/blob/main/.github/CONTRIBUTING.md)
* We're not allowed to accept any PRs without a signed CLA, no matter how small.
If your contribution falls under a company CLA but your membership is not public, expect delays while we confirm.
* All new code requires tests to protect against regressions.
* Contributions must be made against the appropriate branch. See the [contributing guidelines](https://github.com/cloudfoundry/cli/blob/main/.github/CONTRIBUTING.md)
* Contributions must conform to our [style guide](https://github.com/cloudfoundry/cli/wiki/CLI-Product-Specific-Style-Guide). Please reach out to us if you have questions.


#### Note: Please create separate PR for every branch (main, v8 and v7) as needed.

## Description of the Change

Adding a CVE scan GitHub workflow on PRs. This [has been merged to main](https://github.com/cloudfoundry/cli/pull/2977), this PR is for v8 branch.

## Why Is This PR Valuable?

The CVE scan GitHub workflow on PRs helps prevent known CVEs from being added to the codebase.

## Applicable Issues

No applicable issues

## How Urgent Is The Change?

Not urgent

## Other Relevant Parties

No one else
