### PR TITLE
[v8] Allow CF Authentication based on Tokens - user and client tokens 

### DIFF
--- a/actor/v7action/auth.go
+++ b/actor/v7action/auth.go
@@ -25,7 +25,7 @@ func NewDefaultAuthActor(config Config, uaaClient UAAClient) AuthActor {
 }
 
 func (actor defaultAuthActor) Authenticate(credentials map[string]string, origin string, grantType constant.GrantType) error {
-	if grantType == constant.GrantTypePassword && actor.config.UAAGrantType() == string(constant.GrantTypeClientCredentials) {
+	if (grantType == constant.GrantTypePassword || grantType == constant.GrantTypeJwtBearer) && actor.config.UAAGrantType() == string(constant.GrantTypeClientCredentials) {
 		return actionerror.PasswordGrantTypeLogoutRequiredError{}
 	}
 
@@ -45,7 +45,7 @@ func (actor defaultAuthActor) Authenticate(credentials map[string]string, origin
 		actor.config.SetUAAGrantType(string(grantType))
 	}
 
-	if grantType == constant.GrantTypeClientCredentials {
+	if (grantType == constant.GrantTypeClientCredentials || grantType == constant.GrantTypeJwtBearer) && credentials["client_id"] != "" {
 		actor.config.SetUAAClientCredentials(credentials["client_id"], "")
 	}
 

--- a/api/uaa/auth.go
+++ b/api/uaa/auth.go
@@ -62,6 +62,17 @@ func (client Client) Authenticate(creds map[string]string, origin string, grantT
 
 	if grantType == constant.GrantTypePassword {
 		request.SetBasicAuth(client.config.UAAOAuthClient(), client.config.UAAOAuthClientSecret())
+	} else if grantType == constant.GrantTypeJwtBearer {
+		// overwrite client authentication in case of provided parameters in cf auth clientid clientsecret or use defaults as done in password grant
+		clientId := client.config.UAAOAuthClient()
+		clientSecret := client.config.UAAOAuthClientSecret()
+		if creds["client_id"] != "" {
+			clientId = creds["client_id"]
+		}
+		if creds["client_secret"] != "" {
+			clientSecret = creds["client_secret"]
+		}
+		request.SetBasicAuth(clientId, clientSecret)
 	}
 
 	responseBody := AuthResponse{}

--- a/api/uaa/constant/grant_type.go
+++ b/api/uaa/constant/grant_type.go
@@ -10,4 +10,6 @@ const (
 	// GrantTypePassword is used for user's username/password authentication.
 	GrantTypePassword     GrantType = "password"
 	GrantTypeRefreshToken GrantType = "refresh_token"
+	// GrantTypeJwtBearer is used for token based user authentication
+	GrantTypeJwtBearer GrantType = "urn:ietf:params:oauth:grant-type:jwt-bearer"
 )

--- a/api/uaa/refresh_token.go
+++ b/api/uaa/refresh_token.go
@@ -29,7 +29,7 @@ func (client *Client) RefreshAccessToken(refreshToken string) (RefreshedTokens, 
 	switch client.config.UAAGrantType() {
 	case string(constant.GrantTypeClientCredentials):
 		values = client.clientCredentialRefreshBody()
-	case "", string(constant.GrantTypePassword): // CLI used to write empty string for grant type in the case of password; preserve compatibility with old config.json files
+	case "", string(constant.GrantTypePassword), string(constant.GrantTypeJwtBearer): // CLI used to write empty string for grant type in the case of password; preserve compatibility with old config.json files
 		values = client.refreshTokenBody(refreshToken)
 	}
 

--- a/api/uaa/wrapper/uaa_authentication.go
+++ b/api/uaa/wrapper/uaa_authentication.go
@@ -109,5 +109,6 @@ func skipAuthenticationHeader(request *http.Request, body []byte) bool {
 		request.Method == http.MethodPost &&
 		(strings.Contains(stringBody, "grant_type=refresh_token") ||
 			strings.Contains(stringBody, "grant_type=password") ||
+			strings.Contains(stringBody, "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer") ||
 			strings.Contains(stringBody, "grant_type=client_credentials"))
 }

--- a/integration/v7/isolated/auth_command_test.go
+++ b/integration/v7/isolated/auth_command_test.go
@@ -27,7 +27,9 @@ var _ = Describe("auth command", func() {
 
 			Eventually(session).Should(Say("USAGE:"))
 			Eventually(session).Should(Say("cf auth USERNAME PASSWORD\n"))
-			Eventually(session).Should(Say("cf auth CLIENT_ID CLIENT_SECRET --client-credentials\n\n"))
+			Eventually(session).Should(Say("cf auth CLIENT_ID CLIENT_SECRET --client-credentials\n"))
+			Eventually(session).Should(Say("cf auth CLIENT_ID CLIENT_SECRET --assertion ID-TOKEN\n"))
+			Eventually(session).Should(Say("cf auth CLIENT_ID --client-credentials --assertion ACCESS-TOKEN\n"))
 
 			Eventually(session).Should(Say("ENVIRONMENT VARIABLES:"))
 			Eventually(session).Should(Say(`CF_USERNAME=user\s+Authenticating user. Overridden if USERNAME argument is provided.`))
@@ -44,7 +46,8 @@ var _ = Describe("auth command", func() {
 
 			Eventually(session).Should(Say("OPTIONS:"))
 			Eventually(session).Should(Say("--client-credentials\\s+Use \\(non-user\\) service account \\(also called client credentials\\)\n"))
-			Eventually(session).Should(Say("--origin\\s+Indicates the identity provider to be used for authentication\n\n"))
+			Eventually(session).Should(Say("--origin\\s+Indicates the identity provider to be used for authentication\n"))
+			Eventually(session).Should(Say("--assertion\\s+Token based authentication with assertion \\(user\\) or in combination with client-credentials \\(non-user\\)\n"))
 
 			Eventually(session).Should(Say("SEE ALSO:"))
 			Eventually(session).Should(Say("api, login, target"))


### PR DESCRIPTION
(cherry picked from commit de832082898835f39409aca03be947e41ffc5d07)
PR from main: https://github.com/cloudfoundry/cli/pull/3397

## Description of the Change

Enhance the cf auth command with a parameter --assertion. The content of this token should be either a user token in order to perform a jwt-bearer or a client token in order to perform a client_credentials grant with federated trust.

UAA supports JWT bearer since UAA 4.5.0 , see https://docs.cloudfoundry.org/api/uaa/version/77.25.0/index.html#jwt-bearer-token-grant
UAA support the federated client credential flow since 77.25.0

## Why Is This PR Valuable?

CF can be integrated into Github Action without any extra secret setup in Github Repo.
Customer can then decide about using external tokens like github action token for user and/or client authentication.

In a PR you retrieve a id_token from gh action, this can be passed with cf auth --assertion <github id token> so that you are authentication in or to do a cf push ...

## Applicable Issues

* https://github.com/cloudfoundry/cli/issues/3368

## How Urgent Is The Change?

* it is an enhancement but it solves security issues, because CF integrations need to omit secrets and/or client certificates, but integration of github action with CF is only possible if you store a secret in Github

## Other Relevant Parties

Only CF landscapes with a configured trust to external OIDC parties
