### PR TITLE
View Canary deployment status when using `cf app` [v8]

### DIFF
--- a/api/cloudcontroller/ccv3/constant/deployment.go
+++ b/api/cloudcontroller/ccv3/constant/deployment.go
@@ -45,6 +45,10 @@ const (
 	// DeploymentStatusReasonSuperseded means the deployment's status.value is
 	// 'SUPERSEDED'
 	DeploymentStatusReasonSuperseded DeploymentStatusReason = "SUPERSEDED"
+
+	// DeploymentStatusReasonPaused means the deployment's status.value is
+	// 'PAUSED'
+	DeploymentStatusReasonPaused DeploymentStatusReason = "PAUSED"
 )
 
 // DeploymentStatusValue describes the status values a deployment can have

--- a/api/cloudcontroller/ccv3/constant/deployment_strategy.go
+++ b/api/cloudcontroller/ccv3/constant/deployment_strategy.go
@@ -9,4 +9,7 @@ const (
 
 	// Rolling means a new web process will be created for the app and instances will roll from the old one to the new one.
 	DeploymentStrategyRolling DeploymentStrategy = "rolling"
+
+	// Canary means after a web process is created for the app the deployment will pause for evaluation until it is continued or canceled.
+	DeploymentStrategyCanary DeploymentStrategy = "canary"
 )

--- a/command/v7/shared/app_summary_displayer.go
+++ b/command/v7/shared/app_summary_displayer.go
@@ -164,10 +164,22 @@ func (display AppSummaryDisplayer) displayProcessTable(summary v7action.Detailed
 
 	if summary.Deployment.StatusValue == constant.DeploymentStatusValueActive {
 		display.UI.DisplayNewline()
-		display.UI.DisplayText(fmt.Sprintf("%s deployment currently %s (since %s)",
+		display.UI.DisplayText(display.getDeploymentStatusText(summary))
+	}
+}
+
+func (display AppSummaryDisplayer) getDeploymentStatusText(summary v7action.DetailedApplicationSummary) string {
+	var lastStatusChangeTime = display.getLastStatusChangeTime(summary)
+
+	if lastStatusChangeTime != "" {
+		return fmt.Sprintf("%s deployment currently %s (since %s)",
 			cases.Title(language.English, cases.NoLower).String(string(summary.Deployment.Strategy)),
 			summary.Deployment.StatusReason,
-			display.getLastStatusChangeTime(summary)))
+			lastStatusChangeTime)
+	} else {
+		return fmt.Sprintf("%s deployment currently %s",
+			cases.Title(language.English, cases.NoLower).String(string(summary.Deployment.Strategy)),
+			summary.Deployment.StatusReason)
 	}
 }
 

--- a/command/v7/shared/app_summary_displayer.go
+++ b/command/v7/shared/app_summary_displayer.go
@@ -164,9 +164,10 @@ func (display AppSummaryDisplayer) displayProcessTable(summary v7action.Detailed
 
 	if summary.Deployment.StatusValue == constant.DeploymentStatusValueActive {
 		display.UI.DisplayNewline()
-		display.UI.DisplayText(fmt.Sprintf("%s deployment currently %s.",
+		display.UI.DisplayText(fmt.Sprintf("%s deployment currently %s (since %s)",
 			cases.Title(language.English, cases.NoLower).String(string(summary.Deployment.Strategy)),
-			summary.Deployment.StatusReason))
+			summary.Deployment.StatusReason,
+			display.getLastStatusChangeTime(summary)))
 	}
 }
 
@@ -175,6 +176,19 @@ func (display AppSummaryDisplayer) getCreatedTime(summary v7action.DetailedAppli
 		timestamp, err := time.Parse(time.RFC3339, summary.CurrentDroplet.CreatedAt)
 		if err != nil {
 			log.WithField("createdAt", summary.CurrentDroplet.CreatedAt).Errorln("error parsing created at:", err)
+		}
+
+		return display.UI.UserFriendlyDate(timestamp)
+	}
+
+	return ""
+}
+
+func (display AppSummaryDisplayer) getLastStatusChangeTime(summary v7action.DetailedApplicationSummary) string {
+	if summary.Deployment.LastStatusChange != "" {
+		timestamp, err := time.Parse(time.RFC3339, summary.Deployment.LastStatusChange)
+		if err != nil {
+			log.WithField("last_status_change", summary.Deployment.LastStatusChange).Errorln("error parsing last status change:", err)
 		}
 
 		return display.UI.UserFriendlyDate(timestamp)

--- a/command/v7/shared/app_summary_displayer.go
+++ b/command/v7/shared/app_summary_displayer.go
@@ -165,6 +165,10 @@ func (display AppSummaryDisplayer) displayProcessTable(summary v7action.Detailed
 	if summary.Deployment.StatusValue == constant.DeploymentStatusValueActive {
 		display.UI.DisplayNewline()
 		display.UI.DisplayText(display.getDeploymentStatusText(summary))
+		if summary.Deployment.Strategy == constant.DeploymentStrategyCanary && summary.Deployment.StatusReason == constant.DeploymentStatusReasonPaused {
+			display.UI.DisplayNewline()
+			display.UI.DisplayText(fmt.Sprintf("Please run `cf continue-deployment %s` to promote the canary deployment, or `cf cancel-deployment %s` to rollback to the previous version.", summary.Application.Name, summary.Application.Name))
+		}
 	}
 }
 

--- a/command/v7/shared/app_summary_displayer_test.go
+++ b/command/v7/shared/app_summary_displayer_test.go
@@ -727,12 +727,18 @@ var _ = Describe("app summary displayer", func() {
 
 					It("displays the message", func() {
 						Expect(testUI.Out).To(Say(`Canary deployment currently DEPLOYING \(since Mon 29 Jul 13:32:29 EDT 2024\)`))
+						Expect(testUI.Out).NotTo(Say(`promote the canary deployment`))
 					})
 				})
 
 				When("the deployment is paused", func() {
 					BeforeEach(func() {
 						summary = v7action.DetailedApplicationSummary{
+							ApplicationSummary: v7action.ApplicationSummary{
+								Application: resources.Application{
+									Name: "foobar",
+								},
+							},
 							Deployment: resources.Deployment{
 								Strategy:         constant.DeploymentStrategyCanary,
 								StatusValue:      constant.DeploymentStatusValueActive,
@@ -744,6 +750,7 @@ var _ = Describe("app summary displayer", func() {
 
 					It("displays the message", func() {
 						Expect(testUI.Out).To(Say(`Canary deployment currently PAUSED \(since Mon 29 Jul 13:32:29 EDT 2024\)`))
+						Expect(testUI.Out).To(Say("Please run `cf continue-deployment foobar` to promote the canary deployment, or `cf cancel-deployment foobar` to rollback to the previous version."))
 					})
 				})
 
@@ -761,6 +768,7 @@ var _ = Describe("app summary displayer", func() {
 
 					It("displays the message", func() {
 						Expect(testUI.Out).To(Say(`Canary deployment currently CANCELING \(since Mon 29 Jul 13:32:29 EDT 2024\)`))
+						Expect(testUI.Out).NotTo(Say(`promote the canary deployment`))
 					})
 				})
 			})

--- a/command/v7/shared/app_summary_displayer_test.go
+++ b/command/v7/shared/app_summary_displayer_test.go
@@ -659,18 +659,39 @@ var _ = Describe("app summary displayer", func() {
 		When("there is an active deployment", func() {
 			When("the deployment strategy is rolling", func() {
 				When("the deployment is in progress", func() {
-					BeforeEach(func() {
-						summary = v7action.DetailedApplicationSummary{
-							Deployment: resources.Deployment{
-								Strategy:     constant.DeploymentStrategyRolling,
-								StatusValue:  constant.DeploymentStatusValueActive,
-								StatusReason: constant.DeploymentStatusReasonDeploying,
-							},
-						}
+					When("last status change has a timestamp", func() {
+						BeforeEach(func() {
+							summary = v7action.DetailedApplicationSummary{
+								Deployment: resources.Deployment{
+									Strategy:         constant.DeploymentStrategyRolling,
+									StatusValue:      constant.DeploymentStatusValueActive,
+									StatusReason:     constant.DeploymentStatusReasonDeploying,
+									LastStatusChange: "2024-07-29T17:32:29Z",
+								},
+							}
+						})
+
+						It("displays the message", func() {
+							Expect(testUI.Out).To(Say(`Rolling deployment currently DEPLOYING \(since Mon 29 Jul 13:32:29 EDT 2024\)`))
+						})
 					})
 
-					It("displays the message", func() {
-						Expect(testUI.Out).To(Say("Rolling deployment currently DEPLOYING."))
+					When("last status change is an empty string", func() {
+						BeforeEach(func() {
+							summary = v7action.DetailedApplicationSummary{
+								Deployment: resources.Deployment{
+									Strategy:         constant.DeploymentStrategyRolling,
+									StatusValue:      constant.DeploymentStatusValueActive,
+									StatusReason:     constant.DeploymentStatusReasonDeploying,
+									LastStatusChange: "",
+								},
+							}
+						})
+
+						It("displays the message", func() {
+							Expect(testUI.Out).To(Say(`Rolling deployment currently DEPLOYING\n`))
+							Expect(testUI.Out).NotTo(Say(`\(since`))
+						})
 					})
 				})
 
@@ -678,15 +699,68 @@ var _ = Describe("app summary displayer", func() {
 					BeforeEach(func() {
 						summary = v7action.DetailedApplicationSummary{
 							Deployment: resources.Deployment{
-								Strategy:     constant.DeploymentStrategyRolling,
-								StatusValue:  constant.DeploymentStatusValueActive,
-								StatusReason: constant.DeploymentStatusReasonCanceling,
+								Strategy:         constant.DeploymentStrategyRolling,
+								StatusValue:      constant.DeploymentStatusValueActive,
+								StatusReason:     constant.DeploymentStatusReasonCanceling,
+								LastStatusChange: "2024-07-29T17:32:29Z",
 							},
 						}
 					})
 
 					It("displays the message", func() {
-						Expect(testUI.Out).To(Say("Rolling deployment currently CANCELING."))
+						Expect(testUI.Out).To(Say(`Rolling deployment currently CANCELING \(since Mon 29 Jul 13:32:29 EDT 2024\)`))
+					})
+				})
+			})
+			When("the deployment strategy is canary", func() {
+				When("the deployment is in progress", func() {
+					BeforeEach(func() {
+						summary = v7action.DetailedApplicationSummary{
+							Deployment: resources.Deployment{
+								Strategy:         constant.DeploymentStrategyCanary,
+								StatusValue:      constant.DeploymentStatusValueActive,
+								StatusReason:     constant.DeploymentStatusReasonDeploying,
+								LastStatusChange: "2024-07-29T17:32:29Z",
+							},
+						}
+					})
+
+					It("displays the message", func() {
+						Expect(testUI.Out).To(Say(`Canary deployment currently DEPLOYING \(since Mon 29 Jul 13:32:29 EDT 2024\)`))
+					})
+				})
+
+				When("the deployment is paused", func() {
+					BeforeEach(func() {
+						summary = v7action.DetailedApplicationSummary{
+							Deployment: resources.Deployment{
+								Strategy:         constant.DeploymentStrategyCanary,
+								StatusValue:      constant.DeploymentStatusValueActive,
+								StatusReason:     constant.DeploymentStatusReasonPaused,
+								LastStatusChange: "2024-07-29T17:32:29Z",
+							},
+						}
+					})
+
+					It("displays the message", func() {
+						Expect(testUI.Out).To(Say(`Canary deployment currently PAUSED \(since Mon 29 Jul 13:32:29 EDT 2024\)`))
+					})
+				})
+
+				When("the deployment is canceling", func() {
+					BeforeEach(func() {
+						summary = v7action.DetailedApplicationSummary{
+							Deployment: resources.Deployment{
+								Strategy:         constant.DeploymentStrategyCanary,
+								StatusValue:      constant.DeploymentStatusValueActive,
+								StatusReason:     constant.DeploymentStatusReasonCanceling,
+								LastStatusChange: "2024-07-29T17:32:29Z",
+							},
+						}
+					})
+
+					It("displays the message", func() {
+						Expect(testUI.Out).To(Say(`Canary deployment currently CANCELING \(since Mon 29 Jul 13:32:29 EDT 2024\)`))
 					})
 				})
 			})

--- a/resources/deployment_resource.go
+++ b/resources/deployment_resource.go
@@ -59,7 +59,7 @@ func (d *Deployment) UnmarshalJSON(data []byte) error {
 		State         constant.DeploymentState `json:"state,omitempty"`
 		Status        struct {
 			Details struct {
-				LastStatusChange string `json:"last_status_change,omitempty"`
+				LastStatusChange string `json:"last_status_change"`
 			}
 			Value  constant.DeploymentStatusValue  `json:"value"`
 			Reason constant.DeploymentStatusReason `json:"reason"`

--- a/resources/deployment_resource.go
+++ b/resources/deployment_resource.go
@@ -8,17 +8,18 @@ import (
 )
 
 type Deployment struct {
-	GUID          string
-	State         constant.DeploymentState
-	StatusValue   constant.DeploymentStatusValue
-	StatusReason  constant.DeploymentStatusReason
-	RevisionGUID  string
-	DropletGUID   string
-	CreatedAt     string
-	UpdatedAt     string
-	Relationships Relationships
-	NewProcesses  []Process
-	Strategy      constant.DeploymentStrategy
+	GUID             string
+	State            constant.DeploymentState
+	StatusValue      constant.DeploymentStatusValue
+	StatusReason     constant.DeploymentStatusReason
+	LastStatusChange string
+	RevisionGUID     string
+	DropletGUID      string
+	CreatedAt        string
+	UpdatedAt        string
+	Relationships    Relationships
+	NewProcesses     []Process
+	Strategy         constant.DeploymentStrategy
 }
 
 // MarshalJSON converts a Deployment into a Cloud Controller Deployment.
@@ -57,6 +58,9 @@ func (d *Deployment) UnmarshalJSON(data []byte) error {
 		Relationships Relationships            `json:"relationships,omitempty"`
 		State         constant.DeploymentState `json:"state,omitempty"`
 		Status        struct {
+			Details struct {
+				LastStatusChange string `json:"last_status_change,omitempty"`
+			}
 			Value  constant.DeploymentStatusValue  `json:"value"`
 			Reason constant.DeploymentStatusReason `json:"reason"`
 		} `json:"status"`
@@ -76,6 +80,7 @@ func (d *Deployment) UnmarshalJSON(data []byte) error {
 	d.State = ccDeployment.State
 	d.StatusValue = ccDeployment.Status.Value
 	d.StatusReason = ccDeployment.Status.Reason
+	d.LastStatusChange = ccDeployment.Status.Details.LastStatusChange
 	d.DropletGUID = ccDeployment.Droplet.GUID
 	d.NewProcesses = ccDeployment.NewProcesses
 	d.Strategy = ccDeployment.Strategy


### PR DESCRIPTION
## Description of the Change

**As a** developer
**I want** to see deployment status when calling `cf app myapp`
**So that** I can easily tell if that app is currently being deployed to, and what the status is.

**Scenario:** A PAUSED Canary Deployment
**Given** An app has an active/paused Deployment
**When** I call `cf app myapp`
**Then** I see the following line in the CLI output:
```
Canary Deployment currently PAUSED (since [[insert timestamp]])

Please run `cf continue-deployment myapp` to promote the canary deployment, or `cf cancel-deployment myapp` to rollback to the previous version.
```

**Scenario:** A DEPLOYING Canary Deployment
**Given** An app has an active/deploying Deployment
**When** I call `cf app myapp`
**Then** I see the following line in the CLI output:
```
Canary Deployment currently DEPLOYING (since [[insert timestamp]])

```

**Scenario:** A CANCELING Canary Deployment
**Given** An app has an active/canceling Deployment
**When** I call `cf app myapp`
**Then** I see the following line in the CLI output:
```
Canary Deployment currently CANCELING (since [[insert timestamp]])
```

**Scenario:** No Current Deployment
**Given** An app has no ACTIVE Deployments
**When** I call `cf app myapp`
**Then** I see no line about Deployments in the output

CC @a-b 