### PR TITLE
[v7] add missing NetworkPolicyV1Endpoint field to Data struct

### DIFF
--- a/cf/configuration/coreconfig/config_data.go
+++ b/cf/configuration/coreconfig/config_data.go
@@ -31,6 +31,7 @@ type Data struct {
 	LogCacheEndPoint         string
 	MinCLIVersion            string
 	MinRecommendedCLIVersion string
+	NetworkPolicyV1Endpoint  string
 	OrganizationFields       models.OrganizationFields
 	PluginRepos              []models.PluginRepo
 	RefreshToken             string

--- a/cf/configuration/coreconfig/config_data_test.go
+++ b/cf/configuration/coreconfig/config_data_test.go
@@ -55,7 +55,8 @@ var _ = Describe("V3 Config files", func() {
 		}
 		],
 		"MinCLIVersion": "6.0.0",
-		"MinRecommendedCLIVersion": "6.9.0"
+		"MinRecommendedCLIVersion": "6.9.0",
+        "NetworkPolicyV1Endpoint": "the-network-policy-endpoint"
 	}`
 
 	// V2 by virtue of ConfigVersion only
@@ -104,7 +105,8 @@ var _ = Describe("V3 Config files", func() {
 		}
 		],
 		"MinCLIVersion": "6.0.0",
-		"MinRecommendedCLIVersion": "6.9.0"
+		"MinRecommendedCLIVersion": "6.9.0",
+        "NetworkPolicyV1Endpoint": "the-network-policy-endpoint"
 	}`
 
 	Describe("NewData", func() {
@@ -133,6 +135,7 @@ var _ = Describe("V3 Config files", func() {
 				SSHOAuthClient:           "ssh-oauth-client-id",
 				MinCLIVersion:            "6.0.0",
 				MinRecommendedCLIVersion: "6.9.0",
+				NetworkPolicyV1Endpoint:  "the-network-policy-endpoint",
 				OrganizationFields: models.OrganizationFields{
 					GUID: "the-org-guid",
 					Name: "the-org",
@@ -185,6 +188,7 @@ var _ = Describe("V3 Config files", func() {
 				SSHOAuthClient:           "ssh-oauth-client-id",
 				MinCLIVersion:            "6.0.0",
 				MinRecommendedCLIVersion: "6.9.0",
+				NetworkPolicyV1Endpoint:  "the-network-policy-endpoint",
 				OrganizationFields: models.OrganizationFields{
 					GUID: "the-org-guid",
 					Name: "the-org",


### PR DESCRIPTION

## Description of the Change

There is a NetworkPolicyV1Endpoint field missing in a Data struct, this change adds that single field
 
## Why Is This PR Valuable?

Currently the NetworkPolicyV1Endpoint field in your $CF_HOME/config.json file gets wiped out if you execute a cf plugin subcommand while your AccessToken is expired. Your AccessToken is renewed and your config.json file is rewritten, but then the NetworkPolicyV1Endpoint is gone, which then causes your next "cf network-policies" command to fail.
You have to either manually edit the config.json file and add the field back, or do a "cf login ...." again.
Mind that this only happens if using plugin subcommands, not with the builtin cf subcommands like cf apps, cf services etc.

## Applicable Issues

None

## How Urgent Is The Change?

No, just a bug under specific circumstances.

## Other Relevant Parties

Anyone using plugins that need the cf AccessToken.