### PR TITLE
Enable CF API v2 to fix integration tests (API v2 End of Life) [v8]

### DIFF
--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -266,6 +266,7 @@ jobs:
 
           bosh -d cf manifest > /tmp/manifest.yml
           bosh interpolate /tmp/manifest.yml \
+            -o cf-deployment/operations/enable-v2-api.yml \
             -o cf-deployment/operations/use-internal-lookup-for-route-services.yml \
             -o cf-deployment/operations/add-persistent-isolation-segment-diego-cell.yml \
             -o .github/ops-files/use-latest-capi.yml \


### PR DESCRIPTION
## Description of the Change

CF API version 2 is now disabled by default (also see [RFC0032 - CF API v2 End of Life](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0032-cfapiv2-eol.md)),
introduced by [CAPI release 1.201.0](https://github.com/cloudfoundry/capi-release/releases/tag/1.201.0)

Integration tests are failing since this change. 

Example: cf curl /unknown/route delivers "V2 endpoints disabled" instead of "unknown request":

`   {"description":"Unknown request","error_code":"CF-NotFound","code":10000}`

## How Urgent Is The Change?

Urgent. All the PRs are blocked and cannot be merged due to the integration tests' fails.