### PR TITLE
Update help message for restart-app-instance command [main]

### DIFF
--- a/command/common/command_list_v7.go
+++ b/command/common/command_list_v7.go
@@ -125,7 +125,7 @@ type commandList struct {
 	Rollback                           v7.RollbackCommand                           `command:"rollback" description:"Rollback to the specified revision of an app"`
 	StagePackage                       v7.StagePackageCommand                       `command:"stage-package" alias:"stage" description:"Stage a package into a droplet"`
 	Restart                            v7.RestartCommand                            `command:"restart" alias:"rs" description:"Stop all instances of the app, then start them again."`
-	RestartAppInstance                 v7.RestartAppInstanceCommand                 `command:"restart-app-instance" description:"Terminate, then instantiate an app instance"`
+	RestartAppInstance                 v7.RestartAppInstanceCommand                 `command:"restart-app-instance" description:"Stop, then start application instance without updating application environment"`
 	RouterGroups                       v7.RouterGroupsCommand                       `command:"router-groups" description:"List router groups"`
 	Route                              v7.RouteCommand                              `command:"route" alias:"ro" description:"Display route details and mapped destinations"`
 	Routes                             v7.RoutesCommand                             `command:"routes" alias:"r" description:"List all routes in the current space or the current organization"`

--- a/integration/v7/isolated/restart_app_instance_command_test.go
+++ b/integration/v7/isolated/restart_app_instance_command_test.go
@@ -30,13 +30,13 @@ var _ = Describe("restart-app-instance command", func() {
 		It("appears in cf help -a", func() {
 			session := helpers.CF("help", "-a")
 			Eventually(session).Should(Exit(0))
-			Expect(session).To(HaveCommandInCategoryWithDescription("restart-app-instance", "APPS", "Terminate, then instantiate an app instance"))
+			Expect(session).To(HaveCommandInCategoryWithDescription("restart-app-instance", "APPS", "Stop, then start application instance without updating application environment"))
 		})
 
 		It("Displays command usage to output", func() {
 			session := helpers.CF("restart-app-instance", "--help")
 			Eventually(session).Should(Say("NAME:"))
-			Eventually(session).Should(Say("restart-app-instance - Terminate, then instantiate an app instance"))
+			Eventually(session).Should(Say("restart-app-instance - Stop, then start application instance without updating application environment"))
 			Eventually(session).Should(Say("USAGE:"))
 			Eventually(session).Should(Say(`cf restart-app-instance APP_NAME INDEX [--process PROCESS]`))
 			Eventually(session).Should(Say(`OPTIONS:`))


### PR DESCRIPTION
As per the GH [Issue](https://github.com/cloudfoundry/cli/issues/3059), the help message for `restart-app-instance` command is unclear. This PR updates it.