### PR TITLE
Add bundle versionto test file [v8]

### DIFF
--- a/integration/assets/go_calls_ruby/Gemfile.lock
+++ b/integration/assets/go_calls_ruby/Gemfile.lock
@@ -8,3 +8,9 @@ PLATFORMS
 
 DEPENDENCIES
   webrick
+
+RUBY VERSION
+   ruby 3.3.1p55
+
+BUNDLED WITH
+   2.5.18

--- a/integration/helpers/app.go
+++ b/integration/helpers/app.go
@@ -172,6 +172,9 @@ PLATFORMS
 DEPENDENCIES
   irb
   webrick
+	
+BUNDLED WITH
+   2.5.18
 `,
 	), 0666)
 	Expect(err).ToNot(HaveOccurred())

--- a/integration/helpers/app.go
+++ b/integration/helpers/app.go
@@ -174,7 +174,7 @@ DEPENDENCIES
   webrick
 	
 BUNDLED WITH
-   2.5.18
+   2.6.6
 `,
 	), 0666)
 	Expect(err).ToNot(HaveOccurred())

--- a/integration/helpers/app.go
+++ b/integration/helpers/app.go
@@ -172,9 +172,12 @@ PLATFORMS
 DEPENDENCIES
   irb
   webrick
-	
+
+RUBY VERSION
+   ruby 3.3.1p55
+
 BUNDLED WITH
-   2.6.6
+   2.5.18
 `,
 	), 0666)
 	Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
With the new ruby buildpack, tests are failing due to bundle version not being available. This PR fixes the issue.