### PR TITLE
[main] [cherry-pick] Update Go version to 1.26.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module code.cloudfoundry.org/cli/v9
 
-go 1.26.4
+go 1.26.7
 
 require (
 	code.cloudfoundry.org/bytefmt v0.86.0


### PR DESCRIPTION
## Description of the Change

Update Go version to 1.26.7

This PR is cherry-pick of https://github.com/cloudfoundry/cli/pull/3854

## Why Is This PR Valuable?

Keep Go up to date for more security.

