### PR TITLE
Temporarily move integration tests to the push event

### DIFF
--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -24,6 +24,11 @@ on:
       - "Tests"
     types:
       - completed
+  push:
+    branches:
+      - main
+      - v8
+      - v7
 
 jobs:
   run-integration-tests-cf-env:

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -84,14 +84,4 @@ jobs:
         Get-Item Makefile
         make units
 
-
-
-  integration:
-    needs:
-      - units
-      - units-windows
-    name: Integration tests
-    if: ${{ github.event != 'workflow_dispatch' }}
-    uses: ./.github/workflows/tests-integration.yml
-    secrets: inherit
 # vim: set sw=2 ts=2 sts=2 et tw=78 foldlevel=2 fdm=indent nospell:


### PR DESCRIPTION
## Description of the Change

Temporarily move integration tests to the push event

- We will change this commit in the near future to ensure that the integration tests run again on pull requests
