### PR TITLE
Unit test: Fix regex for timezone parsing [v8]

### DIFF
--- a/command/v7/shared/app_summary_displayer_test.go
+++ b/command/v7/shared/app_summary_displayer_test.go
@@ -655,7 +655,7 @@ var _ = Describe("app summary displayer", func() {
 
 		When("there is an active deployment", func() {
 			var LastStatusChangeTimeString = "2024-07-29T17:32:29Z"
-			var dateTimeRegexPattern = `[a-zA-Z]{3}\s\d{2}\s[a-zA-Z]{3}\s\d{2}\:\d{2}\:\d{2}\s[A-Z]{3}\s\d{4}`
+			var dateTimeRegexPattern = `[a-zA-Z]{3}\s\d{2}\s[a-zA-Z]{3}\s\d{2}\:\d{2}\:\d{2}\s[A-Z]{3,4}\s\d{4}`
 			var maxInFlightDefaultValue = 1
 
 			When("the deployment strategy is rolling", func() {


### PR DESCRIPTION
## Description of the Change

The unit tests failed on my local system with time zone `CEST`, as the output is checked against a regex expression that only accepts time zones with three characters. This pull-request allows time zones with three or four characters.


## Why Is This PR Valuable?

Unit tests will run on CEST systems.

## Applicable Issues

none

## How Urgent Is The Change?

Not urgent, it only fixes test issues on local systems.

## Other Relevant Parties

none
