### PR TITLE
Canary rollback command changes [v8]

### DIFF
--- a/command/v7/rollback_command.go
+++ b/command/v7/rollback_command.go
@@ -14,11 +14,12 @@ import (
 type RollbackCommand struct {
 	BaseCommand
 
-	Force           bool          `short:"f" description:"Force rollback without confirmation"`
-	RequiredArgs    flag.AppName  `positional-args:"yes"`
-	Version         flag.Revision `long:"version" required:"true" description:"Roll back to the specified revision"`
-	relatedCommands interface{}   `related_commands:"revisions"`
-	usage           interface{}   `usage:"CF_NAME rollback APP_NAME [--version VERSION] [-f]"`
+	Force           bool                    `short:"f" description:"Force rollback without confirmation"`
+	RequiredArgs    flag.AppName            `positional-args:"yes"`
+	Strategy        flag.DeploymentStrategy `long:"strategy" description:"Deployment strategy can be canary or rolling. When not specified, it defaults to rolling."`
+	Version         flag.Revision           `long:"version" required:"true" description:"Roll back to the specified revision"`
+	relatedCommands interface{}             `related_commands:"revisions"`
+	usage           interface{}             `usage:"CF_NAME rollback APP_NAME [--version VERSION] [-f]"`
 
 	LogCacheClient sharedaction.LogCacheClient
 	Stager         shared.AppStager
@@ -110,6 +111,10 @@ func (cmd RollbackCommand) Execute(args []string) error {
 		Strategy:  constant.DeploymentStrategyRolling,
 		NoWait:    false,
 		AppAction: constant.ApplicationRollingBack,
+	}
+
+	if cmd.Strategy.Name != "" {
+		opts.Strategy = cmd.Strategy.Name
 	}
 
 	startAppErr := cmd.Stager.StartApp(app, cmd.Config.TargetedSpace(), cmd.Config.TargetedOrganization(), revision.GUID, opts)

--- a/command/v7/rollback_command_test.go
+++ b/command/v7/rollback_command_test.go
@@ -219,6 +219,7 @@ var _ = Describe("rollback Command", func() {
 					Expect(application.GUID).To(Equal("123"))
 					Expect(revisionGUID).To(Equal("some-1-guid"))
 					Expect(opts.AppAction).To(Equal(constant.ApplicationRollingBack))
+					Expect(opts.Strategy).To(Equal(constant.DeploymentStrategyRolling))
 
 					Expect(testUI.Out).To(Say("Rolling '%s' back to revision '1' will create a new revision. The new revision will use the settings from revision '1'.", app))
 					Expect(testUI.Out).To(Say("Are you sure you want to continue?"))
@@ -229,6 +230,25 @@ var _ = Describe("rollback Command", func() {
 					Expect(testUI.Err).To(Say("warning-3"))
 
 					Expect(testUI.Out).To(Say("OK"))
+				})
+			})
+
+			When("the strategy flag is passed", func() {
+				BeforeEach(func() {
+					cmd.Strategy.Name = constant.DeploymentStrategyCanary
+
+					_, err := input.Write([]byte("y\n"))
+					Expect(err).NotTo(HaveOccurred())
+				})
+				It("uses the specified strategy to rollback", func() {
+					Expect(fakeAppStager.StartAppCallCount()).To(Equal(1), "GetStartApp call count")
+
+					application, _, _, revisionGUID, opts := fakeAppStager.StartAppArgsForCall(0)
+					Expect(executeErr).NotTo(HaveOccurred())
+					Expect(application.GUID).To(Equal("123"))
+					Expect(revisionGUID).To(Equal("some-1-guid"))
+					Expect(opts.AppAction).To(Equal(constant.ApplicationRollingBack))
+					Expect(opts.Strategy).To(Equal(constant.DeploymentStrategyCanary))
 				})
 			})
 
@@ -265,4 +285,5 @@ var _ = Describe("rollback Command", func() {
 			})
 		})
 	})
+
 })

--- a/integration/v7/isolated/rollback_command_test.go
+++ b/integration/v7/isolated/rollback_command_test.go
@@ -34,8 +34,9 @@ var _ = Describe("rollback command", func() {
 				Expect(session).To(Say("USAGE:"))
 				Expect(session).To(Say(`cf rollback APP_NAME \[--version VERSION\]`))
 				Expect(session).To(Say("OPTIONS:"))
-				Expect(session).To(Say("-f             Force rollback without confirmation"))
-				Expect(session).To(Say("--version      Roll back to the specified revision"))
+				Expect(session).To(Say("-f              Force rollback without confirmation"))
+				Expect(session).To(Say("--strategy      Deployment strategy can be canary or rolling. When not specified, it defaults to rolling."))
+				Expect(session).To(Say("--version       Roll back to the specified revision"))
 				Expect(session).To(Say("SEE ALSO:"))
 				Expect(session).To(Say("revisions"))
 			})
@@ -147,6 +148,22 @@ applications:
 							Eventually(session).Should(Exit(0))
 
 							Expect(session).To(Say(`3\(deployed\)\s+New droplet deployed.`))
+						})
+
+						When("the strategy flag is provided", func() {
+							BeforeEach(func() {
+								_, err := buffer.Write([]byte("y\n"))
+								Expect(err).ToNot(HaveOccurred())
+							})
+
+							It("uses the given strategy to rollback", func() {
+								session := helpers.CFWithStdin(buffer, "rollback", appName, "--version", "1", "--strategy", "canary")
+								Eventually(session).Should(Exit(0))
+
+								Expect(session).To(HaveRollbackPrompt())
+								Expect(session).To(HaveRollbackOutput(appName, orgName, spaceName, userName))
+								Expect(session).To(Say("OK"))
+							})
 						})
 					})
 


### PR DESCRIPTION
Add optional `strategy` flag for `rollback` back command which supports both `canary` and `rolling` deployments.