### PR TITLE
Replace custom DNS lookback address

### DIFF
--- a/api/cloudcontroller/cloud_controller_connection_test.go
+++ b/api/cloudcontroller/cloud_controller_connection_test.go
@@ -292,9 +292,9 @@ var _ = Describe("Cloud Controller Connection", func() {
 						connection = NewConnection(Config{})
 					})
 
-					// loopback.cli.fun is a custom DNS record setup to point to 127.0.0.1
+					// 127.0.0.1.nip.io is a custom DNS record setup to point to 127.0.0.1
 					It("returns a SSLValidationHostnameError", func() {
-						altHostURL := strings.Replace(server.URL(), "127.0.0.1", "loopback.cli.fun", -1)
+						altHostURL := strings.Replace(server.URL(), "127.0.0.1", "127.0.0.1.nip.io", -1)
 						req, err := http.NewRequest(http.MethodGet, altHostURL, nil)
 						Expect(err).ToNot(HaveOccurred())
 						request := &Request{Request: req}
@@ -304,10 +304,10 @@ var _ = Describe("Cloud Controller Connection", func() {
 						Expect(err).To(
 							SatisfyAny(
 								MatchError(ccerror.SSLValidationHostnameError{
-									Message: "x509: certificate is valid for example.com, *.example.com, not loopback.cli.fun",
+									Message: "x509: certificate is valid for example.com, *.example.com, not 127.0.0.1.nip.io",
 								}),
 								MatchError(ccerror.SSLValidationHostnameError{
-									Message: "x509: certificate is valid for example.com, not loopback.cli.fun",
+									Message: "x509: certificate is valid for example.com, not 127.0.0.1.nip.io",
 								})))
 					})
 				})

--- a/api/plugin/plugin_connection_test.go
+++ b/api/plugin/plugin_connection_test.go
@@ -192,9 +192,9 @@ var _ = Describe("Plugin Connection", func() {
 						connection = NewConnection(false, 0)
 					})
 
-					// loopback.cli.fun is a custom DNS record setup to point to 127.0.0.1
+					// 127.0.0.1.nip.io is a DNS record setup to point to 127.0.0.1
 					It("returns a SSLValidationHostnameError", func() {
-						altHostURL := strings.Replace(server.URL(), "127.0.0.1", "loopback.cli.fun", -1)
+						altHostURL := strings.Replace(server.URL(), "127.0.0.1", "127.0.0.1.nip.io", -1)
 						request, err := http.NewRequest(http.MethodGet, altHostURL, nil)
 						Expect(err).ToNot(HaveOccurred())
 
@@ -203,10 +203,10 @@ var _ = Describe("Plugin Connection", func() {
 						Expect(err).To(
 							SatisfyAny(
 								MatchError(pluginerror.SSLValidationHostnameError{
-									Message: "x509: certificate is valid for example.com, *.example.com, not loopback.cli.fun",
+									Message: "x509: certificate is valid for example.com, *.example.com, not 127.0.0.1.nip.io",
 								}),
 								MatchError(pluginerror.SSLValidationHostnameError{
-									Message: "x509: certificate is valid for example.com, not loopback.cli.fun",
+									Message: "x509: certificate is valid for example.com, not 127.0.0.1.nip.io",
 								})))
 					})
 				})


### PR DESCRIPTION
loopback.cli.fun no longer exists

```
$ nslookup loopback.cli.fun
;; Got SERVFAIL reply from 192.19.189.10, trying next server
Server:		192.19.189.30
Address:	192.19.189.30#53

** server can't find loopback.cli.fun: SERVFAIL
```

--- 

Thank you for contributing to the CF CLI! Please read the following:


* Please make sure you have implemented changes in line with the [contributing guidelines](https://github.com/cloudfoundry/cli/blob/main/.github/CONTRIBUTING.md)
* We're not allowed to accept any PRs without a signed CLA, no matter how small.
If your contribution falls under a company CLA but your membership is not public, expect delays while we confirm.
* All new code requires tests to protect against regressions.
* Contributions must be made against the appropriate branch. See the [contributing guidelines](https://github.com/cloudfoundry/cli/blob/main/.github/CONTRIBUTING.md)
* Contributions must conform to our [style guide](https://github.com/cloudfoundry/cli/wiki/CLI-Product-Specific-Style-Guide). Please reach out to us if you have questions.


#### Note: Please create separate PR for every branch (main, v8 and v7) as needed.

## Description of the Change

We must be able to understand the design of your change from this description.
Keep in mind that the maintainer reviewing this PR may not be familiar with or
have worked with the code here recently, so please walk us through the concepts.


## Why Is This PR Valuable?

What benefits will be realized by the code change? What users would want this change? What user need is this change addressing? 

## Applicable Issues

List any applicable GitHub Issues here

## How Urgent Is The Change?

Is the change urgent? If so, explain why it is time-sensitive.

## Other Relevant Parties

Who else is affected by the change? 
