### PR TITLE
Add debian 13 to release test matrix[main]

### DIFF
--- a/.github/workflows/release-update-repos.yml
+++ b/.github/workflows/release-update-repos.yml
@@ -310,6 +310,7 @@ jobs:
         image:
         - debian:11
         - debian:12
+        - debian:13
         - ubuntu:22.04
         - ubuntu:latest
     runs-on: ubuntu-latest
@@ -335,8 +336,8 @@ jobs:
         apt update
         apt install -y wget gnupg
 
-        wget -q -O - ${CLAW_URL}/debian/cli.cloudfoundry.org.key | apt-key add -
-        echo "deb ${CLAW_URL}/debian stable main" | tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+        wget -q -O - ${CLAW_URL}/debian/cli.cloudfoundry.org.key | gpg --dearmor -o /usr/share/keyrings/cloudfoundry-keyring.gpg
+        echo "deb [signed-by=/usr/share/keyrings/cloudfoundry-keyring.gpg] ${CLAW_URL}/debian stable main" | tee /etc/apt/sources.list.d/cloudfoundry-cli.list
 
         apt update
         apt install -y cf${VERSION_MAJOR}-cli


### PR DESCRIPTION
This PR

Adds newly released Debian 13 to CLI's release test matrix.
Removes the usage of apt-key add which has been deprecated.