### PR TITLE
[main] feat(ci): label bosh-lite GCP resources for tracking

### DIFF
--- a/.github/bosh-lite-files/create-director-override.sh
+++ b/.github/bosh-lite-files/create-director-override.sh
@@ -11,6 +11,7 @@ bosh create-env \
  --var-file gcp_credentials_json="${BBL_GCP_SERVICE_ACCOUNT_KEY_PATH}" \
  -v project_id="${BBL_GCP_PROJECT_ID}" \
  -v zone="${BBL_GCP_ZONE}" \
+ -v env_name="${ENV_NAME}" \
  -o ${BBL_STATE_DIR}/bosh-deployment/gcp/cpi.yml \
  -o ${BBL_STATE_DIR}/bosh-deployment/jumpbox-user.yml \
  -o ${BBL_STATE_DIR}/bosh-deployment/uaa.yml \

--- a/.github/ops-files/bosh-lite-vm-type.yml
+++ b/.github/ops-files/bosh-lite-vm-type.yml
@@ -12,4 +12,13 @@
   value: 250000
 - type: replace
   path: /resource_pools/name=vms/cloud_properties/root_disk_size_gb
-  value: 32  
+  value: 32
+# Cost-tracking labels required by the CF infra owners. The google CPI applies
+# these as GCP labels on the director VM. env_name is supplied via -v by
+# create-director-override.sh. (The CPI has no equivalent for disks, so the
+# director's disks are labeled with gcloud in the create workflow instead.)
+- type: replace
+  path: /resource_pools/name=vms/cloud_properties/labels?
+  value:
+    belongs-to: cli
+    environment: ((env_name))

--- a/.github/workflows/create-bosh-lite.yml
+++ b/.github/workflows/create-bosh-lite.yml
@@ -74,6 +74,9 @@ jobs:
       - name: Create bbl env
         run: |
           env_name=${{ steps.setup-bbl-env.outputs.envName }}
+          # Exported so create-director-override.sh (invoked by `bbl up`) can pass
+          # it to `bosh create-env` as -v env_name for the VM cost-tracking labels.
+          export ENV_NAME="$env_name"
           cd $env_name/bbl-state
 
           cp -R ${GITHUB_WORKSPACE}/bosh-bootloader/plan-patches/bosh-lite-gcp/* .
@@ -96,6 +99,51 @@ jobs:
 
       - name: Setup gcloud CLI
         uses: google-github-actions/setup-gcloud@v3
+
+      - name: Label GCP resources for tracking
+        # Best-effort: never fail env creation over a labeling hiccup (that would
+        # trigger teardown of a good env). The director VM itself is labeled by the
+        # CPI (bosh-lite-vm-type.yml); here we cover the resource types the CPI
+        # can't. NOTE: GCP does not support labels on VPC networks, subnets or
+        # firewall rules, so those bbl-created resources cannot be labeled.
+        run: |
+          set -uo pipefail
+          env_name="${{ steps.setup-bbl-env.outputs.envName }}"
+          region="${BBL_GCP_REGION}"
+          labels="belongs-to=cli,environment=${env_name}"
+
+          # Static external IP(s): created by bbl's terraform, name-prefixed with
+          # the env id. Anchor with a trailing '-' so e.g. env "cli-ab" does not
+          # match "cli-abcd-...".
+          for name in $(gcloud compute addresses list --regions="${region}" \
+              --filter="name~^${env_name}-" --format="value(name)"); do
+            echo "Labeling address ${name}"
+            gcloud compute addresses update "${name}" --region="${region}" \
+              --update-labels="${labels}" \
+              || echo "::warning::failed to label address ${name}"
+          done
+
+          # Director disks: discover the director VM by the label the CPI applied,
+          # then label each attached (boot + persistent) disk.
+          gcloud compute instances list \
+            --filter="labels.environment=${env_name}" \
+            --format="csv[no-heading](name,zone.basename())" \
+          | while IFS=, read -r vm zone; do
+              [ -z "${vm}" ] && continue
+              disks="$(gcloud compute instances describe "${vm}" --zone="${zone}" \
+                --format='value(disks[].source)')"
+              old_ifs="${IFS}"; IFS=';'
+              for d in ${disks}; do
+                IFS="${old_ifs}"
+                disk_name="$(basename "${d}")"
+                echo "Labeling disk ${disk_name}"
+                gcloud compute disks update "${disk_name}" --zone="${zone}" \
+                  --update-labels="${labels}" \
+                  || echo "::warning::failed to label disk ${disk_name}"
+                IFS=';'
+              done
+              IFS="${old_ifs}"
+            done
 
       - name: Save bbl state
         run: |


### PR DESCRIPTION
## Description of the Change

This PR adds `belongs-to=cli` / `environment=<env>`  labels to the CF infra resources CI provisions on GCP for tracking


## Why Is This PR Valuable?

This PR helps to track the resource usage of cli.

## Applicable Issues


## How Urgent Is The Change?

Fairly urgent as there is ask to add the labels to infra resources by end of this month.

## Other Relevant Parties

Who else is affected by the change? 
