### PR TITLE
displaybody should respect new line [main]

### DIFF
--- a/util/ui/request_logger_file_writer.go
+++ b/util/ui/request_logger_file_writer.go
@@ -29,7 +29,7 @@ func newRequestLoggerFileWriter(ui *UI, lock *sync.Mutex, filePaths []string) *R
 
 func (display *RequestLoggerFileWriter) DisplayBody([]byte) error {
 	for _, logFile := range display.logFiles {
-		_, err := logFile.WriteString(RedactedValue)
+		_, err := logFile.WriteString(fmt.Sprintf("%s\n", RedactedValue))
 		if err != nil {
 			return err
 		}

--- a/util/ui/request_logger_file_writer_test.go
+++ b/util/ui/request_logger_file_writer_test.go
@@ -54,11 +54,11 @@ var _ = Describe("Request Logger File Writer", func() {
 
 				contents, err := os.ReadFile(logFile1)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(string(contents)).To(Equal(RedactedValue + "\n"))
+				Expect(string(contents)).To(Equal(RedactedValue + "\n\n"))
 
 				contents, err = os.ReadFile(logFile2)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(string(contents)).To(Equal(RedactedValue + "\n"))
+				Expect(string(contents)).To(Equal(RedactedValue + "\n\n"))
 			})
 		})
 


### PR DESCRIPTION
## Description of the Change

REQUEST and RESPONSE should behave the same with CF_TRACE=true and CF_TRACE=testfile. even across request logger.

https://github.com/cloudfoundry/cli/blob/fa795ba5bea096a99e38e90a25eb405e4f1e5308/util/ui/request_logger_terminal_display.go#L27
https://github.com/cloudfoundry/cli/blob/fa795ba5bea096a99e38e90a25eb405e4f1e5308/util/ui/request_logger_file_writer.go#L32

CLI stdout
```
Authenticating...
REQUEST: [2024-07-02T13:42:02Z]
POST /oauth/token HTTP/1.1
Host: login.xxxxx
Accept: application/json
Authorization: [PRIVATE DATA HIDDEN]
Connection: close
Content-Type: application/x-www-form-urlencoded
User-Agent: cf8/8.7.10+5b7ce3c.2024-04-04 (go1.22.1; amd64 linux)
[PRIVATE DATA HIDDEN]

RESPONSE: [2024-07-02T13:42:02Z]
HTTP/1.1 200 OK
```

CLI file output
```
REQUEST: [2024-07-02T11:14:36Z]
POST /oauth/token HTTP/1.1
Host: login.xxx
Accept: application/json
Authorization: [PRIVATE DATA HIDDEN]
Connection: close
Content-Type: application/x-www-form-urlencoded
User-Agent: cf8/8.7.10+5b7ce3c.2024-04-04 (go1.22.1; amd64 linux)
[PRIVATE DATA HIDDEN]
RESPONSE: [2024-07-02T11:14:36Z]
HTTP/1.1 200 OK
```

## Why Is This PR Valuable?

proper parsing across all redaction code (uaa, cloud controler, ...)
https://github.com/cloudfoundry/cli/blob/fa795ba5bea096a99e38e90a25eb405e4f1e5308/api/cloudcontroller/wrapper/request_logger.go#L116
https://github.com/cloudfoundry/cli/blob/fa795ba5bea096a99e38e90a25eb405e4f1e5308/api/uaa/wrapper/request_logger.go#L104

uaa:
```
REQUEST: [2024-07-02T11:14:36Z]
POST /oauth/token HTTP/1.1
Host: login.xxx
Accept: application/json
Authorization: [PRIVATE DATA HIDDEN]
Connection: close
Content-Type: application/x-www-form-urlencoded
User-Agent: cf8/8.7.10+5b7ce3c.2024-04-04 (go1.22.1; amd64 linux)
[PRIVATE DATA HIDDEN]
RESPONSE: [2024-07-02T11:14:36Z]
HTTP/1.1 200 OK
```

cloud controller (including newline)
```
REQUEST: [2024-07-02T11:14:28Z]
GET / HTTP/1.1
Host: api.xxx
Accept: application/json
Content-Type: application/json
User-Agent: cf8/8.7.10+5b7ce3c.2024-04-04 (go1.22.1; amd64 linux)
[application/json Content Hidden]

RESPONSE: [2024-07-02T11:14:28Z]
HTTP/1.1 200 OK
```
## How Urgent Is The Change?

Not urgent
