### PR TITLE
Use docker hub for buildpack download[v8]

### DIFF
--- a/integration/v7/isolated/app_command_test.go
+++ b/integration/v7/isolated/app_command_test.go
@@ -413,13 +413,13 @@ applications:
 					BeforeEach(func() {
 						helpers.SkipIfVersionLessThan(ccversion.MinVersionCNB)
 						helpers.WithJSHelloWorld(func(appDir string) {
-							Eventually(helpers.CF("push", appName, "-p", appDir, "--lifecycle", "cnb", "-b", "docker://gcr.io/paketo-buildpacks/nodejs:latest")).Should(Exit())
+							Eventually(helpers.CF("push", appName, "-p", appDir, "--lifecycle", "cnb", "-b", "docker://docker.io/paketobuildpacks/nodejs:latest")).Should(Exit())
 						})
 					})
 
 					It("displays the app buildpacks", func() {
 						session := helpers.CF("app", appName)
-						Eventually(session).Should(Say(`paketo-buildpacks\/nodejs`))
+						Eventually(session).Should(Say(`paketobuildpacks\/nodejs`))
 						Eventually(session).Should(Exit(0))
 					})
 				})


### PR DESCRIPTION
The buildpack location has changed from gcr to dockerhub. This PR updates the failing tests