### PR TITLE
Add path to checkout action [v8]

### DIFF
--- a/.github/release/release-notes-template.txt
+++ b/.github/release/release-notes-template.txt
@@ -1,0 +1,23 @@
+Package Manager Installation
+----------
+- [apt-get, yum, homebrew](https://github.com/cloudfoundry/cli#getting-started)
+
+Installers
+----------
+- Debian [64 bit](https://packages.cloudfoundry.org/stable?release=debian64&version=new-version&source=github-rel) / [32 bit](https://packages.cloudfoundry.org/stable?release=debian32&version=new-version&source=github-rel) / [arm64](https://packages.cloudfoundry.org/stable?release=debianarm64&version=new-version&source=github-rel) (deb)
+- Redhat [64 bit](https://packages.cloudfoundry.org/stable?release=redhat64&version=new-version&source=github-rel) / [32 bit](https://packages.cloudfoundry.org/stable?release=redhat32&version=new-version&source=github-rel) / [aarch64](https://packages.cloudfoundry.org/stable?release=redhataarch64&version=new-version&source=github-rel) (rpm)
+- macOS [64 bit](https://packages.cloudfoundry.org/stable?release=macosx64&version=new-version&source=github-rel) / [arm](https://packages.cloudfoundry.org/stable?release=macosarm&version=new-version&source=github-rel) (pkg)
+- Windows [64 bit](https://packages.cloudfoundry.org/stable?release=windows64&version=new-version&source=github-rel) / [32 bit](https://packages.cloudfoundry.org/stable?release=windows32&version=new-version&source=github-rel) (zip)
+
+Binaries
+--------
+- Linux [64 bit](https://packages.cloudfoundry.org/stable?release=linux64-binary&version=new-version&source=github-rel) / [32 bit](https://packages.cloudfoundry.org/stable?release=linux32-binary&version=new-version&source=github-rel) / [arm64](https://packages.cloudfoundry.org/stable?release=linuxarm64-binary&version=new-version&source=github-rel) (tgz)
+- macOS [64 bit](https://packages.cloudfoundry.org/stable?release=macosx64-binary&version=new-version&source=github-rel) / [arm](https://packages.cloudfoundry.org/stable?release=macosarm-binary&version=new-version&source=github-rel) (tgz)
+- Windows [64 bit](https://packages.cloudfoundry.org/stable?release=windows64-exe&version=new-version&source=github-rel) / [32 bit](https://packages.cloudfoundry.org/stable?release=windows32-exe&version=new-version&source=github-rel) (zip)
+
+
+Docker
+--------
+```shell
+docker pull cloudfoundry/cli:new-version
+```

--- a/.github/workflows/release-build-sign-upload.yml
+++ b/.github/workflows/release-build-sign-upload.yml
@@ -36,7 +36,6 @@ run-name: "Release: Build Sign Upload [${{ github.ref_name }}]"
 #    SIGNING_KEY_WINDOWS_PASSPHRASE
 #    SIGNING_KEY_WINDOWS_PFX
 
-
 on:
   workflow_dispatch:
 
@@ -50,7 +49,6 @@ defaults:
 jobs:
   setup:
     name: Setup
-    # needs: test
     runs-on: ubuntu-latest
 
     outputs:
@@ -644,24 +642,6 @@ jobs:
           smctl windows certsync
         shell: cmd
 
-      # This is for debugging windows
-      # - name: enable ssh
-      #   if: always()
-      #   run: |
-      #     Get-WindowsCapability -Online
-      #     $componentName = $(Get-WindowsCapability -Online |Where-Object Name -like 'OpenSSH.Server*').Name
-      #     Add-WindowsCapability -Online -Name $componentName
-      #     Get-NetFirewallRule -Name "OpenSSH-Server-In-TCP"
-
-      # - name: ssh session
-      #   if: always()
-      #   run: |
-      #     Start-Service sshd
-      #     echo "IP address below:"
-      #     Get-NetIPAddress | Select-Object -Property IPAddress
-      #     sleep 3600
-      #     Stop-Service sshd
-
       - name: Sign Windows binaries
         run: |
           smctl healthcheck --all
@@ -724,9 +704,6 @@ jobs:
             Compress-Archive -DestinationPath "$installer_zip_filename" -Path *
           popd
           Get-ChildItem "${env:RUNNER_TEMP}"
-
-      # - name: Setup tmate session
-      #   uses: mxschmitt/action-tmate@v3
 
       - name: Save installer and dist files as a GitHub Action Artifact
         uses: actions/upload-artifact@v4
@@ -975,28 +952,30 @@ jobs:
   github-release-draft:
     name: Create GitHub Release Draft
     runs-on: ubuntu-latest
+    env:
+      REPO_DIR: repo
+      ARTIFACTS_DIR: artifacts
     permissions:
       actions: read
       contents: write
     needs:
     - setup
-    - test-rpm-package
-    - test-deb-package
-    - test-macos
-    - test-windows
+    - s3-upload
     steps:
     - name: Download signed artifacts
       uses: actions/download-artifact@v4
       with:
         name: final-artifacts
-        path: artifacts # download all artifacts to 'artifacts/'
+        path: ${{ env.ARTIFACTS_DIR }}
 
     - name: Checkout CLI
       uses: actions/checkout@v4
-    
+      with:
+        path: ${{ env.REPO_DIR }}
+       
     - name: Prepare release notes
       run: |
-        sed -i 's/new-version/${{ needs.setup.outputs.version-build }}/g' .github/release/release-notes-template.txt
+        sed -i 's/new-version/${{ needs.setup.outputs.version-build }}/g' "${{ env.REPO_DIR }}/.github/release/release-notes-template.txt"
         
     - name: Create draft release
       uses: softprops/action-gh-release@v2
@@ -1004,22 +983,22 @@ jobs:
         draft:                   true
         name:                    "DRAFT v${{ needs.setup.outputs.version-build }}"
         tag_name:                "v${{ needs.setup.outputs.version-build }}"
-        body_path:               ".github/release/release-notes-template.txt"
+        body_path:               "${{ env.REPO_DIR }}/.github/release/release-notes-template.txt"
         fail_on_unmatched_files: true
         generate_release_notes: true
         files: |
-          artifacts/cf-cli-linux-rpm-packages/cf*rpm 
-          artifacts/cf-cli-linux-deb-packages/cf*deb
-          artifacts/cf-cli-macos-packages/cf*pkg
-          artifacts/cf-cli-windows-packages/cf*zip
-          artifacts/linux_i686/*tgz
-          artifacts/linux_x86-64/*tgz
-          artifacts/linux_arm64/*tgz
-          artifacts/osx/*tgz
-          artifacts/macosarm/*tgz
-          artifacts/win32/*zip
-          artifacts/winx64/*zip   
-          
+          ${{ env.ARTIFACTS_DIR }}/cf-cli-linux-rpm-packages/cf*rpm 
+          ${{ env.ARTIFACTS_DIR }}/cf-cli-linux-deb-packages/cf*deb
+          ${{ env.ARTIFACTS_DIR }}/cf-cli-macos-packages/cf*pkg
+          ${{ env.ARTIFACTS_DIR }}/cf-cli-windows-packages/cf*zip
+          ${{ env.ARTIFACTS_DIR }}/linux_i686/*tgz
+          ${{ env.ARTIFACTS_DIR }}/linux_x86-64/*tgz
+          ${{ env.ARTIFACTS_DIR }}/linux_arm64/*tgz
+          ${{ env.ARTIFACTS_DIR }}/osx/*tgz
+          ${{ env.ARTIFACTS_DIR }}/macosarm/*tgz
+          ${{ env.ARTIFACTS_DIR }}/win32/*zip
+          ${{ env.ARTIFACTS_DIR }}/winx64/*zip 
+
   update-claw:
     name: Add new release version to CLAW
     runs-on: ubuntu-latest
@@ -1060,5 +1039,5 @@ jobs:
             
             git push
           fi
-        popd    
-# vim: set sw=2 ts=2 sts=2 et tw=78 foldlevel=2 fdm=indent nospell:
+          fi
+        popd

--- a/.github/workflows/release-build-sign-upload.yml
+++ b/.github/workflows/release-build-sign-upload.yml
@@ -826,27 +826,21 @@ jobs:
           signed/win32/*zip \
           signed/winx64/*zip
 
-    - name: Setup aws to upload installers to CLAW S3 bucket
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        aws-access-key-id:     ${{ vars.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY  }}
-        aws-region:            ${{ vars.AWS_REGION }}
-        role-to-assume:        ${{ vars.AWS_S3_ROLE_ARN }}
-        role-skip-session-tagging: true
-        role-duration-seconds:     1200
+    # - name: Setup aws to upload installers to CLAW S3 bucket
+    #   uses: aws-actions/configure-aws-credentials@v4
+    #   with:
+    #     aws-access-key-id:     ${{ vars.AWS_ACCESS_KEY_ID }}
+    #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY  }}
+    #     aws-region:            ${{ vars.AWS_REGION }}
+    #     role-to-assume:        ${{ vars.AWS_S3_ROLE_ARN }}
+    #     role-skip-session-tagging: true
+    #     role-duration-seconds:     1200
 
-    - name: Upload installers to CLAW S3 bucket
-      run: aws s3 sync upload "s3://v${VERSION_MAJOR}-cf-cli-releases/releases/v${VERSION_BUILD}/"
+    # - name: Upload installers to CLAW S3 bucket
+    #   run: aws s3 sync upload "s3://v${VERSION_MAJOR}-cf-cli-releases/releases/v${VERSION_BUILD}/"
 
-    - name: list S3 for human verification
-      run: aws s3 ls "s3://v${VERSION_MAJOR}-cf-cli-releases/releases/v${VERSION_BUILD}/"
-
-    - name: Instruct human to update CLAW
-      run: |
-        echo "Please go to https://github.com/cloudfoundry/CLAW/blob/develop/claw-variables.yml and add the following line to the file:"
-        echo
-        echo "- ${VERSION_BUILD}"
+    # - name: list S3 for human verification
+    #   run: aws s3 ls "s3://v${VERSION_MAJOR}-cf-cli-releases/releases/v${VERSION_BUILD}/"
 
   test-rpm-package:
     name: Test RPM Artifacts
@@ -1037,7 +1031,6 @@ jobs:
                 echo "no new version to commit"
             fi
             
-            git push
-          fi
+            # git push
           fi
         popd

--- a/.github/workflows/release-build-sign-upload.yml
+++ b/.github/workflows/release-build-sign-upload.yml
@@ -826,6 +826,13 @@ jobs:
           signed/win32/*zip \
           signed/winx64/*zip
 
+    - name: Store Artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        if-no-files-found: error
+        name: final-artifacts
+        path: signed/*          
+        
     # - name: Setup aws to upload installers to CLAW S3 bucket
     #   uses: aws-actions/configure-aws-credentials@v4
     #   with:

--- a/.github/workflows/release-build-sign-upload.yml
+++ b/.github/workflows/release-build-sign-upload.yml
@@ -832,22 +832,22 @@ jobs:
         if-no-files-found: error
         name: final-artifacts
         path: signed/*          
-        
-    # - name: Setup aws to upload installers to CLAW S3 bucket
-    #   uses: aws-actions/configure-aws-credentials@v4
-    #   with:
-    #     aws-access-key-id:     ${{ vars.AWS_ACCESS_KEY_ID }}
-    #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY  }}
-    #     aws-region:            ${{ vars.AWS_REGION }}
-    #     role-to-assume:        ${{ vars.AWS_S3_ROLE_ARN }}
-    #     role-skip-session-tagging: true
-    #     role-duration-seconds:     1200
 
-    # - name: Upload installers to CLAW S3 bucket
-    #   run: aws s3 sync upload "s3://v${VERSION_MAJOR}-cf-cli-releases/releases/v${VERSION_BUILD}/"
+    - name: Setup aws to upload installers to CLAW S3 bucket
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-access-key-id:     ${{ vars.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY  }}
+        aws-region:            ${{ vars.AWS_REGION }}
+        role-to-assume:        ${{ vars.AWS_S3_ROLE_ARN }}
+        role-skip-session-tagging: true
+        role-duration-seconds:     1200
 
-    # - name: list S3 for human verification
-    #   run: aws s3 ls "s3://v${VERSION_MAJOR}-cf-cli-releases/releases/v${VERSION_BUILD}/"
+    - name: Upload installers to CLAW S3 bucket
+      run: aws s3 sync upload "s3://v${VERSION_MAJOR}-cf-cli-releases/releases/v${VERSION_BUILD}/"
+
+    - name: list S3 for human verification
+      run: aws s3 ls "s3://v${VERSION_MAJOR}-cf-cli-releases/releases/v${VERSION_BUILD}/"
 
   test-rpm-package:
     name: Test RPM Artifacts
@@ -1038,6 +1038,6 @@ jobs:
                 echo "no new version to commit"
             fi
             
-            # git push
+            git push
           fi
         popd


### PR DESCRIPTION
To keep the downloaded artifacts and checked out repo path separate, added path to checkout action
## Description of the Change

Fix for creating github draft release job. Downloaded artifacts were getting deleted by the checkout action since it was being checked out to $GITHUB_WORKSPACE. So added path to checkout action.


## Why Is This PR Valuable?

Helps with release process

## Applicable Issues

List any applicable GitHub Issues here

## How Urgent Is The Change?

Is the change urgent? If so, explain why it is time-sensitive.

## Other Relevant Parties

Who else is affected by the change? 
