### PR TITLE
Update CAPI v2 docs links to new subdomain [v7]

### DIFF
--- a/api/cloudcontroller/ccv2/client.go
+++ b/api/cloudcontroller/ccv2/client.go
@@ -7,7 +7,7 @@
 // may include features and endpoints of later API versions.
 //
 // For more information on the Cloud Controller API see
-// https://apidocs.cloudfoundry.org/
+// https://v2-apidocs.cloudfoundry.org/
 //
 // # Method Naming Conventions
 //

--- a/api/cloudcontroller/ccv3/client.go
+++ b/api/cloudcontroller/ccv3/client.go
@@ -7,7 +7,7 @@
 // may include features and endpoints of later API versions.
 //
 // For more information on the Cloud Controller API see
-// https://apidocs.cloudfoundry.org/
+// https://v2-apidocs.cloudfoundry.org/
 //
 // # Method Naming Conventions
 //

--- a/cf/commands/curl.go
+++ b/cf/commands/curl.go
@@ -54,7 +54,7 @@ func (cmd *Curl) MetaData() commandregistry.CommandMetadata {
    will be set to application/json. You may override headers with -H and the
    request method with -X.
 
-   For API documentation, please visit http://apidocs.cloudfoundry.org.`),
+   For API documentation, please visit http://v2-apidocs.cloudfoundry.org.`),
 		},
 		Examples: []string{
 			`CF_NAME curl "/v2/apps" -X GET -H "Content-Type: application/x-www-form-urlencoded" -d 'q=name:myapp'`,

--- a/command/v6/curl_command.go
+++ b/command/v6/curl_command.go
@@ -14,7 +14,7 @@ type CurlCommand struct {
 	FailOnHTTPError        bool            `short:"f" long:"fail" description:"Server errors return exit code 22"`
 	IncludeResponseHeaders bool            `short:"i" description:"Include response headers in the output"`
 	OutputFile             flag.Path       `long:"output" description:"Write curl body to FILE instead of stdout"`
-	usage                  interface{}     `usage:"CF_NAME curl PATH [-iv] [-X METHOD] [-H HEADER]... [-d DATA] [--output FILE]\n\n   By default 'CF_NAME curl' will perform a GET to the specified PATH. If data\n   is provided via -d, a POST will be performed instead, and the Content-Type\n   will be set to application/json. You may override headers with -H and the\n   request method with -X.\n\n   For API documentation, please visit http://apidocs.cloudfoundry.org.\n\nEXAMPLES:\n   CF_NAME curl \"/v2/apps\" -X GET -H \"Content-Type: application/x-www-form-urlencoded\" -d 'q=name:myapp'\n   CF_NAME curl \"/v2/apps\" -d @/path/to/file"`
+	usage                  interface{}     `usage:"CF_NAME curl PATH [-iv] [-X METHOD] [-H HEADER]... [-d DATA] [--output FILE]\n\n   By default 'CF_NAME curl' will perform a GET to the specified PATH. If data\n   is provided via -d, a POST will be performed instead, and the Content-Type\n   will be set to application/json. You may override headers with -H and the\n   request method with -X.\n\n   For API documentation, please visit http://v2-apidocs.cloudfoundry.org.\n\nEXAMPLES:\n   CF_NAME curl \"/v2/apps\" -X GET -H \"Content-Type: application/x-www-form-urlencoded\" -d 'q=name:myapp'\n   CF_NAME curl \"/v2/apps\" -d @/path/to/file"`
 }
 
 func (CurlCommand) Setup(config command.Config, ui command.UI) error {

--- a/integration/v6/isolated/curl_command_test.go
+++ b/integration/v6/isolated/curl_command_test.go
@@ -26,7 +26,7 @@ var _ = Describe("curl command", func() {
 		Eventually(session).Should(Say(`\s+is provided via -d, a POST will be performed instead, and the Content-Type\n`))
 		Eventually(session).Should(Say(`\s+will be set to application/json. You may override headers with -H and the\n`))
 		Eventually(session).Should(Say(`\s+request method with -X.\n`))
-		Eventually(session).Should(Say(`\s+For API documentation, please visit http://apidocs.cloudfoundry.org.\n`))
+		Eventually(session).Should(Say(`\s+For API documentation, please visit http://v2-apidocs.cloudfoundry.org.\n`))
 		Eventually(session).Should(Say(`\n`))
 
 		Eventually(session).Should(Say(`EXAMPLES:\n`))

--- a/integration/v7/isolated/curl_command_test.go
+++ b/integration/v7/isolated/curl_command_test.go
@@ -27,7 +27,7 @@ var _ = Describe("curl command", func() {
 		Eventually(session).Should(Say(`\s+is provided via -d, a POST will be performed instead, and the Content-Type\n`))
 		Eventually(session).Should(Say(`\s+will be set to application/json. You may override headers with -H and the\n`))
 		Eventually(session).Should(Say(`\s+request method with -X.\n`))
-		Eventually(session).Should(Say(`\s+For API documentation, please visit http://apidocs.cloudfoundry.org.\n`))
+		Eventually(session).Should(Say(`\s+For API documentation, please visit http://v2-apidocs.cloudfoundry.org.\n`))
 		Eventually(session).Should(Say(`\n`))
 
 		Eventually(session).Should(Say(`EXAMPLES:\n`))


### PR DESCRIPTION
This PR updates CAPI v2 docs links from `apidocs.cloudfoundry.org` to `v2-apidocs.cloudfoundry.org`.
The goal is to signal that v3 is the primary API, also a necessary step in eventually sunsetting v2.

The infrastructure hosting the app serving docs at apidocs.cloudfoundry.org is expected to go down imminently, so this change is needed to avoid dead links.

See capi-release PRs [#440](https://github.com/cloudfoundry/capi-release/pull/440) and [#441](https://github.com/cloudfoundry/capi-release/pull/441)