### PR TITLE
[v8] Remove useless new lines in help

### DIFF
--- a/command/v7/delete_orphaned_routes_command.go
+++ b/command/v7/delete_orphaned_routes_command.go
@@ -3,7 +3,7 @@ package v7
 type DeleteOrphanedRoutesCommand struct {
 	BaseCommand
 
-	usage           interface{} `usage:"CF_NAME delete-orphaned-routes [-f]\n"`
+	usage           interface{} `usage:"CF_NAME delete-orphaned-routes [-f]"`
 	Force           bool        `short:"f" description:"Force deletion without confirmation"`
 	relatedCommands interface{} `related_commands:"delete-route, routes"`
 }

--- a/command/v7/delete_service_broker_command.go
+++ b/command/v7/delete_service_broker_command.go
@@ -9,7 +9,7 @@ type DeleteServiceBrokerCommand struct {
 	BaseCommand
 
 	RequiredArgs    flag.ServiceBroker `positional-args:"yes"`
-	usage           interface{}        `usage:"CF_NAME delete-service-broker SERVICE_BROKER [-f]\n\n"`
+	usage           interface{}        `usage:"CF_NAME delete-service-broker SERVICE_BROKER [-f]"`
 	Force           bool               `short:"f" description:"Force deletion without confirmation"`
 	relatedCommands interface{}        `related_commands:"delete-service, purge-service-offering, service-brokers"`
 }

--- a/command/v7/update_buildpack_command.go
+++ b/command/v7/update_buildpack_command.go
@@ -7,7 +7,7 @@ import (
 	"code.cloudfoundry.org/cli/v8/actor/v7action"
 	"code.cloudfoundry.org/cli/v8/api/cloudcontroller/ccerror"
 	"code.cloudfoundry.org/cli/v8/api/cloudcontroller/ccv3"
-    "code.cloudfoundry.org/cli/v8/api/cloudcontroller/ccversion"
+	"code.cloudfoundry.org/cli/v8/api/cloudcontroller/ccversion"
 	"code.cloudfoundry.org/cli/v8/command"
 	"code.cloudfoundry.org/cli/v8/command/flag"
 	"code.cloudfoundry.org/cli/v8/command/translatableerror"
@@ -28,7 +28,7 @@ type UpdateBuildpackCommand struct {
 	BaseCommand
 
 	RequiredArgs    flag.BuildpackName               `positional-args:"Yes"`
-	usage           interface{}                      `usage:"CF_NAME update-buildpack BUILDPACK [-p PATH | -s STACK | --assign-stack NEW_STACK] [-i POSITION] [--rename NEW_NAME] [--enable|--disable] [--lock|--unlock]\n\nTIP:\nWhen using the 'buildpack' lifecycle type, Path should be a zip file, a url to a zip file, or a local directory. When using the 'cnb' lifecycle, Path should be a cnb file or gzipped oci image. Position is a positive integer, sets priority, and is sorted from lowest to highest.\n\nUse '--assign-stack' with caution. Associating a buildpack with a stack that it does not support may result in undefined behavior. Additionally, changing this association once made may require a local copy of the buildpack.\n\n"`
+	usage           interface{}                      `usage:"CF_NAME update-buildpack BUILDPACK [-p PATH | -s STACK | --assign-stack NEW_STACK] [-i POSITION] [--rename NEW_NAME] [--enable|--disable] [--lock|--unlock]\n\nTIP:\nWhen using the 'buildpack' lifecycle type, Path should be a zip file, a url to a zip file, or a local directory. When using the 'cnb' lifecycle, Path should be a cnb file or gzipped oci image. Position is a positive integer, sets priority, and is sorted from lowest to highest.\n\nUse '--assign-stack' with caution. Associating a buildpack with a stack that it does not support may result in undefined behavior. Additionally, changing this association once made may require a local copy of the buildpack."`
 	relatedCommands interface{}                      `related_commands:"buildpacks, create-buildpack, delete-buildpack"`
 	NewStack        string                           `long:"assign-stack" description:"Assign a stack to a buildpack that does not have a stack association"`
 	Disable         bool                             `long:"disable" description:"Disable the buildpack from being used for staging"`


### PR DESCRIPTION
## Description of the Change

Remove extra new lines from the usage to make the help and generated documentation more readable.

While at it replace a set of spaces with a tab for an import.

## Testing done 

Before the PR, notice the below 3 usage sections have extra empty lines:
```
$ ./out/cf delete-orphaned-routes -h
NAME:
   delete-orphaned-routes - Delete all orphaned routes in the currently targeted space (i.e. those that are not mapped to an app or service instance)

USAGE:
   cf delete-orphaned-routes [-f]


OPTIONS:
   -f      Force deletion without confirmation

SEE ALSO:
   delete-route, routes

$ ./out/cf delete-service-broker -h
NAME:
   delete-service-broker - Delete a service broker

USAGE:
   cf delete-service-broker SERVICE_BROKER [-f]



OPTIONS:
   -f      Force deletion without confirmation

SEE ALSO:
   delete-service, purge-service-offering, service-brokers

$ ./out/cf update-buildpack -h
NAME:
   update-buildpack - Update a buildpack

USAGE:
   cf update-buildpack BUILDPACK [-p PATH | -s STACK | --assign-stack NEW_STACK] [-i POSITION] [--rename NEW_NAME] [--enable|--disable] [--lock|--unlock]

TIP:
When using the 'buildpack' lifecycle type, Path should be a zip file, a url to a zip file, or a local directory. When using the 'cnb' lifecycle, Path should be a cnb file or gzipped oci image. Position is a positive integer, sets priority, and is sorted from lowest to highest.

Use '--assign-stack' with caution. Associating a buildpack with a stack that it does not support may result in undefined behavior. Additionally, changing this association once made may require a local copy of the buildpack.



OPTIONS:
   --assign-stack       Assign a stack to a buildpack that does not have a stack association
   --disable            Disable the buildpack from being used for staging
   --enable             Enable the buildpack to be used for staging
   --lock               Lock the buildpack to prevent updates
   --path, -p           Path to directory or zip file
   --position, -i       The order in which the buildpacks are checked during buildpack auto-detection
   --rename             Rename an existing buildpack
   --stack, -s          Specify stack to disambiguate buildpacks with the same name
   --lifecycle, -l      Specify lifecycle to disambiguate buildpacks with the same name
   --unlock             Unlock the buildpack to enable updates

SEE ALSO:
   buildpacks, create-buildpack, delete-buildpack
```
With the PR, notice the usage no longer has the extra empty lines:
```
$ ./out/cf delete-orphaned-routes -h
NAME:
   delete-orphaned-routes - Delete all orphaned routes in the currently targeted space (i.e. those that are not mapped to an app or service instance)

USAGE:
   cf delete-orphaned-routes [-f]

OPTIONS:
   -f      Force deletion without confirmation

SEE ALSO:
   delete-route, routes
$ ./out/cf delete-service-broker -h
NAME:
   delete-service-broker - Delete a service broker

USAGE:
   cf delete-service-broker SERVICE_BROKER [-f]

OPTIONS:
   -f      Force deletion without confirmation

SEE ALSO:
   delete-service, purge-service-offering, service-brokers
$ ./out/cf update-buildpack -h
NAME:
   update-buildpack - Update a buildpack

USAGE:
   cf update-buildpack BUILDPACK [-p PATH | -s STACK | --assign-stack NEW_STACK] [-i POSITION] [--rename NEW_NAME] [--enable|--disable] [--lock|--unlock]

TIP:
When using the 'buildpack' lifecycle type, Path should be a zip file, a url to a zip file, or a local directory. When using the 'cnb' lifecycle, Path should be a cnb file or gzipped oci image. Position is a positive integer, sets priority, and is sorted from lowest to highest.

Use '--assign-stack' with caution. Associating a buildpack with a stack that it does not support may result in undefined behavior. Additionally, changing this association once made may require a local copy of the buildpack.

OPTIONS:
   --assign-stack       Assign a stack to a buildpack that does not have a stack association
   --disable            Disable the buildpack from being used for staging
   --enable             Enable the buildpack to be used for staging
   --lock               Lock the buildpack to prevent updates
   --path, -p           Path to directory or zip file
   --position, -i       The order in which the buildpacks are checked during buildpack auto-detection
   --rename             Rename an existing buildpack
   --stack, -s          Specify stack to disambiguate buildpacks with the same name
   --lifecycle, -l      Specify lifecycle to disambiguate buildpacks with the same name
   --unlock             Unlock the buildpack to enable updates

SEE ALSO:
   buildpacks, create-buildpack, delete-buildpack
```