### PR TITLE
Make droplet's lifecycle information available

### DIFF
--- a/resources/droplet_resource.go
+++ b/resources/droplet_resource.go
@@ -44,9 +44,9 @@ type DropletBuildpack struct {
 }
 
 // An object describing the lifecycle that was used when staging the droplet
-// possible values for type: "buildpack", "cnd", "docker"
+// possible values for type: "buildpack", "cnb", "docker"
 type DropletLifecycle struct {
-	Type string `json:"name"`
+	Type string `json:"type"`
 }
 
 func (d Droplet) MarshallJSON() ([]byte, error) {


### PR DESCRIPTION
## Description of the Change

The PR makes the droplet's lifecycle information available as a property of the droplet object.

## Why Is This PR Valuable?

Within cf_exporter we want to specify different actions based on which droplet lifecycle is used. Therefore we need to make that information available. 

## Applicable Issues

-

## How Urgent Is The Change?

not urgent

## Other Relevant Parties

Who else is affected by the change? 
