### PR TITLE
Make version flag optional [main]

### DIFF
--- a/integration/v7/isolated/revision_command_test.go
+++ b/integration/v7/isolated/revision_command_test.go
@@ -161,5 +161,50 @@ var _ = Describe("revision command", func() {
 				Expect(session).Should(Say(`foo:   bar1`))
 			})
 		})
+
+		When("the revision version is not mentioned", func() {
+			BeforeEach(func() {
+				helpers.WithHelloWorldApp(func(appDir string) {
+					Eventually(helpers.CF("create-app", appName)).Should(Exit(0))
+					Eventually(helpers.CF("push", appName, "-p", appDir)).Should(Exit(0))
+					Eventually(helpers.CF("push", appName, "-p", appDir)).Should(Exit(0))
+					Eventually(helpers.CF("push", appName, "-p", appDir, "--strategy", "canary")).Should(Exit(0))
+				})
+			})
+
+			It("shows all the deployed revisions", func() {
+				session := helpers.CF("revision", appName)
+				Eventually(session).Should(Exit(0))
+
+				Expect(session).Should(Say(
+					fmt.Sprintf("Showing revisions for app %s in org %s / space %s as %s...", appName, orgName, spaceName, username),
+				))
+				Expect(session).Should(Say(`revision:        2`))
+				Expect(session).Should(Say(`deployed:        true`))
+				Expect(session).Should(Say(`description:     New droplet deployed`))
+				Expect(session).Should(Say(`deployable:      true`))
+				Expect(session).Should(Say(`revision GUID:   \S+\n`))
+				Expect(session).Should(Say(`droplet GUID:    \S+\n`))
+				Expect(session).Should(Say(`created on:      \S+\n`))
+
+				Expect(session).Should(Say(`labels:`))
+				Expect(session).Should(Say(`annotations:`))
+				Expect(session).Should(Say(`application environment variables:`))
+
+				Expect(session).Should(Say(`revision:        3`))
+				Expect(session).Should(Say(`deployed:        true`))
+				Expect(session).Should(Say(`description:     New droplet deployed`))
+				Expect(session).Should(Say(`deployable:      true`))
+				Expect(session).Should(Say(`revision GUID:   \S+\n`))
+				Expect(session).Should(Say(`droplet GUID:    \S+\n`))
+				Expect(session).Should(Say(`created on:      \S+\n`))
+
+				Expect(session).Should(Say(`labels:`))
+				Expect(session).Should(Say(`annotations:`))
+				Expect(session).Should(Say(`application environment variables:`))
+
+				Expect(session).ShouldNot(Say(`revision:        1`))
+			})
+		})
 	})
 })


### PR DESCRIPTION
Make the `--version` flag for `revision` command optional. When no version flag is provided, all the deployed revisions are displayed.

For ex, if we have the an app named dora and we run `revision` command without `version` flag, only deployed revision is displayed.

```
% cf revisions dora
Getting revisions for app dora in org o / space s as admin...

revision      description             deployable   revision guid                          created at
2(deployed)   New droplet deployed.   true         4b688a00-1b3a-415e-8530-4a0820757fc0   2025-01-13T15:05:38Z
1             Initial revision.       true         e931320d-9ef7-46a9-be1d-d3d78648ea04   2025-01-13T15:04:21Z

% cf revision dora
Showing revisions for app dora in org o / space s as admin...

revision:        2
deployed:        true
description:     New droplet deployed.
deployable:      true
revision GUID:   4b688a00-1b3a-415e-8530-4a0820757fc0
droplet GUID:    a2f451cc-3d7d-4c34-9e49-ef56db18ebb9
created on:      2025-01-13T15:05:38Z

labels:
annotations:
application environment variables:
```