### PR TITLE
Small fixes (contribution docu, integration tests)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -33,11 +33,11 @@ After reaching out to the CLI team and the conclusion is to make a PR, please fo
    [Product Style Guide](https://github.com/cloudfoundry/cli/wiki/CLI-Product-Specific-Style-Guide),
    and [Internationalization Guide](https://github.com/cloudfoundry/cli/wiki/Internationalization-Guide).
 1. Fork the project repository.
-1. Create a feature branch from the earliest branch that's [appropriate for your change](#cli-versions) (e.g. `git checkout v7 && git checkout -b better_cli`) and make changes on this branch
+1. Create a feature branch from the earliest branch that's [appropriate for your change](#cli-versions) (e.g. `git checkout v8 && git checkout -b v8_better_cli`) and make changes on this branch
    * Follow the other sections on this page to [set up your development environment](#development-environment-setup), [build `cf`](#building-the-cf-binary) and [run the tests](#testing).
    * Tests are required for any changes.
-1. Push to your fork (e.g. `git push origin better_cli`) and [submit a pull request](https://help.github.com/articles/creating-a-pull-request)
-1. The cf CLI team will merge your changes from the versioned branch (e.g. v7) to master for you after the PR is merged.
+1. Push to your fork (e.g. `git push origin v8_better_cli`) and [submit a pull request](https://help.github.com/articles/creating-a-pull-request)
+1. The cf CLI team will merge your PR after review.
 
 Note: All contributions must be sent using GitHub Pull Requests.
 We prefer a small, focused pull request with a clear message
@@ -97,12 +97,9 @@ how to cross compile binaries for other architectures.
 To run the unit tests:
 ```bash
 cd cli
-make units-full # will run all unit tests
-make units # runs all non-cf directory unit tests
+make units
 ```
-
-**Note: `make units-full` is recommended over `make units` if you are unsure of
-how wide-reaching the intended changes are.**
+(For historic reasons, there are multiple synonyms in the `Makefile`.)
 
 ## Running the Integration tests
 

--- a/integration/v7/isolated/bind_service_command_test.go
+++ b/integration/v7/isolated/bind_service_command_test.go
@@ -132,7 +132,7 @@ var _ = Describe("bind-service command", func() {
 
 	When("the environment is not setup correctly", func() {
 		It("fails with the appropriate errors", func() {
-			helpers.CheckEnvironmentTargetedCorrectly(true, true, ReadOnlyOrg, "bind-service", "app-name", "service-name")
+			helpers.CheckEnvironmentTargetedCorrectly(true, true, ReadOnlyOrg, command, "app-name", "service-name")
 		})
 	})
 

--- a/integration/v7/isolated/unbind_service_command_test.go
+++ b/integration/v7/isolated/unbind_service_command_test.go
@@ -70,7 +70,7 @@ var _ = Describe("unbind-service command", func() {
 
 	When("the environment is not setup correctly", func() {
 		It("fails with the appropriate errors", func() {
-			helpers.CheckEnvironmentTargetedCorrectly(true, true, ReadOnlyOrg, "bind-service", "app-name", "service-name")
+			helpers.CheckEnvironmentTargetedCorrectly(true, true, ReadOnlyOrg, command, "app-name", "service-name")
 		})
 	})
 


### PR DESCRIPTION
## Description of the Change

* use "command" constant for env setup tests
* update branches in contribution guide
* remove "units-full" goal in testing guide (is same as "units" now)

## Why Is This PR Valuable?

Fixes a copy&paste error and updates docu.

## Applicable Issues

(none)

## How Urgent Is The Change?

Not super-urgent.
