### PR TITLE
[v7] Fix linter workflow to fail when go fmt corrects files (cherry-pick from #3132)

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -53,4 +53,4 @@ jobs:
         go-version-file: go.mod
         check-latest: true
     - name: Run go fmt
-      run: go fmt && git diff --exit-code
+      run: make format && git diff --exit-code


### PR DESCRIPTION
## Description of the Change

Fix linter workflow to fail when go fmt corrects files (cherry-pick from #3132)