### PR TITLE
Fix failing unit test timezone bug [v8]

### DIFF
--- a/command/v7/shared/app_summary_displayer_test.go
+++ b/command/v7/shared/app_summary_displayer_test.go
@@ -657,6 +657,9 @@ var _ = Describe("app summary displayer", func() {
 		})
 
 		When("there is an active deployment", func() {
+			var LastStatusChangeTimeString = "2024-07-29T17:32:29Z"
+			var dateTimeRegexPattern = `[a-zA-Z]{3}\s\d{2}\s[a-zA-Z]{3}\s\d{2}\:\d{2}\:\d{2}\s[A-Z]{3}\s\d{4}`
+
 			When("the deployment strategy is rolling", func() {
 				When("the deployment is in progress", func() {
 					When("last status change has a timestamp", func() {
@@ -666,13 +669,14 @@ var _ = Describe("app summary displayer", func() {
 									Strategy:         constant.DeploymentStrategyRolling,
 									StatusValue:      constant.DeploymentStatusValueActive,
 									StatusReason:     constant.DeploymentStatusReasonDeploying,
-									LastStatusChange: "2024-07-29T17:32:29Z",
+									LastStatusChange: LastStatusChangeTimeString,
 								},
 							}
 						})
 
 						It("displays the message", func() {
-							Expect(testUI.Out).To(Say(`Rolling deployment currently DEPLOYING \(since Mon 29 Jul 13:32:29 EDT 2024\)`))
+							var actualOut = fmt.Sprintf("%s", testUI.Out)
+							Expect(actualOut).To(MatchRegexp(`Rolling deployment currently DEPLOYING \(since %s\)`, dateTimeRegexPattern))
 						})
 					})
 
@@ -702,13 +706,14 @@ var _ = Describe("app summary displayer", func() {
 								Strategy:         constant.DeploymentStrategyRolling,
 								StatusValue:      constant.DeploymentStatusValueActive,
 								StatusReason:     constant.DeploymentStatusReasonCanceling,
-								LastStatusChange: "2024-07-29T17:32:29Z",
+								LastStatusChange: LastStatusChangeTimeString,
 							},
 						}
 					})
 
 					It("displays the message", func() {
-						Expect(testUI.Out).To(Say(`Rolling deployment currently CANCELING \(since Mon 29 Jul 13:32:29 EDT 2024\)`))
+						var actualOut = fmt.Sprintf("%s", testUI.Out)
+						Expect(actualOut).To(MatchRegexp(`Rolling deployment currently CANCELING \(since %s\)`, dateTimeRegexPattern))
 					})
 				})
 			})
@@ -720,13 +725,14 @@ var _ = Describe("app summary displayer", func() {
 								Strategy:         constant.DeploymentStrategyCanary,
 								StatusValue:      constant.DeploymentStatusValueActive,
 								StatusReason:     constant.DeploymentStatusReasonDeploying,
-								LastStatusChange: "2024-07-29T17:32:29Z",
+								LastStatusChange: LastStatusChangeTimeString,
 							},
 						}
 					})
 
 					It("displays the message", func() {
-						Expect(testUI.Out).To(Say(`Canary deployment currently DEPLOYING \(since Mon 29 Jul 13:32:29 EDT 2024\)`))
+						var actualOut = fmt.Sprintf("%s", testUI.Out)
+						Expect(actualOut).To(MatchRegexp(`Canary deployment currently DEPLOYING \(since %s\)`, dateTimeRegexPattern))
 						Expect(testUI.Out).NotTo(Say(`promote the canary deployment`))
 					})
 				})
@@ -743,13 +749,14 @@ var _ = Describe("app summary displayer", func() {
 								Strategy:         constant.DeploymentStrategyCanary,
 								StatusValue:      constant.DeploymentStatusValueActive,
 								StatusReason:     constant.DeploymentStatusReasonPaused,
-								LastStatusChange: "2024-07-29T17:32:29Z",
+								LastStatusChange: LastStatusChangeTimeString,
 							},
 						}
 					})
 
 					It("displays the message", func() {
-						Expect(testUI.Out).To(Say(`Canary deployment currently PAUSED \(since Mon 29 Jul 13:32:29 EDT 2024\)`))
+						var actualOut = fmt.Sprintf("%s", testUI.Out)
+						Expect(actualOut).To(MatchRegexp(`Canary deployment currently PAUSED \(since %s\)`, dateTimeRegexPattern))
 						Expect(testUI.Out).To(Say("Please run `cf continue-deployment foobar` to promote the canary deployment, or `cf cancel-deployment foobar` to rollback to the previous version."))
 					})
 				})
@@ -761,13 +768,14 @@ var _ = Describe("app summary displayer", func() {
 								Strategy:         constant.DeploymentStrategyCanary,
 								StatusValue:      constant.DeploymentStatusValueActive,
 								StatusReason:     constant.DeploymentStatusReasonCanceling,
-								LastStatusChange: "2024-07-29T17:32:29Z",
+								LastStatusChange: LastStatusChangeTimeString,
 							},
 						}
 					})
 
 					It("displays the message", func() {
-						Expect(testUI.Out).To(Say(`Canary deployment currently CANCELING \(since Mon 29 Jul 13:32:29 EDT 2024\)`))
+						var actualOut = fmt.Sprintf("%s", testUI.Out)
+						Expect(actualOut).To(MatchRegexp(`Canary deployment currently CANCELING \(since %s\)`, dateTimeRegexPattern))
 						Expect(testUI.Out).NotTo(Say(`promote the canary deployment`))
 					})
 				})


### PR DESCRIPTION
## Description of the Change

Some unit tests that were checking timezones were getting inconsistent results on GitHub runners. Updated the tests to validate the shape of the date and time instead.