### PR TITLE
[main] Fix Windows build relocation error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,16 +190,19 @@ out/cf-cli_osx_arm: $(GOSRC)
 	GOARCH=arm64 GOOS=darwin go build \
 				 -a -ldflags "$(LD_FLAGS)" -o out/cf-cli_osx_arm .
 
-out/cf-cli_win32.exe: $(GOSRC) rsrc.syso
+out/cf-cli_win32.exe: $(GOSRC) rsrc_windows_386.syso
 	GOARCH=386 GOOS=windows go build -tags="forceposix" -o out/cf-cli_win32.exe -ldflags "$(LD_FLAGS)" .
-	rm rsrc.syso
+	rm rsrc_windows_386.syso
 
-out/cf-cli_winx64.exe: $(GOSRC) rsrc.syso
+out/cf-cli_winx64.exe: $(GOSRC) rsrc_windows_amd64.syso
 	GOARCH=amd64 GOOS=windows go build -tags="forceposix" -o out/cf-cli_winx64.exe -ldflags "$(LD_FLAGS)" .
-	rm rsrc.syso
+	rm rsrc_windows_amd64.syso
 
-rsrc.syso:
-	rsrc -ico cf.ico -o rsrc.syso
+rsrc_windows_386.syso:
+	rsrc -arch 386 -ico cf.ico -o rsrc_windows_386.syso
+
+rsrc_windows_amd64.syso:
+	rsrc -arch amd64 -ico cf.ico -o rsrc_windows_amd64.syso
 
 test: units ## (synonym for units)
 


### PR DESCRIPTION
## Description of the Change

Generate architecture-specific rsrc syso files with explicit -arch flags to prevent GOARCH linking conflicts where an amd64 syso file gets linked into a 386 executable.

Before the change:
```
❯ make out/cf-cli_win32.exe
make out/cf-cli_winx64.exe
rsrc -ico cf.ico -o rsrc.syso
GOARCH=386 GOOS=windows go build -tags="forceposix" -o out/cf-cli_win32.exe -ldflags "-w -s -X code.cloudfoundry.org/cli/v8/version.binarySHA=$(git rev-parse --short HEAD) -X code.cloudfoundry.org/cli/v8/version.binaryBuildDate=$(date -u +"%Y-%m-%d") -X code.cloudfoundry.org/cli/v8/version.binaryVersion=$(git describe --tags --abbrev=0)" .
# code.cloudfoundry.org/cli/v8
$WORK/b001/_pkg_.a(rsrc.syso): 814043: unknown relocation type 3
make: *** [out/cf-cli_win32.exe] Error 1
GOARCH=amd64 GOOS=windows go build -tags="forceposix" -o out/cf-cli_winx64.exe -ldflags "-w -s -X code.cloudfoundry.org/cli/v8/version.binarySHA=$(git rev-parse --short HEAD) -X code.cloudfoundry.org/cli/v8/version.binaryBuildDate=$(date -u +"%Y-%m-%d") -X code.cloudfoundry.org/cli/v8/version.binaryVersion=$(git describe --tags --abbrev=0)" .
rm rsrc.syso
```

After the change:
```
❯ make out/cf-cli_win32.exe
make out/cf-cli_winx64.exe
rsrc -arch 386 -ico cf.ico -o rsrc_windows_386.syso
GOARCH=386 GOOS=windows go build -tags="forceposix" -o out/cf-cli_win32.exe -ldflags "-w -s -X code.cloudfoundry.org/cli/v8/version.binarySHA=$(git rev-parse --short HEAD) -X code.cloudfoundry.org/cli/v8/version.binaryBuildDate=$(date -u +"%Y-%m-%d") -X code.cloudfoundry.org/cli/v8/version.binaryVersion=$(git describe --tags --abbrev=0)" .
rm rsrc_windows_386.syso
rsrc -arch amd64 -ico cf.ico -o rsrc_windows_amd64.syso
GOARCH=amd64 GOOS=windows go build -tags="forceposix" -o out/cf-cli_winx64.exe -ldflags "-w -s -X code.cloudfoundry.org/cli/v8/version.binarySHA=$(git rev-parse --short HEAD) -X code.cloudfoundry.org/cli/v8/version.binaryBuildDate=$(date -u +"%Y-%m-%d") -X code.cloudfoundry.org/cli/v8/version.binaryVersion=$(git describe --tags --abbrev=0)" .
rm rsrc_windows_amd64.syso
```

## Why Is This PR Valuable?

Unblocks the release.

## Applicable Issues


## How Urgent Is The Change?

time-sensitive to unblock the release.

## Other Relevant Parties

