### PR TITLE
Add github workflow to keep golang up-to-date (v8)

### DIFF
--- a/.github/workflows/bump-golang.yml
+++ b/.github/workflows/bump-golang.yml
@@ -1,0 +1,34 @@
+name: Bump Go Version
+
+on:
+  schedule:
+    - cron: '0 0 * * 1'  # weekly
+  workflow_dispatch:
+
+jobs:
+  bump-go-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          path: v8
+
+      - name: Set up Go
+        id: setup-go
+        uses: actions/setup-go@v7
+        with:
+          go-version: stable
+
+      - name: Bump go directive in go.mod
+        run: go mod edit -go=${{ steps.setup-go.outputs.go-version }}
+
+      - name: Tidy dependencies
+        run: go mod tidy
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          title: "chore: bump Go version to ${{ steps.setup-go.outputs.go-version }}"
+          branch: bump-go-version-v8
+          body: "Automated PR to bump Go version to `${{ steps.setup-go.outputs.go-version }}` + go mod tidy"
+          base: v8


### PR DESCRIPTION
Thank you for contributing to the CF CLI! Please read the following:


* Please make sure you have implemented changes in line with the [contributing guidelines](https://github.com/cloudfoundry/cli/blob/main/.github/CONTRIBUTING.md)
* We're not allowed to accept any PRs without a signed CLA, no matter how small.
If your contribution falls under a company CLA but your membership is not public, expect delays while we confirm.
* All new code requires tests to protect against regressions.
* Contributions must be made against the appropriate branch. See the [contributing guidelines](https://github.com/cloudfoundry/cli/blob/main/.github/CONTRIBUTING.md)
* Contributions must conform to our [style guide](https://github.com/cloudfoundry/cli/wiki/CLI-Product-Specific-Style-Guide). Please reach out to us if you have questions.


#### Note: Please create separate PR for every branch (main and v8) as needed.

## Description of the Change

v8 version of https://github.com/cloudfoundry/cli/pull/3849

Keeps go version in go.mod up to date.

## Why Is This PR Valuable?

Regularly fixes golang specific CVEs.

## Applicable Issues

List any applicable GitHub Issues here

## How Urgent Is The Change?

Is the change urgent? If so, explain why it is time-sensitive.

## Other Relevant Parties

Who else is affected by the change? 
