### PR TITLE
[main] Switch to python awscli package

### DIFF
--- a/.github/workflows/release-update-repos.yml
+++ b/.github/workflows/release-update-repos.yml
@@ -383,11 +383,13 @@ jobs:
       env:
         DEBIAN_FRONTEND: noninteractive
       run: >
-        sudo apt update &&
-        sudo apt install --yes --no-install-recommends
+        sudo apt update
+        && sudo apt install --yes --no-install-recommends
         gnupg
         createrepo-c
         awscli
+        python3-pip
+        && pip3 install awscli
 
     - name: Setup aws to upload installers to CLAW S3 bucket
       uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
Since linux awscli package is now deprecated and removed, we're switching to the official way of installing aws cli tools via pip.