### PR TITLE
[v8] Fix release pipeline

### DIFF
--- a/.github/workflows/release-build-sign-upload.yml
+++ b/.github/workflows/release-build-sign-upload.yml
@@ -424,7 +424,7 @@ jobs:
     - name: Update Homebrew
       run: |
         brew tap pivotalsoftware/gon
-        brew update --preinstall
+        brew update
         cat "$(brew --repository)/Library/Taps/pivotalsoftware/homebrew-gon/gon.rb" > .github/brew-formulae
 
     - name: Configure Homebrew cache


### PR DESCRIPTION
Update homebrew syntax:  `--preinstall` was deprecated in late 2024
It seems the `brew update` successfully downloads the formula required for the release process without this flag.
