### PR TITLE
Skip running int test workflow for dependabot PRs [v8]

### DIFF
--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -33,6 +33,7 @@ on:
 jobs:
   get-sha:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     outputs:
       gitRef: ${{steps.calculate.outputs.ref}}
     steps:
@@ -85,7 +86,7 @@ jobs:
       - create-cf-env
     outputs:
       env-name: ${{ steps.set-name.outputs.env-name }}
-    if: always()
+    if: ${{ always() && github.actor != 'dependabot[bot]' }}
     steps:
       - name: set env name
         id: set-name
@@ -101,7 +102,11 @@ jobs:
     needs:
       - get-sha
       - set-env-name
-    if: ${{ always() && (github.event_name != 'workflow_dispatch' || inputs.workflow == 'all' || inputs.workflow == 'run-integration-tests-cf-env') }}
+    if: >
+      ${{ always() && 
+      needs.set-env-name.result == 'success' && 
+      (github.event_name != 'workflow_dispatch' || inputs.workflow == 'all' || 
+       inputs.workflow == 'run-integration-tests-cf-env') }}
     uses: ./.github/workflows/tests-integration-reusable.yml
     with:
       name: Integration
@@ -115,7 +120,11 @@ jobs:
     needs:
       - get-sha
       - set-env-name
-    if: ${{ always() && (github.event_name != 'workflow_dispatch' || inputs.workflow == 'all' || inputs.workflow == 'run-integration-tests-cf-env-with-client-creds') }}
+    if: >
+      ${{ always() && 
+      needs.set-env-name.result == 'success' && 
+      (github.event_name != 'workflow_dispatch' || inputs.workflow == 'all' ||
+       inputs.workflow == 'run-integration-tests-cf-env-with-client-creds') }}
     uses: ./.github/workflows/tests-integration-reusable.yml
     with:
       name: Integration client creds
@@ -126,7 +135,7 @@ jobs:
 
   delete-env:
     name: Unclaim environment
-    if: ${{ always() && inputs.env-name == '' }}
+    if: ${{ always() && inputs.env-name == '' && needs.set-env-name.result == 'success' }}
     needs:
       - set-env-name
       - run-integration-tests-cf-env

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -33,7 +33,7 @@ on:
 jobs:
   get-sha:
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]'
+    if: ${{ github.actor != 'dependabot[bot]' }}
     outputs:
       gitRef: ${{steps.calculate.outputs.ref}}
     steps:


### PR DESCRIPTION
Integration test workflow takes a quite a bit of resources and time. There is no need for it to run for dependabot PRs. This PR disables them.