### PR TITLE
[main] feat: add ready indicator to `cf app` command

### DIFF
--- a/api/cloudcontroller/ccv3/process_instance.go
+++ b/api/cloudcontroller/ccv3/process_instance.go
@@ -38,6 +38,8 @@ type ProcessInstance struct {
 	LogRate uint64
 	// State is the state of the instance.
 	State constant.ProcessInstanceState
+	// Routeable is the readiness state of the instance, can be true, false or null.
+	Routable *bool
 	// Type is the process type for the instance.
 	Type string
 	// Uptime is the duration that the instance has been running.
@@ -54,6 +56,7 @@ func (instance *ProcessInstance) UnmarshalJSON(data []byte) error {
 		MemQuota         uint64 `json:"mem_quota"`
 		LogRateLimit     int64  `json:"log_rate_limit"`
 		State            string `json:"state"`
+		Routable         *bool  `json:"routable"`
 		Type             string `json:"type"`
 		Uptime           int64  `json:"uptime"`
 		Usage            struct {
@@ -80,6 +83,7 @@ func (instance *ProcessInstance) UnmarshalJSON(data []byte) error {
 	instance.LogRateLimit = inputInstance.LogRateLimit
 	instance.LogRate = inputInstance.Usage.LogRate
 	instance.State = constant.ProcessInstanceState(inputInstance.State)
+	instance.Routable = inputInstance.Routable
 	instance.Type = inputInstance.Type
 	instance.Uptime, err = time.ParseDuration(fmt.Sprintf("%ds", inputInstance.Uptime))
 	if err != nil {

--- a/command/v7/shared/app_summary_displayer.go
+++ b/command/v7/shared/app_summary_displayer.go
@@ -79,6 +79,14 @@ func formatCPU(instance v7action.ProcessInstance) string {
 	return fmt.Sprintf("%.1f%%", instance.CPUEntitlement.Value*100)
 }
 
+func formatRoutable(b *bool) string {
+	if b == nil {
+		return "-"
+	}
+
+	return fmt.Sprintf("%t", *b)
+}
+
 func (display AppSummaryDisplayer) displayAppInstancesTable(processSummary v7action.ProcessSummary) {
 	table := [][]string{
 		{
@@ -90,6 +98,7 @@ func (display AppSummaryDisplayer) displayAppInstancesTable(processSummary v7act
 			display.UI.TranslateText("disk"),
 			display.UI.TranslateText("logging"),
 			display.UI.TranslateText("details"),
+			display.UI.TranslateText("ready"),
 		},
 	}
 
@@ -112,6 +121,7 @@ func (display AppSummaryDisplayer) displayAppInstancesTable(processSummary v7act
 				"LogRateLimit": formatLogRateLimit(instance.LogRateLimit),
 			}),
 			instance.Details,
+			formatRoutable(instance.Routable),
 		})
 	}
 

--- a/command/v7/shared/app_summary_displayer_test.go
+++ b/command/v7/shared/app_summary_displayer_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 var _ = Describe("app summary displayer", func() {
-	const instanceStatsTitles = `state\s+since\s+cpu entitlement\s+memory\s+disk\s+logging\s+details`
+	const instanceStatsTitles = `state\s+since\s+cpu entitlement\s+memory\s+disk\s+logging\s+details\s+ready`
 
 	var (
 		output *Buffer
@@ -45,6 +45,10 @@ var _ = Describe("app summary displayer", func() {
 
 				BeforeEach(func() {
 					uptime = time.Since(time.Unix(267321600, 0))
+					var (
+						bTrue  = true
+						bFalse = false
+					)
 					summary = v7action.DetailedApplicationSummary{
 						ApplicationSummary: v7action.ApplicationSummary{
 							Application: resources.Application{
@@ -61,7 +65,7 @@ var _ = Describe("app summary displayer", func() {
 									},
 									Sidecars: []resources.Sidecar{},
 									InstanceDetails: []v7action.ProcessInstance{
-										v7action.ProcessInstance{
+										{
 											Index:          0,
 											State:          constant.ProcessInstanceRunning,
 											CPUEntitlement: types.NullFloat64{Value: 0.0, IsSet: true},
@@ -73,8 +77,9 @@ var _ = Describe("app summary displayer", func() {
 											LogRateLimit:   1024 * 5,
 											Uptime:         uptime,
 											Details:        "Some Details 1",
+											Routable:       &bTrue,
 										},
-										v7action.ProcessInstance{
+										{
 											Index:          1,
 											State:          constant.ProcessInstanceRunning,
 											CPUEntitlement: types.NullFloat64{Value: 1.0, IsSet: true},
@@ -86,8 +91,9 @@ var _ = Describe("app summary displayer", func() {
 											LogRateLimit:   1024 * 5,
 											Uptime:         time.Since(time.Unix(330480000, 0)),
 											Details:        "Some Details 2",
+											Routable:       &bTrue,
 										},
-										v7action.ProcessInstance{
+										{
 											Index:          2,
 											State:          constant.ProcessInstanceRunning,
 											CPUEntitlement: types.NullFloat64{Value: 0.03, IsSet: true},
@@ -98,6 +104,7 @@ var _ = Describe("app summary displayer", func() {
 											DiskQuota:      6000000,
 											LogRateLimit:   1024 * 5,
 											Uptime:         time.Since(time.Unix(1277164800, 0)),
+											Routable:       &bFalse,
 										},
 									},
 								},
@@ -110,7 +117,7 @@ var _ = Describe("app summary displayer", func() {
 									},
 									Sidecars: []resources.Sidecar{},
 									InstanceDetails: []v7action.ProcessInstance{
-										v7action.ProcessInstance{
+										{
 											Index:          0,
 											State:          constant.ProcessInstanceRunning,
 											CPUEntitlement: types.NullFloat64{Value: 0.0, IsSet: true},
@@ -121,6 +128,8 @@ var _ = Describe("app summary displayer", func() {
 											DiskQuota:      8000000,
 											LogRateLimit:   256,
 											Uptime:         time.Since(time.Unix(167572800, 0)),
+											Details:        "",
+											Routable:       &bTrue,
 										},
 									},
 								},

--- a/integration/helpers/app_instance_table.go
+++ b/integration/helpers/app_instance_table.go
@@ -10,6 +10,7 @@ import (
 type AppInstanceRow struct {
 	Index          string
 	State          string
+	Ready          string
 	Since          string
 	CPUEntitlement string
 	Memory         string
@@ -56,13 +57,13 @@ func ParseV3AppProcessTable(input []byte) AppTable {
 
 		switch {
 		case strings.HasPrefix(row, "#"):
-			const columnCount = 8
+			const columnCount = 9
 
 			// instance row
 			columns := splitColumns(row)
 			details := ""
 			if len(columns) >= columnCount {
-				details = columns[columnCount-1]
+				details = columns[len(columns)-2]
 			}
 
 			instanceRow := AppInstanceRow{
@@ -74,6 +75,7 @@ func ParseV3AppProcessTable(input []byte) AppTable {
 				Disk:           columns[5],
 				LogRate:        columns[6],
 				Details:        details,
+				Ready:          columns[len(columns)-1],
 			}
 			lastProcessIndex := len(appTable.Processes) - 1
 			appTable.Processes[lastProcessIndex].Instances = append(


### PR DESCRIPTION
## Description of the Change

CC version 3.144.0 introduced readiness checks and with them a new status field for processes: routable. This commit exposes that new field in the `cf app` command to allow users to easily determine the state of their application instances.

See: https://github.com/cloudfoundry/capi-release/releases/tag/1.158.0

Thank you for contributing to the CF CLI! Please read the following:
