### PR TITLE
[main] Command "services": Eliminate duplicate app names

### DIFF
--- a/actor/v7action/service_instance_list_test.go
+++ b/actor/v7action/service_instance_list_test.go
@@ -143,6 +143,8 @@ var _ = Describe("Service Instance List Action", func() {
 		fakeCloudControllerClient.GetServiceCredentialBindingsReturns(
 			[]resources.ServiceCredentialBinding{
 				{Type: "app", ServiceInstanceGUID: "fake-guid-1", AppGUID: "app-1", AppName: "great-app-1", AppSpaceGUID: spaceGUID},
+				// Duplicate binding for (app-1, fake-guid-1) pair to ensure app names are not duplicated
+				{Type: "app", ServiceInstanceGUID: "fake-guid-1", AppGUID: "app-1", AppName: "great-app-1", AppSpaceGUID: spaceGUID},
 				{Type: "app", ServiceInstanceGUID: "fake-guid-1", AppGUID: "app-2", AppName: "great-app-2", AppSpaceGUID: spaceGUID},
 				{Type: "app", ServiceInstanceGUID: "fake-guid-2", AppGUID: "app-3", AppName: "great-app-3", AppSpaceGUID: spaceGUID},
 				{Type: "app", ServiceInstanceGUID: "fake-guid-2", AppGUID: "app-4", AppName: "great-app-4", AppSpaceGUID: spaceGUID},


### PR DESCRIPTION
## Description of the Change

For the "services" command: In case of multiple service bindings per (service instance guid, app guid), eliminate duplicate app names in the "bound apps" section.

Without this PR, you may see repeated app names like in this example:
```
# cf services
Getting service instances in org testorg / space testspace as admin...

name                                 offering        plan              bound apps                                                last operation     broker   upgrade available
service1                             fake-service    fake-async-plan   testapp3, testapp1, testapp1                              create succeeded   sb1      no
service2                             fake-service    fake-async-plan   testapp1, testapp1                                        create succeeded   sb1      no
```

## Why Is This PR Valuable?

Eliminates redundant information in output.

## Applicable Issues

https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0040-service-binding-rotation.md#cf-cli

## How Urgent Is The Change?

Not super-urgent.

## Other Relevant Parties
