### PR TITLE
Improve int workflow failure handling

### DIFF
--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -102,8 +102,8 @@ jobs:
     needs:
       - get-sha
       - set-env-name
-    if: >
-      ${{ always() && 
+    if: ${{ 
+      always() && 
       needs.set-env-name.result == 'success' && 
       (github.event_name != 'workflow_dispatch' || inputs.workflow == 'all' || 
        inputs.workflow == 'run-integration-tests-cf-env') }}
@@ -120,8 +120,8 @@ jobs:
     needs:
       - get-sha
       - set-env-name
-    if: >
-      ${{ always() && 
+    if: ${{ 
+      always() && 
       needs.set-env-name.result == 'success' && 
       (github.event_name != 'workflow_dispatch' || inputs.workflow == 'all' ||
        inputs.workflow == 'run-integration-tests-cf-env-with-client-creds') }}


### PR DESCRIPTION
The if condition syntax is incorrect for int jobs. This PR fixes it.