### PR TITLE
Remove redis ops-file [v7]

### DIFF
--- a/.github/ops-files/replace-redis.yml
+++ b/.github/ops-files/replace-redis.yml
@@ -1,6 +1,0 @@
----
-- type: replace
-  path: /instance_groups/name=api/jobs/name=redis?
-  value: 
-    name: valkey
-    release: capi

--- a/.github/workflows/tests-integration-reusable.yml
+++ b/.github/workflows/tests-integration-reusable.yml
@@ -167,7 +167,6 @@ jobs:
         bosh interpolate /tmp/manifest.yml \
           -o cf-deployment/operations/use-internal-lookup-for-route-services.yml \
           -o cf-deployment/operations/add-persistent-isolation-segment-diego-cell.yml \
-          -o .github/ops-files/replace-redis.yml \
           -o .github/ops-files/use-latest-capi.yml \
           -o .github/ops-files/add-oidc-provider.yml \
           -o .github/ops-files/add-uaa-client-credentials.yml \


### PR DESCRIPTION
Newer cf-deployment has valkey so this ops file is now redundant.