### PR TITLE
Remove v7 references

### DIFF
--- a/.github/workflows/release-update-repos.yml
+++ b/.github/workflows/release-update-repos.yml
@@ -310,7 +310,6 @@ jobs:
         image:
         - debian:11
         - debian:12
-        - ubuntu:20.04
         - ubuntu:22.04
         - ubuntu
     runs-on: ubuntu-latest
@@ -633,31 +632,12 @@ jobs:
         docker run -v $(pwd):/clidir -w /clidir \
           --rm ${{ env.VERSION_BUILD }} sh test.sh
 
-        # If bash reaches this point, it means that tests passed, setting latest
-        if [[ ( ${{ github.ref_name }} == "v8" ) ]]; then
-          echo "LATEST_DOCKER=v8" >> "$GITHUB_ENV"
-        fi
-
-        if [[ ( ${{ github.ref_name }} == "v7" ) ]]; then
-          echo "LATEST_DOCKER=v7" >> "$GITHUB_ENV"
-        fi
-        
         rm test.sh
 
-    - name: Push image if its from v8
-      if: ${{ env.LATEST_DOCKER }} == v8
+    - name: Push image 
       uses: docker/build-push-action@v6
       with:
         context: docker
         push: true
         tags: cloudfoundry/cli:${{ env.VERSION_BUILD }}, cloudfoundry/cli:latest
     
-    - name: Push image if its from v7
-      if: ${{ env.LATEST_DOCKER }} == v7
-      uses: docker/build-push-action@v6
-      with:
-        context: docker
-        push: true
-        tags: cloudfoundry/cli:${{ env.VERSION_BUILD }}
-
-# vim: set sw=2 ts=2 sts=2 et tw=78 foldlevel=2 fdm=indent nospell:


### PR DESCRIPTION
This PR removes v7 references and ubuntu:20.04 runner(which is going out of support in May 2025).