### PR TITLE
Move to bosh lites from shepherd envs

### DIFF
--- a/.github/bosh-lite-files/bosh-lite-dns.tf
+++ b/.github/bosh-lite-files/bosh-lite-dns.tf
@@ -1,0 +1,11 @@
+variable "dns_zone_name" {}
+variable "system_domain_suffix" {}
+
+resource "google_dns_record_set" "default" {
+  name = "*.${var.env_id}.${var.system_domain_suffix}."
+  type = "A"
+  ttl = 300
+
+  managed_zone = var.dns_zone_name
+  rrdatas = [ google_compute_address.bosh-director-ip.address ]
+}

--- a/.github/bosh-lite-files/bosh-lite.tfvars
+++ b/.github/bosh-lite-files/bosh-lite.tfvars
@@ -1,0 +1,2 @@
+system_domain_suffix="app-runtime-interfaces.ci.cloudfoundry.org"
+dns_zone_name="app-runtime-interfaces"

--- a/.github/ops-files/bosh-lite-vm-type.yml
+++ b/.github/ops-files/bosh-lite-vm-type.yml
@@ -1,0 +1,11 @@
+---
+# Configure sizes for bosh-lite on gcp
+- type: replace
+  path: /resource_pools/name=vms/cloud_properties/machine_type
+  value: n2-standard-8
+- type: replace
+  path: /disk_pools/name=disks/disk_size
+  value: 250000
+- type: replace
+  path: /resource_pools/name=vms/cloud_properties/root_disk_size_gb
+  value: 32  

--- a/.github/ops-files/diego-cell-instances.yml
+++ b/.github/ops-files/diego-cell-instances.yml
@@ -2,7 +2,3 @@
 - type: replace
   path: /instance_groups/name=diego-cell/instances
   value: 4
-
-- type: replace
-  path: /instance_groups/name=isolated-diego-cell/jobs/name=rep/properties?/set_kernel_parameters
-  value: false

--- a/.github/ops-files/increase-route-registration-interval.yml
+++ b/.github/ops-files/increase-route-registration-interval.yml
@@ -1,0 +1,12 @@
+---
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=route_registrar/properties?/route_registrar/routes/name=uaa/registration_interval
+  value: 30s
+- type: replace
+  path: /instance_groups/name=api/jobs/name=route_registrar/properties?/route_registrar/routes/name=api/registration_interval
+  value: 30s
+- type: replace
+  path: /instance_groups/name=api/jobs/name=route_registrar/properties?/route_registrar/routes/name=policy-server/registration_interval
+  value: 30s
+- type: remove
+  path: /instance_groups/name=api/jobs/name=route_registrar/properties?/route_registrar/routes/name=api/health_check/timeout

--- a/.github/workflows/create-bosh-lite.yml
+++ b/.github/workflows/create-bosh-lite.yml
@@ -1,0 +1,177 @@
+name: Create environment
+on:
+  workflow_dispatch:
+  workflow_call:
+    outputs:
+      env-name: 
+        value: ${{ jobs.create-env.outputs.envName }}
+        description: "Name of the created environment"
+
+env:
+  BBL_IAAS: gcp
+  BBL_GCP_REGION: us-east1
+  BBL_GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_CREDENTIALS_JSON }}
+  BOSH_DEPLOYMENT: cf
+  BOSH_NON_INTERACTIVE: true
+  BBL_CLI_VERSION: ${{ vars.BBL_CLI_VERSION }}
+  BOSH_CLI_VERSION: ${{ vars.BOSH_CLI_VERSION }}
+  CREDHUB_CLI_VERSION: ${{ vars.CREDHUB_CLI_VERSION }}
+
+jobs:
+  create-env:
+    runs-on: ubuntu-latest
+    outputs:
+      envName: ${{steps.setup-bbl-env.outputs.envName}}
+    steps:      
+      - name: Install Tools
+        run: |
+          go version
+
+          install_location=/usr/local/bin
+
+          sudo curl https://github.com/cloudfoundry/bosh-bootloader/releases/download/v${BBL_CLI_VERSION}/bbl-v${BBL_CLI_VERSION}_linux_amd64 --silent --location --output  $install_location/bbl
+          sudo chmod +x $install_location/bbl
+          bbl --version
+  
+          sudo curl https://github.com/cloudfoundry/bosh-cli/releases/download/v${BOSH_CLI_VERSION}/bosh-cli-${BOSH_CLI_VERSION}-linux-amd64 --silent --output $install_location/bosh --location
+          sudo chmod +x $install_location/bosh
+          bosh --version
+  
+          sudo curl https://github.com/cloudfoundry/credhub-cli/releases/download/${CREDHUB_CLI_VERSION}/credhub-linux-amd64-${CREDHUB_CLI_VERSION}.tgz --silent --location --output /tmp/credhub.tgz
+          sudo tar -xzf /tmp/credhub.tgz -C $install_location  
+          sudo chmod +x $install_location/credhub
+          credhub --version
+
+          sudo apt update
+          sudo apt install -y build-essential unzip wamerican
+
+      - name: Checkout bosh-bootloader
+        uses: actions/checkout@v4
+        with:
+          repository: cloudfoundry/bosh-bootloader
+          path: bosh-bootloader
+
+      - name: Checkout cli
+        uses: actions/checkout@v4
+        with:
+          path: cli
+
+      - name: Setup bbl
+        id: setup-bbl-env
+        run: |
+          env_name="$(grep '^.\{1,4\}$' /usr/share/dict/words |
+          shuf -n1 |
+          tr -dc '[:alnum:]\n\r' |
+          tr '[:upper:]' '[:lower:]')"
+
+          if [ ! -z "${env_name}" ]; then
+            env_name=cli-${env_name}
+            mkdir -p $env_name/bbl-state
+          fi
+          echo "Bbl environment name: $env_name"
+          echo "envName=$env_name" >> $GITHUB_OUTPUT
+
+      - name: Create bbl env
+        run: |
+          env_name=${{ steps.setup-bbl-env.outputs.envName }}
+          cd $env_name/bbl-state
+
+          cp -R ${GITHUB_WORKSPACE}/bosh-bootloader/plan-patches/bosh-lite-gcp/* .
+          bbl plan --name $env_name
+          cp ${GITHUB_WORKSPACE}/cli/.github/bosh-lite-files/bosh-lite-dns.tf terraform/
+          cp ${GITHUB_WORKSPACE}/cli/.github/bosh-lite-files/bosh-lite.tfvars vars/
+          cp ${GITHUB_WORKSPACE}/cli/.github/ops-files/bosh-lite-vm-type.yml bosh-deployment/gcp/
+          bbl up
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS_JSON }}
+
+      - name: Setup gcloud CLI
+        uses: google-github-actions/setup-gcloud@v1
+
+      - name: Save bbl state
+        run: |
+          env_name=${{ steps.setup-bbl-env.outputs.envName }}
+          gsutil -m cp -R -P ./$env_name gs://cf-cli-bosh-lites/
+
+      - name: Checkout cf-deployment
+        uses: actions/checkout@v4
+        with:
+          repository: cloudfoundry/cf-deployment
+          ref: release-candidate
+          path: cf-deployment
+
+      - name: Checkout bosh-deployment
+        uses: actions/checkout@v4
+        with:
+          repository: cloudfoundry/bosh-deployment
+          path: bosh-deployment
+
+      - name: Upload latest CAPI release
+        if: ${{ (vars.USE_LATEST_CAPI == true) || (vars.CAPI_RELEASE_VERSION != '') }}
+        env:
+          capi_release_version: ${{ vars.CAPI_RELEASE_VERSION }}
+        run: |
+          if [ -z "$capi_release_version" ]; then
+            capi_release_version=$(curl -s https://api.github.com/repos/cloudfoundry/capi-release/releases/latest | jq -r .tag_name)
+          fi
+          
+          echo "Latest CAPI release is $capi_release_version"
+          
+          env_name="${{ steps.setup-bbl-env.outputs.envName }}"
+          cd $env_name/bbl-state
+          eval "$(bbl print-env)"
+          
+          jq -r .bosh.jumpbox_private_key metadata.json > /tmp/${env_name}.priv
+
+          bosh upload-release "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=$capi_release_version"          
+      - name: Deploy cf
+        run: |
+          env_name="${{ steps.setup-bbl-env.outputs.envName }}"
+          cd $env_name/bbl-state
+          eval "$(bbl print-env)"
+          bosh update-runtime-config ${GITHUB_WORKSPACE}/bosh-deployment/runtime-configs/dns.yml --name dns
+          STEMCELL_VERSION=$(bosh interpolate ${GITHUB_WORKSPACE}/cf-deployment/cf-deployment.yml --path /stemcells/alias=default/version)
+          bosh upload-stemcell "https://bosh.io/d/stemcells/bosh-warden-boshlite-ubuntu-jammy-go_agent?v=${STEMCELL_VERSION}"
+          bosh update-cloud-config ${GITHUB_WORKSPACE}/cf-deployment/iaas-support/bosh-lite/cloud-config.yml
+          SYSTEM_DOMAIN="$env_name.app-runtime-interfaces.ci.cloudfoundry.org"
+
+          additional_args=''
+          if [ -n "${{ vars.USE_LATEST_CAPI }}" ] || [ -n "${{ vars.CAPI_RELEASE_VERSION }}" ]; then
+            additional_args="-o ${GITHUB_WORKSPACE}/cli/.github/ops-files/use-latest-capi.yml"
+          fi
+
+          bosh interpolate ${GITHUB_WORKSPACE}/cf-deployment/cf-deployment.yml \
+          -o ${GITHUB_WORKSPACE}/cf-deployment/operations/bosh-lite.yml \
+          -o ${GITHUB_WORKSPACE}/cf-deployment/operations/use-compiled-releases.yml \
+          -o ${GITHUB_WORKSPACE}/cf-deployment/operations/enable-v2-api.yml \
+          -o ${GITHUB_WORKSPACE}/cf-deployment/operations/use-internal-lookup-for-route-services.yml \
+          -o ${GITHUB_WORKSPACE}/cli/.github/ops-files/diego-cell-instances.yml \
+          -o ${GITHUB_WORKSPACE}/cli/.github/ops-files/add-uaa-client-credentials.yml \
+          -o ${GITHUB_WORKSPACE}/cli/.github/ops-files/increase-route-registration-interval.yml \
+          -o ${GITHUB_WORKSPACE}/cli/.github/ops-files/add-oidc-provider.yml ${additional_args} \
+          -v client-secret="${{ secrets.CLIENT_SECRET }}" \
+          -v system_domain=${SYSTEM_DOMAIN} \
+          > ./director.yml
+
+          bosh deploy director.yml    
+
+      - name: delete bosh
+        if: failure()
+        run: |
+          env_name="${{ steps.setup-bbl-env.outputs.envName }}"
+          if [ -d ${env_name}/bbl_state ]; then
+            cd ${env_name}/bbl-state
+            eval "$(bbl print-env)"
+            
+            echo "Deleting env ${env_name}"
+            bbl down --no-confirm --gcp-service-account-key=key.json
+
+            echo "Deleting bbl state directory"
+            if gsutil ls gs://cf-cli-bosh-lites | grep -q /${env_name}/; then
+              gsutil rm -R gs://cf-cli-bosh-lites/${env_name} 
+            fi
+          fi
+          

--- a/.github/workflows/delete-bosh-lite.yml
+++ b/.github/workflows/delete-bosh-lite.yml
@@ -1,0 +1,82 @@
+name: Delete environment
+on:
+  workflow_dispatch:
+    inputs:
+      env-name:
+        description: Env name to delete
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      env-name:
+        required: true
+        type: string
+
+env:
+  BBL_IAAS: gcp
+  BBL_GCP_REGION: us-east1
+  BBL_GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_CREDENTIALS_JSON }}
+  BOSH_DEPLOYMENT: cf
+  BOSH_NON_INTERACTIVE: true
+  ENV_NAME: ${{ inputs.env-name }}
+
+jobs:
+  delete-env:
+    runs-on: ubuntu-latest
+    outputs:
+      envName: ${{steps.setup-bbl-env.outputs.env_name}}
+    steps:
+      - name: Install Tools
+        run: |
+          go version
+
+          install_location=/usr/local/bin
+          bbl_version=v9.0.35
+          bosh_cli_artifact=bosh-cli-7.7.2-linux-amd64
+          
+          sudo curl https://github.com/cloudfoundry/bosh-bootloader/releases/download/${bbl_version}/bbl-${bbl_version}_linux_amd64 --silent --location --output  $install_location/bbl
+          sudo chmod +x $install_location/bbl
+          bbl --version
+  
+          sudo curl https://github.com/cloudfoundry/bosh-cli/releases/download/v7.7.2/$bosh_cli_artifact --silent --output $install_location/bosh --location
+          sudo chmod +x $install_location/bosh
+          bosh --version
+  
+          sudo apt update
+          sudo apt install -y build-essential unzip wamerican
+
+      - name: Checkout cli
+        uses: actions/checkout@v4
+        with:
+          path: cli
+
+      - name: Checkout bosh-bootloader
+        uses: actions/checkout@v4
+        with:
+          repository: cloudfoundry/bosh-bootloader
+          path: bosh-bootloader
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS_JSON }}
+
+      - name: Setup gcloud CLI
+        uses: google-github-actions/setup-gcloud@v1
+
+      - name: Download file from GCS
+        run: |
+          gsutil -m cp -P -R gs://cf-cli-bosh-lites/${ENV_NAME} . 
+
+      - name: delete bosh
+        run: |
+          cd ${ENV_NAME}/bbl-state
+          eval "$(bbl print-env)"
+          
+          echo "Deleting env ${ENV_NAME}"
+          echo ${BBL_GCP_SERVICE_ACCOUNT_KEY} > key.json
+          bbl down --no-confirm --gcp-service-account-key=key.json
+        
+      - name: delete gcs bucket
+        run: |
+          gsutil rm -R gs://cf-cli-bosh-lites/${ENV_NAME} 

--- a/.github/workflows/tests-integration-reusable.yml
+++ b/.github/workflows/tests-integration-reusable.yml
@@ -1,64 +1,42 @@
-# GitHub repo level Secrets and Variables
-
-# secrets.CLIENT_SECRET
-# secrets.GITHUB_TOKEN
-# secrets.SHEPHERD_SERVICE_ACCOUNT_TOKEN
-# vars.TEST_FLAKE_ATTEMPTS
-
-name: "pvt: run integration tests"
+name: "REUSABLE: Integration Tests"
 
 on:
   workflow_call:
     inputs:
-      run-with-client-creds:
-        required: true
-        type: boolean
-      os:
-        required: true
-        type: string
       name:
         required: true
         type: string
-      lease-id:
+      env-name:
         required: true
         type: string
-      lease-namespace:
-        required: false
-        type: string
-        default: 'tas-devex'
       gitRef:
         type: string
         default: ${{github.event.workflow_run.head_sha}}
-      nodes:
-        type: string
-        default: "16"
+      run-with-client-creds:
+        required: true
+        type: boolean
 
 env:
-  NODES: ${{ inputs.nodes }}
+  ENV_NAME: ${{ inputs.env-name }}
+  NODES: 12
   FLAKE_ATTEMPTS: ${{ vars.TEST_FLAKE_ATTEMPTS || '4' }}
+  BBL_CLI_VERSION: ${{ vars.BBL_CLI_VERSION }}
+  BOSH_CLI_VERSION: ${{ vars.BOSH_CLI_VERSION }}
+  CREDHUB_CLI_VERSION: ${{ vars.CREDHUB_CLI_VERSION }}
 
 jobs:
   run-integration-tests:
     defaults:
       run:
         shell: bash
-    runs-on: ${{ inputs.os }}
-    container: us-west2-docker.pkg.dev/shepherd-268822/shepherd2/concourse-resource:latest
-    timeout-minutes: 120
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout cli
       uses: actions/checkout@v4
       with:
         ref: ${{inputs.gitRef}}
         fetch-depth: 0
-
-    - name: Checkout cf-acceptance-tests
-      if: ${{ inputs.name == 'cats' }}
-      uses: actions/checkout@v4
-      with:
-        repository: cloudfoundry/cf-acceptance-tests
-        ref: release-candidate
-        path: cf-acceptance-tests
+        path: cli
 
     - name: Checkout CF deployment tasks
       uses: actions/checkout@v4
@@ -69,152 +47,55 @@ jobs:
     - name: Set Up Go
       uses: actions/setup-go@v5
       with:
-        go-version-file: go.mod
+        go-version-file: cli/go.mod
         check-latest: true
 
     - name: Install Tools
-      env:
-        account_token:    ${{ secrets.SHEPHERD_SERVICE_ACCOUNT_TOKEN }}
-        lease_namespace:  ${{ inputs.lease-namespace }}
-        lease_id:         ${{ inputs.lease-id }}
       run: |
         go version
 
-        if [[ ${{ inputs.os }} =~ "windows" ]]
-        then
-          install_location=/usr/bin
-          bbl_artifact=bbl-v8.4.110_windows.exe
-          bosh_cli_artifact=bosh-cli-7.7.2-windows-amd64.exe
-          credhub_artifact=credhub-windows-2.9.4.tgz
-        else
-          install_location=/usr/local/bin
-          bbl_artifact=bbl-v8.4.110_linux_x86-64
-          bosh_cli_artifact=bosh-cli-7.7.2-linux-amd64
-          credhub_artifact=credhub-linux-2.9.4.tgz
-        fi
-        curl https://github.com/cloudfoundry/bosh-bootloader/releases/download/v8.4.110/${bbl_artifact} --silent --location --output  $install_location/bbl
-        chmod +x $install_location/bbl
+        install_location=/usr/local/bin
+
+        sudo curl https://github.com/cloudfoundry/bosh-bootloader/releases/download/v${BBL_CLI_VERSION}/bbl-v${BBL_CLI_VERSION}_linux_amd64 --silent --location --output  $install_location/bbl
+        sudo chmod +x $install_location/bbl
         bbl --version
 
-        curl https://github.com/cloudfoundry/bosh-cli/releases/download/v7.7.2/$bosh_cli_artifact --silent --output $install_location/bosh --location
-        chmod +x $install_location/bosh
+        sudo curl https://github.com/cloudfoundry/bosh-cli/releases/download/v${BOSH_CLI_VERSION}/bosh-cli-${BOSH_CLI_VERSION}-linux-amd64 --silent --output $install_location/bosh --location
+        sudo chmod +x $install_location/bosh
         bosh --version
 
-        curl https://github.com/cloudfoundry/credhub-cli/releases/download/2.9.4/$credhub_artifact --silent --output /tmp/$credhub_artifact --location
-        tar xzvf /tmp/$credhub_artifact
-        mv credhub $install_location/credhub
-        chmod +x $install_location/credhub
+        sudo curl https://github.com/cloudfoundry/credhub-cli/releases/download/${CREDHUB_CLI_VERSION}/credhub-linux-amd64-${CREDHUB_CLI_VERSION}.tgz --silent --location --output /tmp/credhub.tgz
+        sudo tar -xzf /tmp/credhub.tgz -C $install_location  
+        sudo chmod +x $install_location/credhub
         credhub --version
 
-        apt-get update
-        apt-get install -y build-essential unzip
+        sudo apt-get update
+        sudo apt-get install -y build-essential unzip
 
-        shepherd login service-account ${account_token}
-        shepherd get lease ${lease_id} --namespace ${lease_namespace} --json | jq .output > metadata.json
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@v2
+      with:
+        credentials_json: ${{ secrets.GCP_CREDENTIALS_JSON }}
 
-    - name: Add CATS config
-      if: ${{ inputs.name == 'cats' }}
+    - name: Setup gcloud CLI
+      uses: google-github-actions/setup-gcloud@v1
+
+    - name: Download file from GCS
       run: |
-        set -eu
-        env_name=$(jq -r .name metadata.json)
-        API="$(jq -r .cf.api_url metadata.json)"
-        DOMAIN=$(echo $API | sed "s/^api\.//")
-        CF_INT_USERNAME="admin"
-
-        jq -r .bosh.jumpbox_private_key metadata.json > /tmp/${env_name}.priv
-        eval "$(bbl print-env --metadata-file ./metadata.json)"
-
-        credhub login
-        CF_INT_PASSWORD=$(credhub get -n /bosh-lite/cf/cf_admin_password | bosh interpolate --path /value -)
-
-        cat << EOF | jq -S . > cats_config.json
-        {
-          "admin_password": "${CF_INT_PASSWORD}",
-          "admin_user": "${CF_INT_USERNAME}",
-          "api": "${API}",
-          "apps_domain": "${DOMAIN}",
-          "backend" : "diego",
-          "broker_start_timeout": 330,
-          "cf_push_timeout": 210,
-          "default_timeout": 120,
-          "long_curl_timeout": 210,
-          "skip_ssl_validation": true,
-          "use_http": true,
-          "include_apps": true,
-          "include_backend_compatibility": false,
-          "include_container_networking": true,
-          "include_deployments": true,
-          "include_detect": true,
-          "include_docker": true,
-          "include_cnb": true,
-          "include_internet_dependent": true,
-          "include_isolation_segments": true,
-          "isolation_segment_name": "persistent_isolation_segment",
-          "include_private_docker_registry": false,
-          "include_route_services": true,
-          "include_routing": true,
-          "include_routing_isolation_segments": false,
-          "include_security_groups": true,
-          "include_services": true,
-          "include_service_discovery": true,
-          "include_service_instance_sharing": true,
-          "include_ssh": true,
-          "include_sso": false,
-          "include_tasks": true,
-          "include_tcp_routing": true,
-          "include_v3": true,
-          "include_zipkin": true
-        }
-        EOF
-
-        make build
-        echo "$PWD/out" >> $GITHUB_PATH
-        export PATH="$PWD/out:$PATH"
-        cf version
-
-        export CF_USERNAME=${CF_INT_USERNAME}
-        export CF_PASSWORD=${CF_INT_PASSWORD}
-        cf api ${API} --skip-ssl-validation
-        cf auth
-        cf enable-feature-flag diego_docker
-        cf enable-feature-flag diego_cnb
-        cf enable-feature-flag service_instance_sharing
-
-    - name: Run CATS Tests
-      if: ${{ inputs.name == 'cats' }}
-      run: |
-        set -xeu
-
-        export CONFIG
-        CONFIG=$(mktemp)
-
-        original_config="${PWD}/cats_config.json"
-        cp ${original_config} ${CONFIG}
-
-        cd ./cf-acceptance-tests
-        export CF_DIAL_TIMEOUT=11
-        export CF_PLUGIN_HOME=$HOME
-        go version
-
-        ./bin/test \
-          --keep-going \
-          --randomize-all \
-          --skip-package=helpers \
-          --nodes="${NODES}" \
-          --flake-attempts=${FLAKE_ATTEMPTS} \
-          --timeout="2h" \
-          --no-color
+        gsutil -m cp -R -P gs://cf-cli-bosh-lites/${ENV_NAME} . 
 
     - name: Run Integration Tests
-      if: ${{ !inputs.run-with-client-creds  &&  inputs.name != 'cats' }}
+      if: ${{ !inputs.run-with-client-creds }}
       run: |
-        env_name=$(cat metadata.json | jq -r '.name')
-        jq -r .bosh.jumpbox_private_key metadata.json > /tmp/${env_name}.priv
-        eval "$(bbl print-env --metadata-file ./metadata.json)"
-        export CF_INT_PASSWORD="$(credhub get -n /bosh-lite/cf/cf_admin_password | bosh interpolate --path /value -)"
+        pushd ./${ENV_NAME}/bbl-state
+          eval "$(bbl print-env)"
+        popd
+
+        cd cli
+        export CF_INT_PASSWORD="$(credhub get -n /bosh-${ENV_NAME}/cf/cf_admin_password | bosh interpolate --path /value -)"
         export CF_INT_OIDC_USERNAME="admin-oidc"
-        export CF_INT_OIDC_PASSWORD=$(credhub get -n /bosh-lite/cf/uaa_oidc_admin_password | bosh interpolate --path /value -)
-        API_URL="$(jq -r .cf.api_url metadata.json)"
+        export CF_INT_OIDC_PASSWORD=$(credhub get -n /bosh-${ENV_NAME}/cf/uaa_oidc_admin_password | bosh interpolate --path /value -)
+        API_URL="api.${ENV_NAME}.app-runtime-interfaces.ci.cloudfoundry.org"
         export CF_INT_API="https://$API_URL"
         export CF_DIAL_TIMEOUT=15
         export CF_USERNAME=admin
@@ -222,10 +103,10 @@ jobs:
         export PATH="$GOPATH/bin:$PATH"
         export PATH="$PWD/out:$PATH"
         export CF_INT_TEST_NAME="int"
+        export CF_PASSWORD=${CF_INT_PASSWORD}
 
         make build
-
-        export CF_PASSWORD=${CF_INT_PASSWORD}
+          
         cf api ${CF_INT_API} --skip-ssl-validation
         cf auth
 
@@ -237,13 +118,15 @@ jobs:
         CF_INT_CLIENT_ID: 'potato-face'
         CF_INT_CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
       run: |
-        env_name=$(cat metadata.json | jq -r '.name')
-        jq -r .bosh.jumpbox_private_key metadata.json > /tmp/${env_name}.priv
-        eval "$(bbl print-env --metadata-file ./metadata.json)"
-        export CF_INT_PASSWORD="$(credhub get -n /bosh-lite/cf/cf_admin_password | bosh interpolate --path /value -)"
+        pushd ./${ENV_NAME}/bbl-state
+          eval "$(bbl print-env)"
+        popd
+
+        cd cli
+        export CF_INT_PASSWORD="$(credhub get -n /bosh-${ENV_NAME}/cf/cf_admin_password | bosh interpolate --path /value -)"
         export CF_INT_OIDC_USERNAME="admin-oidc"
-        export CF_INT_OIDC_PASSWORD=$(credhub get -n /bosh-lite/cf/uaa_oidc_admin_password | bosh interpolate --path /value -)
-        API_URL="$(jq -r .cf.api_url metadata.json)"
+        export CF_INT_OIDC_PASSWORD=$(credhub get -n /bosh-${ENV_NAME}/cf/uaa_oidc_admin_password | bosh interpolate --path /value -)
+        API_URL="api.${ENV_NAME}.app-runtime-interfaces.ci.cloudfoundry.org"
         export CF_INT_API="https://$API_URL"
         export CF_DIAL_TIMEOUT=15
         export CF_USERNAME=admin
@@ -251,10 +134,10 @@ jobs:
         export PATH="$GOPATH/bin:$PATH"
         export PATH="$PWD/out:$PATH"
         export CF_INT_TEST_NAME="cc"
+        export CF_PASSWORD=${CF_INT_PASSWORD}
 
         make build
 
-        export CF_PASSWORD=${CF_INT_PASSWORD}
         cf api ${CF_INT_API} --skip-ssl-validation
         cf auth
 

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -1,14 +1,3 @@
-# GitHub repo level Secrets and Variables
-
-# secrets.CLIENT_SECRET
-# secrets.SHEPHERD_SERVICE_ACCOUNT_TOKEN
-# vars.CAPI_RELEASE_VERSION
-# vars.SHEPHERD_LEASE_DURATION
-# vars.SHEPHERD_LEASE_NAMESPACE
-# vars.SHEPHERD_TEMPLATE_ARGUMENT
-# vars.SHEPHERD_TEMPLATE_NAME
-# vars.SHEPHERD_TEMPLATE_NAMESPACE
-
 name: "Tests: Integration"
 
 run-name: "Integration [${{ github.event_name }}: ${{ github.event.pull_request.head.sha || github.event.push.after || github.event.workflow_run.head_sha}}]: ${{ github.event.workflow_run.head_commit.message }}"
@@ -24,34 +13,10 @@ on:
           - all
           - run-integration-tests-cf-env
           - run-integration-tests-cf-env-with-client-creds
-          - run-cats-cf-env
-      nodes:
-        description: Number of test nodes
+      env-name:
+        description: Pre-provisioned environment name to use in tests
         required: false
         type: string
-        default: "12"
-      lease_id:
-        description: Pre-provisioned environment lease-id to use in tests
-        required: false
-        type: string
-      lease_namespace:
-        description: Pre-provisioned environment lease namespace to use in tests
-        required: false
-        type: string
-      cfd_version:
-        description: Use specific version of CFD. Leave empty to use latest.
-        default: ""
-        type: string
-      run_unit_tests:
-        description: Run unit tests
-        required: false
-        type: boolean
-        default: true
-      reinstall_cfd:
-        description: Force re-installation of CFD
-        required: false
-        type: boolean
-        default: true
 
   push:
     tags:
@@ -64,9 +29,6 @@ on:
       - "doc/**"
       - ".gitpod.yml"
       - "README.md"
-
-env:
-  SHEPHERD_LEASE_ID: ${{ inputs.lease_id }}
 
 jobs:
   get-sha:
@@ -94,269 +56,82 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        if: ${{ inputs.run_unit_tests }}
         with:
           ref: ${{needs.get-sha.outputs.gitRef}}
           fetch-depth: 0
       - name: Set Up Go
         uses: actions/setup-go@v5
-        if: ${{ inputs.run_unit_tests }}
         with:
           go-version-file: go.mod
           check-latest: true
       - name: Run Units
-        if: ${{ inputs.run_unit_tests }}
         run: make units
 
-  claim-env:
-    name: Claim and Prep Environment
-    outputs:
-      leaseid: ${{steps.claim.outputs.leaseid}}
-    defaults:
-      run:
-        shell: bash
-    runs-on: ubuntu-latest
-    container: us-west2-docker.pkg.dev/shepherd-268822/shepherd2/concourse-resource:latest
+  create-cf-env:
+    name: Create bosh lite env
     needs:
       - get-sha
       - units
+    if: ${{ inputs.env-name == '' }}
+    uses: ./.github/workflows/create-bosh-lite.yml
+    secrets: inherit
+
+  set-env-name:
+    name: Update env name
+    runs-on: ubuntu-latest
+    needs:
+      - get-sha
+      - units
+      - create-cf-env
+    outputs:
+      env-name: ${{ steps.set-name.outputs.env-name }}
+    if: always()
     steps:
-      - name: Checkout cli
-        uses: actions/checkout@v4
-        with:
-          ref: ${{needs.get-sha.outputs.gitRef}}
-
-      - name: Claim Environment
-        id: claim
-        env:
-          account_token:                ${{ secrets.SHEPHERD_SERVICE_ACCOUNT_TOKEN }}
-          template_argument:            ${{ vars.SHEPHERD_TEMPLATE_ARGUMENT        }}
-          template_name:                ${{ vars.SHEPHERD_TEMPLATE_NAME                || 'cfd-bosh-lite@2.0' }}
-          template_namespace:           ${{ vars.SHEPHERD_TEMPLATE_NAMESPACE           || 'official'          }}
-          lease_duration:               ${{ vars.SHEPHERD_LEASE_DURATION               || '8h'                }}
-          cfd_additional_opsfiles_b64:  ${{ vars.SHEPHERD_CFD_ADDITIONAL_OPSFILES_B64  || ''                  }}
-          bosh_additional_opsfiles_b64: ${{ vars.SHEPHERD_BOSH_ADDITIONAL_OPSFILES_B64 || ''                  }}
-          lease_namespace:              ${{ inputs.lease_namespace  || vars.SHEPHERD_LEASE_NAMESPACE || 'tas-devex' }}
-          cfd_version:                  ${{ inputs.cfd_version      || vars.CFD_VERSION              || '' }}
+      - name: set env name
+        id: set-name
         run: |
-          shepherd login service-account ${account_token}
-
-          if [[ -z $SHEPHERD_LEASE_ID ]]; then
-
-            if [ -z "$template_argument" ]; then
-              export template_argument=$(cat <<EOF
-          {
-            "gcp_region": "us-west2",
-            "vm_type": "n1-standard-8",
-            "root_disk_gb": 32,
-            "disk_pool_gb": 150,
-            "cfd_version": "${cfd_version}",
-            "cfd_additional_opsfiles_b64": "${cfd_additional_opsfiles_b64}",
-            "bosh_additional_opsfiles_b64": "${bosh_additional_opsfiles_b64}"
-          }
-          EOF
-              )
-            fi
-
-            lease_id=$( shepherd create lease                           \
-                          --template-argument  "$template_argument"     \
-                          --template-namespace "${template_namespace}"  \
-                          --template           "${template_name}"       \
-                          --namespace          "${lease_namespace}"     \
-                          --duration           "${lease_duration}"      \
-                          --description "Claimed by CF CLI workflow ${{ github.workflow_run.url }}" \
-                          --json \
-                        | jq -r .id
-                      )
+          if [[ -n "${{ inputs.env-name }}" ]]; then
+            echo "env-name=${{ inputs.env-name }}" >> $GITHUB_OUTPUT
           else
-            lease_id=$SHEPHERD_LEASE_ID
+            echo "env-name=${{ needs.create-cf-env.outputs.env-name }}" >> $GITHUB_OUTPUT
           fi
-
-          echo "Shepherd lease ID: ${lease_id}"
-
-          # Give sometime for the lease to complete. Shepherd may take upto an 3 hours to create an env
-          # if the pool is empty.
-          count=0
-          while [ $count -lt 360 ] ; do
-            sleep 30
-            status=$( shepherd get lease ${lease_id} \
-                        --namespace ${lease_namespace} \
-                        --json \
-                      | jq -r .status
-                    )
-            if [ $status == "LEASED" ] ; then
-              shepherd get lease ${lease_id} \
-                --namespace ${lease_namespace} \
-                --json \
-              | jq .output > metadata.json
-              break
-            elif [ $status == "FAILED" -o $status == "EXPIRED" ] ; then
-              echo "There was an error obtaining the lease. Lease status is ${status}."
-              exit 1
-            else
-              echo "Waiting for environment to be ready. Lease status is ${status}."
-            fi
-            count=$(($count+1))
-          done
-
-          env_name=$(jq -r .name metadata.json)
-          echo "env name is ${env_name}"
-          echo "leaseid=${lease_id}" >> "${GITHUB_OUTPUT}"
-
-          cf_deployment_version=$(jq -r '."cf_deployment_version"' metadata.json)
-          echo "cf_deployment_version is ${cf_deployment_version}"
-          echo "cf_deployment_version=${cf_deployment_version}" >> "${GITHUB_OUTPUT}"
-
-      - name: Set Up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-          check-latest: true
-        
-      - name: Install Tools
-        if: ${{ (inputs.lease_id == '') || (inputs.reinstall_cfd == true) }}
-        run: |
-          go version
-
-          install_location=/usr/local/bin
-          bbl_artifact=bbl-v8.4.110_linux_x86-64
-          bosh_cli_artifact=bosh-cli-7.7.2-linux-amd64
-          
-          curl https://github.com/cloudfoundry/bosh-bootloader/releases/download/v8.4.110/${bbl_artifact} --silent --location --output  $install_location/bbl
-          chmod +x $install_location/bbl
-          bbl --version
-  
-          curl https://github.com/cloudfoundry/bosh-cli/releases/download/v7.7.2/$bosh_cli_artifact --silent --output $install_location/bosh --location
-          chmod +x $install_location/bosh
-          bosh --version
-  
-          apt-get update
-          apt-get install -y build-essential unzip
-
-      - name: Upload latest CAPI release
-        if: ${{ (inputs.lease_id == '') || (inputs.reinstall_cfd == true) }}
-        env:
-          capi_release_version: ${{ vars.CAPI_RELEASE_VERSION }}
-        run: |
-          if [ -z "$capi_release_version" ]; then
-            capi_release_version=$(curl -s https://api.github.com/repos/cloudfoundry/capi-release/releases/latest | jq -r .tag_name)
-          fi
-          
-          echo "Latest CAPI release is $capi_release_version"
-          
-          eval "$(bbl print-env --metadata-file metadata.json)"
-          env_name=$(jq -r .name metadata.json)
-          jq -r .bosh.jumpbox_private_key metadata.json > /tmp/${env_name}.priv
-
-          bosh upload-release "https://bosh.io/d/github.com/cloudfoundry/capi-release?v=$capi_release_version"
-
-      - name: Checkout cf-deployment
-        if: ${{ (inputs.lease_id == '') || (inputs.reinstall_cfd == true) }}
-        uses: actions/checkout@v4
-        with:
-          repository: cloudfoundry/cf-deployment
-          path: cf-deployment
-          ref: ${{steps.claim.outputs.cf_deployment_version}}    
-  
-      - name: Checkout cf-deployment-main
-        if: ${{ (inputs.lease_id == '') || (inputs.reinstall_cfd == true) }}
-        uses: actions/checkout@v4
-        with:
-          repository: cloudfoundry/cf-deployment
-          path: cf-deployment-main
-          ref: main          
-
-      - name: Deploy Isolation Segment and OIDC Provider
-        if: ${{ (inputs.lease_id == '') || (inputs.reinstall_cfd == true) }}
-        run: |
-          env_name=$(jq -r .name metadata.json)
-          jq -r .bosh.jumpbox_private_key metadata.json > /tmp/${env_name}.priv
-          eval "$(bbl print-env --metadata-file metadata.json)"
-
-          bosh -d cf manifest > /tmp/manifest.yml
-          bosh interpolate /tmp/manifest.yml \
-            -o cf-deployment-main/operations/enable-v2-api.yml \
-            -o cf-deployment/operations/use-internal-lookup-for-route-services.yml \
-            -o cf-deployment/operations/add-persistent-isolation-segment-diego-cell.yml \
-            -o .github/ops-files/use-latest-capi.yml \
-            -o .github/ops-files/add-oidc-provider.yml \
-            -o .github/ops-files/add-uaa-client-credentials.yml \
-            -o .github/ops-files/diego-cell-instances.yml \
-            -v client-secret="${{ secrets.CLIENT_SECRET }}" \
-            > ./director.yml
-
-          bosh -d cf deploy director.yml -n
-          echo "Deployed CAPI version:"
-          bosh -d cf releases | grep capi
 
   run-integration-tests-cf-env:
     name: Integration tests
     needs:
       - get-sha
-      - units
-      - claim-env
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.workflow == 'all' || inputs.workflow == 'run-integration-tests-cf-env' }}
+      - set-env-name
+    if: ${{ always() && (inputs.workflow == 'all' || inputs.workflow == 'run-integration-tests-cf-env') }}
     uses: ./.github/workflows/tests-integration-reusable.yml
     with:
-      run-with-client-creds: false
-      os: ubuntu-latest
       name: Integration
       gitRef: ${{needs.get-sha.outputs.gitRef}}
-      lease-id: ${{ needs.claim-env.outputs.leaseid }}
-      lease-namespace: ${{ inputs.lease_namespace  || vars.SHEPHERD_LEASE_NAMESPACE || 'tas-devex' }}
-      nodes: ${{ inputs.nodes || '16' }}
+      env-name: ${{ needs.set-env-name.outputs.env-name }}
+      run-with-client-creds: false
     secrets: inherit
 
   run-integration-tests-cf-env-with-client-creds:
     name: Client credentials
     needs:
       - get-sha
-      - units
-      - claim-env
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.workflow == 'all' || inputs.workflow == 'run-integration-tests-cf-env-with-client-creds' }}
+      - set-env-name
+    if: ${{ always() && (inputs.workflow == 'all' || inputs.workflow == 'run-integration-tests-cf-env-with-client-creds') }}
     uses: ./.github/workflows/tests-integration-reusable.yml
     with:
-      run-with-client-creds: true
-      os: ubuntu-latest
       name: Integration client creds
+      env-name: ${{ needs.set-env-name.outputs.env-name }}
       gitRef: ${{needs.get-sha.outputs.gitRef}}
-      lease-id: ${{ needs.claim-env.outputs.leaseid }}
-      lease-namespace: ${{ inputs.lease_namespace  || vars.SHEPHERD_LEASE_NAMESPACE || 'tas-devex' }}
+      run-with-client-creds: true
     secrets: inherit
 
-  run-cats-cf-env:
-    name: CATS
+  delete-env:
+    name: Unclaim environment
+    if: ${{ always() && inputs.env-name == '' }}
     needs:
-      - get-sha
-      - claim-env
+      - set-env-name
       - run-integration-tests-cf-env
       - run-integration-tests-cf-env-with-client-creds
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.workflow == 'all' || inputs.workflow == 'run-cats-cf-env' }}
-    uses: ./.github/workflows/tests-integration-reusable.yml
+    uses: ./.github/workflows/delete-bosh-lite.yml
     with:
-      run-with-client-creds: false
-      os: ubuntu-latest
-      name: cats
-      gitRef: ${{needs.get-sha.outputs.gitRef}}
-      lease-id: ${{ needs.claim-env.outputs.leaseid }}
-      lease-namespace: ${{ inputs.lease_namespace  || vars.SHEPHERD_LEASE_NAMESPACE || 'tas-devex' }}
+      env-name: ${{ needs.set-env-name.outputs.env-name }}
     secrets: inherit
-
-  unclaim-env:
-    name: Unclaim environment
-    if: ${{ inputs.lease_id == '' }}
-    runs-on: ubuntu-latest
-    container: us-west2-docker.pkg.dev/shepherd-268822/shepherd2/concourse-resource:latest
-    needs:
-      - claim-env
-      - run-cats-cf-env
-    steps:
-      - name: unclaim
-        env:
-          account_token:    ${{ secrets.SHEPHERD_SERVICE_ACCOUNT_TOKEN }}
-          lease_namespace:  ${{ inputs.lease_namespace || vars.SHEPHERD_LEASE_NAMESPACE || 'tas-devex' }}
-        run: |
-          shepherd login service-account ${account_token}
-          set -x
-          shepherd delete lease ${{ needs.claim-env.outputs.leaseid }} \
-            --namespace ${lease_namespace}

--- a/integration/assets/go_calls_ruby/Gemfile
+++ b/integration/assets/go_calls_ruby/Gemfile
@@ -1,4 +1,1 @@
 source 'https://rubygems.org'
-ruby '~> 3.0'
-
-gem 'webrick'

--- a/integration/assets/go_calls_ruby/Gemfile.lock
+++ b/integration/assets/go_calls_ruby/Gemfile.lock
@@ -1,16 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    webrick (1.8.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  webrick
-
-RUBY VERSION
-   ruby 3.3.1p55
 
 BUNDLED WITH
-   2.5.18
+   2.5.20

--- a/integration/assets/go_calls_ruby/Godeps/Godeps.json
+++ b/integration/assets/go_calls_ruby/Godeps/Godeps.json
@@ -1,6 +1,0 @@
-{
-  "ImportPath": "github.com/cloudfoundry/cf-acceptance-tests/assets/go_calls_ruby",
-  "GoVersion": "go1.*",
-  "GodepVersion": "v79",
-  "Deps": []
-}

--- a/integration/assets/go_calls_ruby/Godeps/Readme
+++ b/integration/assets/go_calls_ruby/Godeps/Readme
@@ -1,5 +1,0 @@
-This directory tree is generated automatically by godep.
-
-Please do not edit.
-
-See https://github.com/tools/godep for more information.

--- a/integration/assets/go_calls_ruby/Procfile
+++ b/integration/assets/go_calls_ruby/Procfile
@@ -1,3 +1,0 @@
-web: ruby -run -e httpd . -p $PORT
-console: bundle exec irb
-rake: bundle exec rake

--- a/integration/assets/go_calls_ruby/go.mod
+++ b/integration/assets/go_calls_ruby/go.mod
@@ -1,0 +1,5 @@
+module github.com/cloudfoundry/cf-acceptance-tests/assets/go_calls_ruby
+
+go 1.23
+
+toolchain go1.23.7

--- a/integration/assets/go_calls_ruby/site.go
+++ b/integration/assets/go_calls_ruby/site.go
@@ -11,7 +11,12 @@ import (
 func main() {
 	http.HandleFunc("/", hello)
 	fmt.Println("listening...")
-	err := http.ListenAndServe(":"+os.Getenv("PORT"), nil)
+
+	server := &http.Server{
+		Addr:    fmt.Sprintf(":%s", os.Getenv("PORT")),
+		Handler: nil,
+	}
+	err := server.ListenAndServe()
 	if err != nil {
 		panic(err)
 	}
@@ -20,7 +25,6 @@ func main() {
 func hello(res http.ResponseWriter, req *http.Request) {
 	bundlerVersion, err := exec.Command("bundle", "--version").Output()
 	if err != nil {
-		res.WriteHeader(http.StatusInternalServerError)
 		log.Print("ERROR:", err)
 		fmt.Fprintf(res, "ERROR: %v\n", err)
 	} else {

--- a/integration/v7/isolated/app_command_test.go
+++ b/integration/v7/isolated/app_command_test.go
@@ -356,7 +356,7 @@ applications:
 			})
 
 			When("the app exists", func() {
-				When("isolation segments are available", func() {
+				XWhen("isolation segments are available", func() {
 					BeforeEach(func() {
 						Eventually(helpers.CF("create-isolation-segment", RealIsolationSegment)).Should(Exit(0))
 						Eventually(helpers.CF("enable-org-isolation", orgName, RealIsolationSegment)).Should(Exit(0))

--- a/integration/v7/isolated/restage_command_test.go
+++ b/integration/v7/isolated/restage_command_test.go
@@ -271,7 +271,7 @@ applications:
 					})
 				})
 
-				When("isolation segments are available", func() {
+				XWhen("isolation segments are available", func() {
 					BeforeEach(func() {
 						Eventually(helpers.CF("create-isolation-segment", RealIsolationSegment)).Should(Exit(0))
 						Eventually(helpers.CF("enable-org-isolation", orgName, RealIsolationSegment)).Should(Exit(0))


### PR DESCRIPTION
The integration tests used shepherd environments(broadcom hosted) to run. This PR is to create bosh lite environments hosted on CFF GCP. 

The PR adds

Workflows to create, delete bosh lite environments.
Modifies integration tests workflow to use these environments.

CATs job is removed from the integration test workflow. Will try and introduced separate workflow for them.