### PR TITLE
Remove unsed property [v8]

### DIFF
--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -74,6 +74,5 @@ jobs:
       run-with-client-creds: false
       os: ubuntu-latest
       name: cats
-      is-pr: ${{ github.event_name != 'workflow_dispatch' }}
     secrets: inherit
   


### PR DESCRIPTION
The integration workflow file had an unused property which was causing the workflow to fail. This PR removes it.