### PR TITLE
[main] Fix(ci): allow checkout of gated PR head SHA under actions/checkout

### DIFF
--- a/.github/workflows/tests-integration-reusable.yml
+++ b/.github/workflows/tests-integration-reusable.yml
@@ -37,6 +37,10 @@ jobs:
         ref: ${{inputs.gitRef}}
         fetch-depth: 0
         path: cli
+        # gitRef is only ever populated by tests-integration.yml's get-sha
+        # job, which is gated on OWNER/COLLABORATOR authors or the
+        # safe-to-test label.
+        allow-unsafe-pr-checkout: true
 
     - name: Checkout CF deployment tasks
       uses: actions/checkout@v7

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -78,6 +78,10 @@ jobs:
         with:
           ref: ${{needs.get-sha.outputs.gitRef}}
           fetch-depth: 0
+          # get-sha only produces this ref for OWNER/COLLABORATOR authors or
+          # after a maintainer applies the safe-to-test label - see get-sha's
+          # if: condition above.
+          allow-unsafe-pr-checkout: true
       - name: Set Up Go
         uses: actions/setup-go@v6
         with:


### PR DESCRIPTION
## Description of the Change


This PR fixes CI for integration tests  by allowing checkout of gated PR head SHA under actions/checkout


## Why Is This PR Valuable?

Fixes CI

## Applicable Issues



## How Urgent Is The Change?

Fairly urgent to fix the CI

## Other Relevant Parties

Who else is affected by the change? 
