### PR TITLE
Fix panic in "cf curl" command when response contains {{ or }}

### DIFF
--- a/command/v7/curl_command.go
+++ b/command/v7/curl_command.go
@@ -69,7 +69,7 @@ func (cmd CurlCommand) Execute(args []string) error {
 		}
 		cmd.UI.GetOut().Write(responseBodyBytes)
 	} else {
-		cmd.UI.DisplayText(string(bytesToWrite))
+		cmd.UI.DisplayTextLiteral(string(bytesToWrite))
 	}
 
 	return nil

--- a/command/v7/curl_command_test.go
+++ b/command/v7/curl_command_test.go
@@ -97,6 +97,17 @@ var _ = Describe("curl Command", func() {
 		Expect(testUI.Out).To(Say("sarah, teal, and reid were here"))
 	})
 
+	When("the request contains double curly braces", func() {
+		BeforeEach(func() {
+			fakeActor.MakeCurlRequestReturns([]byte("{{ }}"), &http.Response{}, nil)
+		})
+
+		It("returns the literal text", func() {
+			Expect(executeErr).NotTo(HaveOccurred())
+			Expect(testUI.Out).To(Say("{{ }}"))
+		})
+	})
+
 	When("the request errors", func() {
 		BeforeEach(func() {
 			fakeActor.MakeCurlRequestReturns([]byte{}, &http.Response{}, errors.New("this sucks"))


### PR DESCRIPTION
## Description of the Change

Fix "cf curl" command when response contains special characters, e.g. `{{` or `}}`.

## Why Is This PR Valuable?

Avoids "cf" panic.

## Applicable Issues

Fixes https://github.com/cloudfoundry/cli/issues/3594

Similar issue was fixed for "cf env" command:
https://github.com/cloudfoundry/cli/pull/3011 (v7)
https://github.com/cloudfoundry/cli/pull/3002 (v8)
https://github.com/cloudfoundry/cli/pull/3012 (main)

## How Urgent Is The Change?

Not super-urgent.

