### PR TITLE
[main] [Cherry-pick] Update bosh-lite stemcell to ubuntu-noble (#3779)

### DIFF
--- a/.github/workflows/create-bosh-lite.yml
+++ b/.github/workflows/create-bosh-lite.yml
@@ -133,7 +133,7 @@ jobs:
 
           bosh update-runtime-config ${GITHUB_WORKSPACE}/bosh-deployment/runtime-configs/dns.yml --name dns
           STEMCELL_VERSION=$(bosh interpolate ${GITHUB_WORKSPACE}/cf-deployment/cf-deployment.yml --path /stemcells/alias=default/version)
-          bosh upload-stemcell "https://bosh.io/d/stemcells/bosh-warden-boshlite-ubuntu-jammy-go_agent?v=${STEMCELL_VERSION}"
+          bosh upload-stemcell "https://bosh.io/d/stemcells/bosh-warden-boshlite-ubuntu-noble?v=${STEMCELL_VERSION}"
           bosh update-cloud-config ${GITHUB_WORKSPACE}/cf-deployment/iaas-support/bosh-lite/cloud-config.yml
           SYSTEM_DOMAIN="$env_name.app-runtime-interfaces.ci.cloudfoundry.org"
 


### PR DESCRIPTION
## Description of the Change

Update the bosh-lite stemcell to ubuntu-noble for integration test workflow

This PR is cherry-pick of https://github.com/cloudfoundry/cli/pull/3779

## Why Is This PR Valuable?


## Applicable Issues

List any applicable GitHub Issues here

## How Urgent Is The Change?

Fairly urgent as the integration tests are failing

## Other Relevant Parties

Who else is affected by the change? 
