### PR TITLE
[v8][cherry-pick] Fix(ci): correct label gate condition to use event.action instead of event_name

### DIFF
--- a/.github/workflows/remove-safe-to-test-label.yml
+++ b/.github/workflows/remove-safe-to-test-label.yml
@@ -16,6 +16,6 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'safe-to-test')
     steps:
       - name: Remove safe-to-test label
-        run: gh pr edit "${{ github.event.pull_request.number }}" --remove-label "safe-to-test"
+        run: gh pr edit "${{ github.event.pull_request.number }}" --remove-label "safe-to-test" --repo "${{ github.repository }}"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -40,9 +40,11 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       ${{ github.actor != 'dependabot[bot]' && (
+        github.event_name == 'workflow_dispatch' ||
+        github.event_name == 'push' ||
         github.event.pull_request.author_association == 'OWNER' ||
         github.event.pull_request.author_association == 'COLLABORATOR' ||
-        (github.event_name == 'labeled' &&
+        (github.event.action == 'labeled' &&
          github.event.label.name == 'safe-to-test')
       ) }}
     outputs:
@@ -56,6 +58,9 @@ jobs:
           elif [[ "${{ github.event_name }}" == "push" ]]; then
             echo "checkout push request ${{github.event.push.after}}"
             echo "ref=${{github.event.push.after}}" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "checkout workflow_dispatch ref ${{ github.sha }}"
+            echo "ref=${{ github.sha }}" >> $GITHUB_OUTPUT
           else
             echo "checkout else ${{ github.event.workflow_run.head_sha }}"
             echo "ref=${{github.event.workflow_run.head_sha}}" >> $GITHUB_OUTPUT
@@ -97,7 +102,7 @@ jobs:
       - create-cf-env
     outputs:
       env-name: ${{ steps.set-name.outputs.env-name }}
-    if: ${{ always() && github.actor != 'dependabot[bot]' }}
+    if: ${{ always() && needs.get-sha.result == 'success' && github.actor != 'dependabot[bot]' }}
     steps:
       - name: set env name
         id: set-name


### PR DESCRIPTION
## Description of the Change

This PR is cherry-pick of #3809 

This PR fixes the label gate condition to use github.event.action instead of github.event_name.



## Why Is This PR Valuable?


## Applicable Issues

List any applicable GitHub Issues here

## How Urgent Is The Change?

Fairly urgent to fix CI

## Other Relevant Parties

Who else is affected by the change? 