### PR TITLE
Use cf-deployment main branch to for enable v2 api ops file [main]

### DIFF
--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -262,6 +262,14 @@ jobs:
           path: cf-deployment
           ref: ${{steps.claim.outputs.cf_deployment_version}}    
   
+      - name: Checkout cf-deployment-main
+        if: ${{ (inputs.lease_id == '') || (inputs.reinstall_cfd == true) }}
+        uses: actions/checkout@v4
+        with:
+          repository: cloudfoundry/cf-deployment
+          path: cf-deployment-main
+          ref: main          
+
       - name: Deploy Isolation Segment and OIDC Provider
         if: ${{ (inputs.lease_id == '') || (inputs.reinstall_cfd == true) }}
         run: |
@@ -271,7 +279,7 @@ jobs:
 
           bosh -d cf manifest > /tmp/manifest.yml
           bosh interpolate /tmp/manifest.yml \
-            -o cf-deployment/operations/enable-v2-api.yml \
+            -o cf-deployment-main/operations/enable-v2-api.yml \
             -o cf-deployment/operations/use-internal-lookup-for-route-services.yml \
             -o cf-deployment/operations/add-persistent-isolation-segment-diego-cell.yml \
             -o .github/ops-files/use-latest-capi.yml \


### PR DESCRIPTION
Currently, if a cf-d version is pinned for integration workflow run, we check out that version's branch of cf-deployment. But `enable-v2-api.yml` ops-file is available only in main branch of cf-deployment. Due env issues, we need to cf-d version to v44.4 for now. So the workflow fails. This change checks out the main branch of cf-deployment explicitly. 