### PR TITLE
Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,42 +1,90 @@
 version: 2
 updates:
 - package-ecosystem: gomod
-  directory: "/"
+  directory: '/'
   schedule:
-    interval: daily
-    time: '11:00'
+    interval: weekly
+    day:      monday
+    time:     '01:00'
+    timezone: US/Pacific
   open-pull-requests-limit: 2
+  commit-message:
+    prefix: '[main](go)'
+  groups:
+    dependencies:
+      patterns:
+        - '*'
 - package-ecosystem: gomod
-  directory: "/"
-  target-branch: "v8"
+  directory: '/'
+  target-branch: 'v8'
   schedule:
-    interval: daily
-    time: '11:00'
+    interval: weekly
+    day:      monday
+    time:     '01:00'
+    timezone: US/Pacific
   open-pull-requests-limit: 2
+  commit-message:
+    prefix: '[v8](go)'
+  groups:
+    dependencies:
+      patterns:
+        - '*'
 - package-ecosystem: gomod
-  directory: "/"
-  target-branch: "v7"
+  directory: '/'
+  target-branch: 'v7'
   schedule:
-    interval: daily
-    time: '11:00'
+    interval: weekly
+    day:      monday
+    time:     '01:00'
+    timezone: US/Pacific
   open-pull-requests-limit: 2
-- package-ecosystem: "github-actions"
-  directory: "/"
+  commit-message:
+    prefix: '[v7](go)'
+  groups:
+    dependencies:
+      patterns:
+        - '*'
+- package-ecosystem: 'github-actions'
+  directory: '/'
   schedule:
-    interval: daily
-    time: '11:00'
+    interval: weekly
+    day:      monday
+    time:     '01:00'
+    timezone: US/Pacific
   open-pull-requests-limit: 2
-- package-ecosystem: "github-actions"
-  directory: "/"
-  target-branch: "v8"
+  commit-message:
+    prefix: '[main](gha)'
+  groups:
+    dependencies:
+      patterns:
+        - '*'
+- package-ecosystem: 'github-actions'
+  directory: '/'
+  target-branch: 'v8'
   schedule:
-    interval: daily
-    time: '11:00'
+    interval: weekly
+    day:      monday
+    time:     '01:00'
+    timezone: US/Pacific
   open-pull-requests-limit: 2
-- package-ecosystem: "github-actions"
-  directory: "/"
-  target-branch: "v7"
+  commit-message:
+    prefix: '[v8](gha)'
+  groups:
+    dependencies:
+      patterns:
+        - '*'
+- package-ecosystem: 'github-actions'
+  directory: '/'
+  target-branch: 'v7'
   schedule:
-    interval: daily
-    time: '11:00'
+    interval: weekly
+    day:      monday
+    time:     '01:00'
+    timezone: US/Pacific
   open-pull-requests-limit: 2
+  commit-message:
+    prefix: '[v7](gha)'
+  groups:
+    dependencies:
+      patterns:
+        - '*'


### PR DESCRIPTION
To optimize testing and acceptance, we want to group dependabot PRs