### PR TITLE
Add bundle version to test app [main]

### DIFF
--- a/integration/helpers/app.go
+++ b/integration/helpers/app.go
@@ -172,6 +172,9 @@ PLATFORMS
 DEPENDENCIES
   irb
   webrick
+	
+BUNDLED WITH
+   2.5.18
 `,
 	), 0666)
 	Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
With the new ruby buildpack, tests are failing due to bundle version not being available. This PR fixes the issue