### PR TITLE
[main] Update Go version to 1.25.5 to address CVE-2025-61729

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module code.cloudfoundry.org/cli/v9
 
-go 1.25.4
+go 1.25.5
 
 require (
 	code.cloudfoundry.org/bytefmt v0.59.0


### PR DESCRIPTION
## Description of the Change

CVE-2025-61729 (GO-2025-4155) is a high-severity vulnerability affecting Go versions < 1.24.11 and 1.25.0-1.25.4. The vulnerability causes excessive resource consumption in printing error strings for host certificate validation.

This commit updates the Go version from 1.25.4 to 1.25.5, which includes the fix for this CVE.

Reference: https://nvd.nist.gov/vuln/detail/CVE-2025-61729

## Why Is This PR Valuable?

This PR addresses a security issue in TLS when incorrect / spoofed certificate is used. 

## Applicable Issues

[List any applicable GitHub Issues here](https://github.com/golang/go/issues/76445)

## How Urgent Is The Change?

Given the CVSS score of 7.5 (High), a fix is needed asap.

## Other Relevant Parties

None.

## Unit tests

A new version of the cli was built and units tests were run using "make units-full" successfully. A snip is below.

Ginkgo ran 118 suites in 3m37.197455854s
Test Suite Passed
