### PR TITLE
[v8] Optimize integration test execution to reduce infrastructure load related flakes

### DIFF
--- a/.github/workflows/tests-integration-reusable.yml
+++ b/.github/workflows/tests-integration-reusable.yml
@@ -18,7 +18,7 @@ on:
 
 env:
   ENV_NAME: ${{ inputs.env-name }}
-  NODES: 12
+  NODES: 4
   FLAKE_ATTEMPTS: ${{ vars.TEST_FLAKE_ATTEMPTS || '5' }}
   BBL_CLI_VERSION: ${{ vars.BBL_CLI_VERSION }}
   BOSH_CLI_VERSION: ${{ vars.BOSH_CLI_VERSION }}

--- a/Makefile
+++ b/Makefile
@@ -140,9 +140,13 @@ integration-full-tests: integration-tests-full
 integration-tests-full: build integration-cleanup integration-isolated integration-push integration-experimental integration-plugin integration-global integration-selfcontained ## Run all isolated, push, experimental, plugin, selfcontained, and global integration tests
 
 integration-tests-full-ci: install-test-deps integration-cleanup
-	$(ginkgo_int) -nodes $(NODES) \
-		integration/shared/isolated integration/v7/isolated integration/shared/plugin integration/shared/experimental integration/v7/experimental integration/v7/push
-	$(ginkgo_int) integration/shared/global integration/v7/global
+	$(ginkgo_int) -nodes $(NODES) -flake-attempts $(FLAKE_ATTEMPTS) \
+		integration/shared/isolated integration/v7/isolated
+	$(ginkgo_int) -nodes $(NODES) -flake-attempts $(FLAKE_ATTEMPTS) \
+		integration/shared/plugin integration/shared/experimental
+	$(ginkgo_int) -nodes $(NODES) -flake-attempts $(FLAKE_ATTEMPTS) \
+		integration/v7/experimental integration/v7/push
+	$(ginkgo_int) -flake-attempts $(FLAKE_ATTEMPTS) integration/shared/global integration/v7/global
 
 lint: format ## Runs all linters and formatters
 	@echo "Running linters..."


### PR DESCRIPTION
## Description of the Change

This PR optimizes the integration test execution in CI to reduce infrastructure load and improve test reliability. 

The main change splits the `integration-tests-full-ci` Makefile target into 3 sequential batches instead of running all 6 test suites together with high parallelism. Additionally, the number of parallel nodes is reduced from 12 to 4 in the GitHub Actions workflow.

Test suites are now grouped logically into batches that run sequentially with controlled parallelism to prevent infrastructure overload while maintaining reasonable test execution time.

## Why Is This PR Valuable?

This change addresses infrastructure load issues that cause test failures due to resource contention. By reducing concurrent load from 12 parallel nodes to 4 and spreading test execution over time through batching, the tests become significantly more stable and reliable on resource-constrained infrastructure.

Users running integration tests in CI environments with limited resources will benefit from more consistent test results and fewer infrastructure-related failures.

## Applicable Issues

List any applicable GitHub Issues here

## How Urgent Is The Change?

This change improves the reliability of integration tests in CI but is not time-sensitive.
