### PR TITLE
chore(test): extend regexp to verify results from UserFriendlyDate function

### DIFF
--- a/util/ui/ui_test.go
+++ b/util/ui/ui_test.go
@@ -451,7 +451,7 @@ var _ = Describe("UI", func() {
 
 	Describe("UserFriendlyDate", func() {
 		It("formats a time into an ISO8601 string", func() {
-			Expect(ui.UserFriendlyDate(time.Unix(0, 0))).To(MatchRegexp(`\w{3} [0-3]\d \w{3} [0-2]\d:[0-5]\d:[0-5]\d \w+ \d{4}`))
+			Expect(ui.UserFriendlyDate(time.Unix(0, 0))).To(MatchRegexp(`\w{3} [0-3]\d \w{3} [0-2]\d:[0-5]\d:[0-5]\d (\+|-)?\w+ \d{4}`))
 		})
 	})
 })


### PR DESCRIPTION
## Description of the Change


On local machine, unit test for `UserFriendlyDate` machine could have different locale and in turns, failing the expected regexp with additional "+" or "-" in the timezone offset.

This PR is to rectify such issue.

Before
<img width="853" height="246" alt="image" src="https://github.com/user-attachments/assets/8686b0d6-c71e-4e4c-893f-433675340718" />

After
<img width="858" height="55" alt="image" src="https://github.com/user-attachments/assets/f8587027-4d7a-430f-be29-2152da206a10" />

## Why Is This PR Valuable?


No changes to existing functionalities but to improve local developer experience.

## Applicable Issues


N/A

## How Urgent Is The Change?


No urgent

## Other Relevant Parties

Only developers from different locales/timezones
