### PR TITLE
Use docker hub for buildpack download[main]

### DIFF
--- a/integration/v7/isolated/app_command_test.go
+++ b/integration/v7/isolated/app_command_test.go
@@ -411,13 +411,13 @@ applications:
 				When("the app is a CNB app", func() {
 					BeforeEach(func() {
 						helpers.WithJSHelloWorld(func(appDir string) {
-							Eventually(helpers.CF("push", appName, "-p", appDir, "--lifecycle", "cnb", "-b", "docker://gcr.io/paketo-buildpacks/nodejs:latest")).Should(Exit())
+							Eventually(helpers.CF("push", appName, "-p", appDir, "--lifecycle", "cnb", "-b", "docker://docker.io/paketobuildpacks/nodejs:latest")).Should(Exit())
 						})
 					})
 
 					It("displays the app buildpacks", func() {
 						session := helpers.CF("app", appName)
-						Eventually(session).Should(Say(`paketo-buildpacks\/nodejs`))
+						Eventually(session).Should(Say(`paketobuildpacks\/nodejs`))
 						Eventually(session).Should(Exit(0))
 					})
 				})


### PR DESCRIPTION
The buildpack location has changed from gcr to dockerhub. This PR updates the failing tests.