### PR TITLE
Remove unused property [main]

### DIFF
--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -74,5 +74,4 @@ jobs:
       run-with-client-creds: false
       os: ubuntu-latest
       name: cats
-      is-pr: ${{ github.event_name != 'workflow_dispatch' }}
     secrets: inherit


### PR DESCRIPTION
The integration workflow file had an unused property which was causing the workflow to fail. This PR removes it.