### PR TITLE
Bump go to 1.23.1 [v8]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module code.cloudfoundry.org/cli
 
-go 1.22.5
+go 1.23.1
 
 require (
 	code.cloudfoundry.org/bytefmt v0.9.0


### PR DESCRIPTION
Bump go to latest version which fixes CVEs.