### PR TITLE
Update windows runner to v8

### DIFF
--- a/.github/workflows/release-build-sign-upload.yml
+++ b/.github/workflows/release-build-sign-upload.yml
@@ -615,7 +615,7 @@ jobs:
     name: Build Windows
     needs:
     - setup
-    runs-on: windows-2019
+    runs-on: windows-latest
     defaults:
       run:
         shell: pwsh

--- a/.github/workflows/release-update-repos.yml
+++ b/.github/workflows/release-update-repos.yml
@@ -468,7 +468,7 @@ jobs:
 
   update-windows:
     name: Update Windows Chocolatey Package
-    runs-on: windows-2019
+    runs-on: windows-latest
     defaults:
       run:
         shell: pwsh
@@ -537,7 +537,7 @@ jobs:
 
   test-windows:
     name: Test Windows Chocolatey Package
-    runs-on: windows-2019
+    runs-on: windows-latest
     defaults:
       run:
         shell: pwsh

--- a/.github/workflows/test-latest-releases.yml
+++ b/.github/workflows/test-latest-releases.yml
@@ -116,7 +116,7 @@ jobs:
 
   test-windows:
     name: Test Windows Chocolatey Package
-    runs-on: windows-2019
+    runs-on: windows-latest
     defaults:
       run:
         shell: pwsh

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -38,7 +38,6 @@ jobs:
           - macos-latest
           - macos-13
           - windows-latest
-          - windows-2019
     runs-on: ${{ matrix.os }}
     defaults:
       run:


### PR DESCRIPTION
Release workflow is failing windows-2019 runner being deprecated. This PR updates the runner image.