### PR TITLE
Support "trace" log level [v8]

### DIFF
--- a/util/configv3/env.go
+++ b/util/configv3/env.go
@@ -3,10 +3,10 @@ package configv3
 import (
 	"encoding/json"
 	"strconv"
-	"strings"
 	"time"
 
 	"code.cloudfoundry.org/cli/util/trace"
+	log "github.com/sirupsen/logrus"
 )
 
 // EnvOverride represents all the environment variables read by the CF CLI
@@ -115,17 +115,8 @@ func (config *Config) LogLevel() int {
 			return int(envVal)
 		}
 
-		switch strings.ToLower(config.ENV.CFLogLevel) {
-		case "fatal":
-			return 1
-		case "error":
-			return 2
-		case "warn":
-			return 3
-		case "info":
-			return 4
-		case "debug":
-			return 5
+		if level, err := log.ParseLevel(config.ENV.CFLogLevel); err == nil {
+			return int(level)
 		}
 	}
 

--- a/util/configv3/env_test.go
+++ b/util/configv3/env_test.go
@@ -96,6 +96,9 @@ var _ = Describe("Config", func() {
 		Entry("info returns 4", "info", 4),
 		Entry("debug returns 5", "debug", 5),
 		Entry("dEbUg returns 5", "dEbUg", 5),
+		Entry("trace returns 6", "trace", 6),
+		Entry("TrAcE returns 6", "TrAcE", 6),
+		Entry("invalid returns 0", "invalid", 0),
 	)
 
 	Describe("StagingTimeout", func() {


### PR DESCRIPTION
## Description of the Change

This PR allows to use the `trace` keyword to set a log level, as supported by the "logrus" library as seen here https://github.com/sirupsen/logrus/blob/d1e6332644483cfee14de11099f03645561d55f8/logrus.go#L111

The PR takes the approach of parsing log levels using a "logrus" library function instead of duplicating the code locally.

## Why Is This PR Valuable?

It allow to use `CF_LOGL_LEVEL=trace` when debugging, which is supported by the log library.
It would also open the door to the CLI code to use `log.Trace()` for an extra level of logs.
 
## Applicable Issues

Fixes #3525 

## How Urgent Is The Change?

Not urgent.
