### PR TITLE
[v8] Provide default version based on latest tag in branch

### DIFF
--- a/.github/workflows/tests-integration-reusable.yml
+++ b/.github/workflows/tests-integration-reusable.yml
@@ -50,6 +50,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{inputs.gitRef}}
+        fetch-depth: 0
 
     - name: Checkout cf-acceptance-tests
       if: ${{ inputs.name == 'cats' }}

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -99,6 +99,7 @@ jobs:
         if: ${{ inputs.run_unit_tests }}
         with:
           ref: ${{needs.get-sha.outputs.gitRef}}
+          fetch-depth: 0
       - name: Set Up Go
         uses: actions/setup-go@v5
         if: ${{ inputs.run_unit_tests }}

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ FLAKE_ATTEMPTS ?=5
 PACKAGES ?= api actor command types util version integration/helpers
 LC_ALL = "en_US.UTF-8"
 
+CF_BUILD_VERSION ?= $$(git describe --tags --abbrev=0)
 CF_BUILD_SHA ?= $$(git rev-parse --short HEAD)
 CF_BUILD_DATE ?= $$(date -u +"%Y-%m-%d")
 LD_FLAGS_COMMON=-w -s \

--- a/version/version.go
+++ b/version/version.go
@@ -1,6 +1,10 @@
 package version
 
-import "github.com/blang/semver/v4"
+import (
+	"strings"
+
+	"github.com/blang/semver/v4"
+)
 
 const DefaultVersion = "0.0.0-unknown-version"
 
@@ -11,6 +15,8 @@ var (
 )
 
 func VersionString() string {
+	// Remove the "v" prefix from the binary in case it is present
+	binaryVersion = strings.TrimPrefix(binaryVersion, "v")
 	versionString, err := semver.Make(binaryVersion)
 	if err != nil {
 		versionString = semver.MustParse(DefaultVersion)


### PR DESCRIPTION
## Description of the Change

Ensure that a version by default is picked up from the latest tag in a particular branch. This fixes the integration tests errors
