### PR TITLE
[Cherry-pick][main]Update Go version to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module code.cloudfoundry.org/cli/v9
 
-go 1.26.2
+go 1.26.4
 
 require (
 	code.cloudfoundry.org/bytefmt v0.76.0


### PR DESCRIPTION
## Description of the Change

Cherry-pick of #3775 
Update Go version to 1.26.4

## Why Is This PR Valuable?

Keep Go up to date for more security.
