### PR TITLE
Switch test environments to cfd bosh lites [v8]

### DIFF
--- a/.github/ops-files/diego-cell-instances.yml
+++ b/.github/ops-files/diego-cell-instances.yml
@@ -2,3 +2,7 @@
 - type: replace
   path: /instance_groups/name=diego-cell/instances
   value: 4
+
+- type: replace
+  path: /instance_groups/name=isolated-diego-cell/jobs/name=rep/properties?/set_kernel_parameters
+  value: false

--- a/.github/workflows/tests-integration-reusable.yml
+++ b/.github/workflows/tests-integration-reusable.yml
@@ -3,7 +3,7 @@
 # secrets.CLIENT_SECRET
 # secrets.GITHUB_TOKEN
 # secrets.SHEPHERD_SERVICE_ACCOUNT_TOKEN
-# vars.SHEPHERD_POOL_NAME
+# vars.TEST_FLAKE_ATTEMPTS
 
 name: "pvt: run integration tests"
 
@@ -22,17 +22,29 @@ on:
       lease-id:
         required: true
         type: string
+      lease-namespace:
+        required: false
+        type: string
+        default: 'tas-devex'
       gitRef:
         type: string
         default: ${{github.event.workflow_run.head_sha}}
-        
+      nodes:
+        type: string
+        default: "16"
+
+env:
+  NODES: ${{ inputs.nodes }}
+  FLAKE_ATTEMPTS: ${{ vars.TEST_FLAKE_ATTEMPTS || '4' }}
+
 jobs:
   run-integration-tests:
     defaults:
       run:
         shell: bash
-    runs-on: ${{ inputs.os }} 
+    runs-on: ${{ inputs.os }}
     container: us-west2-docker.pkg.dev/shepherd-268822/shepherd2/concourse-resource:latest
+    timeout-minutes: 120
     steps:
     - name: Checkout cli
       uses: actions/checkout@v4
@@ -61,7 +73,9 @@ jobs:
 
     - name: Install Tools
       env:
-        account_token: ${{ secrets.SHEPHERD_SERVICE_ACCOUNT_TOKEN }}
+        account_token:    ${{ secrets.SHEPHERD_SERVICE_ACCOUNT_TOKEN }}
+        lease_namespace:  ${{ inputs.lease-namespace }}
+        lease_id:         ${{ inputs.lease-id }}
       run: |
         go version
 
@@ -95,22 +109,22 @@ jobs:
         apt-get install -y build-essential unzip
 
         shepherd login service-account ${account_token}
-        shepherd get lease ${{ inputs.lease-id }} --namespace tas-devex --json | jq .output > metadata.json
+        shepherd get lease ${lease_id} --namespace ${lease_namespace} --json | jq .output > metadata.json
 
     - name: Add CATS config
       if: ${{ inputs.name == 'cats' }}
       run: |
         set -eu
-        ENV=$(jq -r .name metadata.json)
+        env_name=$(jq -r .name metadata.json)
         API="$(jq -r .cf.api_url metadata.json)"
         DOMAIN=$(echo $API | sed "s/^api\.//")
         CF_INT_USERNAME="admin"
 
-        jq -r .bosh.jumpbox_private_key metadata.json > /tmp/${ENV}.priv
+        jq -r .bosh.jumpbox_private_key metadata.json > /tmp/${env_name}.priv
         eval "$(bbl print-env --metadata-file ./metadata.json)"
 
         credhub login
-        CF_INT_PASSWORD=$(credhub get -n /bosh-$ENV/cf/cf_admin_password | bosh interpolate --path /value -)
+        CF_INT_PASSWORD=$(credhub get -n /bosh-lite/cf/cf_admin_password | bosh interpolate --path /value -)
 
         cat << EOF | jq -S . > cats_config.json
         {
@@ -184,26 +198,24 @@ jobs:
           --keep-going \
           --randomize-all \
           --skip-package=helpers \
-          --nodes="12" \
-          --flake-attempts=2 \
+          --nodes="${NODES}" \
+          --flake-attempts=${FLAKE_ATTEMPTS} \
           --timeout="2h" \
           --no-color
 
     - name: Run Integration Tests
       if: ${{ !inputs.run-with-client-creds  &&  inputs.name != 'cats' }}
       run: |
-        ENV=$(cat metadata.json | jq -r '.name')
-        jq -r .bosh.jumpbox_private_key metadata.json > /tmp/${ENV}.priv
+        env_name=$(cat metadata.json | jq -r '.name')
+        jq -r .bosh.jumpbox_private_key metadata.json > /tmp/${env_name}.priv
         eval "$(bbl print-env --metadata-file ./metadata.json)"
-        export CF_INT_PASSWORD="$(credhub get -n /bosh-$ENV/cf/cf_admin_password | bosh interpolate --path /value -)"
+        export CF_INT_PASSWORD="$(credhub get -n /bosh-lite/cf/cf_admin_password | bosh interpolate --path /value -)"
         export CF_INT_OIDC_USERNAME="admin-oidc"
-        export CF_INT_OIDC_PASSWORD=$(credhub get -n /bosh-$ENV/cf/uaa_oidc_admin_password | bosh interpolate --path /value -)
+        export CF_INT_OIDC_PASSWORD=$(credhub get -n /bosh-lite/cf/uaa_oidc_admin_password | bosh interpolate --path /value -)
         API_URL="$(jq -r .cf.api_url metadata.json)"
         export CF_INT_API="https://$API_URL"
         export CF_DIAL_TIMEOUT=15
         export CF_USERNAME=admin
-        export FLAKE_ATTEMPTS=2
-        export NODES=16
         export GOPATH=$PWD/go
         export PATH="$GOPATH/bin:$PATH"
         export PATH="$PWD/out:$PATH"
@@ -223,18 +235,16 @@ jobs:
         CF_INT_CLIENT_ID: 'potato-face'
         CF_INT_CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
       run: |
-        ENV=$(cat metadata.json | jq -r '.name')
-        jq -r .bosh.jumpbox_private_key metadata.json > /tmp/${ENV}.priv
+        env_name=$(cat metadata.json | jq -r '.name')
+        jq -r .bosh.jumpbox_private_key metadata.json > /tmp/${env_name}.priv
         eval "$(bbl print-env --metadata-file ./metadata.json)"
-        export CF_INT_PASSWORD="$(credhub get -n /bosh-$ENV/cf/cf_admin_password | bosh interpolate --path /value -)"
+        export CF_INT_PASSWORD="$(credhub get -n /bosh-lite/cf/cf_admin_password | bosh interpolate --path /value -)"
         export CF_INT_OIDC_USERNAME="admin-oidc"
-        export CF_INT_OIDC_PASSWORD=$(credhub get -n /bosh-$ENV/cf/uaa_oidc_admin_password | bosh interpolate --path /value -)
+        export CF_INT_OIDC_PASSWORD=$(credhub get -n /bosh-lite/cf/uaa_oidc_admin_password | bosh interpolate --path /value -)
         API_URL="$(jq -r .cf.api_url metadata.json)"
         export CF_INT_API="https://$API_URL"
         export CF_DIAL_TIMEOUT=15
         export CF_USERNAME=admin
-        export FLAKE_ATTEMPTS=2
-        export NODES=16
         export GOPATH=$PWD/go
         export PATH="$GOPATH/bin:$PATH"
         export PATH="$PWD/out:$PATH"
@@ -246,4 +256,4 @@ jobs:
         cf api ${CF_INT_API} --skip-ssl-validation
         cf auth
 
-        make integration-tests-full-ci
+        make integration-tests-ci-client-creds

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -1,3 +1,14 @@
+# GitHub repo level Secrets and Variables
+
+# secrets.CLIENT_SECRET
+# secrets.SHEPHERD_SERVICE_ACCOUNT_TOKEN
+# vars.CAPI_RELEASE_VERSION
+# vars.SHEPHERD_LEASE_DURATION
+# vars.SHEPHERD_LEASE_NAMESPACE
+# vars.SHEPHERD_TEMPLATE_ARGUMENT
+# vars.SHEPHERD_TEMPLATE_NAME
+# vars.SHEPHERD_TEMPLATE_NAMESPACE
+
 name: "Tests: Integration"
 
 run-name: "Integration [${{ github.event_name }}: ${{ github.event.pull_request.head.sha || github.event.push.after || github.event.workflow_run.head_sha}}]: ${{ github.event.workflow_run.head_commit.message }}"
@@ -14,6 +25,30 @@ on:
           - run-integration-tests-cf-env
           - run-integration-tests-cf-env-with-client-creds
           - run-cats-cf-env
+      nodes:
+        description: Number of test nodes
+        required: false
+        type: string
+        default: "12"
+      lease_id:
+        description: Pre-provisioned environment lease-id to use in tests
+        required: false
+        type: string
+      lease_namespace:
+        description: Pre-provisioned environment lease namespace to use in tests
+        required: false
+        type: string
+      run_unit_tests:
+        description: Run unit tests
+        required: false
+        type: boolean
+        default: true
+      reinstall_cfd:
+        description: Force re-installation of CFD
+        required: false
+        type: boolean
+        default: true
+
   push:
     tags:
       - "v8.*"
@@ -27,6 +62,10 @@ on:
       - "doc/**"
       - ".gitpod.yml"
       - "README.md"
+
+env:
+  SHEPHERD_LEASE_ID: ${{ inputs.lease_id }}
+
 jobs:
   get-sha:
     runs-on: ubuntu-latest
@@ -53,14 +92,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        if: ${{ inputs.run_unit_tests == 'true' }}
         with:
           ref: ${{needs.get-sha.outputs.gitRef}}
       - name: Set Up Go
         uses: actions/setup-go@v5
+        if: ${{ inputs.run_unit_tests == 'true' }}
         with:
           go-version-file: go.mod
           check-latest: true
       - name: Run Units
+        if: ${{ inputs.run_unit_tests == 'true' }}
         run: make units
 
   claim-env:
@@ -84,23 +126,57 @@ jobs:
       - name: claim
         id: claim
         env:
-          account_token: ${{ secrets.SHEPHERD_SERVICE_ACCOUNT_TOKEN }}
-          pool_name: ${{ vars.SHEPHERD_POOL_NAME }}
-          pool_namespace: official
+          account_token:       ${{ secrets.SHEPHERD_SERVICE_ACCOUNT_TOKEN }}
+          template_argument:   ${{ vars.SHEPHERD_TEMPLATE_ARGUMENT        }}
+          template_name:       ${{ vars.SHEPHERD_TEMPLATE_NAME       || 'cfd-bosh-lite@1.0' }}
+          template_namespace:  ${{ vars.SHEPHERD_TEMPLATE_NAMESPACE  || 'official'          }}
+          lease_duration:      ${{ vars.SHEPHERD_LEASE_DURATION      || '8h'                }}
+          lease_namespace:     ${{ inputs.lease_namespace  || vars.SHEPHERD_LEASE_NAMESPACE || 'tas-devex' }}
         run: |
           shepherd login service-account ${account_token}
 
-          echo "shepherd create lease --duration 8h --pool ${pool_name} --pool-namespace ${pool_namespace} --namespace tas-devex --description 'CLI GHA'"
-          lease_id=$(shepherd create lease --duration 8h --pool ${pool_name} --pool-namespace ${pool_namespace} --namespace tas-devex --json | jq -r .id)
-          
+          if [[ -z $SHEPHERD_LEASE_ID ]]; then
+
+            if [ -z "$template_argument" ]; then
+              export template_argument='{"gcp_region":    "us-west2",
+                                         "vm_type":       "n1-standard-8",
+                                         "root_disk_gb":  32,
+                                         "disk_pool_gb":  150,
+                                         "cfd_version":   "",
+                                         "additional_opsfiles_b64": ""}'
+            fi
+
+            lease_id=$( shepherd create lease                           \
+                          --template-argument  "$template_argument"     \
+                          --template-namespace "${template_namespace}"  \
+                          --template           "${template_name}"       \
+                          --namespace          "${lease_namespace}"     \
+                          --duration           "${lease_duration}"      \
+                          --description "Claimed by CF CLI workflow ${{ github.workflow_run.url }}" \
+                          --json \
+                        | jq -r .id
+                      )
+          else
+            lease_id=$SHEPHERD_LEASE_ID
+          fi
+
+          echo "Shepherd lease ID: ${lease_id}"
+
           # Give sometime for the lease to complete. Shepherd may take upto an 3 hours to create an env
           # if the pool is empty.
           count=0
           while [ $count -lt 360 ] ; do
             sleep 30
-            status=$(shepherd get lease ${lease_id} --namespace tas-devex --json | jq -r .status)
+            status=$( shepherd get lease ${lease_id} \
+                        --namespace ${lease_namespace} \
+                        --json \
+                      | jq -r .status
+                    )
             if [ $status == "LEASED" ] ; then
-              shepherd get lease ${lease_id} --namespace tas-devex --json | jq .output > metadata.json
+              shepherd get lease ${lease_id} \
+                --namespace ${lease_namespace} \
+                --json \
+              | jq .output > metadata.json
               break
             elif [ $status == "FAILED" -o $status == "EXPIRED" ] ; then
               echo "There was an error obtaining the lease. Lease status is ${status}."
@@ -115,7 +191,7 @@ jobs:
           echo "env name is ${env_name}"
           echo "leaseid=${lease_id}" >> "${GITHUB_OUTPUT}"
 
-          cf_deployment_version=$(jq -r '."cf-deployment_version"' metadata.json)
+          cf_deployment_version=$(jq -r '."cf_deployment_version"' metadata.json)
           echo "cf_deployment_version is ${cf_deployment_version}"
           echo "cf_deployment_version=${cf_deployment_version}" >> "${GITHUB_OUTPUT}"
 
@@ -126,6 +202,7 @@ jobs:
           check-latest: true
         
       - name: Install Tools
+        if: ${{ (inputs.lease_id == '') || (inputs.reinstall_cfd == true) }}
         run: |
           go version
 
@@ -145,11 +222,11 @@ jobs:
           apt-get install -y build-essential unzip
 
       - name: Upload latest CAPI release
+        if: ${{ (inputs.lease_id == '') || (inputs.reinstall_cfd == true) }}
         env:
           capi_release_version: ${{ vars.CAPI_RELEASE_VERSION }}
         run: |
-          if [ -z "$capi_release_version" ]
-          then
+          if [ -z "$capi_release_version" ]; then
             capi_release_version=$(curl -s https://api.github.com/repos/cloudfoundry/capi-release/releases/latest | jq -r .tag_name)
           fi
           
@@ -162,6 +239,7 @@ jobs:
           bosh upload-release "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=$capi_release_version"
 
       - name: Checkout cf-deployment
+        if: ${{ (inputs.lease_id == '') || (inputs.reinstall_cfd == true) }}
         uses: actions/checkout@v4
         with:
           repository: cloudfoundry/cf-deployment
@@ -169,12 +247,12 @@ jobs:
           ref: ${{steps.claim.outputs.cf_deployment_version}}    
   
       - name: Deploy Isolation Segment and OIDC Provider
+        if: ${{ (inputs.lease_id == '') || (inputs.reinstall_cfd == true) }}
         run: |
           env_name=$(jq -r .name metadata.json)
           jq -r .bosh.jumpbox_private_key metadata.json > /tmp/${env_name}.priv
           eval "$(bbl print-env --metadata-file metadata.json)"
 
-          # deploy
           bosh -d cf manifest > /tmp/manifest.yml
           bosh interpolate /tmp/manifest.yml \
             -o cf-deployment/operations/use-internal-lookup-for-route-services.yml \
@@ -204,6 +282,8 @@ jobs:
       name: Integration
       gitRef: ${{needs.get-sha.outputs.gitRef}}
       lease-id: ${{ needs.claim-env.outputs.leaseid }}
+      lease-namespace: ${{ inputs.lease_namespace  || vars.SHEPHERD_LEASE_NAMESPACE || 'tas-devex' }}
+      nodes: ${{ inputs.nodes }}
     secrets: inherit
 
   run-integration-tests-cf-env-with-client-creds:
@@ -220,6 +300,7 @@ jobs:
       name: Integration client creds
       gitRef: ${{needs.get-sha.outputs.gitRef}}
       lease-id: ${{ needs.claim-env.outputs.leaseid }}
+      lease-namespace: ${{ inputs.lease_namespace  || vars.SHEPHERD_LEASE_NAMESPACE || 'tas-devex' }}
     secrets: inherit
 
   run-cats-cf-env:
@@ -237,21 +318,24 @@ jobs:
       name: cats
       gitRef: ${{needs.get-sha.outputs.gitRef}}
       lease-id: ${{ needs.claim-env.outputs.leaseid }}
+      lease-namespace: ${{ inputs.lease_namespace  || vars.SHEPHERD_LEASE_NAMESPACE || 'tas-devex' }}
     secrets: inherit
 
   unclaim-env:
     name: Unclaim environment
+    if: ${{ inputs.lease_id == '' }}
     runs-on: ubuntu-latest
     container: us-west2-docker.pkg.dev/shepherd-268822/shepherd2/concourse-resource:latest
     needs:
       - claim-env
       - run-cats-cf-env
-    if: always()
     steps:
       - name: unclaim
         env:
-          account_token: ${{ secrets.SHEPHERD_SERVICE_ACCOUNT_TOKEN }}
+          account_token:    ${{ secrets.SHEPHERD_SERVICE_ACCOUNT_TOKEN }}
+          lease_namespace:  ${{ inputs.lease_namespace || vars.SHEPHERD_LEASE_NAMESPACE || 'tas-devex' }}
         run: |
           shepherd login service-account ${account_token}
           set -x
-          shepherd delete lease ${{ needs.claim-env.outputs.leaseid }} --namespace tas-devex
+          shepherd delete lease ${{ needs.claim-env.outputs.leaseid }} \
+            --namespace ${lease_namespace}

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ integration/assets/test_plugin/test_plugin
 
 ### VisualStudioCode ###
 .vscode
+.secrets
+.vars

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 CF_DIAL_TIMEOUT ?= 15
 NODES ?= 10
+FLAKE_ATTEMPTS ?=5
 PACKAGES ?= api actor command types util version integration/helpers
 LC_ALL = "en_US.UTF-8"
 
@@ -130,6 +131,7 @@ integration-selfcontained: build install-test-deps
 
 integration-tests: build integration-cleanup integration-isolated integration-push integration-global integration-selfcontained ## Run all isolated, push, selfcontained, and global integration tests
 
+integration-tests-ci-client-creds: build integration-cleanup integration-push integration-global integration-selfcontained
 
 i: integration-tests-full
 integration-full-tests: integration-tests-full

--- a/integration/helpers/org_and_space.go
+++ b/integration/helpers/org_and_space.go
@@ -112,7 +112,7 @@ func GetSpaceGUID(spaceName string) string {
 }
 
 // QuickDeleteOrg deletes the org with the given name, if provided, using
-// 'cf curl /v2/organizations... -X DELETE'.
+// 'cf curl /v3/organizations... -X DELETE'.
 func QuickDeleteOrg(orgName string) {
 	// If orgName is empty, the BeforeSuite has failed and attempting to delete
 	// will produce a meaningless error.
@@ -122,13 +122,13 @@ func QuickDeleteOrg(orgName string) {
 	}
 
 	guid := GetOrgGUID(orgName)
-	url := fmt.Sprintf("/v2/organizations/%s?recursive=true&async=true", guid)
+	url := fmt.Sprintf("/v3/organizations/%s", guid)
 	session := CF("curl", "-X", "DELETE", url)
 	Eventually(session).Should(Exit(0))
 }
 
 // QuickDeleteOrgIfExists deletes the org with the given name, if it exists, using
-// 'cf curl /v2/organizations... -X DELETE'.
+// 'cf curl /v3/organizations... -X DELETE'.
 func QuickDeleteOrgIfExists(orgName string) {
 	session := CF("org", "--guid", orgName)
 	Eventually(session).Should(Exit())
@@ -136,16 +136,16 @@ func QuickDeleteOrgIfExists(orgName string) {
 		return
 	}
 	guid := strings.TrimSpace(string(session.Out.Contents()))
-	url := fmt.Sprintf("/v2/organizations/%s?recursive=true&async=true", guid)
+	url := fmt.Sprintf("/v3/organizations/%s", guid)
 	session = CF("curl", "-X", "DELETE", url)
 	Eventually(session).Should(Exit())
 }
 
 // QuickDeleteSpace deletes the space with the given name, if it exists, using
-// 'cf curl /v2/spaces... -X DELETE'.
+// 'cf curl /v3/spaces... -X DELETE'.
 func QuickDeleteSpace(spaceName string) {
 	guid := GetSpaceGUID(spaceName)
-	url := fmt.Sprintf("/v2/spaces/%s?recursive=true&async=true", guid)
+	url := fmt.Sprintf("/v3/spaces/%s", guid)
 	session := CF("curl", "-X", "DELETE", url)
 	Eventually(session).Should(Exit(0))
 }

--- a/integration/shared/isolated/spaces_command_test.go
+++ b/integration/shared/isolated/spaces_command_test.go
@@ -30,6 +30,10 @@ var _ = Describe("spaces command", func() {
 			helpers.TargetOrg(orgName)
 		})
 
+		AfterEach(func() {
+			helpers.QuickDeleteOrg(orgName)
+		})
+
 		When("there are no spaces", func() {
 			It("displays no spaces found", func() {
 				session := helpers.CF("spaces")

--- a/integration/shared/plugin/api_test.go
+++ b/integration/shared/plugin/api_test.go
@@ -13,11 +13,16 @@ import (
 )
 
 var _ = Describe("plugin API", func() {
+	var orgName string
 	BeforeEach(func() {
+		orgName = ""
 		installTestPlugin()
 	})
 
 	AfterEach(func() {
+		if orgName != "" {
+			helpers.QuickDeleteOrg(orgName)
+		}
 		uninstallTestPlugin()
 	})
 
@@ -63,7 +68,7 @@ var _ = Describe("plugin API", func() {
 	Describe("GetApp", func() {
 		var appName string
 		BeforeEach(func() {
-			createTargetedOrgAndSpace()
+			orgName, _ = createTargetedOrgAndSpace()
 			appName = helpers.PrefixedRandomName("APP")
 			helpers.WithHelloWorldApp(func(appDir string) {
 				Eventually(helpers.CF("push", appName, "--no-start", "-p", appDir, "-b", "staticfile_buildpack", "--no-route")).Should(Exit(0))
@@ -78,7 +83,7 @@ var _ = Describe("plugin API", func() {
 	Describe("GetApps", func() {
 		var appName1, appName2 string
 		BeforeEach(func() {
-			createTargetedOrgAndSpace()
+			orgName, _ = createTargetedOrgAndSpace()
 			appName1 = helpers.PrefixedRandomName("APP")
 			helpers.WithHelloWorldApp(func(appDir string) {
 				Eventually(helpers.CF("push", appName1, "--no-start", "-p", appDir, "-b", "staticfile_buildpack", "--no-route")).Should(Exit(0))
@@ -97,29 +102,35 @@ var _ = Describe("plugin API", func() {
 
 	Describe("GetCurrentOrg", func() {
 		It("gets the current targeted org", func() {
-			org, _ := createTargetedOrgAndSpace()
-			confirmTestPluginOutput("GetCurrentOrg", org)
+			orgName, _ = createTargetedOrgAndSpace()
+			confirmTestPluginOutput("GetCurrentOrg", orgName)
 		})
 	})
 
 	Describe("GetCurrentSpace", func() {
 		It("gets the current targeted Space", func() {
-			_, space := createTargetedOrgAndSpace()
+			var space string
+			orgName, space = createTargetedOrgAndSpace()
 			confirmTestPluginOutput("GetCurrentSpace", space)
 		})
 	})
 
 	Describe("GetOrg", func() {
 		It("gets the given org", func() {
-			org, _ := createTargetedOrgAndSpace()
-			confirmTestPluginOutputWithArg("GetOrg", org, org)
+			orgName, _ = createTargetedOrgAndSpace()
+			confirmTestPluginOutputWithArg("GetOrg", orgName, orgName)
 		})
 	})
 
 	Describe("GetOrgs", func() {
+		var org1, org2 string
+		AfterEach(func() {
+			helpers.QuickDeleteOrg(org1)
+			helpers.QuickDeleteOrg(org2)
+		})
 		It("gets information for multiple orgs", func() {
-			org1, _ := createTargetedOrgAndSpace()
-			org2, _ := createTargetedOrgAndSpace()
+			org1, _ = createTargetedOrgAndSpace()
+			org2, _ = createTargetedOrgAndSpace()
 			orgNameRegexp := fmt.Sprintf("(?:%s|%s)", org1, org2)
 			confirmTestPluginOutput("GetOrgs", orgNameRegexp, orgNameRegexp)
 		})
@@ -127,17 +138,17 @@ var _ = Describe("plugin API", func() {
 
 	Describe("GetOrgUsers", func() {
 		It("returns the org users", func() {
-			org, _ := createTargetedOrgAndSpace()
+			orgName, _ = createTargetedOrgAndSpace()
 			username, _ := helpers.GetCredentials()
-			confirmTestPluginOutputWithArg("GetOrgUsers", org, username)
+			confirmTestPluginOutputWithArg("GetOrgUsers", orgName, username)
 		})
 	})
 
 	Describe("GetOrgUsers", func() {
 		It("returns the org users", func() {
-			org, _ := createTargetedOrgAndSpace()
+			orgName, _ = createTargetedOrgAndSpace()
 			username, _ := helpers.GetCredentials()
-			confirmTestPluginOutputWithArg("GetOrgUsers", org, username)
+			confirmTestPluginOutputWithArg("GetOrgUsers", orgName, username)
 		})
 	})
 
@@ -148,7 +159,7 @@ var _ = Describe("plugin API", func() {
 			broker           *servicebrokerstub.ServiceBrokerStub
 		)
 		BeforeEach(func() {
-			createTargetedOrgAndSpace()
+			orgName, _ = createTargetedOrgAndSpace()
 			serviceInstance1 = helpers.PrefixedRandomName("SI1")
 			serviceInstance2 = helpers.PrefixedRandomName("SI2")
 
@@ -172,7 +183,8 @@ var _ = Describe("plugin API", func() {
 
 	Describe("GetSpace", func() {
 		It("gets the given space", func() {
-			_, space := createTargetedOrgAndSpace()
+			var space string
+			orgName, space = createTargetedOrgAndSpace()
 			confirmTestPluginOutputWithArg("GetSpace", space, space)
 		})
 	})
@@ -181,7 +193,7 @@ var _ = Describe("plugin API", func() {
 		var space1, space2 string
 
 		BeforeEach(func() {
-			_, space1 = createTargetedOrgAndSpace()
+			orgName, space1 = createTargetedOrgAndSpace()
 			space2 = helpers.NewSpaceName()
 			helpers.CreateSpace(space2)
 		})
@@ -195,8 +207,9 @@ var _ = Describe("plugin API", func() {
 	Describe("GetSpaceUsers", func() {
 		It("returns the space users", func() {
 			username, _ := helpers.GetCredentials()
-			org, space := createTargetedOrgAndSpace()
-			session := helpers.CF("GetSpaceUsers", org, space)
+			var space string
+			orgName, space = createTargetedOrgAndSpace()
+			session := helpers.CF("GetSpaceUsers", orgName, space)
 			Eventually(session).Should(Say(username))
 			Eventually(session).Should(Exit(0))
 		})
@@ -210,14 +223,14 @@ var _ = Describe("plugin API", func() {
 
 	Describe("HasOrganization", func() {
 		It("returns true", func() {
-			createTargetedOrgAndSpace()
+			orgName, _ = createTargetedOrgAndSpace()
 			confirmTestPluginOutput("HasOrganization", "true")
 		})
 	})
 
 	Describe("HasSpace", func() {
 		It("returns true", func() {
-			createTargetedOrgAndSpace()
+			orgName, _ = createTargetedOrgAndSpace()
 			confirmTestPluginOutput("HasSpace", "true")
 		})
 	})

--- a/integration/v7/global/running_security_groups_command_test.go
+++ b/integration/v7/global/running_security_groups_command_test.go
@@ -70,6 +70,7 @@ var _ = Describe("running-security-groups command", func() {
 
 			AfterEach(func() {
 				helpers.DeleteSecurityGroup(securityGroup)
+				helpers.QuickDeleteOrg(orgName)
 			})
 
 			It("displays the globally enabled running security groups exits 0", func() {

--- a/integration/v7/global/set_space_role_command_test.go
+++ b/integration/v7/global/set_space_role_command_test.go
@@ -26,6 +26,7 @@ var _ = Describe("set-space-role command", func() {
 
 		AfterEach(func() {
 			helpers.EnableFeatureFlag("set_roles_by_username")
+			helpers.QuickDeleteOrg(orgName)
 		})
 
 		When("the user does not exist", func() {

--- a/integration/v7/global/staging_security_groups_command_test.go
+++ b/integration/v7/global/staging_security_groups_command_test.go
@@ -70,6 +70,7 @@ var _ = Describe("staging-security-groups command", func() {
 
 			AfterEach(func() {
 				helpers.DeleteSecurityGroup(securityGroup)
+				helpers.QuickDeleteOrg(orgName)
 			})
 
 			It("displays the globally enabled staging security groups exits 0", func() {

--- a/integration/v7/isolated/create_space_quota_command_test.go
+++ b/integration/v7/isolated/create_space_quota_command_test.go
@@ -60,6 +60,10 @@ var _ = Describe("create-space-quota command", func() {
 			spaceQuotaName = helpers.QuotaName()
 		})
 
+		AfterEach(func() {
+			helpers.QuickDeleteOrg(orgName)
+		})
+
 		When("the quota name is not provided", func() {
 			It("tells the user that the quota name is required, prints help text, and exits 1", func() {
 				session := helpers.CF("create-space-quota")

--- a/integration/v7/isolated/move_route_command_test.go
+++ b/integration/v7/isolated/move_route_command_test.go
@@ -147,6 +147,8 @@ var _ = Describe("move route command", func() {
 
 					AfterEach(func() {
 						domain.DeleteShared()
+						helpers.QuickDeleteOrg(targetOrgName)
+						helpers.QuickDeleteOrg(orgName)
 					})
 
 					It("Transfers ownership of the route to the destination space", func() {

--- a/integration/v7/isolated/org_users_command_test.go
+++ b/integration/v7/isolated/org_users_command_test.go
@@ -40,6 +40,10 @@ var _ = Describe("org-users command", func() {
 			helpers.CreateOrg(orgName)
 		})
 
+		AfterEach(func() {
+			helpers.QuickDeleteOrg(orgName)
+		})
+
 		When("the target org has multiple users with different roles", func() {
 			var (
 				orgManagerUser     string

--- a/integration/v7/isolated/rename_org_command_test.go
+++ b/integration/v7/isolated/rename_org_command_test.go
@@ -107,6 +107,10 @@ var _ = Describe("rename-org command", func() {
 					helpers.CreateOrg(orgNameNew)
 				})
 
+				AfterEach(func() {
+					helpers.QuickDeleteOrg(orgNameNew)
+				})
+
 				It("fails to rename the org", func() {
 					session := helpers.CF("rename-org", orgName, orgNameNew)
 					userName, _ := helpers.GetCredentials()

--- a/integration/v7/isolated/scale_command_test.go
+++ b/integration/v7/isolated/scale_command_test.go
@@ -105,10 +105,10 @@ var _ = Describe("scale command", func() {
 				helpers.WithProcfileApp(func(appDir string) {
 					Eventually(helpers.CustomCF(helpers.CFEnv{WorkingDirectory: appDir}, "push", appName)).Should(Exit(0))
 				})
-				helpers.WaitForAppMemoryToTakeEffect(appName, 0, 0, false, "1G")
+				helpers.WaitForAppMemoryToTakeEffect(appName, 0, 0, false, "256M")
 			})
 
-			When("scale option flags are not provided", func() {
+			XWhen("scale option flags are not provided", func() {
 				It("displays the current scale properties for all processes", func() {
 					session := helpers.CF("scale", appName)
 
@@ -162,7 +162,7 @@ var _ = Describe("scale command", func() {
 						Consistently(session).ShouldNot(Say("Stopping"))
 						Consistently(session).ShouldNot(Say("Starting"))
 
-						helpers.WaitForAppMemoryToTakeEffect(appName, 0, 0, true, "1G")
+						helpers.WaitForAppMemoryToTakeEffect(appName, 0, 0, true, "256M")
 
 						session = helpers.CF("app", appName)
 						Eventually(session).Should(Exit(0))
@@ -179,7 +179,17 @@ var _ = Describe("scale command", func() {
 					})
 				})
 
-				When("Scaling the memory", func() {
+				When("-f flag provided", func() {
+					It("scales without prompt", func() {
+						session := helpers.CF("scale", appName, "-m", "64M", "-f")
+						Eventually(session).Should(Exit(0))
+						Expect(session).To(Say("Scaling app %s in org %s / space %s as %s...", appName, orgName, spaceName, userName))
+
+						helpers.WaitForAppMemoryToTakeEffect(appName, 0, 0, false, "64M")
+					})
+				})
+
+				XWhen("Scaling the memory", func() {
 					It("scales memory to 64M", func() {
 						buffer := NewBuffer()
 						_, err := buffer.Write([]byte("y\n"))
@@ -194,7 +204,7 @@ var _ = Describe("scale command", func() {
 						helpers.WaitForAppMemoryToTakeEffect(appName, 0, 0, false, "64M")
 					})
 
-					When("-f flag provided", func() {
+					XWhen("-f flag provided", func() {
 						It("scales without prompt", func() {
 							session := helpers.CF("scale", appName, "-m", "64M", "-f")
 							Eventually(session).Should(Exit(0))
@@ -205,7 +215,7 @@ var _ = Describe("scale command", func() {
 					})
 				})
 
-				When("Scaling the disk space", func() {
+				XWhen("Scaling the disk space", func() {
 					It("scales disk to 512M", func() {
 						buffer := NewBuffer()
 						_, err := buffer.Write([]byte("y\n"))
@@ -221,7 +231,7 @@ var _ = Describe("scale command", func() {
 						helpers.WaitForAppDiskToTakeEffect(appName, 0, 0, false, "512M")
 					})
 
-					When("-f flag provided", func() {
+					XWhen("-f flag provided", func() {
 						It("scales without prompt", func() {
 							session := helpers.CF("scale", appName, "-k", "512M", "-f")
 							Eventually(session).Should(Exit(0))
@@ -232,7 +242,7 @@ var _ = Describe("scale command", func() {
 					})
 				})
 
-				When("Scaling the log rate limit", func() {
+				XWhen("Scaling the log rate limit", func() {
 					BeforeEach(func() {
 						helpers.SkipIfVersionLessThan(ccversion.MinVersionLogRateLimitingV3)
 					})
@@ -252,7 +262,7 @@ var _ = Describe("scale command", func() {
 						helpers.WaitForLogRateLimitToTakeEffect(appName, 0, 0, false, "1M")
 					})
 
-					When("-f flag provided", func() {
+					XWhen("-f flag provided", func() {
 						It("scales without prompt", func() {
 							session := helpers.CF("scale", appName, "-l", "1M", "-f")
 							Eventually(session).Should(Exit(0))

--- a/integration/v7/isolated/security_groups_command_test.go
+++ b/integration/v7/isolated/security_groups_command_test.go
@@ -118,6 +118,7 @@ var _ = Describe("security-groups command", func() {
 				helpers.DeleteSecurityGroup(securityGroup3)
 				helpers.DeleteSecurityGroup(securityGroup4)
 				helpers.DeleteSecurityGroup(securityGroup5)
+				helpers.QuickDeleteOrg(orgName)
 			})
 
 			It("displays the security groups exits 0", func() {

--- a/integration/v7/isolated/services_command_test.go
+++ b/integration/v7/isolated/services_command_test.go
@@ -163,11 +163,11 @@ var _ = Describe("services command", func() {
 
 	Context("has shared service instances", func() {
 		var (
-			managedService, appNameOnSpaceA, appNameOnSpaceB string
+			managedService, appNameOnSpaceA, appNameOnSpaceB, orgName string
 		)
 
 		BeforeEach(func() {
-			orgName := helpers.NewOrgName()
+			orgName = helpers.NewOrgName()
 			spaceA := helpers.NewSpaceName()
 			spaceB := helpers.NewSpaceName()
 			managedService = helpers.PrefixedRandomName("MANAGED1")
@@ -191,6 +191,10 @@ var _ = Describe("services command", func() {
 			})
 			Eventually(helpers.CF("bind-service", appNameOnSpaceB, managedService)).Should(Exit(0))
 			helpers.TargetOrgAndSpace(orgName, spaceA)
+		})
+
+		AfterEach(func() {
+			helpers.QuickDeleteOrg(orgName)
 		})
 
 		It("should not output bound apps in the shared spaces", func() {

--- a/integration/v7/isolated/share_private_domain_test.go
+++ b/integration/v7/isolated/share_private_domain_test.go
@@ -58,6 +58,11 @@ var _ = Describe("share-private-domain command", func() {
 			domain.CreatePrivate()
 		})
 
+		AfterEach(func() {
+			helpers.QuickDeleteOrg(sharedWithOrgName)
+			helpers.QuickDeleteOrg(orgName)
+		})
+
 		It("should create the shared domain", func() {
 			session := helpers.CF("share-private-domain", sharedWithOrgName, domainName)
 

--- a/integration/v7/isolated/share_route_command_test.go
+++ b/integration/v7/isolated/share_route_command_test.go
@@ -147,6 +147,7 @@ var _ = Describe("share route command", func() {
 
 					AfterEach(func() {
 						domain.Delete()
+						helpers.QuickDeleteOrg(targetOrgName)
 					})
 
 					It("shared the route to the destination space", func() {

--- a/integration/v7/isolated/space_quota_command_test.go
+++ b/integration/v7/isolated/space_quota_command_test.go
@@ -49,6 +49,10 @@ var _ = Describe("space-quota command", func() {
 			helpers.TargetOrg(orgName)
 		})
 
+		AfterEach(func() {
+			helpers.QuickDeleteOrg(orgName)
+		})
+
 		When("the quota does not exist", func() {
 			It("displays quota not found and exits 1", func() {
 				session := helpers.CF("space-quota", quotaName)

--- a/integration/v7/isolated/space_users_command_test.go
+++ b/integration/v7/isolated/space_users_command_test.go
@@ -42,6 +42,10 @@ var _ = Describe("space-users command", func() {
 			helpers.CreateOrgAndSpace(orgName, spaceName)
 		})
 
+		AfterEach(func() {
+			helpers.QuickDeleteOrg(orgName)
+		})
+
 		When("the target space has multiple users with different roles", func() {
 			var (
 				spaceManagerUser   string

--- a/integration/v7/isolated/spaces_command_test.go
+++ b/integration/v7/isolated/spaces_command_test.go
@@ -60,6 +60,10 @@ var _ = Describe("spaces command", func() {
 			helpers.CreateSpace(spaceName6)
 		})
 
+		AfterEach(func() {
+			helpers.QuickDeleteOrg(orgName)
+		})
+
 		When("the --labels flag is given", func() {
 
 			BeforeEach(func() {

--- a/integration/v7/isolated/start_command_test.go
+++ b/integration/v7/isolated/start_command_test.go
@@ -128,7 +128,7 @@ var _ = Describe("start command", func() {
 					Eventually(session).Should(Say(`routes:\s+%s.%s`, appName, helpers.DefaultSharedDomain()))
 					Eventually(session).Should(Say(`type:\s+web`))
 					Eventually(session).Should(Say(`instances:\s+1/1`))
-					Eventually(session).Should(Say(`memory usage:\s+1024M`))
+					Eventually(session).Should(Say(`memory usage:\s+256M`))
 					Eventually(session).Should(Say(`\s+state\s+since\s+cpu\s+memory\s+disk\s+logging\s+cpu entitlement\s+details`))
 					Eventually(session).Should(Say(`#0\s+(starting|running)\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z`))
 

--- a/integration/v7/isolated/unshare_private_domain_test.go
+++ b/integration/v7/isolated/unshare_private_domain_test.go
@@ -70,6 +70,10 @@ var _ = Describe("unshare-private-domain command", func() {
 				domain.V7Share(sharedToOrgName)
 			})
 
+			AfterEach(func() {
+				helpers.QuickDeleteOrg(sharedToOrgName)
+			})
+
 			It("unshares the domain from the org", func() {
 				buffer := NewBuffer()
 				_, err := buffer.Write([]byte("y\n"))
@@ -96,6 +100,10 @@ var _ = Describe("unshare-private-domain command", func() {
 				domain := helpers.NewDomain(owningOrgName, domainName)
 				domain.CreatePrivate()
 				domain.V7Share(sharedToOrgName)
+			})
+
+			AfterEach(func() {
+				helpers.QuickDeleteOrg(sharedToOrgName)
 			})
 
 			It("does not unshare the domain from the org", func() {

--- a/integration/v7/isolated/unshare_route_command_test.go
+++ b/integration/v7/isolated/unshare_route_command_test.go
@@ -152,6 +152,7 @@ var _ = Describe("unshare route command", func() {
 
 					AfterEach(func() {
 						domain.Delete()
+						helpers.QuickDeleteOrg(targetOrgName)
 					})
 
 					It("unshared the route from the intended space", func() {


### PR DESCRIPTION
## Description of the Change

* Switch environment to cfd-bosh-lite
* Turn off set_kernel_parameters to use cfd-bosh-lite
* Expose shepherd configuration via repo variables
* Update secrets path to bosh-lite
* Expose TEST_FLAKE_ATTEMPTS and TEST_NODES
* Set default FLAKE_ATTEMPTS
* Bump gha test suit timeout from 60 to 120m
* Enter nodes as workflow_dispatch input
* Skip steps if SHEPHERD_LEASE_ID defined
* Skip scaling tests that are testing CAPI
* bosh-light environment default memory is 256Mb
* Fixed the issue with force update of bosh
* Delete created orgs during tests
* Ensure that the orgName is empty for each test
* Prevent double deletion of org
* Lower number of tests running using client credentials to avoid flakes
* Allow user to define namespace of the leased environment
* Pass namespace of the lease to the reusable workflow
