### PR TITLE
Remove v7 from GitHub Actions and Dependabot

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -5,7 +5,6 @@ on:
     tags:
       - "v9.*"
       - "v8.*"
-      - "v7.*"
   pull_request:
     types:
       - opened
@@ -15,7 +14,6 @@ on:
       - main
       - v9
       - v8
-      - v7
     paths-ignore:
       - "doc/**"
       - ".gitpod.yml"

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -56,12 +56,10 @@ on:
   push:
     tags:
       - "v8.*"
-      - "v7.*"
   pull_request_target:
     branches:
       - main
       - v8
-      - v7
     paths-ignore:
       - "doc/**"
       - ".gitpod.yml"

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -13,13 +13,11 @@ on:
     tags:
       - "v9.*"
       - "v8.*"
-      - "v7.*"
   pull_request:
     branches:
       - main
       - v9
       - v8
-      - v7
     paths-ignore:
       - "doc/**"
       - ".gitpod.yml"

--- a/.github/workflows/util-code-quality.yml
+++ b/.github/workflows/util-code-quality.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - main
       - v8
-      - v7
   schedule:
     - cron: '45 5 * * *'
 


### PR DESCRIPTION
- v7 is no longer in support, so let's not waste resources on it

Thank you for contributing to the CF CLI! Please read the following:


* Please make sure you have implemented changes in line with the [contributing guidelines](https://github.com/cloudfoundry/cli/blob/main/.github/CONTRIBUTING.md)
* We're not allowed to accept any PRs without a signed CLA, no matter how small.
If your contribution falls under a company CLA but your membership is not public, expect delays while we confirm.
* All new code requires tests to protect against regressions.
* Contributions must be made against the appropriate branch. See the [contributing guidelines](https://github.com/cloudfoundry/cli/blob/main/.github/CONTRIBUTING.md)
* Contributions must conform to our [style guide](https://github.com/cloudfoundry/cli/wiki/CLI-Product-Specific-Style-Guide). Please reach out to us if you have questions.


#### Note: Please create separate PR for every branch (main, v8 and v7) as needed.

## Description of the Change

We must be able to understand the design of your change from this description.
Keep in mind that the maintainer reviewing this PR may not be familiar with or
have worked with the code here recently, so please walk us through the concepts.


## Why Is This PR Valuable?

What benefits will be realized by the code change? What users would want this change? What user need is this change addressing? 

## Applicable Issues

List any applicable GitHub Issues here

## How Urgent Is The Change?

Is the change urgent? If so, explain why it is time-sensitive.

## Other Relevant Parties

Who else is affected by the change? 
