### PR TITLE
Fix missing completion for 'SpaceSupporter'

### DIFF
--- a/command/flag/space_role.go
+++ b/command/flag/space_role.go
@@ -11,7 +11,7 @@ type SpaceRole struct {
 }
 
 func (SpaceRole) Complete(prefix string) []flags.Completion {
-	return completions([]string{"SpaceManager", "SpaceDeveloper", "SpaceAuditor"}, prefix, false)
+	return completions([]string{"SpaceManager", "SpaceDeveloper", "SpaceAuditor", "SpaceSupporter"}, prefix, false)
 }
 
 func (s *SpaceRole) UnmarshalFlag(val string) error {

--- a/command/flag/space_role_test.go
+++ b/command/flag/space_role_test.go
@@ -16,10 +16,10 @@ var _ = Describe("SpaceRole", func() {
 				completions := spaceRole.Complete(prefix)
 				Expect(completions).To(Equal(matches))
 			},
-			Entry("returns 'SpaceManager', 'SpaceDeveloper' and 'SpaceAuditor' when passed 'S'", "S",
-				[]flags.Completion{{Item: "SpaceManager"}, {Item: "SpaceDeveloper"}, {Item: "SpaceAuditor"}}),
-			Entry("returns 'SpaceManager', 'SpaceDeveloper' and 'SpaceAuditor' when passed 's'", "s",
-				[]flags.Completion{{Item: "SpaceManager"}, {Item: "SpaceDeveloper"}, {Item: "SpaceAuditor"}}),
+			Entry("returns 'SpaceManager', 'SpaceDeveloper', 'SpaceAuditor' and 'SpaceSupporter' when passed 'S'", "S",
+				[]flags.Completion{{Item: "SpaceManager"}, {Item: "SpaceDeveloper"}, {Item: "SpaceAuditor"}, {Item: "SpaceSupporter"}}),
+			Entry("returns 'SpaceManager', 'SpaceDeveloper', 'SpaceAuditor' and 'SpaceSupporter' when passed 's'", "s",
+				[]flags.Completion{{Item: "SpaceManager"}, {Item: "SpaceDeveloper"}, {Item: "SpaceAuditor"}, {Item: "SpaceSupporter"}}),
 			Entry("completes to 'SpaceAuditor' when passed 'Spacea'", "Spacea",
 				[]flags.Completion{{Item: "SpaceAuditor"}}),
 			Entry("completes to 'SpaceDeveloper' when passed 'Spaced'", "Spaced",
@@ -28,8 +28,10 @@ var _ = Describe("SpaceRole", func() {
 				[]flags.Completion{{Item: "SpaceManager"}}),
 			Entry("completes to 'SpaceManager' when passed 'spacEM'", "spacEM",
 				[]flags.Completion{{Item: "SpaceManager"}}),
-			Entry("returns 'SpaceManager', 'SpaceDeveloper' and 'SpaceAuditor' when passed nothing", "",
-				[]flags.Completion{{Item: "SpaceManager"}, {Item: "SpaceDeveloper"}, {Item: "SpaceAuditor"}}),
+			Entry("completes to 'SpaceSupporter' when passed 'Spaces'", "Spaces",
+				[]flags.Completion{{Item: "SpaceSupporter"}}),
+			Entry("returns 'SpaceManager', 'SpaceDeveloper', 'SpaceAuditor' and 'SpaceSupporter' when passed nothing", "",
+				[]flags.Completion{{Item: "SpaceManager"}, {Item: "SpaceDeveloper"}, {Item: "SpaceAuditor"}, {Item: "SpaceSupporter"}}),
 			Entry("completes to nothing when passed 'wut'", "wut",
 				[]flags.Completion{}),
 		)


### PR DESCRIPTION
## Description of the Change

Missing space-role "SpaceSupporter" in the completion choices.
This was forgotten in #2176

## Why Is This PR Valuable?

Helps the users that use shell completion for the `set-space-role` and `unset-space-role`.

## Applicable Issues

List any applicable GitHub Issues here

## How Urgent Is The Change?

Not urgent

## Manual testing ##

```
$ cat ~/cf.zsh
# zsh completion for Cloud Foundry CLI

_cf-cli() {
    # All arguments except the first one
    args=("${COMP_WORDS[@]:1:$COMP_CWORD}")
    # Only split on newlines
    local IFS=$'\n'
    # Call completion (note that the first element of COMP_WORDS is
    # the executable itself)
    COMPREPLY=($(GO_FLAGS_COMPLETION=1 ${COMP_WORDS[0]} "${args[@]}"))
    return 0
}
autoload -U +X bashcompinit && bashcompinit
complete -F _cf-cli cf

$ source ~/cf.zsh

$ out/cf set-space-role marc@example.com cli-org SP1 Space<TAB>
SpaceAuditor    SpaceDeveloper  SpaceManager    SpaceSupporter
```