### PR TITLE
Set job name to integration test type

### DIFF
--- a/.github/workflows/tests-integration-reusable.yml
+++ b/.github/workflows/tests-integration-reusable.yml
@@ -30,6 +30,7 @@ on:
         default: 'official'
 jobs:
   run-integration-tests:
+    name: ${{ inputs.name }}
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
## Description of the Change

This will print type of the test in the action summary, so it is easy to distinct types of tests.

![image](https://github.com/cloudfoundry/cli/assets/585662/b64a6f9e-22ec-4003-b9e2-83e219c066d5)
