### PR TITLE
Fix Missing GUID in CloudController Application Type ( V8)

### DIFF
--- a/api/cloudcontroller/ccv3/requester_test.go
+++ b/api/cloudcontroller/ccv3/requester_test.go
@@ -358,6 +358,7 @@ var _ = Describe("shared request helpers", func() {
 
 					expectedBody := map[string]interface{}{
 						"name": "some-app-name",
+						"guid": "some-app-guid",
 						"lifecycle": map[string]interface{}{
 							"type": "buildpack",
 							"data": map[string]interface{}{
@@ -489,6 +490,7 @@ var _ = Describe("shared request helpers", func() {
 
 				expectedBody := map[string]interface{}{
 					"name": "some-app-name",
+					"guid": "some-app-guid",
 					"lifecycle": map[string]interface{}{
 						"type": "buildpack",
 						"data": map[string]interface{}{

--- a/resources/application_resource.go
+++ b/resources/application_resource.go
@@ -40,6 +40,7 @@ type ApplicationNameOnly struct {
 // MarshalJSON converts an Application into a Cloud Controller Application.
 func (a Application) MarshalJSON() ([]byte, error) {
 	ccApp := ccApplication{
+		GUID:     a.GUID,
 		Name:     a.Name,
 		Metadata: a.Metadata,
 	}


### PR DESCRIPTION
## Description of the Change

- This PR ensures that the Application struct in resources/application.go correctly unmarshals the guid field from the Cloud Controller response JSON. Previously, although the GUID field was defined in the struct, it was not being populated in the UnmarshalJSON method.This caused the Application.GUID field to remain empty during deserialization, potentially impacting downstream logic that relies on application GUIDs for identification or operations.

- The fix adds a.GUID = ccApp.GUID in the custom UnmarshalJSON method to correctly populate the GUID.


## Why Is This PR Valuable?

- Fixes a subtle but critical bug where Application.GUID was always empty when unmarshalled.
- Enables reliable use of the GUID across CLI commands, plugins, and consumers of cfclient.
- Supports automation, scripting, and debugging workflows that depend on accessing the GUID field.



## Applicable Issues
No linked GitHub issue yet.

## How Urgent Is The Change?

Moderately urgent – this fix is important for correct behaviour, especially in automated or programmatic usage of the CF CLI. While not breaking existing commands, it silently fails to expose critical application metadata. One of my test case is failing as I leverage app GUID.

## Other Relevant Parties

- Developers and teams building CF CLI plugins
- Users scripting against CF CLI or relying on its JSON output
- Platform operators debugging apps using CLI tooling
