### PR TITLE
Add CurrentDropletGUID attribute to application resource [v8]

### DIFF
--- a/api/cloudcontroller/ccv3/constant/relationships.go
+++ b/api/cloudcontroller/ccv3/constant/relationships.go
@@ -21,4 +21,7 @@ const (
 
 	// RelationshipTypeQuota is a relationship with a Cloud Controller quota (org quota or space quota).
 	RelationshipTypeQuota RelationshipType = "quota"
+
+	// RelationshipTypeCurrentDroplet is a relationship with a Droplet.
+	RelationshipTypeCurrentDroplet RelationshipType = "current_droplet"
 )

--- a/resources/application_resource.go
+++ b/resources/application_resource.go
@@ -44,18 +44,14 @@ func (a Application) MarshalJSON() ([]byte, error) {
 		Metadata: a.Metadata,
 	}
 
-	relationShips := Relationships{}
+	ccApp.Relationships = Relationships{}
 
 	if a.SpaceGUID != "" {
-		relationShips[constant.RelationshipTypeSpace] = Relationship{GUID: a.SpaceGUID}
+		ccApp.Relationships[constant.RelationshipTypeSpace] = Relationship{GUID: a.SpaceGUID}
 	}
 
 	if a.CurrentDropletGUID != "" {
-		relationShips[constant.RelationshipTypeCurrentDroplet] = Relationship{GUID: a.CurrentDropletGUID}
-	}
-
-	if len(relationShips) > 0 {
-		ccApp.Relationships = relationShips
+		ccApp.Relationships[constant.RelationshipTypeCurrentDroplet] = Relationship{GUID: a.CurrentDropletGUID}
 	}
 
 	if a.LifecycleType == constant.AppLifecycleTypeDocker {


### PR DESCRIPTION
## Where this PR should be backported?

- [x] [main](https://github.com/cloudfoundry/cli/tree/main) - all changes should by default start here ([PR on the main branch](https://github.com/cloudfoundry/cli/pull/3354))
- [x] [v8](https://github.com/cloudfoundry/cli/tree/v8) 
- [ ] [v7](https://github.com/cloudfoundry/cli/tree/v7)

## Description of the Change

The V3 API now allows you to access to the relationships existing beween an app and its current droplet.
This PR make this relationship visible trough a new `CurrentDropletGUID` attribute in the resource `application`.

The community `cf_exporter` currently use the `/v2/spaces/:guid/summary` endpoint to gain access to buildpack associated to an application. Have this relationship visible would help get rid of calls on this endpoint and retrieve informations from bbs about DesiredLRPs and RunningLRPS.

This feature will not cause breaking change.