### PR TITLE
Fix missing completion for AppType 'cnb'

### DIFF
--- a/command/flag/app_type.go
+++ b/command/flag/app_type.go
@@ -5,5 +5,5 @@ import flags "github.com/jessevdk/go-flags"
 type AppType string
 
 func (AppType) Complete(prefix string) []flags.Completion {
-	return completions([]string{"buildpack", "docker"}, prefix, false)
+	return completions([]string{"buildpack", "docker", "cnb"}, prefix, false)
 }

--- a/command/flag/app_type_test.go
+++ b/command/flag/app_type_test.go
@@ -19,14 +19,16 @@ var _ = Describe("AppType", func() {
 
 			Entry("completes to 'buildpack' when passed 'b'", "b",
 				[]flags.Completion{{Item: "buildpack"}}),
+			Entry("completes to 'cnb' when passed 'c'", "c",
+				[]flags.Completion{{Item: "cnb"}}),
 			Entry("completes to 'docker' when passed 'd'", "d",
 				[]flags.Completion{{Item: "docker"}}),
 			Entry("completes to 'buildpack' when passed 'bU'", "bU",
 				[]flags.Completion{{Item: "buildpack"}}),
 			Entry("completes to 'docker' when passed 'Do'", "Do",
 				[]flags.Completion{{Item: "docker"}}),
-			Entry("returns 'buildpack' and 'docker' when passed nothing", "",
-				[]flags.Completion{{Item: "buildpack"}, {Item: "docker"}}),
+			Entry("returns 'buildpack', 'cnb', and 'docker' when passed nothing", "",
+				[]flags.Completion{{Item: "buildpack"}, {Item: "docker"}, {Item: "cnb"}}),
 			Entry("completes to nothing when passed 'wut'", "wut",
 				[]flags.Completion{}),
 		)


### PR DESCRIPTION
## Description of the Change

Missing completion choice `cnb` for the AppType when creating an app.

## Why Is This PR Valuable?

Help the user know the possible choices for an AppType

## Applicable Issues

NA

## How Urgent Is The Change?

Not urgent

## Manual testing

```
$ cat ~/cf.zsh
# zsh completion for Cloud Foundry CLI

_cf-cli() {
    # All arguments except the first one
    args=("${COMP_WORDS[@]:1:$COMP_CWORD}")
    # Only split on newlines
    local IFS=$'\n'
    # Call completion (note that the first element of COMP_WORDS is
    # the executable itself)
    COMPREPLY=($(GO_FLAGS_COMPLETION=1 ${COMP_WORDS[0]} "${args[@]}"))
    return 0
}
autoload -U +X bashcompinit && bashcompinit
complete -F _cf-cli cf
$ source ~/cf.zsh

# Notice that `cnb` is now shown 
$ out/cf create-app myapp --app-type <TAB>
buildpack  cnb        docker
```