### PR TITLE
Add path to checkout action [main]

### DIFF
--- a/.github/workflows/release-build-sign-upload.yml
+++ b/.github/workflows/release-build-sign-upload.yml
@@ -36,7 +36,6 @@ run-name: "Release: Build Sign Upload [${{ github.ref_name }}]"
 #    SIGNING_KEY_WINDOWS_PASSPHRASE
 #    SIGNING_KEY_WINDOWS_PFX
 
-
 on:
   workflow_dispatch:
 
@@ -44,41 +43,12 @@ permissions:
   contents: read
 
 defaults:
-  # top-level defaults subkeys apply to jobs
-  # run subkeys apply to all steps within all jobs
   run:
     shell: bash
 
 jobs:
-
-  # test:
-  #   environment: DEV
-  #   runs-on: ubuntu-latest
-  #   steps:
-    # - name: Setup upterm session
-    #   env:
-    #     AWS_ACCESS_KEY_ID:              ${{ secrets.AWS_ACCESS_KEY_ID }}
-    #     AWS_REGION:                     ${{ secrets.AWS_REGION }}
-    #     AWS_SECRET_ACCESS_KEY:          ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    #     GIT_RELEASE_TARGET_REPO:        ${{ secrets.GIT_RELEASE_TARGET_REPO }}
-    #     GIT_REPO_ACCESS_TOKEN:          ${{ secrets.GIT_REPO_ACCESS_TOKEN }}
-    #     SIGNING_KEY_GPG:                ${{ secrets.SIGNING_KEY_GPG }}
-    #     SIGNING_KEY_GPG_ID:             ${{ secrets.SIGNING_KEY_GPG_ID }}
-    #     SIGNING_KEY_GPG_PASSPHRASE:     ${{ secrets.SIGNING_KEY_GPG_PASSPHRASE }}
-    #     SIGNING_KEY_MAC_ID:             ${{ secrets.SIGNING_KEY_MAC_ID }}
-    #     SIGNING_KEY_MAC_PASSPHRASE:     ${{ secrets.SIGNING_KEY_MAC_PASSPHRASE }}
-    #     SIGNING_KEY_MAC_PFX:            ${{ secrets.SIGNING_KEY_MAC_PFX }}
-    #     SIGNING_KEY_WINDOWS_ID:         ${{ secrets.SIGNING_KEY_WINDOWS_ID }}
-    #     SIGNING_KEY_WINDOWS_PASSPHRASE: ${{ secrets.SIGNING_KEY_WINDOWS_PASSPHRASE }}
-    #     SIGNING_KEY_WINDOWS_PFX:        ${{ secrets.SIGNING_KEY_WINDOWS_PFX }}
-    #     SIGNING_TEST_CA_MAC:            ${{ secrets.SIGNING_TEST_CA_MAC }}
-    #   if: always()
-    #   uses: lhotari/action-upterm@v1
-    #   timeout-minutes: 60
-
   setup:
     name: Setup
-    # needs: test
     runs-on: ubuntu-latest
 
     outputs:
@@ -673,24 +643,6 @@ jobs:
           smctl windows certsync
         shell: cmd
 
-      # This is for debugging windows
-      # - name: enable ssh
-      #   if: always()
-      #   run: |
-      #     Get-WindowsCapability -Online
-      #     $componentName = $(Get-WindowsCapability -Online |Where-Object Name -like 'OpenSSH.Server*').Name
-      #     Add-WindowsCapability -Online -Name $componentName
-      #     Get-NetFirewallRule -Name "OpenSSH-Server-In-TCP"
-
-      # - name: ssh session
-      #   if: always()
-      #   run: |
-      #     Start-Service sshd
-      #     echo "IP address below:"
-      #     Get-NetIPAddress | Select-Object -Property IPAddress
-      #     sleep 3600
-      #     Stop-Service sshd
-
       - name: Sign Windows binaries
         run: |
           smctl healthcheck --all
@@ -753,9 +705,6 @@ jobs:
             Compress-Archive -DestinationPath "$installer_zip_filename" -Path *
           popd
           Get-ChildItem "${env:RUNNER_TEMP}"
-
-      # - name: Setup tmate session
-      #   uses: mxschmitt/action-tmate@v3
 
       - name: Save installer and dist files as a GitHub Action Artifact
         uses: actions/upload-artifact@v4
@@ -1009,28 +958,30 @@ jobs:
   github-release-draft:
     name: Create GitHub Release Draft
     runs-on: ubuntu-latest
+    env:
+      REPO_DIR: repo
+      ARTIFACTS_DIR: artifacts
     permissions:
       actions: read
       contents: write
     needs:
     - setup
-    - test-rpm-package
-    - test-deb-package
-    - test-macos
-    - test-windows
+    - s3-upload
     steps:
     - name: Download signed artifacts
       uses: actions/download-artifact@v4
       with:
         name: final-artifacts
-        path: artifacts # download all artifacts to 'artifacts/'
+        path: ${{ env.ARTIFACTS_DIR }}
 
     - name: Checkout CLI
       uses: actions/checkout@v4
-     
+      with:
+        path: ${{ env.REPO_DIR }}
+       
     - name: Prepare release notes
       run: |
-        sed -i 's/new-version/${{ needs.setup.outputs.version-build }}/g' .github/release/release-notes-template.txt
+        sed -i 's/new-version/${{ needs.setup.outputs.version-build }}/g' "${{ env.REPO_DIR }}/.github/release/release-notes-template.txt"
         
     - name: Create draft release
       uses: softprops/action-gh-release@v2
@@ -1038,22 +989,22 @@ jobs:
         draft:                   true
         name:                    "DRAFT v${{ needs.setup.outputs.version-build }}"
         tag_name:                "v${{ needs.setup.outputs.version-build }}"
-        body_path:               ".github/release/release-notes-template.txt"
+        body_path:               "${{ env.REPO_DIR }}/.github/release/release-notes-template.txt"
         fail_on_unmatched_files: true
         generate_release_notes: true
         files: |
-          artifacts/cf-cli-linux-rpm-packages/cf*rpm 
-          artifacts/cf-cli-linux-deb-packages/cf*deb
-          artifacts/cf-cli-macos-packages/cf*pkg
-          artifacts/cf-cli-windows-packages/cf*zip
-          artifacts/linux_i686/*tgz
-          artifacts/linux_x86-64/*tgz
-          artifacts/linux_arm64/*tgz
-          artifacts/osx/*tgz
-          artifacts/macosarm/*tgz
-          artifacts/win32/*zip
-          artifacts/winx64/*zip   
-          
+          ${{ env.ARTIFACTS_DIR }}/cf-cli-linux-rpm-packages/cf*rpm 
+          ${{ env.ARTIFACTS_DIR }}/cf-cli-linux-deb-packages/cf*deb
+          ${{ env.ARTIFACTS_DIR }}/cf-cli-macos-packages/cf*pkg
+          ${{ env.ARTIFACTS_DIR }}/cf-cli-windows-packages/cf*zip
+          ${{ env.ARTIFACTS_DIR }}/linux_i686/*tgz
+          ${{ env.ARTIFACTS_DIR }}/linux_x86-64/*tgz
+          ${{ env.ARTIFACTS_DIR }}/linux_arm64/*tgz
+          ${{ env.ARTIFACTS_DIR }}/osx/*tgz
+          ${{ env.ARTIFACTS_DIR }}/macosarm/*tgz
+          ${{ env.ARTIFACTS_DIR }}/win32/*zip
+          ${{ env.ARTIFACTS_DIR }}/winx64/*zip 
+
   update-claw:
     name: Add new release version to CLAW
     runs-on: ubuntu-latest
@@ -1094,5 +1045,4 @@ jobs:
             
             git push
           fi
-        popd    
-# vim: set sw=2 ts=2 sts=2 et tw=78 foldlevel=2 fdm=indent nospell:
+        popd


### PR DESCRIPTION
To keep the downloaded artifacts and checked out repo path separate, added path to checkout action

## Description of the Change

Fix for creating github draft release job. Downloaded artifacts were getting deleted by the checkout action since it was being checked out to $GITHUB_WORKSPACE. So added path to checkout action.

## Why Is This PR Valuable?

Helps with release process

## Applicable Issues

List any applicable GitHub Issues here

## How Urgent Is The Change?

Is the change urgent? If so, explain why it is time-sensitive.

## Other Relevant Parties

Who else is affected by the change? 
