### PR TITLE
Print max-in-flight value alongside deployment status [main]

### DIFF
--- a/api/cloudcontroller/ccv3/constant/deployment.go
+++ b/api/cloudcontroller/ccv3/constant/deployment.go
@@ -31,3 +31,5 @@ const (
 	DeploymentStatusValueActive    DeploymentStatusValue = "ACTIVE"
 	DeploymentStatusValueFinalized DeploymentStatusValue = "FINALIZED"
 )
+
+const DeploymentMaxInFlightDefaultValue int = 1

--- a/command/v7/shared/app_summary_displayer.go
+++ b/command/v7/shared/app_summary_displayer.go
@@ -162,6 +162,12 @@ func (display AppSummaryDisplayer) displayProcessTable(summary v7action.Detailed
 	if summary.Deployment.StatusValue == constant.DeploymentStatusValueActive {
 		display.UI.DisplayNewline()
 		display.UI.DisplayText(display.getDeploymentStatusText(summary))
+
+		var maxInFlight = summary.Deployment.Options.MaxInFlight
+		if maxInFlight > 0 && maxInFlight != constant.DeploymentMaxInFlightDefaultValue {
+			display.UI.DisplayText(fmt.Sprintf("max-in-flight: %d", maxInFlight))
+		}
+
 		if summary.Deployment.Strategy == constant.DeploymentStrategyCanary && summary.Deployment.StatusReason == constant.DeploymentStatusReasonPaused {
 			display.UI.DisplayNewline()
 			display.UI.DisplayText(fmt.Sprintf("Please run `cf continue-deployment %s` to promote the canary deployment, or `cf cancel-deployment %s` to rollback to the previous version.", summary.Application.Name, summary.Application.Name))
@@ -171,25 +177,15 @@ func (display AppSummaryDisplayer) displayProcessTable(summary v7action.Detailed
 
 func (display AppSummaryDisplayer) getDeploymentStatusText(summary v7action.DetailedApplicationSummary) string {
 	var lastStatusChangeTime = display.getLastStatusChangeTime(summary)
-
 	if lastStatusChangeTime != "" {
 		return fmt.Sprintf("%s deployment currently %s (since %s)",
 			cases.Title(language.English, cases.NoLower).String(string(summary.Deployment.Strategy)),
 			summary.Deployment.StatusReason,
 			lastStatusChangeTime)
 	} else {
-		var sb strings.Builder
-		sb.WriteString(fmt.Sprintf("%s deployment currently %s.",
+		return fmt.Sprintf("%s deployment currently %s.",
 			cases.Title(language.English, cases.NoLower).String(string(summary.Deployment.Strategy)),
-			summary.Deployment.StatusReason))
-
-		if summary.Deployment.Strategy == constant.DeploymentStrategyCanary && summary.Deployment.StatusReason == constant.DeploymentStatusReasonPaused {
-			sb.WriteString("\n")
-			sb.WriteString(fmt.Sprintf(
-				"Please run `cf continue-deployment %s` to promote the canary deployment, or `cf cancel-deployment %s` to rollback to the previous version.",
-				summary.Application.Name, summary.Application.Name))
-		}
-		return sb.String()
+			summary.Deployment.StatusReason)
 	}
 }
 

--- a/command/v7/shared/app_summary_displayer_test.go
+++ b/command/v7/shared/app_summary_displayer_test.go
@@ -721,10 +721,12 @@ var _ = Describe("app summary displayer", func() {
 							var actualOut = fmt.Sprintf("%s", testUI.Out)
 							Expect(actualOut).To(MatchRegexp(`Rolling deployment currently DEPLOYING \(since %s\)`, dateTimeRegexPattern))
 						})
+
 						It("displays max-in-flight value", func() {
 							Expect(testUI.Out).To(Say(`max-in-flight: 2`))
 						})
 					})
+
 					When("last status change has a timestamp and max-in-flight is default", func() {
 						BeforeEach(func() {
 							summary = v7action.DetailedApplicationSummary{
@@ -744,10 +746,12 @@ var _ = Describe("app summary displayer", func() {
 							var actualOut = fmt.Sprintf("%s", testUI.Out)
 							Expect(actualOut).To(MatchRegexp(`Rolling deployment currently DEPLOYING \(since %s\)`, dateTimeRegexPattern))
 						})
+
 						It("does not display max-in-flight", func() {
 							Expect(testUI.Out).NotTo(Say(`max-in-flight`))
 						})
 					})
+
 					// 'unset' is important for the newer-CLI-than-CAPI scenario
 					When("last status change has a timestamp and max-in-flight is unset", func() {
 						BeforeEach(func() {
@@ -765,6 +769,7 @@ var _ = Describe("app summary displayer", func() {
 							var actualOut = fmt.Sprintf("%s", testUI.Out)
 							Expect(actualOut).To(MatchRegexp(`Rolling deployment currently DEPLOYING \(since %s\)`, dateTimeRegexPattern))
 						})
+
 						It("does not display max-in-flight", func() {
 							Expect(testUI.Out).NotTo(Say(`max-in-flight`))
 						})
@@ -789,10 +794,12 @@ var _ = Describe("app summary displayer", func() {
 							Expect(testUI.Out).To(Say(`Rolling deployment currently DEPLOYING`))
 							Expect(testUI.Out).NotTo(Say(`\(since`))
 						})
+
 						It("displays max-in-flight value", func() {
 							Expect(testUI.Out).To(Say(`max-in-flight: 2`))
 						})
 					})
+
 					When("last status change is an empty string and max-in-flight is default", func() {
 						BeforeEach(func() {
 							summary = v7action.DetailedApplicationSummary{
@@ -812,6 +819,7 @@ var _ = Describe("app summary displayer", func() {
 							Expect(testUI.Out).To(Say(`Rolling deployment currently DEPLOYING`))
 							Expect(testUI.Out).NotTo(Say(`\(since`))
 						})
+
 						It("does not display max-in-flight", func() {
 							Expect(testUI.Out).NotTo(Say(`max-in-flight`))
 						})
@@ -838,10 +846,12 @@ var _ = Describe("app summary displayer", func() {
 							var actualOut = fmt.Sprintf("%s", testUI.Out)
 							Expect(actualOut).To(MatchRegexp(`Rolling deployment currently CANCELING \(since %s\)`, dateTimeRegexPattern))
 						})
+
 						It("displays max-in-flight value", func() {
 							Expect(testUI.Out).To(Say(`max-in-flight: 2`))
 						})
 					})
+
 					When("max-in-flight value is default", func() {
 						BeforeEach(func() {
 							summary = v7action.DetailedApplicationSummary{
@@ -861,6 +871,7 @@ var _ = Describe("app summary displayer", func() {
 							var actualOut = fmt.Sprintf("%s", testUI.Out)
 							Expect(actualOut).To(MatchRegexp(`Rolling deployment currently CANCELING \(since %s\)`, dateTimeRegexPattern))
 						})
+
 						It("does not display max-in-flight", func() {
 							Expect(testUI.Out).NotTo(Say(`max-in-flight`))
 						})
@@ -889,10 +900,12 @@ var _ = Describe("app summary displayer", func() {
 							Expect(actualOut).To(MatchRegexp(`Canary deployment currently DEPLOYING \(since %s\)`, dateTimeRegexPattern))
 							Expect(testUI.Out).NotTo(Say(`promote the canary deployment`))
 						})
+
 						It("displays max-in-flight value", func() {
 							Expect(testUI.Out).To(Say(`max-in-flight: 2`))
 						})
 					})
+
 					When("max-in-flight value is default", func() {
 						BeforeEach(func() {
 							summary = v7action.DetailedApplicationSummary{
@@ -913,6 +926,7 @@ var _ = Describe("app summary displayer", func() {
 							Expect(actualOut).To(MatchRegexp(`Canary deployment currently DEPLOYING \(since %s\)`, dateTimeRegexPattern))
 							Expect(testUI.Out).NotTo(Say(`promote the canary deployment`))
 						})
+
 						It("does not display max-in-flight", func() {
 							Expect(testUI.Out).NotTo(Say(`max-in-flight`))
 						})
@@ -945,6 +959,7 @@ var _ = Describe("app summary displayer", func() {
 							Expect(actualOut).To(MatchRegexp(`Canary deployment currently PAUSED \(since %s\)`, dateTimeRegexPattern))
 							Expect(testUI.Out).To(Say("Please run `cf continue-deployment foobar` to promote the canary deployment, or `cf cancel-deployment foobar` to rollback to the previous version."))
 						})
+
 						It("displays max-in-flight value", func() {
 							Expect(testUI.Out).To(Say(`max-in-flight: 2`))
 						})
@@ -974,6 +989,7 @@ var _ = Describe("app summary displayer", func() {
 							Expect(actualOut).To(MatchRegexp(`Canary deployment currently PAUSED \(since %s\)`, dateTimeRegexPattern))
 							Expect(testUI.Out).To(Say("Please run `cf continue-deployment foobar` to promote the canary deployment, or `cf cancel-deployment foobar` to rollback to the previous version."))
 						})
+
 						It("does not display max-in-flight", func() {
 							Expect(testUI.Out).NotTo(Say(`max-in-flight`))
 						})
@@ -1001,6 +1017,7 @@ var _ = Describe("app summary displayer", func() {
 							Expect(actualOut).To(MatchRegexp(`Canary deployment currently CANCELING \(since %s\)`, dateTimeRegexPattern))
 							Expect(testUI.Out).NotTo(Say(`promote the canary deployment`))
 						})
+
 						It("displays max-in-flight value", func() {
 							Expect(testUI.Out).To(Say(`max-in-flight: 2`))
 						})
@@ -1025,6 +1042,7 @@ var _ = Describe("app summary displayer", func() {
 							Expect(actualOut).To(MatchRegexp(`Canary deployment currently CANCELING \(since %s\)`, dateTimeRegexPattern))
 							Expect(testUI.Out).NotTo(Say(`promote the canary deployment`))
 						})
+
 						It("does not display max-in-flight", func() {
 							Expect(testUI.Out).NotTo(Say(`max-in-flight`))
 						})
@@ -1049,6 +1067,7 @@ var _ = Describe("app summary displayer", func() {
 					cases.Title(language.English, cases.NoLower).String(string(summary.Deployment.Strategy)),
 					summary.Deployment.StatusReason)))
 			})
+
 			It("does not display max-in-flight", func() {
 				Expect(testUI.Out).NotTo(Say(`max-in-flight`))
 			})

--- a/command/v7/shared/app_summary_displayer_test.go
+++ b/command/v7/shared/app_summary_displayer_test.go
@@ -718,8 +718,7 @@ var _ = Describe("app summary displayer", func() {
 						})
 
 						It("displays the message", func() {
-							var actualOut = fmt.Sprintf("%s", testUI.Out)
-							Expect(actualOut).To(MatchRegexp(`Rolling deployment currently DEPLOYING \(since %s\)`, dateTimeRegexPattern))
+							Expect(testUI.Out).To(Say(`Rolling deployment currently DEPLOYING \(since %s\)`, dateTimeRegexPattern))
 						})
 
 						It("displays max-in-flight value", func() {
@@ -743,8 +742,7 @@ var _ = Describe("app summary displayer", func() {
 						})
 
 						It("displays the message", func() {
-							var actualOut = fmt.Sprintf("%s", testUI.Out)
-							Expect(actualOut).To(MatchRegexp(`Rolling deployment currently DEPLOYING \(since %s\)`, dateTimeRegexPattern))
+							Expect(testUI.Out).To(Say(`Rolling deployment currently DEPLOYING \(since %s\)`, dateTimeRegexPattern))
 						})
 
 						It("does not display max-in-flight", func() {
@@ -752,8 +750,7 @@ var _ = Describe("app summary displayer", func() {
 						})
 					})
 
-					// 'unset' is important for the newer-CLI-than-CAPI scenario
-					When("last status change has a timestamp and max-in-flight is unset", func() {
+					When("an older version of CAPI does not return max-in-flight", func() {
 						BeforeEach(func() {
 							summary = v7action.DetailedApplicationSummary{
 								Deployment: resources.Deployment{
@@ -766,8 +763,7 @@ var _ = Describe("app summary displayer", func() {
 						})
 
 						It("displays the message", func() {
-							var actualOut = fmt.Sprintf("%s", testUI.Out)
-							Expect(actualOut).To(MatchRegexp(`Rolling deployment currently DEPLOYING \(since %s\)`, dateTimeRegexPattern))
+							Expect(testUI.Out).To(Say(`Rolling deployment currently DEPLOYING \(since %s\)`, dateTimeRegexPattern))
 						})
 
 						It("does not display max-in-flight", func() {
@@ -843,8 +839,7 @@ var _ = Describe("app summary displayer", func() {
 						})
 
 						It("displays the message", func() {
-							var actualOut = fmt.Sprintf("%s", testUI.Out)
-							Expect(actualOut).To(MatchRegexp(`Rolling deployment currently CANCELING \(since %s\)`, dateTimeRegexPattern))
+							Expect(testUI.Out).To(Say(`Rolling deployment currently CANCELING \(since %s\)`, dateTimeRegexPattern))
 						})
 
 						It("displays max-in-flight value", func() {
@@ -868,8 +863,7 @@ var _ = Describe("app summary displayer", func() {
 						})
 
 						It("displays the message", func() {
-							var actualOut = fmt.Sprintf("%s", testUI.Out)
-							Expect(actualOut).To(MatchRegexp(`Rolling deployment currently CANCELING \(since %s\)`, dateTimeRegexPattern))
+							Expect(testUI.Out).To(Say(`Rolling deployment currently CANCELING \(since %s\)`, dateTimeRegexPattern))
 						})
 
 						It("does not display max-in-flight", func() {
@@ -878,6 +872,7 @@ var _ = Describe("app summary displayer", func() {
 					})
 				})
 			})
+
 			When("the deployment strategy is canary", func() {
 				When("the deployment is in progress", func() {
 					When("max-in-flight value is non-default", func() {
@@ -896,8 +891,7 @@ var _ = Describe("app summary displayer", func() {
 						})
 
 						It("displays the message", func() {
-							var actualOut = fmt.Sprintf("%s", testUI.Out)
-							Expect(actualOut).To(MatchRegexp(`Canary deployment currently DEPLOYING \(since %s\)`, dateTimeRegexPattern))
+							Expect(testUI.Out).To(Say(`Canary deployment currently DEPLOYING \(since %s\)`, dateTimeRegexPattern))
 							Expect(testUI.Out).NotTo(Say(`promote the canary deployment`))
 						})
 
@@ -922,8 +916,7 @@ var _ = Describe("app summary displayer", func() {
 						})
 
 						It("displays the message", func() {
-							var actualOut = fmt.Sprintf("%s", testUI.Out)
-							Expect(actualOut).To(MatchRegexp(`Canary deployment currently DEPLOYING \(since %s\)`, dateTimeRegexPattern))
+							Expect(testUI.Out).To(Say(`Canary deployment currently DEPLOYING \(since %s\)`, dateTimeRegexPattern))
 							Expect(testUI.Out).NotTo(Say(`promote the canary deployment`))
 						})
 
@@ -955,8 +948,7 @@ var _ = Describe("app summary displayer", func() {
 						})
 
 						It("displays the message", func() {
-							var actualOut = fmt.Sprintf("%s", testUI.Out)
-							Expect(actualOut).To(MatchRegexp(`Canary deployment currently PAUSED \(since %s\)`, dateTimeRegexPattern))
+							Expect(testUI.Out).To(Say(`Canary deployment currently PAUSED \(since %s\)`, dateTimeRegexPattern))
 							Expect(testUI.Out).To(Say("Please run `cf continue-deployment foobar` to promote the canary deployment, or `cf cancel-deployment foobar` to rollback to the previous version."))
 						})
 
@@ -964,6 +956,7 @@ var _ = Describe("app summary displayer", func() {
 							Expect(testUI.Out).To(Say(`max-in-flight: 2`))
 						})
 					})
+
 					When("max-in-flight value is default", func() {
 						BeforeEach(func() {
 							summary = v7action.DetailedApplicationSummary{
@@ -985,8 +978,7 @@ var _ = Describe("app summary displayer", func() {
 						})
 
 						It("displays the message", func() {
-							var actualOut = fmt.Sprintf("%s", testUI.Out)
-							Expect(actualOut).To(MatchRegexp(`Canary deployment currently PAUSED \(since %s\)`, dateTimeRegexPattern))
+							Expect(testUI.Out).To(Say(`Canary deployment currently PAUSED \(since %s\)`, dateTimeRegexPattern))
 							Expect(testUI.Out).To(Say("Please run `cf continue-deployment foobar` to promote the canary deployment, or `cf cancel-deployment foobar` to rollback to the previous version."))
 						})
 
@@ -1013,8 +1005,7 @@ var _ = Describe("app summary displayer", func() {
 						})
 
 						It("displays the message", func() {
-							var actualOut = fmt.Sprintf("%s", testUI.Out)
-							Expect(actualOut).To(MatchRegexp(`Canary deployment currently CANCELING \(since %s\)`, dateTimeRegexPattern))
+							Expect(testUI.Out).To(Say(`Canary deployment currently CANCELING \(since %s\)`, dateTimeRegexPattern))
 							Expect(testUI.Out).NotTo(Say(`promote the canary deployment`))
 						})
 
@@ -1022,6 +1013,7 @@ var _ = Describe("app summary displayer", func() {
 							Expect(testUI.Out).To(Say(`max-in-flight: 2`))
 						})
 					})
+
 					When("max-in-flight value is default", func() {
 						BeforeEach(func() {
 							summary = v7action.DetailedApplicationSummary{
@@ -1038,8 +1030,7 @@ var _ = Describe("app summary displayer", func() {
 						})
 
 						It("displays the message", func() {
-							var actualOut = fmt.Sprintf("%s", testUI.Out)
-							Expect(actualOut).To(MatchRegexp(`Canary deployment currently CANCELING \(since %s\)`, dateTimeRegexPattern))
+							Expect(testUI.Out).To(Say(`Canary deployment currently CANCELING \(since %s\)`, dateTimeRegexPattern))
 							Expect(testUI.Out).NotTo(Say(`promote the canary deployment`))
 						})
 

--- a/command/v7/shared/app_summary_displayer_test.go
+++ b/command/v7/shared/app_summary_displayer_test.go
@@ -817,45 +817,7 @@ var _ = Describe("app summary displayer", func() {
 						Expect(actualOut).To(MatchRegexp(`Canary deployment currently CANCELING \(since %s\)`, dateTimeRegexPattern))
 						Expect(testUI.Out).NotTo(Say(`promote the canary deployment`))
 					})
-				})
-			})
-			When("the deployment strategy is canary", func() {
-				When("the deployment is paused", func() {
-					BeforeEach(func() {
-						summary = v7action.DetailedApplicationSummary{
-							ApplicationSummary: v7action.ApplicationSummary{
-								Application: resources.Application{
-									Name: "some-app",
-								},
-							},
-							Deployment: resources.Deployment{
-								Strategy:     constant.DeploymentStrategyCanary,
-								StatusValue:  constant.DeploymentStatusValueActive,
-								StatusReason: constant.DeploymentStatusReasonPaused,
-							},
-						}
-					})
 
-					It("displays the message", func() {
-						Expect(testUI.Out).To(Say("Canary deployment currently PAUSED."))
-						Expect(testUI.Out).To(Say("Please run `cf continue-deployment some-app` to promote the canary deployment, or `cf cancel-deployment some-app` to rollback to the previous version."))
-					})
-				})
-
-				When("the deployment is cancelled", func() {
-					BeforeEach(func() {
-						summary = v7action.DetailedApplicationSummary{
-							Deployment: resources.Deployment{
-								Strategy:     constant.DeploymentStrategyCanary,
-								StatusValue:  constant.DeploymentStatusValueActive,
-								StatusReason: constant.DeploymentStatusReasonCanceling,
-							},
-						}
-					})
-
-					It("displays the message", func() {
-						Expect(testUI.Out).To(Say("Canary deployment currently CANCELING."))
-					})
 				})
 			})
 		})

--- a/integration/v7/isolated/app_command_test.go
+++ b/integration/v7/isolated/app_command_test.go
@@ -267,7 +267,7 @@ applications:
 							session := helpers.CF("restart", appName, "--strategy", "rolling")
 
 							session1 := helpers.CF("app", appName)
-							Eventually(session1).Should(Say("Rolling deployment currently DEPLOYING."))
+							Eventually(session1).Should(Say("Rolling deployment currently DEPLOYING"))
 							Eventually(session).Should(Exit(0))
 							Eventually(session1).Should(Exit(0))
 						})
@@ -279,9 +279,11 @@ applications:
 								return helpers.CF("cancel-deployment", appName).Wait()
 							}).Should(Exit(0))
 
-							session2 := helpers.CF("app", appName)
-							Eventually(session2).Should(Say("Rolling deployment currently CANCELING."))
-							Eventually(session2).Should(Exit(0))
+							Eventually(func(g Gomega) {
+								session := helpers.CF("app", appName).Wait()
+								g.Expect(session).Should(Say("Rolling deployment currently CANCELING"))
+								g.Expect(session).Should(Exit(0))
+							  }).Should(Succeed())
 						})
 					})
 				})
@@ -292,19 +294,21 @@ applications:
 							Eventually(helpers.CF("restart", appName, "--strategy", "canary")).Should(Exit(0))
 
 							session1 := helpers.CF("app", appName)
-							Eventually(session1).Should(Say("Canary deployment currently PAUSED."))
+							Eventually(session1).Should(Say("Canary deployment currently PAUSED"))
 							Eventually(session1).Should(Exit(0))
 						})
 					})
 
 					When("the deployment is cancelled after it is paused", func() {
-						It("no deployment information is displayed", func() {
+						It("displays the message", func() {
 							Eventually(helpers.CF("restart", appName, "--strategy", "canary")).Should(Exit(0))
 							Eventually(helpers.CF("cancel-deployment", appName)).Should(Exit(0))
 
-							session2 := helpers.CF("app", appName)
-							Eventually(session2).ShouldNot(Say("Canary deployment currently CANCELING."))
-							Eventually(session2).Should(Exit(0))
+							Eventually(func(g Gomega) {
+								session := helpers.CF("app", appName).Wait()
+								g.Expect(session).Should(Say("Canary deployment currently CANCELING"))
+								g.Expect(session).Should(Exit(0))
+							  }).Should(Succeed())
 						})
 					})
 				})


### PR DESCRIPTION
## Description of the Change
This prints `max-in-flight: <value>` after the deployment status, when there is an Active deployment for an app and when max-in-flight is set to a non-default value

## Why Is This PR Valuable?
It provides the user with information/confirmation that they have set a non-default max-in-flight value

## Applicable Issues/PRs

this PR is based on #3096 and is therefore blocked on that PR getting merged into `main`

+@joaopapereira @weresch 