### PR TITLE
Migrate github.com/SermoDigital to github.com/golang-jwt for 1.27.0 c…

### DIFF
--- a/actor/v7action/logging.go
+++ b/actor/v7action/logging.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/cli/v9/actor/sharedaction"
-	"github.com/SermoDigital/jose/jws"
+	utiljwt "code.cloudfoundry.org/cli/v9/util/jwt"
 )
 
 func (actor Actor) GetStreamingLogsForApplicationByNameAndSpace(appName string, spaceGUID string, client sharedaction.LogCacheClient) (<-chan sharedaction.LogMessage, <-chan error, context.CancelFunc, Warnings, error) {
@@ -92,17 +92,17 @@ func (actor Actor) refreshAccessTokenIfNecessary() (*time.Duration, error) {
 	}
 
 	accessToken = strings.TrimPrefix(accessToken, "bearer ")
-	token, err := jws.ParseJWT([]byte(accessToken))
+	claims, err := utiljwt.Parse(accessToken)
 	if err != nil {
 		return nil, err
 	}
 
 	var timeToRefresh time.Duration
-	expiration, ok := token.Claims().Expiration()
-	if !ok {
+	expiration, err := claims.GetExpirationTime()
+	if err != nil || expiration == nil {
 		return nil, errors.New("Failed to get an expiry time from the current access token")
 	}
-	expiresIn := time.Until(expiration)
+	expiresIn := time.Until(expiration.Time)
 	if expiresIn >= 2*time.Minute {
 		timeToRefresh = expiresIn - time.Minute
 	} else {
@@ -115,14 +115,14 @@ func (actor Actor) tokenExpiryTime(accessToken string) (*time.Duration, error) {
 	var expiresIn time.Duration
 
 	accessTokenString := strings.TrimPrefix(accessToken, "bearer ")
-	token, err := jws.ParseJWT([]byte(accessTokenString))
+	claims, err := utiljwt.Parse(accessTokenString)
 	if err != nil {
 		return nil, err
 	}
 
-	expiration, ok := token.Claims().Expiration()
-	if ok {
-		expiresIn = time.Until(expiration)
+	expiration, err := claims.GetExpirationTime()
+	if err == nil && expiration != nil {
+		expiresIn = time.Until(expiration.Time)
 	}
 	return &expiresIn, nil
 }

--- a/actor/v7action/logging.go
+++ b/actor/v7action/logging.go
@@ -92,7 +92,7 @@ func (actor Actor) refreshAccessTokenIfNecessary() (*time.Duration, error) {
 	}
 
 	accessToken = strings.TrimPrefix(accessToken, "bearer ")
-	claims, err := utiljwt.Parse(accessToken)
+	claims, err := utiljwt.ParseUnverified(accessToken)
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +115,7 @@ func (actor Actor) tokenExpiryTime(accessToken string) (*time.Duration, error) {
 	var expiresIn time.Duration
 
 	accessTokenString := strings.TrimPrefix(accessToken, "bearer ")
-	claims, err := utiljwt.Parse(accessTokenString)
+	claims, err := utiljwt.ParseUnverified(accessTokenString)
 	if err != nil {
 		return nil, err
 	}

--- a/actor/v7action/token.go
+++ b/actor/v7action/token.go
@@ -14,7 +14,7 @@ func (actor Actor) RefreshAccessToken() (string, error) {
 	refreshToken := actor.Config.RefreshToken()
 
 	accessTokenString := strings.TrimPrefix(actor.Config.AccessToken(), "bearer ")
-	claims, err := utiljwt.Parse(accessTokenString)
+	claims, err := utiljwt.ParseUnverified(accessTokenString)
 
 	if err == nil {
 		expiration, err := claims.GetExpirationTime()
@@ -39,5 +39,5 @@ func (actor Actor) RefreshAccessToken() (string, error) {
 
 func (actor Actor) ParseAccessToken(accessToken string) (jwtv5.MapClaims, error) {
 	tokenStr := strings.TrimPrefix(accessToken, "bearer ")
-	return utiljwt.Parse(tokenStr)
+	return utiljwt.ParseUnverified(tokenStr)
 }

--- a/actor/v7action/token.go
+++ b/actor/v7action/token.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/SermoDigital/jose/jws"
-	"github.com/SermoDigital/jose/jwt"
+	utiljwt "code.cloudfoundry.org/cli/v9/util/jwt"
+	jwtv5 "github.com/golang-jwt/jwt/v5"
 )
 
 func (actor Actor) RefreshAccessToken() (string, error) {
@@ -14,12 +14,12 @@ func (actor Actor) RefreshAccessToken() (string, error) {
 	refreshToken := actor.Config.RefreshToken()
 
 	accessTokenString := strings.TrimPrefix(actor.Config.AccessToken(), "bearer ")
-	token, err := jws.ParseJWT([]byte(accessTokenString))
+	claims, err := utiljwt.Parse(accessTokenString)
 
 	if err == nil {
-		expiration, ok := token.Claims().Expiration()
-		if ok {
-			expiresIn = time.Until(expiration)
+		expiration, err := claims.GetExpirationTime()
+		if err == nil && expiration != nil {
+			expiresIn = time.Until(expiration.Time)
 		}
 	}
 
@@ -37,7 +37,7 @@ func (actor Actor) RefreshAccessToken() (string, error) {
 	return actor.Config.AccessToken(), nil
 }
 
-func (actor Actor) ParseAccessToken(accessToken string) (jwt.JWT, error) {
+func (actor Actor) ParseAccessToken(accessToken string) (jwtv5.MapClaims, error) {
 	tokenStr := strings.TrimPrefix(accessToken, "bearer ")
-	return jws.ParseJWT([]byte(tokenStr))
+	return utiljwt.Parse(tokenStr)
 }

--- a/api/cloudcontroller/wrapper/uaa_authentication.go
+++ b/api/cloudcontroller/wrapper/uaa_authentication.go
@@ -81,7 +81,7 @@ func (t *UAAAuthentication) refreshTokenIfNecessary(accessToken string) error {
 	var expiresIn time.Duration
 
 	tokenStr := strings.TrimPrefix(accessToken, "bearer ")
-	claims, err := utiljwt.Parse(tokenStr)
+	claims, err := utiljwt.ParseUnverified(tokenStr)
 
 	if err == nil {
 		expiration, err := claims.GetExpirationTime()

--- a/api/cloudcontroller/wrapper/uaa_authentication.go
+++ b/api/cloudcontroller/wrapper/uaa_authentication.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/SermoDigital/jose/jws"
+	utiljwt "code.cloudfoundry.org/cli/v9/util/jwt"
 
 	"code.cloudfoundry.org/cli/v9/api/cloudcontroller"
 	"code.cloudfoundry.org/cli/v9/api/uaa"
@@ -81,12 +81,12 @@ func (t *UAAAuthentication) refreshTokenIfNecessary(accessToken string) error {
 	var expiresIn time.Duration
 
 	tokenStr := strings.TrimPrefix(accessToken, "bearer ")
-	token, err := jws.ParseJWT([]byte(tokenStr))
+	claims, err := utiljwt.Parse(tokenStr)
 
 	if err == nil {
-		expiration, ok := token.Claims().Expiration()
-		if ok {
-			expiresIn = time.Until(expiration)
+		expiration, err := claims.GetExpirationTime()
+		if err == nil && expiration != nil {
+			expiresIn = time.Until(expiration.Time)
 		}
 	}
 

--- a/api/cloudcontroller/wrapper/uaa_authentication_test.go
+++ b/api/cloudcontroller/wrapper/uaa_authentication_test.go
@@ -9,8 +9,7 @@ import (
 
 	"code.cloudfoundry.org/cli/v9/api/uaa"
 
-	"github.com/SermoDigital/jose/crypto"
-	"github.com/SermoDigital/jose/jws"
+	jwtv5 "github.com/golang-jwt/jwt/v5"
 
 	"code.cloudfoundry.org/cli/v9/api/cloudcontroller/ccerror"
 
@@ -225,9 +224,8 @@ var _ = Describe("UAA Authentication", func() {
 })
 
 func buildTokenString(expiration time.Time) (string, error) {
-	c := jws.Claims{}
-	c.SetExpiration(expiration)
-	token := jws.NewJWT(c, crypto.Unsecured)
-	tokenBytes, err := token.Serialize(nil)
-	return string(tokenBytes), err
+	claims := jwtv5.MapClaims{"exp": jwtv5.NewNumericDate(expiration)}
+	token := jwtv5.NewWithClaims(jwtv5.SigningMethodNone, claims)
+	tokenBytes, err := token.SignedString(jwtv5.UnsafeAllowNoneSignatureType)
+	return tokenBytes, err
 }

--- a/cf/api/authentication/authentication.go
+++ b/cf/api/authentication/authentication.go
@@ -189,7 +189,7 @@ func (uaa UAARepository) RefreshAuthToken() (string, error) {
 
 func (uaa UAARepository) RefreshToken(t string) (string, error) {
 	tokenStr := strings.TrimPrefix(t, "bearer ")
-	claims, err := utiljwt.Parse(tokenStr)
+	claims, err := utiljwt.ParseUnverified(tokenStr)
 	if err != nil {
 		return "", err
 	}

--- a/cf/api/authentication/authentication.go
+++ b/cf/api/authentication/authentication.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/SermoDigital/jose/jws"
+	utiljwt "code.cloudfoundry.org/cli/v9/util/jwt"
 
 	"code.cloudfoundry.org/cli/v9/cf/configuration/coreconfig"
 	"code.cloudfoundry.org/cli/v9/cf/errors"
@@ -189,12 +189,12 @@ func (uaa UAARepository) RefreshAuthToken() (string, error) {
 
 func (uaa UAARepository) RefreshToken(t string) (string, error) {
 	tokenStr := strings.TrimPrefix(t, "bearer ")
-	token, err := jws.ParseJWT([]byte(tokenStr))
+	claims, err := utiljwt.Parse(tokenStr)
 	if err != nil {
 		return "", err
 	}
-	expiration, ok := token.Claims().Expiration()
-	if ok && expiration.Sub(time.Now()) > accessTokenExpirationMargin {
+	expiration, err := claims.GetExpirationTime()
+	if err == nil && expiration != nil && expiration.Sub(time.Now()) > accessTokenExpirationMargin {
 		return t, nil
 	}
 

--- a/cf/util/testhelpers/configuration/access_token.go
+++ b/cf/util/testhelpers/configuration/access_token.go
@@ -6,8 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/SermoDigital/jose/crypto"
-	"github.com/SermoDigital/jose/jws"
+	jwtv5 "github.com/golang-jwt/jwt/v5"
 
 	"code.cloudfoundry.org/cli/v9/cf/configuration/coreconfig"
 )
@@ -24,9 +23,8 @@ func EncodeAccessToken(tokenInfo coreconfig.TokenInfo) (accessToken string, err 
 
 // BuildTokenString builds a minimal JWT with the given time as expiration claim.
 func BuildTokenString(expiration time.Time) string {
-	c := jws.Claims{}
-	c.SetExpiration(expiration)
-	token := jws.NewJWT(c, crypto.Unsecured)
-	tokenBytes, _ := token.Serialize(nil)
+	claims := jwtv5.MapClaims{"exp": jwtv5.NewNumericDate(expiration)}
+	token := jwtv5.NewWithClaims(jwtv5.SigningMethodNone, claims)
+	tokenBytes, _ := token.SignedString(jwtv5.UnsafeAllowNoneSignatureType)
 	return string(tokenBytes)
 }

--- a/command/v7/actor.go
+++ b/command/v7/actor.go
@@ -15,7 +15,7 @@ import (
 	"code.cloudfoundry.org/cli/v9/resources"
 	"code.cloudfoundry.org/cli/v9/types"
 	"code.cloudfoundry.org/cli/v9/util/configv3"
-	"github.com/SermoDigital/jose/jwt"
+	jwtv5 "github.com/golang-jwt/jwt/v5"
 )
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . Actor
@@ -197,7 +197,7 @@ type Actor interface {
 	MapRoute(routeGUID string, appGUID string, destinationProtocol string, destinationPort int) (v7action.Warnings, error)
 	Marketplace(filter v7action.MarketplaceFilter) ([]v7action.ServiceOfferingWithPlans, v7action.Warnings, error)
 	MoveRoute(routeGUID string, spaceGUID string) (v7action.Warnings, error)
-	ParseAccessToken(accessToken string) (jwt.JWT, error)
+	ParseAccessToken(accessToken string) (jwtv5.MapClaims, error)
 	PollBuild(buildGUID string, appName string) (resources.Droplet, v7action.Warnings, error)
 	PollPackage(pkg resources.Package) (resources.Package, v7action.Warnings, error)
 	PollStart(app resources.Application, noWait bool, handleProcessStats func(string)) (v7action.Warnings, error)

--- a/command/v7/oauth_token_command.go
+++ b/command/v7/oauth_token_command.go
@@ -26,8 +26,8 @@ func (cmd OauthTokenCommand) Execute(_ []string) error {
 			return errors.New(cmd.UI.TranslateText("Access token is invalid."))
 		}
 
-		expiration, success := token.Claims().Expiration()
-		if !success {
+		expiration, err := token.GetExpirationTime()
+		if err != nil || expiration == nil {
 			return errors.New(cmd.UI.TranslateText("Access token is missing expiration claim."))
 		}
 

--- a/command/v7/oauth_token_command_test.go
+++ b/command/v7/oauth_token_command_test.go
@@ -8,8 +8,7 @@ import (
 	. "code.cloudfoundry.org/cli/v9/command/v7"
 	"code.cloudfoundry.org/cli/v9/command/v7/v7fakes"
 	"code.cloudfoundry.org/cli/v9/util/ui"
-	"github.com/SermoDigital/jose/crypto"
-	"github.com/SermoDigital/jose/jws"
+	jwtv5 "github.com/golang-jwt/jwt/v5"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gbytes"
@@ -71,7 +70,7 @@ var _ = Describe("oauth-token command", func() {
 
 		When("the existing access token is invalid", func() {
 			BeforeEach(func() {
-				token := jws.NewJWT(jws.Claims{}, crypto.SigningMethodHS256)
+				token := jwtv5.MapClaims{}
 				fakeConfig.AccessTokenReturns("invalid-existing-access-token")
 				fakeActor.ParseAccessTokenReturns(token, errors.New("Access token is invalid"))
 			})
@@ -89,7 +88,7 @@ var _ = Describe("oauth-token command", func() {
 
 		When("the existing access token does not have an expiry time", func() {
 			BeforeEach(func() {
-				token := jws.NewJWT(jws.Claims{}, crypto.SigningMethodHS256)
+				token := jwtv5.MapClaims{}
 				fakeConfig.AccessTokenReturns("existing-access-token")
 				fakeActor.ParseAccessTokenReturns(token, nil)
 			})

--- a/command/v7/v7fakes/fake_actor.go
+++ b/command/v7/v7fakes/fake_actor.go
@@ -18,7 +18,7 @@ import (
 	"code.cloudfoundry.org/cli/v9/resources"
 	"code.cloudfoundry.org/cli/v9/types"
 	"code.cloudfoundry.org/cli/v9/util/configv3"
-	"github.com/SermoDigital/jose/jwt"
+	jwtv5 "github.com/golang-jwt/jwt/v5"
 )
 
 type FakeActor struct {
@@ -2701,17 +2701,17 @@ type FakeActor struct {
 		result1 v7action.Warnings
 		result2 error
 	}
-	ParseAccessTokenStub        func(string) (jwt.JWT, error)
+	ParseAccessTokenStub        func(string) (jwtv5.MapClaims, error)
 	parseAccessTokenMutex       sync.RWMutex
 	parseAccessTokenArgsForCall []struct {
 		arg1 string
 	}
 	parseAccessTokenReturns struct {
-		result1 jwt.JWT
+		result1 jwtv5.MapClaims
 		result2 error
 	}
 	parseAccessTokenReturnsOnCall map[int]struct {
-		result1 jwt.JWT
+		result1 jwtv5.MapClaims
 		result2 error
 	}
 	PollBuildStub        func(string, string) (resources.Droplet, v7action.Warnings, error)
@@ -15519,7 +15519,7 @@ func (fake *FakeActor) MoveRouteReturnsOnCall(i int, result1 v7action.Warnings, 
 	}{result1, result2}
 }
 
-func (fake *FakeActor) ParseAccessToken(arg1 string) (jwt.JWT, error) {
+func (fake *FakeActor) ParseAccessToken(arg1 string) (jwtv5.MapClaims, error) {
 	fake.parseAccessTokenMutex.Lock()
 	ret, specificReturn := fake.parseAccessTokenReturnsOnCall[len(fake.parseAccessTokenArgsForCall)]
 	fake.parseAccessTokenArgsForCall = append(fake.parseAccessTokenArgsForCall, struct {
@@ -15544,7 +15544,7 @@ func (fake *FakeActor) ParseAccessTokenCallCount() int {
 	return len(fake.parseAccessTokenArgsForCall)
 }
 
-func (fake *FakeActor) ParseAccessTokenCalls(stub func(string) (jwt.JWT, error)) {
+func (fake *FakeActor) ParseAccessTokenCalls(stub func(string) (jwtv5.MapClaims, error)) {
 	fake.parseAccessTokenMutex.Lock()
 	defer fake.parseAccessTokenMutex.Unlock()
 	fake.ParseAccessTokenStub = stub
@@ -15557,28 +15557,28 @@ func (fake *FakeActor) ParseAccessTokenArgsForCall(i int) string {
 	return argsForCall.arg1
 }
 
-func (fake *FakeActor) ParseAccessTokenReturns(result1 jwt.JWT, result2 error) {
+func (fake *FakeActor) ParseAccessTokenReturns(result1 jwtv5.MapClaims, result2 error) {
 	fake.parseAccessTokenMutex.Lock()
 	defer fake.parseAccessTokenMutex.Unlock()
 	fake.ParseAccessTokenStub = nil
 	fake.parseAccessTokenReturns = struct {
-		result1 jwt.JWT
+		result1 jwtv5.MapClaims
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeActor) ParseAccessTokenReturnsOnCall(i int, result1 jwt.JWT, result2 error) {
+func (fake *FakeActor) ParseAccessTokenReturnsOnCall(i int, result1 jwtv5.MapClaims, result2 error) {
 	fake.parseAccessTokenMutex.Lock()
 	defer fake.parseAccessTokenMutex.Unlock()
 	fake.ParseAccessTokenStub = nil
 	if fake.parseAccessTokenReturnsOnCall == nil {
 		fake.parseAccessTokenReturnsOnCall = make(map[int]struct {
-			result1 jwt.JWT
+			result1 jwtv5.MapClaims
 			result2 error
 		})
 	}
 	fake.parseAccessTokenReturnsOnCall[i] = struct {
-		result1 jwt.JWT
+		result1 jwtv5.MapClaims
 		result2 error
 	}{result1, result2}
 }

--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
+	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20260802141513-ef3492d7dac3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,8 @@ github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1v
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=
 github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/integration/helpers/token.go
+++ b/integration/helpers/token.go
@@ -26,7 +26,7 @@ func BuildTokenString(expiration time.Time) string {
 // ParseTokenString takes a string typed token and returns a jwt.JWT struct representation of that token
 func ParseTokenString(token string) jwtv5.MapClaims {
 	strippedToken := strings.TrimPrefix(token, "bearer ")
-	claims, err := utiljwt.Parse(strippedToken)
+	claims, err := utiljwt.ParseUnverified(strippedToken)
 	Expect(err).NotTo(HaveOccurred())
 	return claims
 }

--- a/integration/helpers/token.go
+++ b/integration/helpers/token.go
@@ -4,29 +4,29 @@ import (
 	"strings"
 	"time"
 
-	"github.com/SermoDigital/jose/crypto"
-	"github.com/SermoDigital/jose/jws"
-	"github.com/SermoDigital/jose/jwt"
+	utiljwt "code.cloudfoundry.org/cli/v9/util/jwt"
+	jwtv5 "github.com/golang-jwt/jwt/v5"
 	. "github.com/onsi/gomega"
 )
 
 // BuildTokenString returns a string typed JSON web token with the specified expiration time
 func BuildTokenString(expiration time.Time) string {
-	c := jws.Claims{}
-	c.SetExpiration(expiration)
-	c.Set("user_name", "some-user")
-	c.Set("user_id", "some-guid")
-	c.Set("origin", "uaa")
-	token := jws.NewJWT(c, crypto.Unsecured)
-	tokenBytes, err := token.Serialize(nil)
+	claims := jwtv5.MapClaims{
+		"exp":       jwtv5.NewNumericDate(expiration),
+		"user_name": "some-user",
+		"user_id":   "some-guid",
+		"origin":    "uaa",
+	}
+	token := jwtv5.NewWithClaims(jwtv5.SigningMethodNone, claims)
+	tokenBytes, err := token.SignedString(jwtv5.UnsafeAllowNoneSignatureType)
 	Expect(err).NotTo(HaveOccurred())
 	return string(tokenBytes)
 }
 
 // ParseTokenString takes a string typed token and returns a jwt.JWT struct representation of that token
-func ParseTokenString(token string) jwt.JWT {
+func ParseTokenString(token string) jwtv5.MapClaims {
 	strippedToken := strings.TrimPrefix(token, "bearer ")
-	jwt, err := jws.ParseJWT([]byte(strippedToken))
+	claims, err := utiljwt.Parse(strippedToken)
 	Expect(err).NotTo(HaveOccurred())
-	return jwt
+	return claims
 }

--- a/integration/v7/selfcontained/selfcontained_suite_test.go
+++ b/integration/v7/selfcontained/selfcontained_suite_test.go
@@ -14,8 +14,7 @@ import (
 	"code.cloudfoundry.org/cli/v9/integration/helpers"
 	"code.cloudfoundry.org/cli/v9/integration/v7/selfcontained/fake"
 	"code.cloudfoundry.org/cli/v9/util/configv3"
-	"github.com/SermoDigital/jose/crypto"
-	"github.com/SermoDigital/jose/jws"
+	jwtv5 "github.com/golang-jwt/jwt/v5"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"gopkg.in/yaml.v2"
@@ -44,10 +43,12 @@ var _ = BeforeEach(func() {
 	keyPair, err := rsa.GenerateKey(rand.Reader, 2048)
 	Expect(err).NotTo(HaveOccurred())
 
-	jwt := jws.NewJWT(jws.Claims{
-		"exp": time.Now().Add(time.Hour).Unix(),
-	}, crypto.SigningMethodRS256)
-	token, err = jwt.Serialize(keyPair)
+	jwtToken := jwtv5.NewWithClaims(jwtv5.SigningMethodRS256, jwtv5.MapClaims{
+		"exp": jwtv5.NewNumericDate(time.Now().Add(time.Hour)),
+	})
+	var tokenString string
+	tokenString, err = jwtToken.SignedString(keyPair)
+	token = []byte(tokenString)
 	Expect(err).NotTo(HaveOccurred())
 })
 

--- a/util/configv3/default_user_config.go
+++ b/util/configv3/default_user_config.go
@@ -1,8 +1,6 @@
 package configv3
 
-import (
-	"github.com/SermoDigital/jose/jws"
-)
+import utiljwt "code.cloudfoundry.org/cli/v9/util/jwt"
 
 type DefaultUserConfig struct {
 	// ConfigFile stores the configuration from the .cf/config
@@ -29,22 +27,20 @@ func decodeUserFromJWT(accessToken string) (User, error) {
 		return User{}, nil
 	}
 
-	token, err := jws.ParseJWT([]byte(accessToken[7:]))
+	claims, err := utiljwt.Parse(accessToken[7:])
 	if err != nil {
 		return User{}, err
 	}
 
-	claims := token.Claims()
-
 	var name, GUID, origin string
 	var isClient bool
-	if claims.Has("user_name") {
-		name = claims.Get("user_name").(string)
-		GUID = claims.Get("user_id").(string)
-		origin = claims.Get("origin").(string)
+	if value, ok := claims["user_name"].(string); ok {
+		name = value
+		GUID, _ = claims["user_id"].(string)
+		origin, _ = claims["origin"].(string)
 		isClient = false
 	} else {
-		name = claims.Get("client_id").(string)
+		name, _ = claims["client_id"].(string)
 		GUID = name
 		isClient = true
 	}

--- a/util/configv3/default_user_config.go
+++ b/util/configv3/default_user_config.go
@@ -27,7 +27,7 @@ func decodeUserFromJWT(accessToken string) (User, error) {
 		return User{}, nil
 	}
 
-	claims, err := utiljwt.Parse(accessToken[7:])
+	claims, err := utiljwt.ParseUnverified(accessToken[7:])
 	if err != nil {
 		return User{}, err
 	}

--- a/util/jwt/jwt.go
+++ b/util/jwt/jwt.go
@@ -1,0 +1,15 @@
+package jwt
+
+import (
+	"strings"
+
+	jwtv5 "github.com/golang-jwt/jwt/v5"
+)
+
+// Parse parses JWT claims without validating the access token signature.
+func Parse(accessToken string) (jwtv5.MapClaims, error) {
+	tokenString := strings.TrimPrefix(accessToken, "bearer ")
+	claims := jwtv5.MapClaims{}
+	_, _, err := new(jwtv5.Parser).ParseUnverified(tokenString, claims)
+	return claims, err
+}

--- a/util/jwt/jwt.go
+++ b/util/jwt/jwt.go
@@ -6,8 +6,9 @@ import (
 	jwtv5 "github.com/golang-jwt/jwt/v5"
 )
 
-// Parse parses JWT claims without validating the access token signature.
-func Parse(accessToken string) (jwtv5.MapClaims, error) {
+// ParseUnverified parses JWT claims without validating the access token signature.
+// The returned claims must not be used for authentication or authorization.
+func ParseUnverified(accessToken string) (jwtv5.MapClaims, error) {
 	tokenString := strings.TrimPrefix(accessToken, "bearer ")
 	claims := jwtv5.MapClaims{}
 	_, _, err := new(jwtv5.Parser).ParseUnverified(tokenString, claims)


### PR DESCRIPTION
…ompat

#### Note: Please create separate PR for every branch (main and v8) as needed.

## Description of the Change

This PR switches from using github.com/SermoDigital to use github.com/golang-jwt as there are issues with SermoDigital and golang 1.27.0 (https://github.com/cloudfoundry/cf_exporter/actions/runs/32944433448/job/98102027604).

```
goroutine 1 [running]:
crypto.RegisterHash(...)
	/opt/hostedtoolcache/go/1.27.0/x64/src/crypto/crypto.go:158
github.com/SermoDigital/jose/crypto.init.0()
	/home/runner/work/cf_exporter/cf_exporter/vendor/github.com/SermoDigital/jose/crypto/none.go:11 +0x25
FAIL	github.com/cloudfoundry/cf_exporter/v2/fetcher	0.008s
=== RUN   TestFilters
Running Suite: Filters Suite

```

_Note: PR has been created with the usage of AI_

## Why Is This PR Valuable?

Makes it possible to bump golang to v1.27.0.

## Applicable Issues

List any applicable GitHub Issues here

## How Urgent Is The Change?

Is the change urgent? If so, explain why it is time-sensitive.

## Other Relevant Parties

Who else is affected by the change? 
