### PR TITLE
[V7] Change the workflow event to pull_request_target

### DIFF
--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -7,7 +7,7 @@ on:
       - "v9.*"
       - "v8.*"
       - "v7.*"
-  pull_request:
+  pull_request_target:
     branches:
       - main
       - v9


### PR DESCRIPTION
## Description of the Change

We are changing this to be able to access the secrets needed to run integration tests and claim the environment for it.