### PR TITLE
[v8] Add version of go and ignore gems when checking for CVEs

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,3 @@
+ignore:
+  - package:
+      type: gem

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module code.cloudfoundry.org/cli
 
-go 1.22
+go 1.22.5
 
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20230612151507-41ef4d1f67a4


### PR DESCRIPTION
## Description of the Change

The only Gemfiles that we have currently are under fixtures which are not used in our code so it is safe to ignore them
