### PR TITLE
[main] Bump MacOS runner to macos-14 for unit tests

### DIFF
--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -36,7 +36,7 @@ jobs:
           - ubuntu-latest
           - ubuntu-22.04
           - macos-latest
-          - macos-13
+          - macos-14
           - windows-latest
     runs-on: ${{ matrix.os }}
     defaults:


### PR DESCRIPTION
## Description of the Change

Considering `macos-13` runners are going out of support (https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/) bump to `macos-14`.

Note we are using `macos-latest` already which will take care of testing against latest macos version.

## Why Is This PR Valuable?

Future proof test.

## Applicable Issues


## How Urgent Is The Change?

N/A

## Other Relevant Parties

N/A