### PR TITLE
chore: migrate away from deprecated io/ioutil imports

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -45,7 +45,7 @@ that conveys the intent of your change.
 
 # Development Environment Setup
 
-## Install Golang 1.18
+## Install Golang 1.26
 
 Documentation on installing GoLang can be found [here](https://golang.org/doc/install). While
 the CF CLI might be compatible with other versions of GoLang, this is the only

--- a/cf/actors/push.go
+++ b/cf/actors/push.go
@@ -2,14 +2,13 @@ package actors
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
 
-    "errors"
+	"errors"
 
-    "code.cloudfoundry.org/cli/v9/cf/api/applicationbits"
+	"code.cloudfoundry.org/cli/v9/cf/api/applicationbits"
 	"code.cloudfoundry.org/cli/v9/cf/api/resources"
 	"code.cloudfoundry.org/cli/v9/cf/appfiles"
 	. "code.cloudfoundry.org/cli/v9/cf/i18n"
@@ -84,7 +83,7 @@ func (actor PushActorImpl) ProcessPath(dirOrZipFile string, f func(string) error
 		return nil
 	}
 
-	tempDir, err := ioutil.TempDir("", "unzipped-app")
+	tempDir, err := os.MkdirTemp("", "unzipped-app")
 	if err != nil {
 		return err
 	}

--- a/cf/api/buildpack_bits.go
+++ b/cf/api/buildpack_bits.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	gonet "net"
 	"net/http"
@@ -52,7 +51,7 @@ func zipErrorHelper(err error) error {
 }
 
 func (repo CloudControllerBuildpackBitsRepository) CreateBuildpackZipFile(buildpackPath string) (*os.File, string, error) {
-	zipFileToUpload, err := ioutil.TempFile("", "buildpack-upload")
+	zipFileToUpload, err := os.CreateTemp("", "buildpack-upload")
 	if err != nil {
 		os.RemoveAll(zipFileToUpload.Name())
 		return nil, "", fmt.Errorf("%s: %s", T("Couldn't create temp file for upload"), err.Error())

--- a/cf/api/curl.go
+++ b/cf/api/curl.go
@@ -3,7 +3,7 @@ package api
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httputil"
 	"net/textproto"
@@ -64,7 +64,7 @@ func (repo CloudControllerCurlRepository) Request(method, path, headerString, bo
 	headerBytes, _ := httputil.DumpResponse(res, false)
 	resHeaders = string(headerBytes)
 
-	bytes, err := ioutil.ReadAll(res.Body)
+	bytes, err := io.ReadAll(res.Body)
 	if err != nil {
 		err = fmt.Errorf("%s: %s", T("Error reading response"), err.Error())
 	}

--- a/cf/appfiles/app_files.go
+++ b/cf/appfiles/app_files.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha1"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -212,7 +211,7 @@ func (appfiles ApplicationFiles) WalkAppFiles(dir string, onEachFile func(string
 }
 
 func loadIgnoreFile(dir string) CfIgnore {
-	fileContents, err := ioutil.ReadFile(filepath.Join(dir, ".cfignore"))
+	fileContents, err := os.ReadFile(filepath.Join(dir, ".cfignore"))
 	if err != nil {
 		return NewCfIgnore("")
 	}

--- a/cf/commands/application/push.go
+++ b/cf/commands/application/push.go
@@ -2,7 +2,6 @@ package application
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strconv"
@@ -818,7 +817,7 @@ func (cmd Push) ValidateContextAndAppParams(appsFromManifest []models.AppParams,
 }
 
 func (cmd *Push) uploadApp(appGUID, appDir, appDirOrZipFile string, localFiles []models.AppFileFields) error {
-	uploadDir, err := ioutil.TempDir("", "apps")
+	uploadDir, err := os.MkdirTemp("", "apps")
 	if err != nil {
 		return err
 	}
@@ -834,7 +833,7 @@ func (cmd *Push) uploadApp(appGUID, appDir, appDirOrZipFile string, localFiles [
 		return err
 	}
 
-	zipFile, err := ioutil.TempFile("", "uploads")
+	zipFile, err := os.CreateTemp("", "uploads")
 	if err != nil {
 		return err
 	}

--- a/cf/commands/curl.go
+++ b/cf/commands/curl.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -152,5 +151,5 @@ func (cmd Curl) writeToFile(responseBody, filePath string) (err error) {
 		return
 	}
 
-	return ioutil.WriteFile(filePath, []byte(responseBody), 0644)
+	return os.WriteFile(filePath, []byte(responseBody), 0644)
 }

--- a/cf/commands/pluginrepo/add_plugin_repo.go
+++ b/cf/commands/pluginrepo/add_plugin_repo.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -99,7 +99,7 @@ func (cmd *AddPluginRepo) Execute(c flags.FlagContext) error {
 		return errors.New(repoURL + T(" is not responding. Please make sure it is a valid plugin repo."))
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return errors.New(T("Error reading response from server: ") + err.Error())
 	}

--- a/cf/configuration/config_disk_persistor.go
+++ b/cf/configuration/config_disk_persistor.go
@@ -1,7 +1,6 @@
 package configuration
 
 import (
-	"io/ioutil"
 	"os"
 )
 
@@ -70,7 +69,7 @@ func (dp DiskPersistor) read(data DataInterface) error {
 		return err
 	}
 
-	jsonBytes, err := ioutil.ReadFile(dp.filePath)
+	jsonBytes, err := os.ReadFile(dp.filePath)
 	if err != nil {
 		return err
 	}
@@ -85,6 +84,6 @@ func (dp DiskPersistor) write(data DataInterface) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(dp.filePath, bytes, filePermissions)
+	err = os.WriteFile(dp.filePath, bytes, filePermissions)
 	return err
 }

--- a/cf/flagcontext/flag_content_helper.go
+++ b/cf/flagcontext/flag_content_helper.go
@@ -2,7 +2,7 @@ package flagcontext
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 )
 
@@ -18,7 +18,7 @@ func GetContentsFromOptionalFlagValue(input string) ([]byte, error) {
 	trimmedInput := strings.Trim(input, `"'`)
 	if strings.HasPrefix(trimmedInput, `@`) {
 		trimmedInput = strings.Trim(trimmedInput[1:], `"'`)
-		bs, err := ioutil.ReadFile(trimmedInput)
+		bs, err := os.ReadFile(trimmedInput)
 		if err != nil {
 			return []byte{}, err
 		}
@@ -26,7 +26,7 @@ func GetContentsFromOptionalFlagValue(input string) ([]byte, error) {
 		return bs, nil
 	}
 
-	bs, err := ioutil.ReadFile(trimmedInput)
+	bs, err := os.ReadFile(trimmedInput)
 	if err != nil {
 		return []byte(trimmedInput), nil
 	}

--- a/cf/manifest/manifest_disk_repository.go
+++ b/cf/manifest/manifest_disk_repository.go
@@ -3,7 +3,6 @@ package manifest
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -82,7 +81,7 @@ func (repo DiskRepository) readAllYAMLFiles(path string) (mergedMap generic.Map,
 }
 
 func parseManifest(file io.Reader) (yamlMap generic.Map, err error) {
-	manifest, err := ioutil.ReadAll(file)
+	manifest, err := io.ReadAll(file)
 	if err != nil {
 		return
 	}

--- a/cf/net/gateway.go
+++ b/cf/net/gateway.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -250,7 +249,7 @@ func (gateway Gateway) performRequestForResponseBytes(request *Request) ([]byte,
 	}
 	defer rawResponse.Body.Close()
 
-	bytes, err := ioutil.ReadAll(rawResponse.Body)
+	bytes, err := io.ReadAll(rawResponse.Body)
 	if err != nil {
 		return bytes, nil, rawResponse, fmt.Errorf("%s: %s", T("Error reading response"), err.Error())
 	}
@@ -267,7 +266,7 @@ func (gateway Gateway) PerformRequestForJSONResponse(request *Request, response 
 	bytes, headers, rawResponse, err := gateway.performRequestForResponseBytes(request)
 	if err != nil {
 		if rawResponse != nil && rawResponse.Body != nil {
-			b, _ := ioutil.ReadAll(rawResponse.Body)
+			b, _ := io.ReadAll(rawResponse.Body)
 			_ = json.Unmarshal(b, &response)
 		}
 		return headers, err
@@ -361,7 +360,7 @@ func (gateway Gateway) doRequestHandlingAuth(request *Request) (*http.Response, 
 	httpReq := request.HTTPReq
 
 	if request.SeekableBody != nil {
-		httpReq.Body = ioutil.NopCloser(request.SeekableBody)
+		httpReq.Body = io.NopCloser(request.SeekableBody)
 	}
 
 	if gateway.authenticator != nil {
@@ -390,8 +389,8 @@ func (gateway Gateway) doRequestAndHandlerError(request *Request) (*http.Respons
 
 	if rawResponse.StatusCode > 299 {
 		defer rawResponse.Body.Close()
-		jsonBytes, _ := ioutil.ReadAll(rawResponse.Body)
-		rawResponse.Body = ioutil.NopCloser(bytes.NewBuffer(jsonBytes))
+		jsonBytes, _ := io.ReadAll(rawResponse.Body)
+		rawResponse.Body = io.NopCloser(bytes.NewBuffer(jsonBytes))
 		err = gateway.errHandler(rawResponse.StatusCode, jsonBytes)
 	}
 

--- a/cf/net/request_dumper.go
+++ b/cf/net/request_dumper.go
@@ -2,7 +2,7 @@ package net
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -54,9 +54,9 @@ func (p RequestDumper) DumpRequest(req *http.Request) {
 		return
 	}
 
-	requestBody, err := ioutil.ReadAll(req.Body)
+	requestBody, err := io.ReadAll(req.Body)
 	req.Body.Close()
-	req.Body = ioutil.NopCloser(bytes.NewBuffer(requestBody))
+	req.Body = io.NopCloser(bytes.NewBuffer(requestBody))
 
 	if len(requestBody) == 0 {
 		return

--- a/cf/terminal/tee_printer.go
+++ b/cf/terminal/tee_printer.go
@@ -3,7 +3,6 @@ package terminal
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 )
 
 type TeePrinter struct {
@@ -14,14 +13,14 @@ type TeePrinter struct {
 
 func NewTeePrinter(w io.Writer) *TeePrinter {
 	return &TeePrinter{
-		outputBucket: ioutil.Discard,
+		outputBucket: io.Discard,
 		stdout:       w,
 	}
 }
 
 func (t *TeePrinter) SetOutputBucket(bucket io.Writer) {
 	if bucket == nil {
-		bucket = ioutil.Discard
+		bucket = io.Discard
 	}
 
 	t.outputBucket = bucket

--- a/cf/util/json/json_parser.go
+++ b/cf/util/json/json_parser.go
@@ -3,7 +3,7 @@ package json
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 )
 
@@ -64,7 +64,7 @@ func readJSONFile(path string) ([]byte, error) {
 		return nil, err
 	}
 
-	bytes, err := ioutil.ReadAll(file)
+	bytes, err := io.ReadAll(file)
 	if err != nil {
 		return nil, err
 	}

--- a/i18n/resources/i18n_resources.go
+++ b/i18n/resources/i18n_resources.go
@@ -19,7 +19,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -412,7 +411,7 @@ func RestoreAsset(dir, name string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(_filePath(dir, name), data, info.Mode())
+	err = os.WriteFile(_filePath(dir, name), data, info.Mode())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION

#### Note: Please create separate PR for every branch (main and v8) as needed.

## Description of the Change

Code refactoring to migrate `io/ioutil` imports to re-organized `io` and `os` modules.

## Why Is This PR Valuable?

What benefits will be realized by the code change? What users would want this change? What user need is this change addressing?

This will future-proof for any possible migration to next Go major version or in case where `ioutil` gets deprecated abruptly.

## Applicable Issues

List any applicable GitHub Issues here
N/A

## How Urgent Is The Change?

Is the change urgent? If so, explain why it is time-sensitive.
Not urgent

## Other Relevant Parties

Who else is affected by the change? 
N/A
