### PR TITLE
Run integration tests for PRs

### DIFF
--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -101,7 +101,7 @@ jobs:
     needs:
       - get-sha
       - set-env-name
-    if: ${{ always() && (inputs.workflow == 'all' || inputs.workflow == 'run-integration-tests-cf-env') }}
+    if: ${{ always() && (github.event_name != 'workflow_dispatch' || inputs.workflow == 'all' || inputs.workflow == 'run-integration-tests-cf-env') }}
     uses: ./.github/workflows/tests-integration-reusable.yml
     with:
       name: Integration
@@ -115,7 +115,7 @@ jobs:
     needs:
       - get-sha
       - set-env-name
-    if: ${{ always() && (inputs.workflow == 'all' || inputs.workflow == 'run-integration-tests-cf-env-with-client-creds') }}
+    if: ${{ always() && (github.event_name != 'workflow_dispatch' || inputs.workflow == 'all' || inputs.workflow == 'run-integration-tests-cf-env-with-client-creds') }}
     uses: ./.github/workflows/tests-integration-reusable.yml
     with:
       name: Integration client creds


### PR DESCRIPTION
Currently the integration test workflow runs for opened PRs, but the tests job is getting skipped. This PR fixes that.