### PR TITLE
Support the --no-wait flag for `cf continue-deployment` [main]

### DIFF
--- a/command/v7/continue_deployment_command.go
+++ b/command/v7/continue_deployment_command.go
@@ -9,7 +9,8 @@ type ContinueDeploymentCommand struct {
 	BaseCommand
 
 	RequiredArgs    flag.AppName `positional-args:"yes"`
-	usage           interface{}  `usage:"CF_NAME continue-deployment APP_NAME\n\nEXAMPLES:\n   cf continue-deployment my-app"`
+	NoWait          bool         `long:"no-wait" description:"Exit when the first instance of the web process is healthy"`
+	usage           interface{}  `usage:"CF_NAME continue-deployment APP_NAME [--no-wait]\n\nEXAMPLES:\n   cf continue-deployment my-app"`
 	relatedCommands interface{}  `related_commands:"app, push"`
 }
 
@@ -58,7 +59,7 @@ func (cmd *ContinueDeploymentCommand) Execute(args []string) error {
 		cmd.UI.DisplayText(instanceDetails)
 	}
 
-	warnings, err = cmd.Actor.PollStartForDeployment(application, deployment.GUID, false, handleInstanceDetails)
+	warnings, err = cmd.Actor.PollStartForDeployment(application, deployment.GUID, cmd.NoWait, handleInstanceDetails)
 	cmd.UI.DisplayNewline()
 	cmd.UI.DisplayWarnings(warnings)
 	if err != nil {

--- a/command/v7/continue_deployment_command_test.go
+++ b/command/v7/continue_deployment_command_test.go
@@ -45,6 +45,7 @@ var _ = Describe("Continue deployment command", func() {
 
 		cmd = ContinueDeploymentCommand{
 			RequiredArgs: flag.AppName{AppName: appName},
+			NoWait:       noWait,
 			BaseCommand: BaseCommand{
 				UI:          testUI,
 				Config:      fakeConfig,
@@ -68,7 +69,6 @@ var _ = Describe("Continue deployment command", func() {
 	})
 
 	JustBeforeEach(func() {
-		cmd.NoWait = noWait
 		executeErr = cmd.Execute(nil)
 	})
 
@@ -208,10 +208,6 @@ var _ = Describe("Continue deployment command", func() {
 					})
 
 					When("the --no-wait flag is not provided", func() {
-						BeforeEach(func() {
-							noWait = false
-						})
-
 						It("polls and waits", func() {
 							Expect(fakeActor.PollStartForDeploymentCallCount()).To(Equal(1))
 
@@ -224,7 +220,7 @@ var _ = Describe("Continue deployment command", func() {
 
 					When("the --no-wait flag is provided", func() {
 						BeforeEach(func() {
-							noWait = true
+							cmd.NoWait = true
 						})
 
 						It("polls without waiting", func() {

--- a/command/v7/continue_deployment_command_test.go
+++ b/command/v7/continue_deployment_command_test.go
@@ -215,7 +215,7 @@ var _ = Describe("Continue deployment command", func() {
 						It("polls and waits", func() {
 							Expect(fakeActor.PollStartForDeploymentCallCount()).To(Equal(1))
 
-							var invokedApplication, invokedGuid, invokedNoWait, _ = fakeActor.PollStartForDeploymentArgsForCall(0)
+							invokedApplication, invokedGuid, invokedNoWait, _ := fakeActor.PollStartForDeploymentArgsForCall(0)
 							Expect(invokedApplication).To(Equal(returnedApplication))
 							Expect(invokedGuid).To(Equal(deploymentGUID))
 							Expect(invokedNoWait).To(Equal(false))
@@ -230,7 +230,7 @@ var _ = Describe("Continue deployment command", func() {
 						It("polls without waiting", func() {
 							Expect(fakeActor.PollStartForDeploymentCallCount()).To(Equal(1))
 
-							var invokedApplication, invokedGuid, invokedNoWait, _ = fakeActor.PollStartForDeploymentArgsForCall(0)
+							invokedApplication, invokedGuid, invokedNoWait, _ := fakeActor.PollStartForDeploymentArgsForCall(0)
 							Expect(invokedApplication).To(Equal(returnedApplication))
 							Expect(invokedGuid).To(Equal(deploymentGUID))
 							Expect(invokedNoWait).To(Equal(true))

--- a/integration/v7/isolated/continue_deployment_test.go
+++ b/integration/v7/isolated/continue_deployment_test.go
@@ -23,21 +23,22 @@ var _ = Describe("Continue Deployment", func() {
 
 		It("displays the help information", func() {
 			session := helpers.CF("continue-deployment", "--help")
+			Eventually(session).Should(Say(`NAME:`))
+			Eventually(session).Should(Say(`continue-deployment - Continue the most recent deployment for an app.\n`))
+			Eventually(session).Should(Say(`\n`))
 
-			Eventually(session).Should(Say(`NAME:
-   continue-deployment - Continue the most recent deployment for an app.
+			Eventually(session).Should(Say(`USAGE:`))
+			Eventually(session).Should(Say(`cf continue-deployment APP_NAME\n`))
+			Eventually(session).Should(Say(`\n`))
 
-USAGE:
-   cf continue-deployment APP_NAME [--no-wait]
+			Eventually(session).Should(Say(`EXAMPLES:`))
+			Eventually(session).Should(Say(`cf continue-deployment my-app\n`))
+			Eventually(session).Should(Say(`\n`))
 
-EXAMPLES:
-   cf continue-deployment my-app
+			Eventually(session).Should(Say(`SEE ALSO:`))
+			Eventually(session).Should(Say(`app, push`))
 
-OPTIONS:
-   --no-wait      Exit when the first instance of the web process is healthy
-
-SEE ALSO:
-   app, push`))
+			Eventually(session).Should(Exit(0))
 		})
 	})
 

--- a/integration/v7/isolated/continue_deployment_test.go
+++ b/integration/v7/isolated/continue_deployment_test.go
@@ -28,11 +28,15 @@ var _ = Describe("Continue Deployment", func() {
 			Eventually(session).Should(Say(`\n`))
 
 			Eventually(session).Should(Say(`USAGE:`))
-			Eventually(session).Should(Say(`cf continue-deployment APP_NAME\n`))
+			Eventually(session).Should(Say(`cf continue-deployment APP_NAME \[--no-wait\]\n`))
 			Eventually(session).Should(Say(`\n`))
 
 			Eventually(session).Should(Say(`EXAMPLES:`))
 			Eventually(session).Should(Say(`cf continue-deployment my-app\n`))
+			Eventually(session).Should(Say(`\n`))
+
+			Eventually(session).Should(Say(`OPTIONS:`))
+			Eventually(session).Should(Say(`--no-wait\s+Exit when the first instance of the web process is healthy`))
 			Eventually(session).Should(Say(`\n`))
 
 			Eventually(session).Should(Say(`SEE ALSO:`))

--- a/integration/v7/isolated/continue_deployment_test.go
+++ b/integration/v7/isolated/continue_deployment_test.go
@@ -23,22 +23,21 @@ var _ = Describe("Continue Deployment", func() {
 
 		It("displays the help information", func() {
 			session := helpers.CF("continue-deployment", "--help")
-			Eventually(session).Should(Say(`NAME:`))
-			Eventually(session).Should(Say(`continue-deployment - Continue the most recent deployment for an app.\n`))
-			Eventually(session).Should(Say(`\n`))
 
-			Eventually(session).Should(Say(`USAGE:`))
-			Eventually(session).Should(Say(`cf continue-deployment APP_NAME\n`))
-			Eventually(session).Should(Say(`\n`))
+			Eventually(session).Should(Say(`NAME:
+   continue-deployment - Continue the most recent deployment for an app.
 
-			Eventually(session).Should(Say(`EXAMPLES:`))
-			Eventually(session).Should(Say(`cf continue-deployment my-app\n`))
-			Eventually(session).Should(Say(`\n`))
+USAGE:
+   cf continue-deployment APP_NAME [--no-wait]
 
-			Eventually(session).Should(Say(`SEE ALSO:`))
-			Eventually(session).Should(Say(`app, push`))
+EXAMPLES:
+   cf continue-deployment my-app
 
-			Eventually(session).Should(Exit(0))
+OPTIONS:
+   --no-wait      Exit when the first instance of the web process is healthy
+
+SEE ALSO:
+   app, push`))
 		})
 	})
 


### PR DESCRIPTION
## Description of the Change

Supports the `--no-wait` flag for the `cf continue-deployment` command.

## Why Is This PR Valuable?

It brings the `continue-deployment` command into alignment with other commands that deal with deployments (e.g. `cf push`, `cf restage`).

## How Urgent Is The Change?

Urgent, as we'd like to include this in our pending release.

## Related PRs

- #3122