### PR TITLE
Fix double quote error on locale

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CF_DIAL_TIMEOUT ?= 15
 NODES ?= 10
 FLAKE_ATTEMPTS ?=5
 PACKAGES ?= api actor command types util version integration/helpers
-LC_ALL = "en_US.UTF-8"
+LC_ALL = en_US.UTF-8
 
 ## TODO: Change when new version is released
 CF_BUILD_VERSION ?= v9.0.0


### PR DESCRIPTION
Else this evaluates to ""en_US.UTF-8"" and see this warning
```
bash: warning: setlocale: LC_ALL: cannot change locale ("en_US.UTF-8"): No such file or directory 
```