### PR TITLE
Remove Per-Route Options from the Apps and the App commands

### DIFF
--- a/command/v7/apps_command.go
+++ b/command/v7/apps_command.go
@@ -79,7 +79,7 @@ func (cmd AppsCommand) Execute(args []string) error {
 func getURLs(routes []resources.Route) string {
 	var routeURLs []string
 	for _, route := range routes {
-		routeURLs = append(routeURLs, route.URL+route.FormattedOptions())
+		routeURLs = append(routeURLs, route.URL)
 	}
 
 	return strings.Join(routeURLs, ", ")

--- a/command/v7/apps_command_test.go
+++ b/command/v7/apps_command_test.go
@@ -239,7 +239,7 @@ var _ = Describe("apps Command", func() {
 				Expect(testUI.Out).To(Say(`Getting apps in org some-org / space some-space as steve\.\.\.`))
 
 				Expect(testUI.Out).To(Say(`name\s+requested state\s+processes\s+routes`))
-				Expect(testUI.Out).To(Say(`some-app-1\s+started\s+web:2/2, console:0/0, worker:0/1\s+some-app-1.some-other-domain {loadbalancing=least-connection}, some-app-1.some-domain`))
+				Expect(testUI.Out).To(Say(`some-app-1\s+started\s+web:2/2, console:0/0, worker:0/1\s+some-app-1.some-other-domain, some-app-1.some-domain`))
 
 				Expect(testUI.Err).To(Say("warning-1"))
 				Expect(testUI.Err).To(Say("warning-2"))


### PR DESCRIPTION
## Per-Route Options in the Apps and the App commands
 
CLI Support for Generic Per-Route Options were introduced with the extension of the output of the commands app and apps. The per-route options are being shown directly behind the routes as a comma separated list of key-value pairs in the curly braces. For example:
 
```
cf app
Getting apps in org org1 / space space1 as user1...
 
name         requested state   processes   routes
app1           started                 web:1/1        test1.test/bu2 {loadbalancing=least-connections}
 
 
cf apps
Showing health and status for app app1 in org org1 / space space1 as user1...
 
name:                     app1
requested state:   started
routes:                   test1.test, test1.test/bu2 {loadbalancing=least-connections}
 
 
cf route test --hostname test1 --path /bu16
 Showing route test1.test/bu16 in org org1 / space space1 as user1...
 
domain:     test
host:       test1
port:       
path:       /bu16
protocol:   http
options:    {loadbalancing=round-robin}
```

There were some concerns, that this output might become too verbose and is considered being a breaking change.
This PR is removing the per-route options from the app and apps commands.
 
## Applicable Issues
 
[GitHub Issue](https://github.com/cloudfoundry/cli/issues/3314)
 
## How Urgent Is The Change?
 
No urgency

