### PR TITLE
Remove explicit cli version check from plugin system

### DIFF
--- a/actor/pluginaction/install.go
+++ b/actor/pluginaction/install.go
@@ -6,8 +6,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/blang/semver/v4"
-
 	"code.cloudfoundry.org/cli/actor/actionerror"
 	"code.cloudfoundry.org/cli/api/plugin"
 	"code.cloudfoundry.org/cli/util/configv3"
@@ -88,10 +86,6 @@ func (actor Actor) GetAndValidatePlugin(pluginMetadata PluginMetadata, commandLi
 		return configv3.Plugin{}, actionerror.PluginInvalidError{Err: err}
 	}
 
-	cliVersion, err := semver.Make(actor.config.BinaryVersion())
-	if err != nil {
-		return configv3.Plugin{}, actionerror.PluginInvalidError{Err: err}
-	}
 	var pluginLibraryMajorVersion int
 	hasPluginLibraryVersion := plugin.LibraryVersion != configv3.PluginVersion{}
 	if !hasPluginLibraryVersion {
@@ -100,13 +94,8 @@ func (actor Actor) GetAndValidatePlugin(pluginMetadata PluginMetadata, commandLi
 		pluginLibraryMajorVersion = plugin.LibraryVersion.Major
 	}
 
-	switch cliVersion.Major {
-	case 6, 7, 8, 9:
-		if pluginLibraryMajorVersion > 1 {
-			return configv3.Plugin{}, actionerror.PluginInvalidLibraryVersionError{}
-		}
-	default:
-		panic("unrecognized major version")
+	if pluginLibraryMajorVersion > 1 {
+		return configv3.Plugin{}, actionerror.PluginInvalidLibraryVersionError{}
 	}
 
 	installedPlugins := actor.config.Plugins()


### PR DESCRIPTION
## Description of the Change

The code does not need to enumerate versions since the code being run is the code that either handles or does not handle the specified library version. 