### PR TITLE
[main][cherry-pick] Fix(ci): restrict integration tests to trusted contributors or safe-to-test label

### DIFF
--- a/.github/workflows/remove-safe-to-test-label.yml
+++ b/.github/workflows/remove-safe-to-test-label.yml
@@ -1,0 +1,21 @@
+name: Remove safe-to-test label on new commits
+
+on:
+  pull_request_target:
+    branches:
+      - main
+      - v8
+    types:
+      - synchronize
+
+jobs:
+  remove-label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: contains(github.event.pull_request.labels.*.name, 'safe-to-test')
+    steps:
+      - name: Remove safe-to-test label
+        run: gh pr edit "${{ github.event.pull_request.number }}" --remove-label "safe-to-test"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -25,6 +25,11 @@ on:
     branches:
       - main
       - v8
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
     paths-ignore:
       - "doc/**"
       - ".gitpod.yml"
@@ -34,7 +39,13 @@ jobs:
 
   get-sha:
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: |
+      ${{ github.actor != 'dependabot[bot]' && (
+        github.event.pull_request.author_association == 'OWNER' ||
+        github.event.pull_request.author_association == 'COLLABORATOR' ||
+        (github.event_name == 'labeled' &&
+         github.event.label.name == 'safe-to-test')
+      ) }}
     outputs:
       gitRef: ${{steps.calculate.outputs.ref}}
     steps:


### PR DESCRIPTION
## Description of the Change

This PR is cherry-pick of #3805 
This PR restricts integration tests to trusted contributors or safe-to-test label


## Why Is This PR Valuable?
This PR improves the security posture of the integration test CI workflow by ensuring only trusted contributors can trigger test runs against repository infrastructure. It also reduces maintainer overhead by automatically signaling(by removing the  safe-to-test label) when a PR needs re-approval after new commits are pushed.

## Applicable Issues

List any applicable GitHub Issues here

## How Urgent Is The Change?

Fairly urget

## Other Relevant Parties

Who else is affected by the change? 
