### PR TITLE
[main] Fix CI client-creds integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,13 @@ integration-selfcontained: build install-test-deps
 
 integration-tests: build integration-cleanup integration-isolated integration-push integration-global integration-selfcontained ## Run all isolated, push, selfcontained, and global integration tests
 
-integration-tests-ci-client-creds: build integration-cleanup integration-push integration-global integration-selfcontained
+integration-tests-ci-client-creds: build install-test-deps integration-cleanup
+	$(ginkgo_int) -nodes $(NODES) -flake-attempts $(FLAKE_ATTEMPTS) \
+		integration/v7/push
+	$(ginkgo_int) -flake-attempts $(FLAKE_ATTEMPTS) \
+		integration/shared/global integration/v7/global
+	$(ginkgo_int) -nodes $(NODES) -flake-attempts $(FLAKE_ATTEMPTS) \
+		integration/v7/selfcontained
 
 i: integration-tests-full
 integration-full-tests: integration-tests-full

--- a/actor/versioncheck/minimum_version_check.go
+++ b/actor/versioncheck/minimum_version_check.go
@@ -8,6 +8,9 @@ func IsMinimumAPIVersionMet(current string, minimum string) (bool, error) {
 	if minimum == "" {
 		return true, nil
 	}
+	if current == "" {
+		return false, nil
+	}
 
 	currentSemver, err := semver.Make(current)
 	if err != nil {

--- a/actor/versioncheck/minimum_version_check_test.go
+++ b/actor/versioncheck/minimum_version_check_test.go
@@ -56,6 +56,17 @@ var _ = Describe("IsMinimumAPIVersionMet", func() {
 		})
 	})
 
+	Context("current version is empty", func() {
+		BeforeEach(func() {
+			currentVersion = ""
+		})
+
+		It("returns false with no errors", func() {
+			Expect(minAPIVersionMet).To(Equal(false))
+			Expect(executeErr).ToNot(HaveOccurred())
+		})
+	})
+
 	Context("current version is less than min", func() {
 		BeforeEach(func() {
 			currentVersion = "3.22.0"


### PR DESCRIPTION
## Description of the Change

Fixed the CI client-creds integration tests

- Added--flake-attempts to `integration-tests-ci-client-creds` to retry transient BOSH Lite staging failures
- Also fix a pre-existing regression in `IsMinimumAPIVersionMet`: when the current API version is empty (as in the selfcontained Kubernetes auth test, which sets up config manually without calling `cf api`),`semver.Make("")` was called and returned "Version string empty", causing`cf apps` to fail. Guard against empty `current` by returning false (minimum not met, use fallback path) instead of erroring. The test failure was introduced by #3726 (embedded process instances for `cf apps`summary), which added the `IsMinimumAPIVersionMet(actor.Config.APIVersion(), ...)` call but did not account for contexts where APIVersion is unset.

## Why Is This PR Valuable?
This helps to fix the CI checks.

## Applicable Issues

List any applicable GitHub Issues here

## How Urgent Is The Change?

Fairly urgent to fix the CI checks

## Other Relevant Parties

Who else is affected by the change? 
